### PR TITLE
fix: Temporal context mismatch errors (#11)

### DIFF
--- a/plugin/src/index.test.ts
+++ b/plugin/src/index.test.ts
@@ -1362,7 +1362,11 @@ describe("resolveProjectContext worktree preference", () => {
       return null;
     });
 
-    const result = await resolveProjectContext(directory, { vcsDir }, worktreeDir);
+    const result = await resolveProjectContext(
+      directory,
+      { vcsDir },
+      worktreeDir,
+    );
 
     expect(result.effectiveDir).toBe(worktreeDir);
     expect(result.projectId).toBe("worktree-proj-id");

--- a/plugin/src/index.test.ts
+++ b/plugin/src/index.test.ts
@@ -11,6 +11,7 @@ import {
   extractCompletedTask,
   extractCreatedChangeId,
   isLongRunningTool,
+  resolveProjectContext,
 } from "./index";
 import {
   createTempDir,
@@ -21,6 +22,7 @@ import {
 import { addProjectWisdom } from "./storage/project-wisdom";
 import { ADV_TOOL_NAMES } from "./tool-registry";
 import { createDiskStore as createLegacyStore } from "./storage/store-disk";
+import { getProjectId } from "./utils/project-id";
 
 // Mock plugin-init to bypass Temporal requirement in integration tests.
 // Degraded-mode tests (malformed project.json) are preserved by checking
@@ -40,6 +42,18 @@ vi.mock("./plugin-init", async () => {
         return { store: null, initError };
       }
     },
+  };
+});
+
+vi.mock("./utils/project-id", async () => {
+  const actual =
+    await vi.importActual<typeof import("./utils/project-id")>(
+      "./utils/project-id",
+    );
+  return {
+    ...actual,
+    getProjectId: vi.fn(),
+    getExternalRoot: vi.fn(() => "/mock/external/root"),
   };
 });
 
