### PR TITLE
Fix ADV status spine consistency

### DIFF
--- a/docs/adv-context-agreement.md
+++ b/docs/adv-context-agreement.md
@@ -76,9 +76,13 @@ The snapshot is included automatically when ADV tools expose current change stat
 | Trigger | Mechanism |
 |---------|-----------|
 | Change loaded for work | `adv_change_show` |
-| Gate transitions | `adv_gate_complete` response and next `adv_change_show` call |
-| Task switches | Reflected in next `adv_change_show` call |
+| Task started | `adv_task_update` → `in_progress` |
+| Task completed | `adv_task_update` → `done` |
+| Task ready for work | `adv_task_ready` |
+| Gate transitions | `adv_gate_complete` response |
 | Project overview | Recent entries in `adv_status` |
+
+> **rq-ctxsnap2.3 compliance:** Task-level triggers (`adv_task_update` → `in_progress`, `adv_task_update` → `done`, `adv_task_ready`) now emit the snapshot directly rather than deferring to the next `adv_change_show` call.
 
 ### Graceful Degradation
 

--- a/docs/adv-context-agreement.md
+++ b/docs/adv-context-agreement.md
@@ -42,7 +42,7 @@ A compact box (max 10 lines) included in `_contextSnapshot` output fields across
 
 ### Gate Labels
 
-Full gate IDs are abbreviated for compactness:
+Gate IDs are rendered directly (no abbreviation map is currently defined):
 
 | Gate ID | Label |
 |---------|-------|
@@ -50,8 +50,8 @@ Full gate IDs are abbreviated for compactness:
 | `discovery` | `discovery` |
 | `design` | `design` |
 | `planning` | `planning` |
-| `execution` | `exec` |
-| `acceptance` | `accept` |
+| `execution` | `execution` |
+| `acceptance` | `acceptance` |
 | `release` | `release` |
 
 ### Rendered Example
@@ -61,7 +61,7 @@ Full gate IDs are abbreviated for compactness:
 ║ CONTEXT: improveContextAgreement                         ║
 ║ Improve context agreement                                ║
 ║                                                          ║
-║ Gates: [✓ proposal] [✓ discovery] [○ design] [○ exec]...║
+║ Gates: [✓ proposal] [✓ discovery] [○ design] [○ execution]...
 ║ Success: 3 criteria                                      ║
 ║ Tasks: 7 done | 1 active | 2 pending                    ║
 ║ Current: tk-abc123 (Implement feature X)                 ║
@@ -123,6 +123,7 @@ Emit when the agent switches `workdir` to a different repository for a cross-rep
 | `plugin/src/tools/change.ts` | Builds snapshot from change/gates/tasks/proposal, adds `_contextSnapshot` to output |
 | `plugin/src/tools/status.ts` | Adds `_contextSnapshot` to each recent change in `adv_status` |
 | `plugin/src/tools/gate.ts` | Emits updated `_contextSnapshot` in `adv_gate_complete` responses |
+| `plugin/src/tools/task.ts` | Emits `_contextSnapshot` on `adv_task_update` (→ `in_progress` / → `done`) and `adv_task_ready` |
 
 ## Spec
 

