### PR TITLE
Improve archive worktree merge finalization

### DIFF
--- a/.adv/specs/advance/spec.json
+++ b/.adv/specs/advance/spec.json
@@ -501,6 +501,53 @@
       ]
     },
     {
+      "id": "rq-releaseFinalization01",
+      "title": "Archive Finalization Refreshes Basis and Preserves Cleanup Safety",
+      "body": "Phase 9 Git Finalization must refresh the current default-branch basis before deciding local merge-back versus PR workflow. Clean low-risk cases prefer a linear-history fast path (`--ff-only` when already current, reconcile only when needed). Conflicting or risky cases must stop or route to PR workflow before cleanup. Worktree deletion remains forbidden until merged-state verification proves the change branch is fully integrated.",
+      "priority": "must",
+      "tags": ["workflow", "archive", "worktree", "git"],
+      "scenarios": [
+        {
+          "id": "rq-releaseFinalization01.1",
+          "title": "Clean archive refresh uses local fast path",
+          "given": [
+            "A change branch is already on the current default-branch basis",
+            "No overlap-risk or PR-only policy applies"
+          ],
+          "when": "Phase 9 Git Finalization chooses an integration path",
+          "then": [
+            "The archive uses the local `--ff-only` path",
+            "No branch rewrite is required"
+          ]
+        },
+        {
+          "id": "rq-releaseFinalization01.2",
+          "title": "Conflicting reconcile stops before cleanup",
+          "given": [
+            "A change branch must reconcile with a fresher default branch",
+            "Compatibility preflight or rebase finds conflicts"
+          ],
+          "when": "Phase 9 Git Finalization evaluates the reconcile path",
+          "then": [
+            "The archive reports the conflicting files",
+            "The archive does not delete the worktree"
+          ]
+        },
+        {
+          "id": "rq-releaseFinalization01.3",
+          "title": "Risky archive routes to PR workflow",
+          "given": [
+            "A change has overlap-risk, PR-only policy, or non-fast-forward publish risk"
+          ],
+          "when": "Phase 9 Git Finalization chooses an integration path",
+          "then": [
+            "The archive routes to PR workflow instead of forcing local merge-back",
+            "Cleanup remains blocked until merged-state verification succeeds"
+          ]
+        }
+      ]
+    },
+    {
       "id": "rq-autonomy01",
       "title": "Human Checkpoint Contract",
       "body": "ADV must pause for human input only at explicit approval/judgment checkpoints and auto-continue through clean agent-owned workflow steps. Human checkpoints are: proposal confirmation, agreement sign-off, design approval when real tradeoffs depend on user values, when the design validator returns CONFLICT, or when contract-compromise risk is present, acceptance, archive sign-off, cancellation approval, and doom-loop recovery. All other clean workflow steps (discovery, deterministic design, prep, apply, harden, and scope-driven re-entry) proceed sequentially without prompting the user when no unresolved user-value tradeoff, contract-compromise risk, or required approval exists.",

--- a/.opencode/command/adv-archive.md
+++ b/.opencode/command/adv-archive.md
@@ -3,15 +3,21 @@ name: adv-archive
 description: Archive completed change: apply spec deltas and finalize git
 phaseGoal: "Promote the change from contract to law: apply spec deltas, capture wisdom, clean up."
 ---
+
 <!-- manifest: adv-archive · gate: release · requiresChangeId: true · prereqs: [adv-harden] · scope: reads[specs, proposal, tasks, codebase] · modifies[specs] -->
+
 # ADV Archive — Finalize Completed Change
+
 Archive change → apply deltas to specs → mandatory Phase 9 Git Finalization (commit, merge, verify, cleanup).
+
 ## Exits
-| Exit | Condition |
-|------|-----------|
+
+| Exit        | Condition                                      |
+| ----------- | ---------------------------------------------- |
 | ✅ Complete | All gates passed, specs updated, git finalized |
-| 🎤 Blocked | Incomplete gates/tasks or merge conflicts |
-| 🔁 Dry Run | Preview only, no changes |
+| 🎤 Blocked  | Incomplete gates/tasks or merge conflicts      |
+| 🔁 Dry Run  | Preview only, no changes                       |
+
 <UserRequest>
   $ARGUMENTS
 </UserRequest>
@@ -20,7 +26,9 @@ Parse `$ARGUMENTS`: `change-id` (required), `--dry-run` (optional).
 If empty → `adv_change_list` → auto-select the only plausible change; ask via `question` only if multiple plausible targets remain.
 
 ---
+
 ## Phase 1: Pre-Archive Checks
+
 1. `adv_change_show` → verify status "active"
 2. `adv_task_list` → all tasks must be "done". If incomplete → ARCHIVE BLOCKED banner → stop
 3. `adv_change_validate strict: true` → if fails → show errors/warnings → stop and review the validation output before retrying
@@ -28,32 +36,45 @@ If empty → `adv_change_list` → auto-select the only plausible change; ask vi
 5. `adv_investment_report changeId: {id}` → include investment summary in archive report (informational)
 
 ---
+
 ## Phase 2: Archive Preview
+
 Display: change ID/title, task count, delta count per capability, affected spec files, docs to generate, archive location.
 
 ---
+
 ## Phase 3: Dry Run
+
 If `--dry-run` → emit DRY RUN COMPLETE → stop.
 
 ---
+
 ## Phase 4: Gate Status
+
 `adv_gate_status` → display all 7 gates. If any incomplete before `release` → stop with guidance.
 
 ---
+
 ## Phase 5: User Signoff
+
 Ask via `question`: "Archive '{change-id}' and apply to specs?" Options: Sign off and archive (Recommended), Dry run first, Cancel.
 
 If approved → `adv_gate_complete changeId: {id} gateId: release` → proceed.
 
 ---
+
 ## Phase 6: Execute Archive
+
 `adv_change_archive changeId: <target>` — applies deltas, updates SQLite, generates docs, moves to archive.
 
 ---
+
 ## Phase 7: Verify
+
 For each affected capability: `adv_spec action: "show"` → verify new requirements present. Verify archive directory exists with change.json and ARCHIVE_SUMMARY.md.
 
 ---
+
 ## Phase 8: Archive Report
 
 Use the archive terminal variant of the Gate Handoff Voice spine (see `docs/command-voice-standard.md § Gate Handoff Voice` — archive variant: `Problem` / `Chosen direction` / `Delivered` + shipped footer):
@@ -80,18 +101,60 @@ What shipped, what spec deltas applied.
 ```
 
 ---
-## Phase 9: Git Finalization (Mandatory)
-### Step 1: Stage and Commit
-Stage `.adv/specs/`, `docs/specs/`, `.adv/archive/`, `.opencode/`, `plugin/src/`, `ADV_INSTRUCTIONS.md`, `README.md`, and any touched docs in `docs/`. Do NOT stage generated build artifacts. Commit: `chore: archive {change-id}`. If commit fails → stop.
-### Step 2: Detect Default Branch
-`git rev-parse --verify main` || `trunk` || `git symbolic-ref refs/remotes/origin/HEAD` || `git config --get init.defaultBranch`. If UNKNOWN or remote HEAD looks stale → ask user.
-### Step 3: Check Context
-`git branch --show-current` → if on `change/{change-id}` → merge required. If on default branch → skip merge.
-### Step 4: Merge
-`git checkout {default-branch}` → `git merge --no-edit change/{change-id}`. If conflicts → stop, user resolves. Alternative (PR workflow): push + `gh pr create`.
 
-### Step 4.5: Publish Safety (when pushing a default branch)
+## Phase 9: Git Finalization (Mandatory)
+
+### Step 1: Stage and Commit
+
+Stage `.adv/specs/`, `docs/specs/`, `.adv/archive/`, `.opencode/`, `plugin/src/`, `ADV_INSTRUCTIONS.md`, `README.md`, and any touched docs in `docs/`. Do NOT stage generated build artifacts. Commit: `chore: archive {change-id}`. If commit fails → stop.
+
+### Step 2: Detect Default Branch
+
+`git rev-parse --verify main` || `trunk` || `git symbolic-ref refs/remotes/origin/HEAD` || `git config --get init.defaultBranch`. If UNKNOWN or remote HEAD looks stale → ask user.
+
+### Step 3: Check Context
+
+`git branch --show-current` → if on `change/{change-id}` → merge required. If on default branch → skip merge.
+
+### Step 3.5: Overlap + Policy Scan
+
+- Reuse overlap signals already surfaced by `/adv-apply` when available
+- If other active changes touch same files or same local subsystem → mark `overlap-risk`
+- If branch policy, review requirement, or publish safety makes local merge-back the wrong fit → mark `pr-risk`
+
+### Step 4: Refresh Merge Basis
+
+- `git fetch origin {default-branch}` when `origin` exists
+- If fetch succeeds → use `origin/{default-branch}` as freshness reference
+- If fetch fails and a PR/publish path is required → stop and ask the user before proceeding
+- If no remote is configured or local-only archive is intended → continue with local `{default-branch}`
+
+### Step 4.5: Choose Integration Path
+
+Allowed outcomes:
+
+- **LOCAL_FINISH / fast path** — branch is already on current default-branch basis → `git checkout {default-branch}` → `git merge --ff-only change/{change-id}`
+- **LOCAL_FINISH / reconcile path** — no `overlap-risk`, no `pr-risk`, but trunk moved → run compatibility preflight, then rebase, then fast-forward merge
+- **PR workflow path** — `overlap-risk`, `pr-risk`, failed lightweight verification, or non-fast-forward publish risk → push + `gh pr create` (or queue entry when project policy uses one)
+
+### Step 4.6: Compatibility Preflight (for reconcile path)
+
+- From the change branch: `git merge --no-commit --no-ff {freshness-ref}`
+- If clean → `git merge --abort` → continue
+- If conflicts → capture `git diff --name-only --diff-filter=U` → `git merge --abort` → stop with conflicting files. × Do NOT delete worktree
+
+### Step 4.7: Reconcile (for reconcile path)
+
+- `git rebase {freshness-ref}`
+- If rebase conflicts → capture `git diff --name-only --diff-filter=U` → `git rebase --abort` → stop with conflicting files. × Do NOT delete worktree
+- Run lightweight verification for touched scope (targeted checks first, repo smoke check if no narrower command exists)
+- If verification fails → route to PR workflow path or stop when project policy forbids it
+- After clean verification: `git checkout {default-branch}` → `git merge --ff-only change/{change-id}`
+
+### Step 4.8: Publish Safety (when pushing a default branch)
+
 If archive finalization needs a remote push from the default branch:
+
 - `git fetch origin` (if fetch fails or auth is unclear → stop and ask the user before proceeding)
 - `git log --oneline origin/{default-branch}..HEAD` → inspect the commits that will publish
 - If `origin/{default-branch}..HEAD` is a clean fast-forward → `git push origin {default-branch}`
@@ -99,21 +162,33 @@ If archive finalization needs a remote push from the default branch:
 - Before any `--force-with-lease` prompt, show both `origin/{default-branch}..HEAD` and `HEAD..origin/{default-branch}` so the user sees local-only and remote-only commits
 - Use `--force-with-lease` only after explicit user approval via the `question` tool confirms a non-fast-forward publish is intended
 - If remote divergence is detected and intent is unclear → stop and ask the user
+
 ### Step 5: Verify
+
 `git log --oneline {default-branch}..change/{change-id}` → MUST return empty. If non-empty → stop, × do NOT delete worktree.
+
 ### Step 6: Cleanup Worktree
+
 Only if in worktree AND merge verified: `worktree_delete branch: "change/{change-id}" reason: "Change {change-id} merged"`. If unavailable → emit info.
+
 ### Step 7: Temp Artifacts
+
 Remove `*.bak`, `*.tmp`, `*.orig` (excluding node_modules).
+
 ### Completion
+
 Emit GIT FINALIZATION COMPLETE: commit SHA, merge target, verification status, worktree cleanup status, artifacts removed.
 
 ---
+
 ## Error Handling
+
 Delta application error → ARCHIVE FAILED banner with delta ID, target, error. Change NOT archived → fix and retry.
 
 ---
+
 ## Key Tool
-| Purpose | Tool |
-|---------|------|
+
+| Purpose | Tool                                |
+| ------- | ----------------------------------- |
 | Archive | `adv_change_archive changeId: <id>` |

--- a/.opencode/command/adv-harden.md
+++ b/.opencode/command/adv-harden.md
@@ -3,32 +3,44 @@ name: adv-harden
 description: "Detect low-quality code, verify test coverage, clean up; block archive on open findings"
 phaseGoal: "Verify production-readiness. Auto-fix scoped issues. Stop on drift."
 ---
+
 <!-- manifest: adv-harden · requiresChangeId: true · prereqs: [adv-review] · scope: reads[specs, proposal, tasks, codebase] · modifies[codebase] -->
+
 # ADV Harden — Release-Stage Quality Analysis
+
 Orchestrate multi-dimensional hardening via sub-agents. This command is part of the release stage and **blocks archive if actionable `REVIEW_FINDINGS` are unresolved.**
+
 ## Exits
-| Exit | Condition |
-|------|-----------|
-| ✅ READY | No blockers/high findings; release stage ready for archive |
-| 🔁 NEEDS_WORK | High findings → agent fixes → re-verifies |
-| 🎤 BLOCKED | Blocker or unresolved review findings → user decides |
+
+| Exit          | Condition                                                  |
+| ------------- | ---------------------------------------------------------- |
+| ✅ READY      | No blockers/high findings; release stage ready for archive |
+| 🔁 NEEDS_WORK | High findings → agent fixes → re-verifies                  |
+| 🎤 BLOCKED    | Blocker or unresolved review findings → user decides       |
 
 > **SUB-AGENT CONTEXT**: Return findings as JSON. Skip status markers.
 > **CHECKLIST**: Follow [docs/checklists/harden-checklist.md](../../docs/checklists/harden-checklist.md).
-<UserRequest>
-  $ARGUMENTS
-</UserRequest>
+> <UserRequest>
+> $ARGUMENTS
+> </UserRequest>
+
 ## Parse Flags
+
 Extract from `$ARGUMENTS`:
+
 - `change-id`: Target change (prompt if missing)
 - `--no-cleanup`: Skip cleanup phase
 - `--execute`: Delete cleanup files (default: preview)
 - `--interactive`: Select individual files to delete
 - `--force`: No prompts (requires --execute)
+
 ## Target Resolution
+
 1. If change-id provided → use directly
 2. If empty → `adv_change_list` → select via `question` tool
+
 ## Phase 0: Load Skill
+
 `skill("adv-slop-detection")` → provides shared slop-detection methodology used by both `/adv-slop-scan` and this command's AI-slop scanner. If the skill is unavailable, continue with the embedded scanner contract below.
 
 ### Harden Methodology
@@ -43,14 +55,14 @@ Reusable hardening methodology for ADV harden workflows. Provides the 6-scanner 
 
 Every hardening pass must run all 6 scanners:
 
-| Scanner | Focus |
-|---------|-------|
-| Test Coverage | File-level coverage ratio, TDD evidence audit |
-| AI-Slop Detection | Placeholders, type erosion, naive patterns, structural issues |
+| Scanner               | Focus                                                            |
+| --------------------- | ---------------------------------------------------------------- |
+| Test Coverage         | File-level coverage ratio, TDD evidence audit                    |
+| AI-Slop Detection     | Placeholders, type erosion, naive patterns, structural issues    |
 | Documentation Hygiene | Conflict detection, staleness audit, deletion of superseded docs |
-| Cleanup | Temp files, debug code, dead imports, orphaned tests |
-| Production Readiness | Security, reliability, performance, maintainability |
-| Deployment Readiness | Env vars, migrations, external services, CI/CD, infrastructure |
+| Cleanup               | Temp files, debug code, dead imports, orphaned tests             |
+| Production Readiness  | Security, reliability, performance, maintainability              |
+| Deployment Readiness  | Env vars, migrations, external services, CI/CD, infrastructure   |
 
 All 6 must be executed. Skipping requires explicit justification.
 
@@ -62,22 +74,31 @@ All 6 must be executed. Skipping requires explicit justification.
 - **No workflow sequencing** — the command owns phase ordering and sub-agent orchestration
 
 ## Pre-flight
+
 ### Fetch Change Context
+
 `adv_change_show` + `adv_task_list` for target change.
+
 ### Gate Prerequisite Check
+
 `adv_gate_status changeId: {change-id}`
 
 If acceptance gate NOT complete (status != 'done' and status != 'legacy') → emit HARDEN BLOCKED banner citing incomplete acceptance gate → stop. Required action: `/adv-review {change-id}`.
+
 ### Cancellation & Cross-Repo Audit
+
 **Step 1: Unapproved cancellations** — From `adv_task_list`, find cancelled tasks. Verify each has `task.cancellation.approved_by_user === true`. If any lack approval → emit HARDEN BLOCKED banner listing unapproved tasks → stop.
 
 **Step 2: Cross-repo completion** — For tasks with `target_repo`/`target_path`, verify status is `done` (or approved-cancelled). If incomplete → emit HARDEN BLOCKED banner listing incomplete cross-repo tasks → stop.
+
 ### Review Findings Audit
+
 Verify all actionable review findings addressed before running scanners.
 
 **Step 1:** Load stored `REVIEW_FINDINGS` from task notes or proposal. If unavailable, warn but don't block.
 
 **Step 2:** Classify each finding:
+
 - Actionable: `blocker:`, `issue:`, `suggestion:`, `question:` (NOT `nit:`)
 - Resolved: fixed in subsequent task (evidence in `completed_by` notes) ✓
 - Rejected with evidence: documented evidence shows the finding is invalid or out of scope ✓
@@ -86,24 +107,35 @@ Verify all actionable review findings addressed before running scanners.
 If unresolved actionable findings → emit HARDEN BLOCKED banner listing each with `[{label}] {file}:{line} — {what}` → stop. Required: fix or reject with documented evidence showing the finding is invalid or out of scope.
 
 If all resolved → emit REVIEW FINDINGS AUDIT: PASSED banner → proceed.
+
 ### Merge Compatibility Check
+
 Dry-run merge of change branch into default branch. Non-destructive — nothing committed.
 
 Skip if not in a worktree.
+
 1. Detect default branch: `git rev-parse --verify main` || `trunk` || `git symbolic-ref refs/remotes/origin/HEAD`
 2. Fetch: `git fetch origin {default-branch} 2>/dev/null || true`
 3. Dry-run: `git merge --no-commit --no-ff origin/{default-branch}`
 4. If clean → `git merge --abort` → PASSED banner → proceed
 5. If conflicts → capture `git diff --name-only --diff-filter=U` → `git merge --abort` → HARDEN BLOCKED banner listing conflicting files → stop
+6. A clean pass proves merge compatibility only. `/adv-archive` still chooses `--ff-only`, reconcile, or PR workflow based on freshness and risk.
+
 ### Extract Details
+
 From change data: affected files, task completion status, spec deltas/scenarios.
+
 ### Worktree Context Propagation
+
 Sub-agents inherit default project root, NOT current workdir. When in a worktree:
+
 1. `pwd` → record as `{workdir}`
 2. Include in every sub-agent prompt: `WORKING DIRECTORY: {workdir}` — all file paths relative to this directory
 
 ---
+
 ## Technical Debt Quadrant
+
 Classify debt using Fowler's quadrant:
 | | Prudent | Reckless |
 |---|---------|----------|
@@ -111,7 +143,9 @@ Classify debt using Fowler's quadrant:
 | **Inadvertent** | "Now we know better" → Refactor | "What's layering?" → Train |
 
 ---
+
 ## Sub-Agent Resilience
+
 Sub-agents may return empty/failed results. Detection: empty string, missing `"dimension"` key, error-only output.
 
 Protocol: retry once → if still fails → inline fallback analysis → never skip a dimension.
@@ -125,8 +159,11 @@ Protocol: retry once → if still fails → inline fallback analysis → never s
 | Deployment | New env vars, migrations, config changes, CI/CD updates |
 
 ---
+
 ## Phase 1: Spawn Analysis Sub-Agents
+
 **Harden Context Packet (inject into every sub-agent spawn prompt):**
+
 ```
 WORKING DIRECTORY: {workdir}
 CHANGE: {change-id} | {title} | gate: release
@@ -141,19 +178,27 @@ TASK EVIDENCE SUMMARY:
   - ...
 EXPECTED OUTPUT: {dimension-specific JSON schema}
 ```
+
 Build packet from `adv_task_list` and `adv_change_show` outputs at spawn time. Inject verbatim — do NOT give explore agents ADV tool access.
 
 Spawn **6 parallel sub-agents** (`subagent_type: "explore"`). Each receives the Harden Context Packet above plus dimension-specific instructions.
+
 ### Sub-Agent 1: Test Coverage Scanner
+
 Analyze test coverage: for each source file check for test file, calculate coverage ratio, check TDD adherence (red/green evidence via `adv_run_test`; `adv_task_evidence` is fallback only), report test runner availability.
 
 Return JSON with: `dimension: "test_coverage"`, `files_with_tests`, `files_without_tests`, `coverage_percent`, `tdd_audit`, `issues`.
+
 ### Sub-Agent 2: AI-Slop Detection Scanner
+
 Use the methodology from `adv-slop-detection` loaded in Phase 0 for this scanner dimension. Preserve the same severity ladder as the dedicated slop-scan workflow: BLOCKER (security/data loss) > HIGH (silent failures) > MEDIUM (debt) > LOW (style).
 
 Return JSON with: `dimension: "ai_slop"`, `summary` (total, blockers, high, by_category), `issues` (severity, category, file, line, pattern, code_snippet, message, fix_suggestion), `debt_quadrant`.
+
 ### Sub-Agent 3: Documentation Hygiene Scanner
+
 Analyze doc quality for affected files:
+
 1. **Conflicts** — docs describing behavior differently than code, referencing deleted/renamed items, duplicates across files, contradictions
 2. **Staleness** — references to removed features/APIs, non-compiling examples, outdated generated files
 3. **Verbosity** — prose that should be tables, info repeated from code, misplaced sections
@@ -163,11 +208,15 @@ Analyze doc quality for affected files:
 Severity: BLOCKER (contradicts impl) > HIGH (stale refs to deleted code) > MEDIUM (duplicates, verbose) > LOW (missing inline docs).
 
 Return JSON with: `dimension: "documentation_hygiene"`, `conflicts`, `stale`, `deletions`, `updates_needed`, `verbose`, `inline_docs`, `issues`.
+
 ### Sub-Agent 4: Cleanup Scanner
-Find cleanup candidates: temp files (*.bak, *.tmp, *.orig, *~, *.swp), marked files (ONETIME-*, DELETE-AFTER-*), dev directories (poc/, scratch/, temp/), dead imports, orphaned tests, debug code (console.log, debugger, print()). Preserve: scripts/, tools/, migrations.
+
+Find cleanup candidates: temp files (_.bak, _.tmp, _.orig, _~, _.swp), marked files (ONETIME-_, DELETE-AFTER-\*), dev directories (poc/, scratch/, temp/), dead imports, orphaned tests, debug code (console.log, debugger, print()). Preserve: scripts/, tools/, migrations.
 
 Return JSON with: `dimension: "cleanup"`, `extension_based`, `explicitly_marked`, `dev_directories`, `dead_imports`, `debug_code`, `total_candidates`.
+
 ### Sub-Agent 5: Production Readiness Scanner
+
 Check quality gates for affected files:
 | Area | Checks |
 |------|--------|
@@ -179,7 +228,9 @@ Check quality gates for affected files:
 Complexity thresholds: 1-10 low, 11-20 moderate, 21-50 high (refactor), 51+ very high (block).
 
 Return JSON with: `dimension: "production_readiness"`, `security`, `reliability`, `performance`, `maintainability` (each with pass/issues), `complexity_hotspots`, `overall_status`.
+
 ### Sub-Agent 6: Deployment & Operational Readiness Scanner
+
 Check deployment readiness for affected files:
 | Area | Checks |
 |------|--------|
@@ -196,28 +247,40 @@ Severity: BLOCKER (missing migration, hardcoded secret, destructive without roll
 Return JSON with: `dimension: "deployment_readiness"`, `environment`, `migrations`, `external_services`, `ci_cd`, `infrastructure`, `feature_flags`, `deployment_steps`, `overall_status`, `issues`.
 
 ---
+
 ## Phase 2: Synthesis
+
 > **Anti-Loop**: After sub-agents return → `>>> SYNTHESIS COMPLETE <<<` → proceed.
+
 ### Aggregate Issues
+
 Combine by severity: BLOCKER > HIGH > MEDIUM > LOW.
+
 ### Severity Scoring
+
 ```
 Impact (1-5): Security=5, Production=4, Friction=3, Debt=2, Style=1
 Effort (1-5): <1hr=5, <1day=4, <1week=3, <1sprint=2, >1sprint=1
 Priority = Impact × Effort
   20-25: Critical | 12-19: High | 6-11: Medium | 1-5: Low
 ```
+
 ### Minimum Findings Enforcement
+
 Count non-nit findings. If <3 → require genuinely-clean justification with scanner-level evidence per [harden-checklist.md](../../docs/checklists/harden-checklist.md).
+
 ### Status Determination
-| Status | Criteria |
-|--------|----------|
-| READY | No BLOCKER, no HIGH, ≤3 MEDIUM |
+
+| Status     | Criteria                         |
+| ---------- | -------------------------------- |
+| READY      | No BLOCKER, no HIGH, ≤3 MEDIUM   |
 | NEEDS_WORK | No BLOCKER but HIGH or >3 MEDIUM |
-| BLOCKED | Any BLOCKER |
+| BLOCKED    | Any BLOCKER                      |
 
 ---
+
 ## Phase 3: Remediation
+
 If READY → skip to cleanup.
 
 If NEEDS_WORK or BLOCKED → fix all validated in-scope findings. × No report-only, future-work, or accepted-debt path for validated in-scope findings. Proceed with fixes.
@@ -237,8 +300,11 @@ This is the single declarative drift detection rule. It applies to every finding
 If fixing → establish CONTRACT ACTIVE banner listing issues grouped by category → spawn fix sub-agents → verify → update status.
 
 ---
+
 ## Phase 3.5: Post-Remediation Re-Verification
+
 After remediation fixes, re-verify affected dimensions before status determination:
+
 1. For each dimension with fixed findings, spawn a **targeted** `explore` scanner with the Harden Context Packet plus:
    - `PRIOR FINDINGS: [{finding_id, original_issue, fix_applied}]`
    - `SCOPE: evaluate only whether the listed findings are resolved`
@@ -250,7 +316,9 @@ After remediation fixes, re-verify affected dimensions before status determinati
 × Only re-scan dimensions with fixed findings. Do NOT re-run all 6 scanners.
 
 ---
+
 ## Phase 4: Cleanup
+
 Skip if `--no-cleanup`.
 
 Aggregate cleanup candidates from scanner + session artifacts. Display preview listing temp files, debug code, marked files with sizes.
@@ -262,10 +330,15 @@ Aggregate cleanup candidates from scanner + session artifacts. Display preview l
 | `--force` | Delete without prompts |
 
 ---
+
 ## Final Report
+
 ### Mark Harden Gate
+
 If READY → do **not** complete a gate here; `/adv-archive` owns the `release` gate.
+
 ### Report Display
+
 Emit HARDENING REPORT banner with per-dimension results:
 | Dimension | Metrics |
 |-----------|---------|
@@ -278,6 +351,7 @@ Emit HARDENING REPORT banner with per-dimension results:
 | Cleanup | candidates count, action taken |
 
 Include: fixes applied, gate status, next steps (`/adv-archive`), remaining items, debt tracking guidance.
+
 ### Completion
 
 Use the Gate Handoff Voice spine (see `docs/command-voice-standard.md § Gate Handoff Voice`):
@@ -301,9 +375,11 @@ What was cleaned, hardened, and verified for release.
 **Auto-continue:** If status is READY, immediately begin `/adv-archive` inline. The archive command itself will stop at the sign-off boundary for user approval of the final release. Do not add an extra "shall I proceed?" before starting archive.
 
 ---
+
 ## Key Tools
-| Purpose | Tool |
-|---------|------|
-| Load change | `adv_change_show` |
-| List tasks | `adv_task_list` |
-| Show spec | `adv_spec action: "show" capability: <name>` |
+
+| Purpose     | Tool                                         |
+| ----------- | -------------------------------------------- |
+| Load change | `adv_change_show`                            |
+| List tasks  | `adv_task_list`                              |
+| Show spec   | `adv_spec action: "show" capability: <name>` |

--- a/ADV_INSTRUCTIONS.md
+++ b/ADV_INSTRUCTIONS.md
@@ -4,42 +4,42 @@ Specs are laws. Requirements are formally defined, validated, and enforced.
 
 ## Notation
 
-| Symbol | Meaning |
-|--------|---------|
-| `→` | Sequence / leads to |
-| `←` | Blocked by / depends on |
-| `✓` | Complete / verified |
-| `○` | Pending / optional |
-| `×` | Forbidden / never |
-| `⚠` | Attention / warning |
+| Symbol | Meaning                 |
+| ------ | ----------------------- |
+| `→`    | Sequence / leads to     |
+| `←`    | Blocked by / depends on |
+| `✓`    | Complete / verified     |
+| `○`    | Pending / optional      |
+| `×`    | Forbidden / never       |
+| `⚠`    | Attention / warning     |
 
 ## Core Decision Rules
 
-| When | Then |
-|------|------|
-| Spec conflicts with proposal | Spec wins |
-| Gate incomplete | Archive blocked |
-| 3 failed task attempts | Stop → `[ADV:BLOCKED]` → escalate |
-| Cross-repo task | Execute in target repo via `workdir` |
-| User requests cancellation | Require approval via `adv_task_cancel` |
-| TDD required + trivial task | Mark trivial with reason, skip TDD |
-| User requests skip + gate required | `[ADV:ATTN]` → ask for sign-off |
+| When                               | Then                                   |
+| ---------------------------------- | -------------------------------------- |
+| Spec conflicts with proposal       | Spec wins                              |
+| Gate incomplete                    | Archive blocked                        |
+| 3 failed task attempts             | Stop → `[ADV:BLOCKED]` → escalate      |
+| Cross-repo task                    | Execute in target repo via `workdir`   |
+| User requests cancellation         | Require approval via `adv_task_cancel` |
+| TDD required + trivial task        | Mark trivial with reason, skip TDD     |
+| User requests skip + gate required | `[ADV:ATTN]` → ask for sign-off        |
 
 ## HITL Boundary Model
 
 Each workflow phase has a defined collaboration mode. Agents self-enforce these boundaries.
 
-| Phase | Mode | Detail |
-|-------|------|--------|
-| `/adv-idea` | Collaborative | Fully collaborative; ideation loop before a proposal exists |
-| `/adv-problem` | Collaborative | Fully collaborative; issue triage before deciding fix path |
-| `/adv-proposal` | Collaborative | Fully collaborative; approve at end |
-| `/adv-research` | Collaborative | Fully collaborative; approve at end |
-| `/adv-prep` | HITL hard gate | Vision document → explicit user approval → `userApproved: true` on prep gate |
-| `/adv-apply` | Autonomous | No "Begin work" prompt; proceeds after prep approval. Escalate only on failure |
-| `/adv-review` | Autonomous + drift detection | Auto-fix within scope; stop on drift |
-| `/adv-harden` | Autonomous + drift detection | Auto-fix scoped issues; stop on drift |
-| `/adv-archive` | Autonomous | Apply spec deltas, capture wisdom, finalize git |
+| Phase           | Mode                         | Detail                                                                         |
+| --------------- | ---------------------------- | ------------------------------------------------------------------------------ |
+| `/adv-idea`     | Collaborative                | Fully collaborative; ideation loop before a proposal exists                    |
+| `/adv-problem`  | Collaborative                | Fully collaborative; issue triage before deciding fix path                     |
+| `/adv-proposal` | Collaborative                | Fully collaborative; approve at end                                            |
+| `/adv-research` | Collaborative                | Fully collaborative; approve at end                                            |
+| `/adv-prep`     | HITL hard gate               | Vision document → explicit user approval → `userApproved: true` on prep gate   |
+| `/adv-apply`    | Autonomous                   | No "Begin work" prompt; proceeds after prep approval. Escalate only on failure |
+| `/adv-review`   | Autonomous + drift detection | Auto-fix within scope; stop on drift                                           |
+| `/adv-harden`   | Autonomous + drift detection | Auto-fix scoped issues; stop on drift                                          |
+| `/adv-archive`  | Autonomous                   | Apply spec deltas, capture wisdom, finalize git                                |
 
 ### Drift Detection Rule
 
@@ -61,6 +61,7 @@ For changes created before HITL enforcement, `/adv-apply` emits a soft advisory 
 ### Human Checkpoints (Pause Required)
 
 ADV pauses ONLY at these checkpoints:
+
 - Proposal confirmation — user confirms problem statement
 - Agreement sign-off — user approves objectives and acceptance criteria
 - Design approval — ONLY when real tradeoffs depend on user values or product vision, OR when the design validator returns CONFLICT, OR when the agent identifies contract-compromise risk (rq-designval04)
@@ -77,6 +78,7 @@ When the user selects an "approve" or "approve and continue" option at any check
 ### Between-Checkpoint Flow
 
 Between checkpoints, only system-level interrupts cause pauses:
+
 - Doom-loop detection (3 failed task attempts)
 - Cost governance / investment check-in (judgment calls to surface)
 - Drift detection (auto-fix boundary exceeded in review/harden)
@@ -90,60 +92,68 @@ No other pauses or "shall I continue?" prompts are permitted.
 
 Each workflow command has a defined phase goal. These are canonical in `manifest.ts` (`phaseGoal` field on `CommandDef`). Agents should self-check: "Am I still working toward this phase's goal?"
 
-| Phase | Goal |
-|-------|------|
-| `/adv-proposal` | Clarify the problem, user needs, and acceptance criteria scope. Establish *what* and *why* — no *how*. |
-| `/adv-research` | Produce a defined, fully-researched proposed plan ready for user approval. Validate the *how*. |
-| `/adv-prep` | Complete the flight-check: every gap closed, every dependency mapped, every task ready — ready for autonomous implementation. |
-| `/adv-apply` | Execute the approved plan autonomously. Add discovered tasks within scope. Escalate only on failure. |
-| `/adv-review` | Verify implementation matches the approved plan. Auto-fix within scope. Stop on drift. |
-| `/adv-harden` | Verify production-readiness. Auto-fix scoped issues. Stop on drift. |
-| `/adv-archive` | Promote the change from contract to law: apply spec deltas, capture wisdom, clean up. |
+| Phase           | Goal                                                                                                                          |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `/adv-proposal` | Clarify the problem, user needs, and acceptance criteria scope. Establish _what_ and _why_ — no _how_.                        |
+| `/adv-research` | Produce a defined, fully-researched proposed plan ready for user approval. Validate the _how_.                                |
+| `/adv-prep`     | Complete the flight-check: every gap closed, every dependency mapped, every task ready — ready for autonomous implementation. |
+| `/adv-apply`    | Execute the approved plan autonomously. Add discovered tasks within scope. Escalate only on failure.                          |
+| `/adv-review`   | Verify implementation matches the approved plan. Auto-fix within scope. Stop on drift.                                        |
+| `/adv-harden`   | Verify production-readiness. Auto-fix scoped issues. Stop on drift.                                                           |
+| `/adv-archive`  | Promote the change from contract to law: apply spec deltas, capture wisdom, clean up.                                         |
 
 ## Commands
+
 ### Core Workflow
-| Command | Purpose |
-|---------|---------|
-| `/adv-idea` | Explore rough ideas before drafting a proposal |
-| `/adv-problem` | Triage issues before fixing or drafting a proposal |
-| `/adv-status` | Show project overview: specs, active changes, and next-step recommendations |
-| `/adv-proposal <summary>` | Extract problem statement, success criteria, and constraints without creating tasks |
-| `/adv-validate <change-id>` | Validate change compliance against specs; block archive on failure |
-| `/adv-apply <change-id>` | Implement change with TDD, retry on failure, and final verification |
-| `/adv-archive <change-id>` | Archive completed change: apply spec deltas and finalize git |
+
+| Command                     | Purpose                                                                             |
+| --------------------------- | ----------------------------------------------------------------------------------- |
+| `/adv-idea`                 | Explore rough ideas before drafting a proposal                                      |
+| `/adv-problem`              | Triage issues before fixing or drafting a proposal                                  |
+| `/adv-status`               | Show project overview: specs, active changes, and next-step recommendations         |
+| `/adv-proposal <summary>`   | Extract problem statement, success criteria, and constraints without creating tasks |
+| `/adv-validate <change-id>` | Validate change compliance against specs; block archive on failure                  |
+| `/adv-apply <change-id>`    | Implement change with TDD, retry on failure, and final verification                 |
+| `/adv-archive <change-id>`  | Archive completed change: apply spec deltas and finalize git                        |
+
 ### Pre-Implementation
-| Command | Purpose |
-|---------|---------|
-| `/adv-clarify` | Ask clarifying questions to resolve ambiguous requirements |
-| `/adv-research <target>` | Produce a defined, fully-researched proposed plan ready for user approval |
-| `/adv-discover <change-id>` | Gather context, analyze current state, identify objectives, and obtain user agreement |
-| `/adv-design <change-id>` | Validate architecture decisions, produce implementation strategy, and present design for user review |
-| `/adv-prep <change-id>` | Analyze gaps and synthesize tasks from validated research findings |
+
+| Command                     | Purpose                                                                                              |
+| --------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `/adv-clarify`              | Ask clarifying questions to resolve ambiguous requirements                                           |
+| `/adv-research <target>`    | Produce a defined, fully-researched proposed plan ready for user approval                            |
+| `/adv-discover <change-id>` | Gather context, analyze current state, identify objectives, and obtain user agreement                |
+| `/adv-design <change-id>`   | Validate architecture decisions, produce implementation strategy, and present design for user review |
+| `/adv-prep <change-id>`     | Analyze gaps and synthesize tasks from validated research findings                                   |
+
 ### Post-Implementation
-| Command | Purpose |
-|---------|---------|
-| `/adv-review <change-id>` | Review code for correctness, security, and architecture; emit REVIEW_FINDINGS |
+
+| Command                   | Purpose                                                                                 |
+| ------------------------- | --------------------------------------------------------------------------------------- |
+| `/adv-review <change-id>` | Review code for correctness, security, and architecture; emit REVIEW_FINDINGS           |
 | `/adv-harden <change-id>` | Detect low-quality code, verify test coverage, clean up; block archive on open findings |
-| `/adv-audit [capability]` | Detect drift between specs and current implementation |
-| `/adv-slop-scan [path]` | Scan for AI slop patterns including defensive and nested code |
+| `/adv-audit [capability]` | Detect drift between specs and current implementation                                   |
+| `/adv-slop-scan [path]`   | Scan for AI slop patterns including defensive and nested code                           |
+
 ### Fast-Track / Advanced
-| Command | Purpose |
-|---------|---------|
-| `/adv-task` | Fast-track a discussed change: synthesize contract, validate best practices, prep, and hand off |
-| `/adv-refactor <change-id>` | Refresh a stale proposal to reflect current codebase state |
-| `/adv-coordinate` | Detect and resolve conflicts across multiple active changes |
-| `/adv-improve` | Suggest targeted improvements to existing specs or implementation |
-| `/adv-tron [target]` | Investigate codebase structure, hotspots, risks, and suggest follow-up agenda candidates |
+
+| Command                     | Purpose                                                                                         |
+| --------------------------- | ----------------------------------------------------------------------------------------------- |
+| `/adv-task`                 | Fast-track a discussed change: synthesize contract, validate best practices, prep, and hand off |
+| `/adv-refactor <change-id>` | Refresh a stale proposal to reflect current codebase state                                      |
+| `/adv-coordinate`           | Detect and resolve conflicts across multiple active changes                                     |
+| `/adv-improve`              | Suggest targeted improvements to existing specs or implementation                               |
+| `/adv-tron [target]`        | Investigate codebase structure, hotspots, risks, and suggest follow-up agenda candidates        |
 
 ## Command Boundaries
 
-| Command | Produces | × MUST NOT | Gate |
-|---------|----------|------------|------|
-| proposal | Problem statement, criteria, constraints | Create tasks, complete gates, impl decisions | None |
-| research | Validated approach, findings in proposal.md | Create tasks, complete non-research gates | research |
-| prep | Task graph, gap analysis, sequencing | Complete non-prep gates, architecture decisions | prep |
-| task | Change + tasks + gates (fast-track exempt) | — | research + prep |
-| apply | Implementation via TDD | Auto-complete research/prep gates | implementation |
+| Command  | Produces                                    | × MUST NOT                                      | Gate            |
+| -------- | ------------------------------------------- | ----------------------------------------------- | --------------- |
+| proposal | Problem statement, criteria, constraints    | Create tasks, complete gates, impl decisions    | None            |
+| research | Validated approach, findings in proposal.md | Create tasks, complete non-research gates       | research        |
+| prep     | Task graph, gap analysis, sequencing        | Complete non-prep gates, architecture decisions | prep            |
+| task     | Change + tasks + gates (fast-track exempt)  | —                                               | research + prep |
+| apply    | Implementation via TDD                      | Auto-complete research/prep gates               | implementation  |
 
 - Only `/adv-prep` (and exempt `/adv-task`) may call `adv_task_add`
 - `/adv-apply` stops if research or prep gates pending
@@ -153,24 +163,26 @@ Each workflow command has a defined phase goal. These are canonical in `manifest
 
 Emit at START of each response:
 
-| Marker | When | Emoji |
-|--------|------|-------|
-| `[ADV:WORK]` | Agent actively working | 🟩 |
-| `[ADV:TOOLING]` | Tool run or sub-agent in flight | 🟨 |
-| `[ADV:ATTN]` | User needed (approval, question, or agent finished) | 🟥 |
-| `[ADV:BLOCKED]` | Doom-loop / stuck / crash | 🟥💀 |
-| `[ADV:TASK_STATUS_REPORT]` | Task report | — |
+| Marker                     | When                                                | Emoji |
+| -------------------------- | --------------------------------------------------- | ----- |
+| `[ADV:WORK]`               | Agent actively working                              | 🟩    |
+| `[ADV:TOOLING]`            | Tool run or sub-agent in flight                     | 🟨    |
+| `[ADV:ATTN]`               | User needed (approval, question, or agent finished) | 🟥    |
+| `[ADV:BLOCKED]`            | Doom-loop / stuck / crash                           | 🟥💀  |
+| `[ADV:TASK_STATUS_REPORT]` | Task report                                         | —     |
 
 Tab title: `<emoji> <normalized change>` (strip verb prefixes, Title Case). System-emitted: `[ADV:ACCUMULATED_WISDOM]`, `[ADV:TODO_CONTINUATION]`, `[ADV:RECORD_WISDOM]`
 
 ### Context Snapshot
 
 `adv_change_show` includes `_contextSnapshot` — compact summary closing the context agreement gap:
+
 - Change ID/title, gate progress (`[✓ research] [○ impl] ...`), task counts, current task, workdir
 
 Emitted on: `adv_change_show`, `adv_gate_complete`, `adv_task_update` to `in_progress`.
 
 **Cross-Repo Switch** — emit via `formatCrossRepoSwitch()`:
+
 ```
 ╔═══════════════════════════════════════════════════════════╗
 ║ 🔀 SWITCHING REPOSITORY CONTEXT                          ║
@@ -187,23 +199,24 @@ Emitted on: `adv_change_show`, `adv_gate_complete`, `adv_task_update` to `in_pro
 
 Forbidden: `~/.local/share/opencode/plugins/advance/**/{change.json,proposal.md,agenda.jsonl,wisdom.jsonl,handoff.json}`
 
-| Need | Tool |
-|------|------|
-| Change + tasks | `adv_change_show` |
-| Update proposal | `adv_change_update` (× never re-call `adv_change_create`) |
-| Specific task + changeId | `adv_task_show` |
-| Ready tasks | `adv_task_ready` |
-| All tasks | `adv_task_list` |
-| Active changes | `adv_change_list` |
-| Validate | `adv_change_validate` |
-| Agenda | `adv_agenda_list` |
-| Wisdom | `adv_wisdom_list` |
+| Need                     | Tool                                                      |
+| ------------------------ | --------------------------------------------------------- |
+| Change + tasks           | `adv_change_show`                                         |
+| Update proposal          | `adv_change_update` (× never re-call `adv_change_create`) |
+| Specific task + changeId | `adv_task_show`                                           |
+| Ready tasks              | `adv_task_ready`                                          |
+| All tasks                | `adv_task_list`                                           |
+| Active changes           | `adv_change_list`                                         |
+| Validate                 | `adv_change_validate`                                     |
+| Agenda                   | `adv_agenda_list`                                         |
+| Wisdom                   | `adv_wisdom_list`                                         |
 
 On direct-read failure → stop, call `adv_change_show` or `adv_task_show`.
 
 ### Question Tool UX
 
 Write-in option enforced by P26 (`rules.yaml`). ADV notes:
+
 - Contextual write-in labels (`Other`, `Different approach`) — not generic
 - 2-5 options including write-in, concise labels
 - Leave custom input enabled
@@ -242,29 +255,31 @@ Every `/adv-apply` task with file changes in its workdir MUST produce a git comm
 
 **Apply-loop ordering:**
 
-| Step | Action |
-|------|--------|
-| 3a | Start — `adv_task_update status: "in_progress"` |
-| 3b | Red Phase — write failing test |
-| 3c | Green Phase — implement, tests pass |
-| 3c.5 | **Checkpoint** — `adv_task_checkpoint` |
-| 3d | Complete — `adv_task_update status: "done"` |
+| Step | Action                                          |
+| ---- | ----------------------------------------------- |
+| 3a   | Start — `adv_task_update status: "in_progress"` |
+| 3b   | Red Phase — write failing test                  |
+| 3c   | Green Phase — implement, tests pass             |
+| 3c.5 | **Checkpoint** — `adv_task_checkpoint`          |
+| 3d   | Complete — `adv_task_update status: "done"`     |
 
 **Failure classification:**
 
-| Classification | Action |
-|----------------|--------|
-| `SEMANTIC` (hook rejection, merge conflict) | Diagnose, re-run (retry budget) |
-| `ENVIRONMENTAL` (not a git repo, detached HEAD) | Escalate via `question` |
-| `TRANSIENT` (index.lock contention) | Tool retries internally; remaining failure → SEMANTIC |
+| Classification                                  | Action                                                |
+| ----------------------------------------------- | ----------------------------------------------------- |
+| `SEMANTIC` (hook rejection, merge conflict)     | Diagnose, re-run (retry budget)                       |
+| `ENVIRONMENTAL` (not a git repo, detached HEAD) | Escalate via `question`                               |
+| `TRANSIENT` (index.lock contention)             | Tool retries internally; remaining failure → SEMANTIC |
 
 **Commit message format:**
+
 - Complete: `task(tk-xxxx): completed`
 - Cancel: `task(tk-xxxx): cancel — <reason>`
 
 **Staging:** `git add -A` — `.gitignore` is the safety net.
 
 **Anti-patterns:**
+
 - × Do NOT run git from inside a Temporal workflow or activity
 - × Do NOT create `--allow-empty` commits
 - × Do NOT bypass checkpoint for "small" tasks — clean-tree returns `{status:'clean'}` without committing
@@ -273,19 +288,19 @@ Cross-link: `/adv-apply` command (`.opencode/command/adv-apply.md`) step 3c.5. `
 
 ### Doom Loop Detection
 
-| Exit | Condition |
-|------|-----------|
-| ✓ Done | Acceptance criteria met |
-| 🔁 Doom Loop | 3 failed attempts |
+| Exit             | Condition                     |
+| ---------------- | ----------------------------- |
+| ✓ Done           | Acceptance criteria met       |
+| 🔁 Doom Loop     | 3 failed attempts             |
 | 🌍 Environmental | Missing dependency → escalate |
 
 After 3 failures: STOP → `[ADV:BLOCKED]` → document all 3 attempts → ask via `question`. Record `strategy_label` in `error_recovery.attempts[]`.
 
-| × Bad | ✓ Good |
-|-------|--------|
+| × Bad               | ✓ Good                 |
+| ------------------- | ---------------------- |
 | Retry same approach | Try different strategy |
-| Silent retries | Document each attempt |
-| 4+ same method | Escalate after 3 |
+| Silent retries      | Document each attempt  |
+| 4+ same method      | Escalate after 3       |
 
 ### Investment Check-In
 
@@ -293,13 +308,14 @@ When an ADV change reaches /adv-apply, pending judgment calls are surfaced befor
 
 ### Cross-Repo Execution
 
-| × Invalid Cancellation | ✓ Correct |
-|------------------------|-----------|
-| "Out of scope for this repo" | Switch `workdir`, execute |
-| "Different repository" | Switch `workdir`, execute |
-| "Cannot modify external code" | Use `workdir` parameter |
+| × Invalid Cancellation        | ✓ Correct                 |
+| ----------------------------- | ------------------------- |
+| "Out of scope for this repo"  | Switch `workdir`, execute |
+| "Different repository"        | Switch `workdir`, execute |
+| "Cannot modify external code" | Use `workdir` parameter   |
 
 Rules:
+
 1. Tasks with `target_repo`/`target_path` → execute in target directory
 2. Switch `workdir` for all tool calls on that task
 3. "Different repo" is × NEVER valid cancellation
@@ -330,6 +346,7 @@ Validated in-scope findings from review/harden MUST be fixed before archive. No 
 ### Touched-Scope Quality Ownership
 
 Quality obligations extend to:
+
 - Directly touched implementation files
 - Adjacent tests and docs
 - Same-pattern local subsystem issues (P25 related-scan)
@@ -338,22 +355,23 @@ Do NOT expand into implicit repo-wide refactors or untouched subsystems. Campsit
 
 ## 6-Gate Quality Checklist
 
-| Gate | Triggered By |
-|------|--------------|
-| 1. `research` | `/adv-research` |
-| 2. `prep` | `/adv-prep` |
-| 3. `implementation` | All tasks done |
-| 4. `review` | `/adv-review` |
-| 5. `harden` | `/adv-harden` |
-| 6. `signoff` | User confirmation |
+| Gate                | Triggered By      |
+| ------------------- | ----------------- |
+| 1. `research`       | `/adv-research`   |
+| 2. `prep`           | `/adv-prep`       |
+| 3. `implementation` | All tasks done    |
+| 4. `review`         | `/adv-review`     |
+| 5. `harden`         | `/adv-harden`     |
+| 6. `signoff`        | User confirmation |
 
 Gates are sequential. Archive blocks until all 6 satisfied. See [docs/adv-gates.md](docs/adv-gates.md).
 
 Gate behaviors:
+
 - `research`/`prep` evaluate full change including completed tasks — completed work is evidence to validate, not acceptance proof. Add follow-up tasks where gaps found.
 - `review` emits `REVIEW_FINDINGS` block (blocker, issue, suggestion, question).
 - `harden` blocks on unresolved review findings (except `nit:`). Runs merge compatibility check first.
-- `archive` runs Phase 9 Git Finalization: stage → commit → detect default branch → merge/PR → verify → cleanup worktree → remove temp artifacts.
+- `archive` runs Phase 9 Git Finalization: stage → commit → detect default branch → refresh basis → choose `--ff-only` / reconcile / PR path → verify → cleanup worktree → remove temp artifacts.
 
 ## Command Execution Model
 
@@ -371,18 +389,19 @@ Slash commands are top-level entry points for the user/session, not an internal 
 
 Available to agents with `task: true` in their frontmatter: `adv`, `build`, `plan`. Use when 3+ independent scan dimensions benefit from parallelism.
 
-| Command | Inline | Sub-Agent |
-|---------|--------|-----------|
-| research | Context7 + Kagi + lgrep | librarian + adv-researcher (single-level only) |
-| review | Sequential per dimension | explore × 5 + librarian + general |
-| harden | Sequential scans | explore × 6 |
-| audit | Sequential pipeline | explore × 4 |
-| slop-scan | Sequential categories | explore × 9 (single-level only) |
-| tron | lgrep + read | adv-tron agent |
-| task | Context7 + Kagi | librarian + adv-researcher |
-| refactor | Sequential drift | explore × 3 |
+| Command   | Inline                   | Sub-Agent                                      |
+| --------- | ------------------------ | ---------------------------------------------- |
+| research  | Context7 + Kagi + lgrep  | librarian + adv-researcher (single-level only) |
+| review    | Sequential per dimension | explore × 5 + librarian + general              |
+| harden    | Sequential scans         | explore × 6                                    |
+| audit     | Sequential pipeline      | explore × 4                                    |
+| slop-scan | Sequential categories    | explore × 9 (single-level only)                |
+| tron      | lgrep + read             | adv-tron agent                                 |
+| task      | Context7 + Kagi          | librarian + adv-researcher                     |
+| refactor  | Sequential drift         | explore × 3                                    |
 
 Rules:
+
 - Sub-agents × NEVER spawn sub-agents (`enforceTaskPolicy` blocks nesting)
 - Cap parallel bursts at 3-4
 - Batch independent work into single spawn message
@@ -396,13 +415,13 @@ Inline-only: `/adv-status`, `/adv-idea`, `/adv-problem`, `/adv-proposal`, `/adv-
 
 ### Delegation Routing
 
-| Priority | Check | Result |
-| --- | --- | --- |
-| 1 | `metadata.delegation_hint` set? | Use hint value |
-| 2 | `tdd_intent == "not_applicable"`? | `delegate_allowed` |
-| 3 | Title matches `isTrivialTask` patterns? | `delegate_allowed` |
-| 4 | Risk signals (multi-file, cross-repo, architectural keywords)? | `inline_required` |
-| 5 | Default | `inline_required` |
+| Priority | Check                                                          | Result             |
+| -------- | -------------------------------------------------------------- | ------------------ |
+| 1        | `metadata.delegation_hint` set?                                | Use hint value     |
+| 2        | `tdd_intent == "not_applicable"`?                              | `delegate_allowed` |
+| 3        | Title matches `isTrivialTask` patterns?                        | `delegate_allowed` |
+| 4        | Risk signals (multi-file, cross-repo, architectural keywords)? | `inline_required`  |
+| 5        | Default                                                        | `inline_required`  |
 
 ADV code-writing delegation targets `adv-engineer` (not `general`). Verify-burst and non-ADV multi-step work remain on `general`.
 
@@ -436,26 +455,26 @@ After each phase, use `adv_change_update` to record compact summaries. Do not du
 
 ### Agent Tiers
 
-| Tier | Agents | Loading |
-|------|--------|---------|
-| **Primary** (user-selectable top-level) | `adv`, `plan`, `build` | Global `~/.config/opencode/agents/` |
+| Tier                                           | Agents                                                       | Loading                             |
+| ---------------------------------------------- | ------------------------------------------------------------ | ----------------------------------- |
+| **Primary** (user-selectable top-level)        | `adv`, `plan`, `build`                                       | Global `~/.config/opencode/agents/` |
 | **Common subagents** (spawnable via Task tool) | `explore`, `general`, `librarian`, `mechanic`, `prioritizer` | Global `~/.config/opencode/agents/` |
-| **ADV Specialist** (spawnable, bundled global) | `adv-researcher`, `adv-engineer` | Global `~/.config/opencode/agents/` |
-| **Repo-Local** (spawnable, repo-scoped) | `adv-tron` | Repo-local `.opencode/agents/` |
+| **ADV Specialist** (spawnable, bundled global) | `adv-researcher`, `adv-engineer`                             | Global `~/.config/opencode/agents/` |
+| **Repo-Local** (spawnable, repo-scoped)        | `adv-tron`                                                   | Repo-local `.opencode/agents/`      |
 
 > **Primary vs subagent:** Only `mode: subagent` agents are spawnable via the Task tool. `adv`, `plan`, and `build` are primary agents — users switch to them directly; they cannot be invoked through sub-agent spawning.
 
 ### Agent Roster
 
-| Agent | Use For | Tools |
-|-------|---------|-------|
-| `librarian` | Docs, API refs, code examples | Context7, grep.app, Kagi |
-| `adv-researcher` | Architecture validation, simplicity | Context7, Kagi, ADV read-only |
-| `explore` | Codebase navigation, find usages | Read, Glob, Grep, lgrep |
-| `adv-engineer` | Delegated ADV code-writing executor | Full write (read/write/edit/bash) + narrow ADV reads + evidence |
-| `general` | Verify-only bursts + generic multi-step non-ADV work | Full tool access |
-| `mechanic` | System/infra issues | Vision, bash, read/write |
-| `adv-tron` | Reconnaissance, hotspot detection | Read, Glob, Grep, lgrep |
+| Agent            | Use For                                              | Tools                                                           |
+| ---------------- | ---------------------------------------------------- | --------------------------------------------------------------- |
+| `librarian`      | Docs, API refs, code examples                        | Context7, grep.app, Kagi                                        |
+| `adv-researcher` | Architecture validation, simplicity                  | Context7, Kagi, ADV read-only                                   |
+| `explore`        | Codebase navigation, find usages                     | Read, Glob, Grep, lgrep                                         |
+| `adv-engineer`   | Delegated ADV code-writing executor                  | Full write (read/write/edit/bash) + narrow ADV reads + evidence |
+| `general`        | Verify-only bursts + generic multi-step non-ADV work | Full tool access                                                |
+| `mechanic`       | System/infra issues                                  | Vision, bash, read/write                                        |
+| `adv-tron`       | Reconnaissance, hotspot detection                    | Read, Glob, Grep, lgrep                                         |
 
 > **Note:** `adv-tron` is a repo-local agent — only available in ADV-enabled repos (repos with `.opencode/agents/adv-tron.md`). `adv-researcher` and `adv-engineer` are bundled global specialists — synced to `~/.config/opencode/agents/` by this repo's sync script; they are available in any session where the global install has been synced from an ADV-enabled repo. All ADV-shipped sub-agents follow the `adv-<name>` naming convention.
 
@@ -468,6 +487,7 @@ Enabled in `/adv-research` Phase 1.5. Improves research quality via domain-speci
 Flow: search trusted skill directories only (`~/.config/opencode/skills/*/SKILL.md`, repo `skills/*/SKILL.md`) → read YAML frontmatter → match `keywords` against tech stack + change domain → `skill("{name}")` → apply guidance.
 
 Skill metadata:
+
 ```yaml
 ---
 name: my-skill
@@ -484,16 +504,17 @@ Graceful degradation: skip skills without frontmatter or `keywords`. No matches 
 
 Commands and skills serve different roles. Use this table to decide where new functionality belongs:
 
-| Use a **command** when | Use a **skill** when |
-|------------------------|----------------------|
-| User-facing workflow entry point | Reusable methodology or analysis protocol |
-| Mutates ADV state (changes, tasks, gates) | Read-only guidance or checklist framework |
-| Owns a gate completion | Loaded by multiple commands or sub-agents |
-| Requires explicit user invocation | Domain knowledge independent of workflow state |
+| Use a **command** when                    | Use a **skill** when                           |
+| ----------------------------------------- | ---------------------------------------------- |
+| User-facing workflow entry point          | Reusable methodology or analysis protocol      |
+| Mutates ADV state (changes, tasks, gates) | Read-only guidance or checklist framework      |
+| Owns a gate completion                    | Loaded by multiple commands or sub-agents      |
+| Requires explicit user invocation         | Domain knowledge independent of workflow state |
 
 ### Reference Pattern
 
 `adv-tron` is the canonical example of a command backed by a skill:
+
 - **Command** (`.opencode/command/adv-tron.md`) — owns orchestration, sub-agent spawning, ADV state reads, user interaction
 - **Skill** (`skills/adv-tron/SKILL.md`) — holds investigation protocol, search priorities, evidence requirements, report schema
 - **Fallback** — command includes embedded protocol if skill is unavailable
@@ -506,21 +527,25 @@ Commands that fan out to sub-agents with reusable methodology should follow this
 `adv-idea`, `adv-problem`, `adv-proposal`, `adv-research`, `adv-task`, `adv-validate`, `adv-archive`, `adv-status`, `adv-coordinate`, `adv-clarify`, `adv-refactor`, `adv-improve`, `adv-design`, `adv-audit`
 
 **Command + dedicated backing skill** (loads a single-purpose skill with inline fallback):
+
 - `adv-tron` → `adv-tron` skill
 
 **Command + shared/cross-cutting skill** (loads a reusable methodology skill also used by other commands):
+
 - `adv-prep` → `adv-cost-governance-methodology` (Phase J: judgment-call identification)
 - `adv-apply` → `adv-cost-governance-methodology` (Phase 1.5: investment check-in)
 - `adv-harden` → `adv-slop-detection` (Phase 0: AI-slop scanner methodology)
 - `adv-slop-scan` → `adv-slop-detection` (Phase 0: two-phase detection strategy)
 
 **Command with embedded methodology** (inlined `## Phase 0: Embedded Methodology` block; may also load a cross-cutting skill):
+
 - `adv-discover` — dynamic skill discovery (Phase 1.5) + embedded methodology
 - `adv-prep` — embedded prep methodology + `adv-cost-governance-methodology`
 - `adv-apply` — embedded apply methodology + `adv-cost-governance-methodology`
 - `adv-review` — methodology inlined in `.opencode/command/adv-review.md` Phase 0
 
 **Dynamic skill discovery** (no fixed backing skill; scans and loads matching skills at runtime):
+
 - `adv-discover` — loads skills matching change domain via `skill("{name}")` (Phase 1.5)
 - `adv-research` — references skill discovery protocol; may load matching skills
 
@@ -562,15 +587,16 @@ ADV always isolates mutating work in per-change worktrees. There are no exemptio
 ### Worktree Reuse
 
 Before creating: `git worktree list --porcelain` → find `change/{change-id}` branch.
+
 - Path exists → auto-reuse (switch `workdir`)
 - Path missing → `git worktree prune` → proceed fresh
 
 ### Spec Divergence
 
-| Data | Location | Shared? |
-|------|----------|---------|
-| Specs (`.adv/specs/`) | In-repo, git-tracked | No (branch-local) |
-| Changes, archive, wisdom, agenda | External | Yes (keyed by project-id) |
+| Data                             | Location             | Shared?                   |
+| -------------------------------- | -------------------- | ------------------------- |
+| Specs (`.adv/specs/`)            | In-repo, git-tracked | No (branch-local)         |
+| Changes, archive, wisdom, agenda | External             | Yes (keyed by project-id) |
 
 Implication: spec changes in worktree A invisible to B until merged. `/adv-validate` and `/adv-audit` in B may see stale specs. Mitigation: merge promptly after archive (Phase 9 handles this).
 
@@ -587,7 +613,7 @@ Multi-session only: parent writes `handoff.json` → child reads/clears on start
 
 ### Worktree Cleanup
 
-`/adv-archive` Phase 9 handles: stage → commit → detect default branch → merge/PR → verify → `worktree_delete` → remove `.bak`/`.tmp`/`.orig`. × Never delete worktree with unmerged commits.
+`/adv-archive` Phase 9 handles: stage → commit → detect default branch → refresh basis → choose `--ff-only` / reconcile / PR path → verify → `worktree_delete` → remove `.bak`/`.tmp`/`.orig`. × Never delete worktree with unmerged commits.
 
 If `worktree_create`/`worktree_delete` unavailable: `[ADV:INFO] Worktree tools not available — proceeding in-place.`
 

--- a/docs/adv-gates.md
+++ b/docs/adv-gates.md
@@ -81,7 +81,7 @@ Absorbs the old `harden` gate. Before running quality scanners, `/adv-harden` pe
 3. **Review findings audit** — validated in-scope findings must be resolved (no report-only, future-work, or accepted-debt path)
 4. **Merge compatibility check** — non-destructive dry-run merge against the default branch (`git merge --no-commit --no-ff`); blocks on conflicts
 
-`/adv-archive` runs Phase 9 Git Finalization: stage → commit → detect default branch → merge/PR → verify → cleanup worktree → remove temp artifacts. During archive, durable convention/pattern wisdom can also be promoted to project-level wisdom so lessons survive beyond a single change.
+`/adv-archive` runs Phase 9 Git Finalization: stage → commit → detect default branch → refresh basis → choose `--ff-only` / reconcile / PR path → verify → cleanup worktree → remove temp artifacts. During archive, durable convention/pattern wisdom can also be promoted to project-level wisdom so lessons survive beyond a single change.
 
 ## Re-Entry (Scope Expansion)
 

--- a/docs/specs/advance.md
+++ b/docs/specs/advance.md
@@ -617,6 +617,59 @@ The canonical ADV workflow is seven sequential gates: proposal, discovery, desig
 
 ---
 
+### Archive Finalization Refreshes Basis and Preserves Cleanup Safety
+
+**ID:** `rq-releaseFinalization01` | **Priority:** **[MUST]**
+
+Phase 9 Git Finalization must refresh the current default-branch basis before deciding local merge-back versus PR workflow. Clean low-risk cases prefer a linear-history fast path (`--ff-only` when already current, reconcile only when needed). Conflicting or risky cases must stop or route to PR workflow before cleanup. Worktree deletion remains forbidden until merged-state verification proves the change branch is fully integrated.
+
+**Tags:** `workflow`, `archive`, `worktree`, `git`
+
+#### Scenarios
+
+**Clean archive refresh uses local fast path** (`rq-releaseFinalization01.1`)
+
+**Given:**
+
+- A change branch is already on the current default-branch basis
+- No overlap-risk or PR-only policy applies
+
+**When:** Phase 9 Git Finalization chooses an integration path
+
+**Then:**
+
+- The archive uses the local `--ff-only` path
+- No branch rewrite is required
+
+**Conflicting reconcile stops before cleanup** (`rq-releaseFinalization01.2`)
+
+**Given:**
+
+- A change branch must reconcile with a fresher default branch
+- Compatibility preflight or rebase finds conflicts
+
+**When:** Phase 9 Git Finalization evaluates the reconcile path
+
+**Then:**
+
+- The archive reports the conflicting files
+- The archive does not delete the worktree
+
+**Risky archive routes to PR workflow** (`rq-releaseFinalization01.3`)
+
+**Given:**
+
+- A change has overlap-risk, PR-only policy, or non-fast-forward publish risk
+
+**When:** Phase 9 Git Finalization chooses an integration path
+
+**Then:**
+
+- The archive routes to PR workflow instead of forcing local merge-back
+- Cleanup remains blocked until merged-state verification succeeds
+
+---
+
 ### Human Checkpoint Contract
 
 **ID:** `rq-autonomy01` | **Priority:** **[MUST]**

--- a/plugin/src/adv-autonomy-quality-assets.test.ts
+++ b/plugin/src/adv-autonomy-quality-assets.test.ts
@@ -353,6 +353,22 @@ describe("Investment Check-In Policy (addCostTimeInvestment)", () => {
     }
   });
 