@@ -1327,5 +1341,60 @@ describe("Plugin init: project.path fallback", () => {
     const result = await hooks.tool!.adv_status.execute({}, context);
     const parsed = parseToolOutput(result);
     expect(parsed).toHaveProperty("specs");
+  });
+});
+
+describe("resolveProjectContext worktree preference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("prefers valid worktree over directory and project.vcsDir", async () => {
+    const worktreeDir = "/worktree/path";
+    const directory = "/directory/path";
+    const vcsDir = "/vcs/dir";
+
+    // getProjectId returns ID only for worktreeDir
+    vi.mocked(getProjectId).mockImplementation(async (dir: string) => {
+      if (dir === worktreeDir) return "worktree-proj-id";
+      if (dir === directory) return null;
+      if (dir === vcsDir) return "vcs-proj-id";
+      return null;
+    });
+
+    const result = await resolveProjectContext(directory, { vcsDir }, worktreeDir);
+
+    expect(result.effectiveDir).toBe(worktreeDir);
+    expect(result.projectId).toBe("worktree-proj-id");
+  });
+
+  test("falls back to directory when worktree is undefined", async () => {
+    const directory = "/directory/path";
+
+    vi.mocked(getProjectId).mockImplementation(async (dir: string) => {
+      if (dir === directory) return "dir-proj-id";
+      return null;
+    });
+
+    const result = await resolveProjectContext(directory);
+
+    expect(result.effectiveDir).toBe(directory);
+    expect(result.projectId).toBe("dir-proj-id");
+  });
+
+  test("falls back to project.vcsDir when worktree and directory both invalid", async () => {
+    const directory = "/directory/path";
+    const vcsDir = "/vcs/dir";
+
+    vi.mocked(getProjectId).mockImplementation(async (dir: string) => {
+      if (dir === directory) return null;
+      if (dir === vcsDir) return "vcs-proj-id";
+      return null;
+    });
+
+    const result = await resolveProjectContext(directory, { vcsDir });
+
+    expect(result.effectiveDir).toBe(vcsDir);
+    expect(result.projectId).toBe("vcs-proj-id");
   });
 });

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -139,16 +139,27 @@ const resolveStatus = (s: PluginState): StatusMarker => {
 const debugLog = (msg: string): void => appendDebugLog("index", msg);
 const hooksLogger = createLogger("hooks");
 
-async function resolveProjectContext(
+export async function resolveProjectContext(
   directory: string,
   project?: { vcsDir?: string },
+  worktree?: string,
 ): Promise<{
   effectiveDir: string;
   projectId: string | null;
   externalRoot?: string;
 }> {
+  // Resolution order: worktree → directory → project.vcsDir → legacy fallback
   let effectiveDir = directory;
   let projectId = await getProjectId(effectiveDir);
+
+  if (worktree && worktree !== directory) {
+    debugLog(`trying worktree: ${worktree}`);
+    const wtId = await getProjectId(worktree);
+    if (wtId) {
+      effectiveDir = worktree;
+      projectId = wtId;
+    }
+  }
 
   if (!projectId && project?.vcsDir && project.vcsDir !== directory) {
     debugLog(
@@ -197,6 +208,7 @@ export const AdvancePlugin: Plugin = async ({
   const { effectiveDir, projectId, externalRoot } = await resolveProjectContext(
     directory,
     project,
+    worktree,
   );
   await migrateLegacyStateIfNeeded(effectiveDir, projectId, externalRoot);
 

--- a/plugin/src/storage/store-temporal.test.ts
+++ b/plugin/src/storage/store-temporal.test.ts
@@ -685,8 +685,9 @@ describe("Temporal store backend adapter", () => {
 
     expect(result.success).toBe(true);
     expect(changeHandle.query).toHaveBeenCalledTimes(2);
-    // Transient retry path stays on Temporal only; legacy is untouched.
-    expect(legacy.changes.get).not.toHaveBeenCalled();
+    // Guard calls legacy.changes.get before each Temporal query attempt.
+    // With one transient failure + one success = 2 guard calls.
+    expect(legacy.changes.get).toHaveBeenCalledTimes(2);
   });
 
   it("on fallback error with no disk snapshot, throws original error", async () => {
@@ -728,8 +729,9 @@ describe("Temporal store backend adapter", () => {
     );
 
     expect(changeHandle.query).toHaveBeenCalledTimes(1);
-    // Legacy was consulted once for re-seed; result was empty so we threw.
-    expect(legacy.changes.get).toHaveBeenCalledTimes(1);
+    // Guard calls legacy once before Temporal query, then re-seed calls
+    // legacy once. Total: 2 legacy reads.
+    expect(legacy.changes.get).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -772,8 +774,9 @@ describe("Temporal store backend adapter", () => {
       });
 
       await expect(adapted.changes.get("chg-variant")).rejects.toThrow(msg);
-      // Legacy consulted once for re-seed attempt.
-      expect(legacy.changes.get).toHaveBeenCalledTimes(1);
+      // Guard calls legacy once before Temporal query, then re-seed calls
+      // legacy once. Total: 2 legacy reads.
+      expect(legacy.changes.get).toHaveBeenCalledTimes(2);
     },
   );
 
@@ -857,8 +860,9 @@ describe("Temporal store backend adapter", () => {
     const result = await adapted.changes.get("chg-orphan");
     expect(result.success).toBe(true);
     expect(result.data?.id).toBe("chg-orphan");
-    // Disk read happened for re-seed, workflow re-started, then re-queried.
-    expect(legacy.changes.get).toHaveBeenCalledTimes(1);
+    // Guard calls legacy before first query, re-seed reads disk, guard
+    // calls legacy again before second query. Total: 3 legacy reads.
+    expect(legacy.changes.get).toHaveBeenCalledTimes(3);
     expect(start).toHaveBeenCalledTimes(1);
     expect(query).toHaveBeenCalledTimes(2);
   });
@@ -1827,6 +1831,241 @@ describe("Temporal store backend adapter", () => {
         deltas: {},
       };
       expect(() => ChangeSchema.parse(legacyChange)).not.toThrow();
+    });
+  });
+
+  describe("shared change-scoped Temporal owner guard", () => {
+    it("gates.get rejects with AdvProjectContextMismatch when change is owned by another project", async () => {
+      const legacy = makeLegacyStore();
+      legacy.changes.get = vi.fn(async () => ({
+        success: true,
+        data: {
+          id: "chg1",
+          title: "Change 1",
+          status: "draft",
+          created_at: "2026-04-18T00:00:00.000Z",
+          tasks: [],
+          deltas: {},
+          adv_project_id: "owner-proj",
+        },
+      }));
+
+      const changeHandle = {
+        query: vi.fn(async () => null),
+        executeUpdate: vi.fn(async () => null),
+        signal: vi.fn(async () => {}),
+      };
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy,
+        temporal: bundle as any,
+        projectId: "current-proj",
+      });
+
+      await expect(adapted.gates.get("chg1")).rejects.toMatchObject({
+        name: "AdvProjectContextMismatch",
+        changeId: "chg1",
+        owningProjectId: "owner-proj",
+        currentProjectId: "current-proj",
+      });
+
+      // Guard must block before querying Temporal
+      expect(changeHandle.query).not.toHaveBeenCalled();
+    });
+
+    it("gates.complete rejects with AdvProjectContextMismatch when change is owned by another project", async () => {
+      const legacy = makeLegacyStore();
+      legacy.changes.get = vi.fn(async () => ({
+        success: true,
+        data: {
+          id: "chg1",
+          title: "Change 1",
+          status: "draft",
+          created_at: "2026-04-18T00:00:00.000Z",
+          tasks: [],
+          deltas: {},
+          adv_project_id: "owner-proj",
+        },
+      }));
+
+      const changeHandle = {
+        query: vi.fn(async () => null),
+        executeUpdate: vi.fn(async () => null),
+        signal: vi.fn(async () => {}),
+      };
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy,
+        temporal: bundle as any,
+        projectId: "current-proj",
+      });
+
+      await expect(
+        adapted.gates.complete("chg1", "proposal"),
+      ).rejects.toMatchObject({
+        name: "AdvProjectContextMismatch",
+        changeId: "chg1",
+        owningProjectId: "owner-proj",
+        currentProjectId: "current-proj",
+      });
+
+      expect(changeHandle.executeUpdate).not.toHaveBeenCalled();
+    });
+
+    it("tasks.list rejects with AdvProjectContextMismatch when change is owned by another project", async () => {
+      const legacy = makeLegacyStore();
+      legacy.changes.get = vi.fn(async () => ({
+        success: true,
+        data: {
+          id: "chg1",
+          title: "Change 1",
+          status: "draft",
+          created_at: "2026-04-18T00:00:00.000Z",
+          tasks: [],
+          deltas: {},
+          adv_project_id: "owner-proj",
+        },
+      }));
+
+      const changeHandle = {
+        query: vi.fn(async () => null),
+        executeUpdate: vi.fn(async () => null),
+        signal: vi.fn(async () => {}),
+      };
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy,
+        temporal: bundle as any,
+        projectId: "current-proj",
+      });
+
+      await expect(adapted.tasks.list("chg1")).rejects.toMatchObject({
+        name: "AdvProjectContextMismatch",
+        changeId: "chg1",
+        owningProjectId: "owner-proj",
+        currentProjectId: "current-proj",
+      });
+
+      expect(changeHandle.query).not.toHaveBeenCalled();
+    });
+
+    it("allows same-project access when adv_project_id matches", async () => {
+      const legacy = makeLegacyStore();
+      legacy.changes.get = vi.fn(async () => ({
+        success: true,
+        data: {
+          id: "chg1",
+          title: "Change 1",
+          status: "draft",
+          created_at: "2026-04-18T00:00:00.000Z",
+          tasks: [],
+          deltas: {},
+          adv_project_id: "current-proj",
+        },
+      }));
+
+      const state = {
+        projectId: "current-proj",
+        changeId: "chg1",
+        title: "Change 1",
+        initializedAt: "2026-04-18T00:00:00.000Z",
+        id: "chg1",
+        status: "draft",
+        createdAt: "2026-04-18T00:00:00.000Z",
+        tasks: [],
+        wisdom: [],
+        gates: {
+          proposal: { status: "pending" },
+          discovery: { status: "pending" },
+          design: { status: "pending" },
+          planning: { status: "pending" },
+          execution: { status: "pending" },
+          acceptance: { status: "pending" },
+          release: { status: "pending" },
+        },
+        reentry_history: [],
+        artifacts: {},
+      };
+
+      const changeHandle = {
+        query: vi.fn(async () => state),
+        executeUpdate: vi.fn(async () => null),
+        signal: vi.fn(async () => {}),
+      };
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy,
+        temporal: bundle as any,
+        projectId: "current-proj",
+      });
+
+      const result = await adapted.gates.get("chg1");
+      expect(result).toBeDefined();
+      expect(changeHandle.query).toHaveBeenCalled();
+    });
+
+    it("allows best-effort access for ownerless legacy changes", async () => {
+      const legacy = makeLegacyStore();
+      legacy.changes.get = vi.fn(async () => ({
+        success: true,
+        data: {
+          id: "chg1",
+          title: "Change 1",
+          status: "draft",
+          created_at: "2026-04-18T00:00:00.000Z",
+          tasks: [],
+          deltas: {},
+        },
+      }));
+
+      const state = {
+        projectId: "current-proj",
+        changeId: "chg1",
+        title: "Change 1",
+        initializedAt: "2026-04-18T00:00:00.000Z",
+        id: "chg1",
+        status: "draft",
+        createdAt: "2026-04-18T00:00:00.000Z",
+        tasks: [],
+        wisdom: [],
+        gates: {
+          proposal: { status: "pending" },
+          discovery: { status: "pending" },
+          design: { status: "pending" },
+          planning: { status: "pending" },
+          execution: { status: "pending" },
+          acceptance: { status: "pending" },
+          release: { status: "pending" },
+        },
+        reentry_history: [],
+        artifacts: {},
+      };
+
+      const changeHandle = {
+        query: vi.fn(async () => state),
+        executeUpdate: vi.fn(async () => null),
+        signal: vi.fn(async () => {}),
+      };
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy,
+        temporal: bundle as any,
+        projectId: "current-proj",
+      });
+
+      const result = await adapted.gates.get("chg1");
+      expect(result).toBeDefined();
+      expect(changeHandle.query).toHaveBeenCalled();
     });
   });
 });

--- a/plugin/src/storage/store-temporal.test.ts
+++ b/plugin/src/storage/store-temporal.test.ts
@@ -2012,6 +2012,97 @@ describe("Temporal store backend adapter", () => {
       expect(changeHandle.query).toHaveBeenCalled();
     });
 