--- a/plugin/src/commands-spine-assets.test.ts
+++ b/plugin/src/commands-spine-assets.test.ts
@@ -33,7 +33,9 @@ function checkSpine(content: string, fileName: string): SpineCheck {
   const lines = content.split("\n");
 
   const problemIndex = lines.findIndex((l) => l.trim() === "## Problem");
-  const chosenIndex = lines.findIndex((l) => l.trim() === "## Chosen direction");
+  const chosenIndex = lines.findIndex(
+    (l) => l.trim() === "## Chosen direction",
+  );
   const deliveredIndex = lines.findIndex((l) => l.trim() === "## Delivered");
 
   const hasProblem = problemIndex !== -1;
@@ -84,16 +86,14 @@ function checkSpine(content: string, fileName: string): SpineCheck {
   return { file: fileName, hasSpine: true, errors };
 }
 
-function checkRetiredHeadings(content: string, fileName: string): string[] {
+function checkRetiredHeadings(content: string, _fileName: string): string[] {
   const errors: string[] = [];
   const lines = content.split("\n");
 
   for (let i = 0; i < lines.length; i++) {
     const trimmed = lines[i].trim();
     if (trimmed === "## Next stage") {
-      errors.push(
-        `Line ${i + 1}: retired heading \`## Next stage\` found`,
-      );
+      errors.push(`Line ${i + 1}: retired heading \`## Next stage\` found`);
     }
     if (trimmed === "## Next") {
       errors.push(`Line ${i + 1}: retired heading \`## Next\` found`);

--- a/plugin/src/commands-spine-assets.test.ts
+++ b/plugin/src/commands-spine-assets.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Command Doc Gate Handoff Spine Asset Tests
+ *
+ * Verifies that every `.opencode/command/adv-*.md` file containing the
+ * gate handoff spine (## Problem / ## Chosen direction / ## Delivered)
+ * uses the canonical format defined in `docs/command-voice-standard.md`.
+ *
+ * Also bans retired headings (`## Next stage`, `## Next`) everywhere.
+ */
+
+import { describe, expect, test } from "vitest";
+import { readFileSync, readdirSync } from "fs";
+import { join, resolve } from "path";
+
+const REPO_ROOT = resolve(__dirname, "../..");
+const COMMAND_DIR = join(REPO_ROOT, ".opencode/command");
+
+function listCommandFiles(): string[] {
+  const entries = readdirSync(COMMAND_DIR);
+  return entries
+    .filter((f) => f.startsWith("adv-") && f.endsWith(".md"))
+    .sort();
+}
+
+interface SpineCheck {
+  file: string;
+  hasSpine: boolean;
+  errors: string[];
+}
+
+function checkSpine(content: string, fileName: string): SpineCheck {
+  const errors: string[] = [];
+  const lines = content.split("\n");
+
+  const problemIndex = lines.findIndex((l) => l.trim() === "## Problem");
+  const chosenIndex = lines.findIndex((l) => l.trim() === "## Chosen direction");
+  const deliveredIndex = lines.findIndex((l) => l.trim() === "## Delivered");
+
+  const hasProblem = problemIndex !== -1;
+  const hasChosen = chosenIndex !== -1;
+  const hasDelivered = deliveredIndex !== -1;
+  const hasSpine = hasProblem && hasChosen && hasDelivered;
+
+  if (!hasSpine) {
+    return { file: fileName, hasSpine: false, errors };
+  }
+
+  // Order check
+  if (problemIndex > chosenIndex) {
+    errors.push("`## Problem` must appear before `## Chosen direction`");
+  }
+  if (chosenIndex > deliveredIndex) {
+    errors.push("`## Chosen direction` must appear before `## Delivered`");
+  }
+
+  // Find `---` separator after ## Delivered
+  let separatorIndex = -1;
+  for (let i = deliveredIndex + 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      separatorIndex = i;
+      break;
+    }
+  }
+  if (separatorIndex === -1) {
+    errors.push("Missing `---` separator after `## Delivered`");
+  }
+
+  // Find footer line with **{change-id}** after the separator
+  if (separatorIndex !== -1) {
+    let footerIndex = -1;
+    for (let i = separatorIndex + 1; i < lines.length; i++) {
+      if (lines[i].includes("**{change-id}**")) {
+        footerIndex = i;
+        break;
+      }
+    }
+    if (footerIndex === -1) {
+      errors.push(
+        "Missing footer line containing `**{change-id}**` after `---` separator",
+      );
+    }
+  }
+
+  return { file: fileName, hasSpine: true, errors };
+}
+
+function checkRetiredHeadings(content: string, fileName: string): string[] {
+  const errors: string[] = [];
+  const lines = content.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed === "## Next stage") {
+      errors.push(
+        `Line ${i + 1}: retired heading \`## Next stage\` found`,
+      );
+    }
+    if (trimmed === "## Next") {
+      errors.push(`Line ${i + 1}: retired heading \`## Next\` found`);
+    }
+  }
+
+  return errors;
+}
+
+describe("Command doc gate handoff spine format", () => {
+  const commandFiles = listCommandFiles();
+
+  test("at least one command doc exists", () => {
+    expect(commandFiles.length).toBeGreaterThan(0);
+  });
+
+  const spineResults: SpineCheck[] = [];
+  const retiredErrors: { file: string; errors: string[] }[] = [];
+
+  for (const file of commandFiles) {
+    const content = readFileSync(join(COMMAND_DIR, file), "utf8");
+    const spineResult = checkSpine(content, file);
+    if (spineResult.hasSpine) {
+      spineResults.push(spineResult);
+    }
+    const retired = checkRetiredHeadings(content, file);
+    if (retired.length > 0) {
+      retiredErrors.push({ file, errors: retired });
+    }
+  }
+
+  test("no retired headings in any command doc", () => {
+    const messages = retiredErrors.map(
+      ({ file, errors }) => `${file}:\n  ${errors.join("\n  ")}`,
+    );
+    expect(
+      retiredErrors,
+      `Retired headings detected:\n\n${messages.join("\n\n")}`,
+    ).toHaveLength(0);
+  });
+
+  test("all spine-bearing command docs have correct format", () => {
+    const failures = spineResults.filter((r) => r.errors.length > 0);
+    const messages = failures.map(
+      ({ file, errors }) => `${file}:\n  ${errors.join("\n  ")}`,
+    );
+    expect(
+      failures,
+      `Spine format errors:\n\n${messages.join("\n\n")}`,
+    ).toHaveLength(0);
+  });
+
+  test("known gate-handoff commands have a spine", () => {
+    // These commands are expected to produce a gate handoff spine
+    const expectedSpineFiles = [
+      "adv-apply.md",
+      "adv-archive.md",
+      "adv-design.md",
+      "adv-discover.md",
+      "adv-harden.md",
+      "adv-prep.md",
+      "adv-proposal.md",
+      "adv-review.md",
+      "adv-task.md",
+    ];
+
+    const missingSpine = expectedSpineFiles.filter(
+      (file) => !spineResults.some((r) => r.file === file),
+    );
+
+    expect(
+      missingSpine,
+      `Expected gate-handoff commands missing spine:\n  ${missingSpine.join("\n  ")}`,
+    ).toHaveLength(0);
+  });
+});

--- a/plugin/src/tools/task.test.ts
+++ b/plugin/src/tools/task.test.ts
@@ -185,6 +185,19 @@ describe("Task Tools", () => {
       expect(parsed.ready).toHaveLength(1);
       expect(parsed.ready[0].id).toBe("tk-task0002");
     });
+
+    test("emits _contextSnapshot in response", async () => {
+      const result = await taskTools.adv_task_ready.execute(
+        { changeId: "addFeature" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed._contextSnapshot).toBeDefined();
+      expect(typeof parsed._contextSnapshot).toBe("string");
+      expect(parsed._contextSnapshot).toContain("addFeature");
+      expect(parsed._contextSnapshot).toMatch(/[╔╗╚╝║═]/);
+    });
   });
 
   describe("adv_task_update", () => {
@@ -285,6 +298,61 @@ describe("Task Tools", () => {
 
       const final = await store.tasks.get("tk-task0001");
       expect(final!.metadata?.tdd_intent).toBe("inline");
+    });
+
+    test("emits _contextSnapshot on in_progress transition (rq-ctxsnap2.3)", async () => {
+      const result = await taskTools.adv_task_update.execute(
+        { taskId: "tk-task0001", status: "in_progress" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed._contextSnapshot).toBeDefined();
+      expect(typeof parsed._contextSnapshot).toBe("string");
+      expect(parsed._contextSnapshot).toContain("addFeature");
+      expect(parsed._contextSnapshot).toMatch(/[╔╗╚╝║═]/);
+    });
+
+    test("emits _contextSnapshot on done transition", async () => {
+      const result = await taskTools.adv_task_update.execute(
+        { taskId: "tk-task0001", status: "done" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed._contextSnapshot).toBeDefined();
+      expect(typeof parsed._contextSnapshot).toBe("string");
+      expect(parsed._contextSnapshot).toContain("addFeature");
+    });
+
+    test("does NOT emit _contextSnapshot on pending transition", async () => {
+      // First move to in_progress, then back to pending
+      await taskTools.adv_task_update.execute(
+        { taskId: "tk-task0001", status: "in_progress" },
+        store,
+      );
+
+      const result = await taskTools.adv_task_update.execute(
+        { taskId: "tk-task0001", status: "pending" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed._contextSnapshot).toBeUndefined();
+    });
+
+    test("does NOT emit _contextSnapshot for nonexistent task", async () => {
+      const result = await taskTools.adv_task_update.execute(
+        { taskId: "nonexistent", status: "done" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toBeDefined();
+      expect(parsed._contextSnapshot).toBeUndefined();
     });
   });
 

--- a/plugin/src/tools/task.ts
+++ b/plugin/src/tools/task.ts
@@ -21,6 +21,7 @@ import {
 } from "../validator/task-classifier";
 import { validateEvidenceSemantics } from "../validator/evidence";
 import { formatToolOutput, paginate } from "../utils/tool-output";
+import { fetchChangeContextSnapshot } from "../utils/context-snapshot";
 
 // =============================================================================
 // Tool Definitions
@@ -102,7 +103,11 @@ export const taskTools = {
     },
     execute: async ({ changeId }: { changeId: string }, store: Store) => {
       const result = await store.tasks.ready(changeId);
-      return formatToolOutput(result);
+      const snapshot = await fetchChangeContextSnapshot(store, changeId);
+      return formatToolOutput({
+        ...result,
+        ...(snapshot ? { _contextSnapshot: snapshot } : {}),
+      });
     },
   },
 
@@ -150,6 +155,10 @@ export const taskTools = {
         });
       }
 
+      // Resolve changeId for snapshot emission (rq-ctxsnap2.3 compliance)
+      const taskShowResult = await store.tasks.show(taskId);
+      const changeId = taskShowResult?.changeId;
+
       const task = await store.tasks.update(
         taskId,
         status,
@@ -160,7 +169,20 @@ export const taskTools = {
       if (!task) {
         return formatToolOutput({ error: `Task not found: ${taskId}` });
       }
-      return formatToolOutput({ success: true, task });
+
+      // Emit snapshot on meaningful transitions (in_progress, done)
+      const output: Record<string, unknown> = { success: true, task };
+      if (
+        changeId &&
+        (status === "in_progress" || status === "done")
+      ) {
+        const snapshot = await fetchChangeContextSnapshot(store, changeId);
+        if (snapshot) {
+          output._contextSnapshot = snapshot;
+        }
+      }
+
+      return formatToolOutput(output);
     },
   },
 

--- a/plugin/src/tools/task.ts
+++ b/plugin/src/tools/task.ts
@@ -172,10 +172,7 @@ export const taskTools = {
 
       // Emit snapshot on meaningful transitions (in_progress, done)
       const output: Record<string, unknown> = { success: true, task };
-      if (
-        changeId &&
-        (status === "in_progress" || status === "done")
-      ) {
+      if (changeId && (status === "in_progress" || status === "done")) {
         const snapshot = await fetchChangeContextSnapshot(store, changeId);
         if (snapshot) {
           output._contextSnapshot = snapshot;

--- a/plugin/src/utils/context-snapshot.test.ts
+++ b/plugin/src/utils/context-snapshot.test.ts
@@ -5,14 +5,21 @@
  * internal state visible to the user.
  */
 
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   buildChangeContextSnapshot,
+  fetchChangeContextSnapshot,
   formatContextSnapshot,
   formatCrossRepoSwitch,
   type ContextSnapshotInput,
   type CrossRepoSwitchInput,
 } from "./context-snapshot";
+import { createStore, type Store } from "../storage/store";
+import {
+  createTempDir,
+  cleanupTempDir,
+  createTestProject,
+} from "../__tests__/setup";
 
 describe("formatContextSnapshot", () => {
   const baseInput: ContextSnapshotInput = {
@@ -239,5 +246,60 @@ describe("buildChangeContextSnapshot", () => {
 
     expect(output).toContain("Wisdom: 3 entries");
     expect(output).toContain("2 pattern");
+  });
+});
+
+describe("fetchChangeContextSnapshot", () => {
+  let tempDir: string;
+  let store: Store;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    await createTestProject(tempDir);
+    store = await createStore(tempDir);
+  });
+
+  afterEach(async () => {
+    store.close();
+    await cleanupTempDir(tempDir);
+  });
+
+  test("returns a formatted snapshot for an existing change", async () => {
+    const snapshot = await fetchChangeContextSnapshot(store, "addFeature");
+
+    expect(snapshot).toBeDefined();
+    expect(snapshot).toContain("addFeature");
+    expect(snapshot).toContain("Add New Feature");
+    expect(snapshot).toContain("Gates:");
+    expect(snapshot).toContain("Tasks:");
+    expect(snapshot).toMatch(/[╔╗╚╝║═]/);
+  });
+
+  test("returns undefined for non-existent change", async () => {
+    const snapshot = await fetchChangeContextSnapshot(store, "nonExistent");
+
+    expect(snapshot).toBeUndefined();
+  });
+
+  test("uses provided gates override", async () => {
+    const overrideGates = {
+      proposal: { status: "done" as const },
+      discovery: { status: "done" as const },
+      design: { status: "done" as const },
+      planning: { status: "done" as const },
+      execution: { status: "done" as const },
+      acceptance: { status: "done" as const },
+      release: { status: "done" as const },
+    };
+
+    const snapshot = await fetchChangeContextSnapshot(
+      store,
+      "addFeature",
+      overrideGates,
+    );
+
+    expect(snapshot).toBeDefined();
+    expect(snapshot).toContain("[✓ proposal]");
+    expect(snapshot).toContain("[✓ release]");
   });
 });

--- a/plugin/src/utils/context-snapshot.ts
+++ b/plugin/src/utils/context-snapshot.ts
@@ -109,6 +109,36 @@ function summarizeWisdom(wisdom?: SnapshotWisdomLike[]): {
   };
 }
 
+import type { Store } from "../storage/store";
+import { loadProposalWithFallback } from "../storage/json";
+import { join } from "path";
+
+export async function fetchChangeContextSnapshot(
+  store: Store,
+  changeId: string,
+  gates?: Record<string, GateInfo>,
+): Promise<string | undefined> {
+  const result = await store.changes.get(changeId);
+  if (!result.success || !result.data) {
+    return undefined;
+  }
+
+  const change = result.data;
+  const changeDir = join(store.paths.changes, changeId);
+  const { content: proposalText } = await loadProposalWithFallback(
+    changeDir,
+    change.title,
+  );
+  const latestGates = gates ?? (await store.gates.get(changeId)) ?? undefined;
+
+  return buildChangeContextSnapshot({
+    change,
+    proposalText,
+    gates: latestGates,
+    workdir: store.paths.root,
+  });
+}
+
 export function buildChangeContextSnapshot({
   change,
   proposalText,


### PR DESCRIPTION
## Summary
- add task-level `_contextSnapshot` emission for `adv_task_update` and `adv_task_ready`
- add `fetchChangeContextSnapshot` wrapper and tests for snapshot/handoff consistency
- align context-agreement docs with actual gate-label behavior