+  test("adv-archive.md refreshes basis before choosing local or PR archive path", () => {
+    const content = readAsset(join(COMMAND_DIR, "adv-archive.md"));
+    expect(content).toMatch(/Refresh Merge Basis/i);
+    expect(content).toMatch(/git fetch origin \{default-branch\}/);
+    expect(content).toMatch(/git merge --ff-only change\/\{change-id\}/);
+    expect(content).toMatch(/git rebase \{freshness-ref\}/);
+    expect(content).toMatch(/PR workflow path/i);
+  });
+
+  test("adv-archive.md preserves cleanup safety on reconcile conflicts", () => {
+    const content = readAsset(join(COMMAND_DIR, "adv-archive.md"));
+    expect(content).toMatch(/git rebase --abort/);
+    expect(content).toMatch(/do NOT delete worktree/i);
+    expect(content).toMatch(/conflicting files/i);
+  });
+
   test("SETUP.md documents P28 rule and cost-governance file", () => {
     const content = readAsset(SETUP);
     expect(content).toMatch(/P28/);


### PR DESCRIPTION
## Summary
- refresh archive merge basis before choosing local merge-back vs PR workflow
- prefer `--ff-only` fast path, use reconcile only when needed, and preserve worktree cleanup safety on conflicts
- document and test the new release-finalization policy across command docs, instructions, and specs