+    it("tasks.add rejects with AdvProjectContextMismatch before executeUpdate", async () => {
+      const legacy = makeLegacyStore();
+      legacy.changes.get = vi.fn(async () => ({
+        success: true,
+        data: {
+          id: "chg1",
+          title: "Change 1",
+          status: "draft",
+          created_at: "2026-04-18T00:00:00.000Z",
+          tasks: [],
+          deltas: {},
+          adv_project_id: "owner-proj",
+        },
+      }));
+
+      const changeHandle = {
+        query: vi.fn(async () => null),
+        executeUpdate: vi.fn(async () => null),
+        signal: vi.fn(async () => {}),
+      };
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy,
+        temporal: bundle as any,
+        projectId: "current-proj",
+      });
+
+      await expect(adapted.tasks.add("chg1", "new task")).rejects.toMatchObject(
+        {
+          name: "AdvProjectContextMismatch",
+          changeId: "chg1",
+          owningProjectId: "owner-proj",
+          currentProjectId: "current-proj",
+        },
+      );
+
+      // Guard must block before invoking executeUpdate
+      expect(changeHandle.executeUpdate).not.toHaveBeenCalled();
+    });
+
+    it("falls through guard when legacy disk read throws (best-effort)", async () => {
+      const legacy = makeLegacyStore();
+      legacy.changes.get = vi.fn(async () => {
+        throw new Error("EACCES: read-only filesystem");
+      });
+
+      const state = {
+        projectId: "current-proj",
+        changeId: "chg1",
+        title: "Change 1",
+        initializedAt: "2026-04-18T00:00:00.000Z",
+        id: "chg1",
+        status: "draft",
+        createdAt: "2026-04-18T00:00:00.000Z",
+        tasks: [],
+        wisdom: [],
+        gates: {
+          proposal: { status: "pending" },
+          discovery: { status: "pending" },
+          design: { status: "pending" },
+          planning: { status: "pending" },
+          execution: { status: "pending" },
+          acceptance: { status: "pending" },
+          release: { status: "pending" },
+        },
+        reentry_history: [],
+        artifacts: {},
+      };
+
+      const changeHandle = {
+        query: vi.fn(async () => state),
+        executeUpdate: vi.fn(async () => null),
+        signal: vi.fn(async () => {}),
+      };
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy,
+        temporal: bundle as any,
+        projectId: "current-proj",
+      });
+
+      // Should NOT throw guard error; should pass through to Temporal
+      const result = await adapted.gates.get("chg1");
+      expect(result).toBeDefined();
+      expect(changeHandle.query).toHaveBeenCalled();
+    });
+
     it("allows best-effort access for ownerless legacy changes", async () => {
       const legacy = makeLegacyStore();
       legacy.changes.get = vi.fn(async () => ({

--- a/plugin/src/storage/store-temporal.test.ts
+++ b/plugin/src/storage/store-temporal.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createTemporalStoreBackend } from "./store-temporal";
 import type { Store } from "./store-types";
+import { ChangeSchema } from "../types";
 
 vi.mock("../utils/debug-log", () => ({
   createLogger: vi.fn(() => ({
@@ -1707,6 +1708,125 @@ describe("Temporal store backend adapter", () => {
       await expect(
         adapted.tasks.add("chg1", "new task"),
       ).resolves.toBeDefined();
+    });
+  });
+
+  describe("owner metadata (adv_project_id)", () => {
+    it("maps ChangeWorkflowState.projectId to adv_project_id on changes.get", async () => {
+      const state = {
+        projectId: "owner-proj",
+        changeId: "chg1",
+        title: "Change 1",
+        initializedAt: "2026-04-18T00:00:00.000Z",
+        id: "chg1",
+        status: "draft",
+        createdAt: "2026-04-18T00:00:00.000Z",
+        tasks: [],
+        wisdom: [],
+        gates: {
+          proposal: { status: "pending" },
+          discovery: { status: "pending" },
+          design: { status: "pending" },
+          planning: { status: "pending" },
+          execution: { status: "pending" },
+          acceptance: { status: "pending" },
+          release: { status: "pending" },
+        },
+        reentry_history: [],
+        artifacts: {},
+      };
+
+      const changeHandle = {
+        query: vi.fn(async () => state),
+        executeUpdate: vi.fn(async () => null),
+        signal: vi.fn(async () => {}),
+      };
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy: makeLegacyStore(),
+        temporal: bundle as any,
+        projectId: "owner-proj",
+      });
+
+      const result = await adapted.changes.get("chg1");
+      expect(result.success).toBe(true);
+      expect((result.data as any).adv_project_id).toBe("owner-proj");
+    });
+
+    it("dual-writes adv_project_id to disk snapshot after mutations", async () => {
+      const legacy = makeLegacyStore();
+
+      const stateAfterAdd = {
+        projectId: "current-proj",
+        changeId: "chg1",
+        title: "Change 1",
+        initializedAt: "2026-04-26T00:00:00.000Z",
+        id: "chg1",
+        status: "draft",
+        createdAt: "2026-04-26T00:00:00.000Z",
+        tasks: [
+          {
+            id: "tk-new",
+            title: "new task",
+            status: "pending",
+            priority: 0,
+            created_at: "2026-04-26T00:00:00.000Z",
+            tdd_phase: "none",
+          },
+        ],
+        wisdom: [],
+        gates: {
+          proposal: { status: "pending" },
+          discovery: { status: "pending" },
+          design: { status: "pending" },
+          planning: { status: "pending" },
+          execution: { status: "pending" },
+          acceptance: { status: "pending" },
+          release: { status: "pending" },
+        },
+        reentry_history: [],
+        artifacts: {},
+      };
+
+      const changeHandle = {
+        query: vi.fn(async () => stateAfterAdd),
+        executeUpdate: vi.fn(async () => stateAfterAdd.tasks[0]),
+        signal: vi.fn(async () => {}),
+      };
+
+      const bundle = {
+        client: { workflow: { getHandle: routeHandle(changeHandle) } },
+      };
+      const adapted = createTemporalStoreBackend({
+        legacy,
+        temporal: bundle as any,
+        projectId: "current-proj",
+      });
+
+      await adapted.tasks.add("chg1", "new task");
+
+      // Wait a tick for the fire-and-forget dual-write
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(legacy.changes.save).toHaveBeenCalled();
+      const savedCall = (legacy.changes.save as any).mock.calls.find(
+        (call: any[]) => call[0]?.id === "chg1",
+      );
+      expect(savedCall[0].adv_project_id).toBe("current-proj");
+    });
+
+    it("ChangeSchema accepts legacy snapshots without adv_project_id", () => {
+      const legacyChange = {
+        id: "legacy-chg",
+        title: "Legacy",
+        status: "draft",
+        created_at: "2026-04-18T00:00:00.000Z",
+        tasks: [],
+        deltas: {},
+      };
+      expect(() => ChangeSchema.parse(legacyChange)).not.toThrow();
     });
   });
 });

--- a/plugin/src/storage/store-temporal.ts
+++ b/plugin/src/storage/store-temporal.ts
@@ -116,6 +116,48 @@ function getChangeHandle(
 }
 
 /**
+ * Typed error thrown when a change-scoped operation targets a change
+ * owned by a different project than the current store binding.
+ */
+class AdvProjectContextMismatchError extends Error {
+  readonly name = "AdvProjectContextMismatch";
+  constructor(
+    readonly changeId: string,
+    readonly owningProjectId: string,
+    readonly currentProjectId: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Shared guard: before returning a Temporal workflow handle for a change,
+ * verify the change's owner (via legacy disk snapshot) matches the
+ * current store's project binding. Ownerless legacy changes are
+ * best-effort compatible — the guard passes through silently.
+ */
+async function getGuardedChangeHandle(
+  input: TemporalStoreBackendInput,
+  changeId: string,
+): Promise<WorkflowHandleLike> {
+  const legacyResult = await input.legacy.changes.get(changeId);
+  if (legacyResult.success && legacyResult.data?.adv_project_id) {
+    const owningProjectId = legacyResult.data.adv_project_id;
+    if (owningProjectId !== input.projectId) {
+      throw new AdvProjectContextMismatchError(
+        changeId,
+        owningProjectId,
+        input.projectId,
+        `Change '${changeId}' is owned by project '${owningProjectId}' (current: '${input.projectId}'). ` +
+          `Open the change in its owning project's context, or verify the linked-project configuration.`,
+      );
+    }
+  }
+  return getChangeHandle(input, changeId);
+}
+
+/**
  * Build an idempotent `onTransientFailure` hook that calls `reinitStsl`
  * at most once per outer op (KD-2, KD-4). `withTemporalRetry` fires its
  * hook on every transient failure — without per-op idempotency, a
@@ -280,8 +322,8 @@ export function createTemporalStoreBackend(
    */
   const dualWriteAfterMutation = async (changeId: string): Promise<void> => {
     try {
-      const state = (await runTemporalQuery(() =>
-        getChangeHandle(input, changeId).query(changeStateQuery),
+      const state = (await runTemporalQuery(async () =>
+        (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
       )) as ChangeWorkflowState;
       setCachedChange(state);
       emitChangeSummarySignal(changeId, state);
@@ -391,14 +433,14 @@ export function createTemporalStoreBackend(
    * gets a fresh handle bound to the (possibly post-reconnect) client.
    */
   const resolveStateOrQuery = async (
-    getHandle: () => WorkflowHandleLike,
+    getHandle: () => WorkflowHandleLike | Promise<WorkflowHandleLike>,
     result: unknown,
   ): Promise<ChangeWorkflowState> => {
     if (result && typeof result === "object" && "changeId" in result) {
       return result as ChangeWorkflowState;
     }
-    return (await runTemporalQuery(() =>
-      getHandle().query(changeStateQuery),
+    return (await runTemporalQuery(async () =>
+      (await getHandle()).query(changeStateQuery),
     )) as ChangeWorkflowState;
   };
 
@@ -473,8 +515,8 @@ export function createTemporalStoreBackend(
       return null;
     }
     try {
-      const state = (await runTemporalQuery(() =>
-        getChangeHandle(input, changeId).query(changeStateQuery),
+      const state = (await runTemporalQuery(async () =>
+        (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
       )) as ChangeWorkflowState;
       indexTasksFromState(state);
       return setCachedChange(state);
@@ -496,8 +538,8 @@ export function createTemporalStoreBackend(
       return { success: true, data: cached };
     }
     try {
-      const state = (await runTemporalQuery(() =>
-        getChangeHandle(input, changeId).query(changeStateQuery),
+      const state = (await runTemporalQuery(async () =>
+        (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
       )) as ChangeWorkflowState;
       indexTasksFromState(state);
       return { success: true, data: setCachedChange(state) };
@@ -996,13 +1038,13 @@ export function createTemporalStoreBackend(
       },
       close: async (changeId: string, closure: ChangeClosure) => {
         invalidateChange(changeId);
-        const raw = await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(closeChangeUpdate, {
+        const raw = await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(closeChangeUpdate, {
             args: [closure],
           }),
         );
         const result = await resolveStateOrQuery(
-          () => getChangeHandle(input, changeId),
+          async () => await getGuardedChangeHandle(input, changeId),
           raw,
         );
         indexTasksFromState(result);
@@ -1066,13 +1108,13 @@ export function createTemporalStoreBackend(
         for (const id of changeIds) {
           try {
             invalidateChange(id);
-            const raw = await runTemporal(() =>
-              getChangeHandle(input, id).executeUpdate(closeChangeUpdate, {
+            const raw = await runTemporal(async () =>
+              (await getGuardedChangeHandle(input, id)).executeUpdate(closeChangeUpdate, {
                 args: [closure],
               }),
             );
             const result = await resolveStateOrQuery(
-              () => getChangeHandle(input, id),
+              async () => await getGuardedChangeHandle(input, id),
               raw,
             );
             indexTasksFromState(result);
@@ -1130,8 +1172,8 @@ export function createTemporalStoreBackend(
         ];
         for (const [kind, path] of updates) {
           if (!path) continue;
-          await runTemporal(() =>
-            getChangeHandle(input, changeId).executeUpdate(
+          await runTemporal(async () =>
+            (await getGuardedChangeHandle(input, changeId)).executeUpdate(
               updateArtifactMetadataUpdate,
               {
                 args: [kind, { path, updatedAt: new Date().toISOString() }],
@@ -1145,8 +1187,8 @@ export function createTemporalStoreBackend(
     tasks: {
       ...legacy.tasks,
       list: async (changeId: string, status?: string, filter?: string) => {
-        const tasks = (await runTemporalQuery(() =>
-          getChangeHandle(input, changeId).query(
+        const tasks = (await runTemporalQuery(async () =>
+          (await getGuardedChangeHandle(input, changeId)).query(
             changeTasksQuery,
             status,
             filter,
@@ -1158,8 +1200,8 @@ export function createTemporalStoreBackend(
         return tasks;
       },
       ready: async (changeId: string) => {
-        const state = (await runTemporalQuery(() =>
-          getChangeHandle(input, changeId).query(changeStateQuery),
+        const state = (await runTemporalQuery(async () =>
+          (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
         )) as ChangeWorkflowState;
         indexTasksFromState(state);
         return getReadyTasksFromChangeState(state);
@@ -1174,8 +1216,8 @@ export function createTemporalStoreBackend(
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         invalidateChange(changeId);
-        const result = (await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(updateTaskUpdate, {
+        const result = (await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(updateTaskUpdate, {
             args: [
               taskId,
               {
@@ -1192,8 +1234,8 @@ export function createTemporalStoreBackend(
       },
       add: async (changeId, content, options) => {
         invalidateChange(changeId);
-        const created = (await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(addTaskUpdate, {
+        const created = (await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(addTaskUpdate, {
             args: [
               {
                 title: content,
@@ -1214,15 +1256,15 @@ export function createTemporalStoreBackend(
       get: async (taskId) => {
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
-        return (await runTemporalQuery(() =>
-          getChangeHandle(input, changeId).query(changeTaskQuery, taskId),
+        return (await runTemporalQuery(async () =>
+          (await getGuardedChangeHandle(input, changeId)).query(changeTaskQuery, taskId),
         )) as Awaited<ReturnType<Store["tasks"]["get"]>>;
       },
       show: async (taskId) => {
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
-        const task = await runTemporalQuery(() =>
-          getChangeHandle(input, changeId).query(changeTaskQuery, taskId),
+        const task = await runTemporalQuery(async () =>
+          (await getGuardedChangeHandle(input, changeId)).query(changeTaskQuery, taskId),
         );
         if (!task) return null;
         return { task: task as Task, changeId };
@@ -1230,21 +1272,21 @@ export function createTemporalStoreBackend(
       getRun: async (taskId) => {
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
-        return (await runTemporalQuery(() =>
-          getChangeHandle(input, changeId).query(changeTaskRunQuery, taskId),
+        return (await runTemporalQuery(async () =>
+          (await getGuardedChangeHandle(input, changeId)).query(changeTaskRunQuery, taskId),
         )) as Awaited<ReturnType<Store["tasks"]["getRun"]>>;
       },
       listRuns: async (changeId) => {
-        return (await runTemporalQuery(() =>
-          getChangeHandle(input, changeId).query(changeTaskRunsQuery),
+        return (await runTemporalQuery(async () =>
+          (await getGuardedChangeHandle(input, changeId)).query(changeTaskRunsQuery),
         )) as Awaited<ReturnType<Store["tasks"]["listRuns"]>>;
       },
       recordRunEvent: async (taskId, event) => {
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         invalidateChange(changeId);
-        const result = (await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(
+        const result = (await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
             recordTaskRunEventUpdate,
             {
               args: [taskId, event],
@@ -1258,8 +1300,8 @@ export function createTemporalStoreBackend(
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         invalidateChange(changeId);
-        const result = (await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(
+        const result = (await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
             recordTaskEvidenceUpdate,
             {
               args: [taskId, phase, evidence],
@@ -1273,8 +1315,8 @@ export function createTemporalStoreBackend(
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         invalidateChange(changeId);
-        const result = (await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(setTaskPhaseUpdate, {
+        const result = (await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(setTaskPhaseUpdate, {
             args: [taskId, phase],
           }),
         )) as Awaited<ReturnType<Store["tasks"]["setPhase"]>>;
@@ -1285,8 +1327,8 @@ export function createTemporalStoreBackend(
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         invalidateChange(changeId);
-        const result = (await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(cancelTaskUpdate, {
+        const result = (await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(cancelTaskUpdate, {
             args: [taskId, cancellation],
           }),
         )) as Awaited<ReturnType<Store["tasks"]["cancel"]>>;
@@ -1297,8 +1339,8 @@ export function createTemporalStoreBackend(
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         invalidateChange(changeId);
-        const result = (await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(
+        const result = (await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
             reclassifyTaskTddUpdate,
             {
               args: [taskId, reclassification],
@@ -1313,8 +1355,8 @@ export function createTemporalStoreBackend(
       ...legacy.wisdom,
       add: async (changeId, type: WisdomType, content, sourceTask) => {
         invalidateChange(changeId);
-        const raw = await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(
+        const raw = await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
             addChangeWisdomUpdate,
             {
               args: [type, content, sourceTask],
@@ -1322,7 +1364,7 @@ export function createTemporalStoreBackend(
           ),
         );
         const state = await resolveStateOrQuery(
-          () => getChangeHandle(input, changeId),
+          async () => await getGuardedChangeHandle(input, changeId),
           raw,
         );
         setCachedChange(state);
@@ -1339,8 +1381,8 @@ export function createTemporalStoreBackend(
         return latest;
       },
       list: async (changeId: string) => {
-        const state = (await runTemporalQuery(() =>
-          getChangeHandle(input, changeId).query(changeStateQuery),
+        const state = (await runTemporalQuery(async () =>
+          (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
         )) as ChangeWorkflowState;
         return state.wisdom;
       },
@@ -1348,20 +1390,20 @@ export function createTemporalStoreBackend(
     gates: {
       ...legacy.gates,
       get: async (changeId: string) => {
-        const state = (await runTemporalQuery(() =>
-          getChangeHandle(input, changeId).query(changeStateQuery),
+        const state = (await runTemporalQuery(async () =>
+          (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
         )) as ChangeWorkflowState;
         return state.gates;
       },
       complete: async (changeId: string, gateId: GateId, notes?: string) => {
         invalidateChange(changeId);
-        const raw = await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(completeGateUpdate, {
+        const raw = await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(completeGateUpdate, {
             args: [gateId, notes, "agent"],
           }),
         );
         const state = await resolveStateOrQuery(
-          () => getChangeHandle(input, changeId),
+          async () => await getGuardedChangeHandle(input, changeId),
           raw,
         );
         setCachedChange(state);
@@ -1377,8 +1419,8 @@ export function createTemporalStoreBackend(
         approvalEvidence,
       ) => {
         invalidateChange(changeId);
-        const raw = await runTemporal(() =>
-          getChangeHandle(input, changeId).executeUpdate(reopenFromGateUpdate, {
+        const raw = await runTemporal(async () =>
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(reopenFromGateUpdate, {
             args: [
               fromGate,
               reason,
@@ -1388,7 +1430,7 @@ export function createTemporalStoreBackend(
           }),
         );
         const state = await resolveStateOrQuery(
-          () => getChangeHandle(input, changeId),
+          async () => await getGuardedChangeHandle(input, changeId),
           raw,
         );
         setCachedChange(state);
@@ -1419,7 +1461,7 @@ function hydrateMemoFromPSW(
 ): void {
   void (async () => {
     try {
-      const pswState = (await runTemporalQuery(() => {
+      const pswState = (await runTemporalQuery(async () => {
         const handle = getProjectHandleForInput(input);
         if (!handle) {
           throw new Error("hydrateMemoFromPSW: no project handle available");

--- a/plugin/src/storage/store-temporal.ts
+++ b/plugin/src/storage/store-temporal.ts
@@ -98,6 +98,7 @@ function mapTemporalChangeStateToChange(state: ChangeWorkflowState): Change {
     wisdom: state.wisdom,
     gates: state.gates,
     reentry_history: state.reentry_history,
+    adv_project_id: state.projectId,
   };
 }
 
@@ -869,6 +870,20 @@ export function createTemporalStoreBackend(
           throw err;
         }
 
+        const changeWithOwner: Change = {
+          ...created.data,
+          adv_project_id: input.projectId,
+        };
+        try {
+          await legacy.changes.save(changeWithOwner);
+        } catch (saveErr) {
+          logger.debug(
+            `Disk save of adv_project_id skipped for change ${changeWithOwner.id}: ${
+              saveErr instanceof Error ? saveErr.message : String(saveErr)
+            }`,
+          );
+        }
+
         updateOverlay(created.data.id, {
           created_at: created.data.created_at,
           created_by: created.data.created_by,
@@ -879,6 +894,7 @@ export function createTemporalStoreBackend(
           judgment_calls: created.data.judgment_calls,
           batch_surfaced_at: created.data.batch_surfaced_at,
           cross_project_origin: created.data.cross_project_origin,
+          adv_project_id: input.projectId,
         });
         return result;
       },
@@ -898,6 +914,7 @@ export function createTemporalStoreBackend(
           judgment_calls: change.judgment_calls,
           batch_surfaced_at: change.batch_surfaced_at,
           cross_project_origin: change.cross_project_origin,
+          adv_project_id: change.adv_project_id,
         });
       },
       list: async (filter) => {

--- a/plugin/src/storage/store-temporal.ts
+++ b/plugin/src/storage/store-temporal.ts
@@ -141,7 +141,21 @@ async function getGuardedChangeHandle(
   input: TemporalStoreBackendInput,
   changeId: string,
 ): Promise<WorkflowHandleLike> {
-  const legacyResult = await input.legacy.changes.get(changeId);
+  let legacyResult: Awaited<ReturnType<typeof input.legacy.changes.get>>;
+  try {
+    legacyResult = await input.legacy.changes.get(changeId);
+  } catch (err) {
+    // Best-effort: legacy disk read failure (transient I/O, missing
+    // file, permissions) MUST NOT cascade as a guard rejection. Pass
+    // through to Temporal — the underlying error will surface from
+    // the actual workflow call if it's persistent.
+    logger.debug(
+      `Owner guard skipped for change ${changeId}: legacy read failed (${
+        err instanceof Error ? err.message : String(err)
+      })`,
+    );
+    return getChangeHandle(input, changeId);
+  }
   if (legacyResult.success && legacyResult.data?.adv_project_id) {
     const owningProjectId = legacyResult.data.adv_project_id;
     if (owningProjectId !== input.projectId) {

--- a/plugin/src/storage/store-temporal.ts
+++ b/plugin/src/storage/store-temporal.ts
@@ -1053,9 +1053,12 @@ export function createTemporalStoreBackend(
       close: async (changeId: string, closure: ChangeClosure) => {
         invalidateChange(changeId);
         const raw = await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, changeId)).executeUpdate(closeChangeUpdate, {
-            args: [closure],
-          }),
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
+            closeChangeUpdate,
+            {
+              args: [closure],
+            },
+          ),
         );
         const result = await resolveStateOrQuery(
           async () => await getGuardedChangeHandle(input, changeId),
@@ -1123,9 +1126,12 @@ export function createTemporalStoreBackend(
           try {
             invalidateChange(id);
             const raw = await runTemporal(async () =>
-              (await getGuardedChangeHandle(input, id)).executeUpdate(closeChangeUpdate, {
-                args: [closure],
-              }),
+              (await getGuardedChangeHandle(input, id)).executeUpdate(
+                closeChangeUpdate,
+                {
+                  args: [closure],
+                },
+              ),
             );
             const result = await resolveStateOrQuery(
               async () => await getGuardedChangeHandle(input, id),
@@ -1215,7 +1221,9 @@ export function createTemporalStoreBackend(
       },
       ready: async (changeId: string) => {
         const state = (await runTemporalQuery(async () =>
-          (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
+          (await getGuardedChangeHandle(input, changeId)).query(
+            changeStateQuery,
+          ),
         )) as ChangeWorkflowState;
         indexTasksFromState(state);
         return getReadyTasksFromChangeState(state);
@@ -1231,17 +1239,20 @@ export function createTemporalStoreBackend(
         if (!changeId) return null;
         invalidateChange(changeId);
         const result = (await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, changeId)).executeUpdate(updateTaskUpdate, {
-            args: [
-              taskId,
-              {
-                status: status as Task["status"],
-                notes,
-                implementationSummary,
-                errorRecovery,
-              },
-            ],
-          }),
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
+            updateTaskUpdate,
+            {
+              args: [
+                taskId,
+                {
+                  status: status as Task["status"],
+                  notes,
+                  implementationSummary,
+                  errorRecovery,
+                },
+              ],
+            },
+          ),
         )) as Awaited<ReturnType<Store["tasks"]["update"]>>;
         await dualWriteAfterMutation(changeId);
         return result;
@@ -1249,17 +1260,20 @@ export function createTemporalStoreBackend(
       add: async (changeId, content, options) => {
         invalidateChange(changeId);
         const created = (await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, changeId)).executeUpdate(addTaskUpdate, {
-            args: [
-              {
-                title: content,
-                type: options?.type,
-                section: options?.section,
-                blockedBy: options?.blockedBy,
-                metadata: options?.metadata,
-              },
-            ],
-          }),
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
+            addTaskUpdate,
+            {
+              args: [
+                {
+                  title: content,
+                  type: options?.type,
+                  section: options?.section,
+                  blockedBy: options?.blockedBy,
+                  metadata: options?.metadata,
+                },
+              ],
+            },
+          ),
         )) as Awaited<ReturnType<Store["tasks"]["add"]>>;
         if (created && typeof created === "object" && "id" in created) {
           taskChangeIndex.set((created as { id: string }).id, changeId);
@@ -1271,14 +1285,20 @@ export function createTemporalStoreBackend(
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         return (await runTemporalQuery(async () =>
-          (await getGuardedChangeHandle(input, changeId)).query(changeTaskQuery, taskId),
+          (await getGuardedChangeHandle(input, changeId)).query(
+            changeTaskQuery,
+            taskId,
+          ),
         )) as Awaited<ReturnType<Store["tasks"]["get"]>>;
       },
       show: async (taskId) => {
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         const task = await runTemporalQuery(async () =>
-          (await getGuardedChangeHandle(input, changeId)).query(changeTaskQuery, taskId),
+          (await getGuardedChangeHandle(input, changeId)).query(
+            changeTaskQuery,
+            taskId,
+          ),
         );
         if (!task) return null;
         return { task: task as Task, changeId };
@@ -1287,12 +1307,17 @@ export function createTemporalStoreBackend(
         const changeId = await resolveChangeId(taskId);
         if (!changeId) return null;
         return (await runTemporalQuery(async () =>
-          (await getGuardedChangeHandle(input, changeId)).query(changeTaskRunQuery, taskId),
+          (await getGuardedChangeHandle(input, changeId)).query(
+            changeTaskRunQuery,
+            taskId,
+          ),
         )) as Awaited<ReturnType<Store["tasks"]["getRun"]>>;
       },
       listRuns: async (changeId) => {
         return (await runTemporalQuery(async () =>
-          (await getGuardedChangeHandle(input, changeId)).query(changeTaskRunsQuery),
+          (await getGuardedChangeHandle(input, changeId)).query(
+            changeTaskRunsQuery,
+          ),
         )) as Awaited<ReturnType<Store["tasks"]["listRuns"]>>;
       },
       recordRunEvent: async (taskId, event) => {
@@ -1330,9 +1355,12 @@ export function createTemporalStoreBackend(
         if (!changeId) return null;
         invalidateChange(changeId);
         const result = (await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, changeId)).executeUpdate(setTaskPhaseUpdate, {
-            args: [taskId, phase],
-          }),
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
+            setTaskPhaseUpdate,
+            {
+              args: [taskId, phase],
+            },
+          ),
         )) as Awaited<ReturnType<Store["tasks"]["setPhase"]>>;
         await dualWriteAfterMutation(changeId);
         return result;
@@ -1342,9 +1370,12 @@ export function createTemporalStoreBackend(
         if (!changeId) return null;
         invalidateChange(changeId);
         const result = (await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, changeId)).executeUpdate(cancelTaskUpdate, {
-            args: [taskId, cancellation],
-          }),
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
+            cancelTaskUpdate,
+            {
+              args: [taskId, cancellation],
+            },
+          ),
         )) as Awaited<ReturnType<Store["tasks"]["cancel"]>>;
         await dualWriteAfterMutation(changeId);
         return result;
@@ -1396,7 +1427,9 @@ export function createTemporalStoreBackend(
       },
       list: async (changeId: string) => {
         const state = (await runTemporalQuery(async () =>
-          (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
+          (await getGuardedChangeHandle(input, changeId)).query(
+            changeStateQuery,
+          ),
         )) as ChangeWorkflowState;
         return state.wisdom;
       },
@@ -1405,16 +1438,21 @@ export function createTemporalStoreBackend(
       ...legacy.gates,
       get: async (changeId: string) => {
         const state = (await runTemporalQuery(async () =>
-          (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
+          (await getGuardedChangeHandle(input, changeId)).query(
+            changeStateQuery,
+          ),
         )) as ChangeWorkflowState;
         return state.gates;
       },
       complete: async (changeId: string, gateId: GateId, notes?: string) => {
         invalidateChange(changeId);
         const raw = await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, changeId)).executeUpdate(completeGateUpdate, {
-            args: [gateId, notes, "agent"],
-          }),
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
+            completeGateUpdate,
+            {
+              args: [gateId, notes, "agent"],
+            },
+          ),
         );
         const state = await resolveStateOrQuery(
           async () => await getGuardedChangeHandle(input, changeId),
@@ -1434,14 +1472,17 @@ export function createTemporalStoreBackend(
       ) => {
         invalidateChange(changeId);
         const raw = await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, changeId)).executeUpdate(reopenFromGateUpdate, {
-            args: [
-              fromGate,
-              reason,
-              scopeDelta,
-              approvalEvidence ?? reopenedBy,
-            ],
-          }),
+          (await getGuardedChangeHandle(input, changeId)).executeUpdate(
+            reopenFromGateUpdate,
+            {
+              args: [
+                fromGate,
+                reason,
+                scopeDelta,
+                approvalEvidence ?? reopenedBy,
+              ],
+            },
+          ),
         );
         const state = await resolveStateOrQuery(
           async () => await getGuardedChangeHandle(input, changeId),

--- a/plugin/src/tools/gate.test.ts
+++ b/plugin/src/tools/gate.test.ts
@@ -995,7 +995,9 @@ describe("adv_gate_complete planning — readiness enforcement", () => {
 
   describe("AdvProjectContextMismatch diagnostics", () => {
     test("adv_gate_status returns structured mismatch fields when store throws mismatch", async () => {
-      const mismatchError = new Error("Change 'chg1' is owned by project 'owner-proj'");
+      const mismatchError = new Error(
+        "Change 'chg1' is owned by project 'owner-proj'",
+      );
       (mismatchError as any).name = "AdvProjectContextMismatch";
       (mismatchError as any).changeId = "chg1";
       (mismatchError as any).owningProjectId = "owner-proj";
@@ -1013,11 +1015,15 @@ describe("adv_gate_complete planning — readiness enforcement", () => {
       expect(parsed.changeId).toBe("chg1");
       expect(parsed.owningProjectId).toBe("owner-proj");
       expect(parsed.currentProjectId).toBe("current-proj");
-      expect(parsed.hint).toContain("Open the change in its owning project's context");
+      expect(parsed.hint).toContain(
+        "Open the change in its owning project's context",
+      );
     });
 
     test("adv_gate_complete returns structured mismatch fields when store throws mismatch", async () => {
-      const mismatchError = new Error("Change 'chg1' is owned by project 'owner-proj'");
+      const mismatchError = new Error(
+        "Change 'chg1' is owned by project 'owner-proj'",
+      );
       (mismatchError as any).name = "AdvProjectContextMismatch";
       (mismatchError as any).changeId = "chg1";
       (mismatchError as any).owningProjectId = "owner-proj";
@@ -1035,7 +1041,9 @@ describe("adv_gate_complete planning — readiness enforcement", () => {
       expect(parsed.changeId).toBe("addFeature");
       expect(parsed.owningProjectId).toBe("owner-proj");
       expect(parsed.currentProjectId).toBe("current-proj");
-      expect(parsed.hint).toContain("Open the change in its owning project's context");
+      expect(parsed.hint).toContain(
+        "Open the change in its owning project's context",
+      );
     });
   });
 });

--- a/plugin/src/tools/gate.test.ts
+++ b/plugin/src/tools/gate.test.ts
@@ -992,4 +992,50 @@ describe("adv_gate_complete planning — readiness enforcement", () => {
     const failures = parsed.readinessFailures as Array<Record<string, unknown>>;
     expect(failures.some((f) => f.code === "TASK_TDD_INVERSION")).toBe(true);
   });
+
+  describe("AdvProjectContextMismatch diagnostics", () => {
+    test("adv_gate_status returns structured mismatch fields when store throws mismatch", async () => {
+      const mismatchError = new Error("Change 'chg1' is owned by project 'owner-proj'");
+      (mismatchError as any).name = "AdvProjectContextMismatch";
+      (mismatchError as any).changeId = "chg1";
+      (mismatchError as any).owningProjectId = "owner-proj";
+      (mismatchError as any).currentProjectId = "current-proj";
+
+      vi.spyOn(store.changes, "get").mockRejectedValueOnce(mismatchError);
+
+      const result = await gateTools.adv_gate_status.execute(
+        { changeId: "chg1" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.errorClass).toBe("AdvProjectContextMismatch");
+      expect(parsed.changeId).toBe("chg1");
+      expect(parsed.owningProjectId).toBe("owner-proj");
+      expect(parsed.currentProjectId).toBe("current-proj");
+      expect(parsed.hint).toContain("Open the change in its owning project's context");
+    });
+
+    test("adv_gate_complete returns structured mismatch fields when store throws mismatch", async () => {
+      const mismatchError = new Error("Change 'chg1' is owned by project 'owner-proj'");
+      (mismatchError as any).name = "AdvProjectContextMismatch";
+      (mismatchError as any).changeId = "chg1";
+      (mismatchError as any).owningProjectId = "owner-proj";
+      (mismatchError as any).currentProjectId = "current-proj";
+
+      vi.spyOn(store.gates, "complete").mockRejectedValueOnce(mismatchError);
+
+      const result = await gateTools.adv_gate_complete.execute(
+        { changeId: "addFeature", gateId: "proposal" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.errorClass).toBe("AdvProjectContextMismatch");
+      expect(parsed.changeId).toBe("addFeature");
+      expect(parsed.owningProjectId).toBe("owner-proj");
+      expect(parsed.currentProjectId).toBe("current-proj");
+      expect(parsed.hint).toContain("Open the change in its owning project's context");
+    });
+  });
 });

--- a/plugin/src/tools/gate.ts
+++ b/plugin/src/tools/gate.ts
@@ -62,6 +62,19 @@ async function completeGateAndBuildResponse({
   try {
     await store.gates.complete(changeId, gateId, notes);
   } catch (saveError) {
+    if ((saveError as Error).name === "AdvProjectContextMismatch") {
+      const e = saveError as unknown as Record<string, unknown>;
+      return formatToolOutput({
+        error: (saveError as Error).message,
+        changeId,
+        gateId,
+        errorClass: "AdvProjectContextMismatch",
+        owningProjectId: e.owningProjectId,
+        currentProjectId: e.currentProjectId,
+        hint:
+          "Open the change in its owning project's context, or verify the linked-project configuration.",
+      });
+    }
     return formatToolOutput({
       error: `Failed to complete gate: ${(saveError as Error).message}`,
       changeId,
@@ -227,27 +240,43 @@ export const gateTools = {
         ),
     },
     execute: async ({ changeId }: { changeId: string }, store: Store) => {
-      const result = await store.changes.get(changeId);
-      if (!result.success) {
-        return formatToolOutput({ error: result.error });
-      }
-      if (!result.data) {
-        return formatToolOutput({ error: `Change not found: ${changeId}` });
-      }
+      try {
+        const result = await store.changes.get(changeId);
+        if (!result.success) {
+          return formatToolOutput({ error: result.error });
+        }
+        if (!result.data) {
+          return formatToolOutput({ error: `Change not found: ${changeId}` });
+        }
 
-      // Get or create gates
-      const gates = result.data.gates ?? createDefaultGates();
-      const incomplete = getIncompleteGates(gates);
-      const canArchive = allGatesSatisfied(gates);
-      const nextGate = incomplete.length > 0 ? incomplete[0] : null;
+        // Get or create gates
+        const gates = result.data.gates ?? createDefaultGates();
+        const incomplete = getIncompleteGates(gates);
+        const canArchive = allGatesSatisfied(gates);
+        const nextGate = incomplete.length > 0 ? incomplete[0] : null;
 
-      return formatToolOutput({
-        changeId,
-        gates,
-        incomplete,
-        canArchive,
-        nextGate,
-      });
+        return formatToolOutput({
+          changeId,
+          gates,
+          incomplete,
+          canArchive,
+          nextGate,
+        });
+      } catch (error) {
+        if ((error as Error).name === "AdvProjectContextMismatch") {
+          const e = error as unknown as Record<string, unknown>;
+          return formatToolOutput({
+            error: (error as Error).message,
+            changeId,
+            errorClass: "AdvProjectContextMismatch",
+            owningProjectId: e.owningProjectId,
+            currentProjectId: e.currentProjectId,
+            hint:
+              "Open the change in its owning project's context, or verify the linked-project configuration.",
+          });
+        }
+        throw error;
+      }
     },
   },
 
@@ -311,15 +340,32 @@ export const gateTools = {
         });
       }
 
-      const result = await store.changes.get(changeId);
-      if (!result.success) {
-        return formatToolOutput({ error: result.error });
-      }
-      if (!result.data) {
-        return formatToolOutput({ error: `Change not found: ${changeId}` });
+      let change: Change;
+      try {
+        const result = await store.changes.get(changeId);
+        if (!result.success) {
+          return formatToolOutput({ error: result.error });
+        }
+        if (!result.data) {
+          return formatToolOutput({ error: `Change not found: ${changeId}` });
+        }
+        change = result.data;
+      } catch (error) {
+        if ((error as Error).name === "AdvProjectContextMismatch") {
+          const e = error as unknown as Record<string, unknown>;
+          return formatToolOutput({
+            error: (error as Error).message,
+            changeId,
+            errorClass: "AdvProjectContextMismatch",
+            owningProjectId: e.owningProjectId,
+            currentProjectId: e.currentProjectId,
+            hint:
+              "Open the change in its owning project's context, or verify the linked-project configuration.",
+          });
+        }
+        throw error;
       }
 
-      const change = result.data;
       const gates: Gates = change.gates ?? createDefaultGates();
 
       // Check sequence enforcement

--- a/plugin/src/tools/gate.ts
+++ b/plugin/src/tools/gate.ts
@@ -71,8 +71,7 @@ async function completeGateAndBuildResponse({
         errorClass: "AdvProjectContextMismatch",
         owningProjectId: e.owningProjectId,
         currentProjectId: e.currentProjectId,
-        hint:
-          "Open the change in its owning project's context, or verify the linked-project configuration.",
+        hint: "Open the change in its owning project's context, or verify the linked-project configuration.",
       });
     }
     return formatToolOutput({
@@ -271,8 +270,7 @@ export const gateTools = {
             errorClass: "AdvProjectContextMismatch",
             owningProjectId: e.owningProjectId,
             currentProjectId: e.currentProjectId,
-            hint:
-              "Open the change in its owning project's context, or verify the linked-project configuration.",
+            hint: "Open the change in its owning project's context, or verify the linked-project configuration.",
           });
         }
         throw error;
@@ -359,8 +357,7 @@ export const gateTools = {
             errorClass: "AdvProjectContextMismatch",
             owningProjectId: e.owningProjectId,
             currentProjectId: e.currentProjectId,
-            hint:
-              "Open the change in its owning project's context, or verify the linked-project configuration.",
+            hint: "Open the change in its owning project's context, or verify the linked-project configuration.",
           });
         }
         throw error;

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1048,6 +1048,12 @@ export const ChangeSchema = z
      * that origin validation is required before agreement.
      */
     cross_project_origin: CrossProjectOriginSchema.optional(),
+    /**
+     * Temporal project ID that owns this change. Persisted on disk snapshots
+     * so the shared guard can detect cross-project context mismatches.
+     * Optional for legacy compatibility — ownerless changes are best-effort.
+     */
+    adv_project_id: z.string().optional(),
   })
   .passthrough(); // Allow extra fields for forward/backward compatibility
 

--- a/plugin/src/utils/safe-execute.ts
+++ b/plugin/src/utils/safe-execute.ts
@@ -185,6 +185,13 @@ export function formatErrorResponse(
 
   // Handle standard Error objects
   if (error instanceof Error) {
+    // Preserve structured fields from AdvProjectContextMismatch errors
+    if (error.name === "AdvProjectContextMismatch") {
+      const e = error as unknown as Record<string, unknown>;
+      enrichment.changeId = e.changeId;
+      enrichment.owningProjectId = e.owningProjectId;
+      enrichment.currentProjectId = e.currentProjectId;
+    }
     return formatToolOutput({
       error: error.message,
       tool: toolName,


### PR DESCRIPTION
## Summary

Fixes GitHub issue #11 — change-scoped ADV tools now detect wrong project/worktree context **before** querying Temporal workflows and return typed `AdvProjectContextMismatch` diagnostics instead of opaque `ServiceError`.

## Problem

When a change is created in project A and then queried from project B (e.g. wrong worktree, OpenCode pointing at the wrong directory), Temporal returns generic ServiceErrors that give no actionable diagnostic. The agent has no signal that the underlying cause is project-context mismatch, leading to confusing failure modes.

## Fix

Five focused changes:

1. **Worktree-aware project resolution** (`plugin/src/index.ts`): `resolveProjectContext` now accepts and prefers a valid OpenCode `worktree` over `directory` and `project.vcsDir` during plugin init. Resolution order: `worktree → directory → project.vcsDir → legacy fallback`.
2. **Owner metadata persistence** (`plugin/src/types.ts`, `plugin/src/storage/store-temporal.ts`): `ChangeSchema` gains optional `adv_project_id`. `mapTemporalChangeStateToChange` maps `state.projectId`. Create / save / overlay paths persist owner metadata. Optional + `.passthrough()` for legacy compat.
3. **Shared change-scoped guard** (`plugin/src/storage/store-temporal.ts`): `AdvProjectContextMismatchError` typed class. New `getGuardedChangeHandle` helper checks owner via legacy disk snapshot **before** every Temporal query/update. ~31 callsites updated. Best-effort: legacy read failures fall through (don't cascade as guard rejection).
4. **Structured tool diagnostics** (`plugin/src/tools/gate.ts`, `plugin/src/utils/safe-execute.ts`): `adv_gate_status` / `adv_gate_complete` catch mismatch errors and return `errorClass: 'AdvProjectContextMismatch'` with `changeId`, `owningProjectId`, `currentProjectId`, and recovery hint. `formatErrorResponse` enrichment preserves these fields for any other tool.
5. **Comprehensive tests**: 13 new tests + 2 review-remediation tests across `index.test.ts`, `store-temporal.test.ts`, `gate.test.ts`. Full suite: **1988 passed**, 0 failed, 1 skipped.

## Verification

- Typecheck: clean
- Lint: clean
- Tests: 1988 passing
- Workflow-bundle boundary: clean
- Review (auto-remediated): 2 issues fixed, 2 suggestions rejected with evidence, 1 nit deferred

## ⚠ Integration Note

This branch was forked from a pre-existing worktree session snapshot (`47c7c50`). Trunk has since landed an unrelated refactor splitting `plugin/src/storage/store-temporal.ts` into `plugin/src/storage/store-temporal/{shared,changes,gates,tasks,wisdom,index}.ts`. The merge will surface a `modify/delete` conflict on `store-temporal.ts` that requires porting the AdvProjectContextMismatch guard, owner metadata, and ~31 callsite updates onto the split structure.

The fix itself is correct and well-tested. The port is mechanical (~30 min) — see code in `plugin/src/storage/store-temporal.ts` for the guard pattern that needs distributing across the split files.

## Files Changed

- `plugin/src/index.ts` (+14)
- `plugin/src/index.test.ts` (+69)
- `plugin/src/storage/store-temporal.ts` (+173 in fix scope, plus base diff from snapshot)
- `plugin/src/storage/store-temporal.test.ts` (+450)
- `plugin/src/tools/gate.ts` (+98)
- `plugin/src/tools/gate.test.ts` (+46)
- `plugin/src/types.ts` (+6)
- `plugin/src/utils/safe-execute.ts` (+7)

Closes #11