### PR TITLE
Archive improveAdvScopeAndFollowupIntegrity — fast-follow lineage + scope-discovery protocol

### DIFF
--- a/plugin/src/storage/store-disk.ts
+++ b/plugin/src/storage/store-disk.ts
@@ -38,6 +38,7 @@ import { basename, join } from "path";
 import type {
   Change,
   ChangeClosure,
+  ChangeStatus,
   Spec,
   Task,
   TaskRunEvent,
@@ -953,7 +954,7 @@ export async function createDiskStore(
           Boolean(r.success && r.data),
         )
         .map((r) => r.data);
-      const byStatus = {
+      const byStatus: Record<ChangeStatus, number> = {
         draft: 0,
         pending: 0,
         active: 0,
@@ -978,7 +979,10 @@ export async function createDiskStore(
             now,
           ),
         )
-        .sort((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt));
+        .sort((a, b) => {
+          const cmp = b.lastActivityAt.localeCompare(a.lastActivityAt);
+          return cmp !== 0 ? cmp : a.id.localeCompare(b.id);
+        });
       return {
         specs: { count: specs.length, capabilities: specs },
         changes: {

--- a/plugin/src/storage/store-temporal-memo.ts
+++ b/plugin/src/storage/store-temporal-memo.ts
@@ -54,6 +54,7 @@ export interface ChangeSummary {
     pending: number;
   };
   lastActivityAt: string;
+  /** Same-project fast-follow lineage (optional) */
   fast_follow_of?: FastFollowOf;
   /** Monotonic version for PSW signal dedupe */
   sourceVersion: number;

--- a/plugin/src/temporal/contracts.ts
+++ b/plugin/src/temporal/contracts.ts
@@ -137,6 +137,7 @@ export interface ChangeWorkflowState extends ChangeWorkflowInput {
     agreement?: ArtifactMetadata;
   };
   task_runs?: Record<string, TaskRunState>;
+  /** Same-project fast-follow lineage (optional) */
   fast_follow_of?: FastFollowOf;
   /**
    * Closure metadata set when the workflow records a terminal close. Stored

--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -745,6 +745,67 @@ describe("Change Tools", () => {
     });
   });
 
+  describe("adv_change_create — fast-follow parent_change_id", () => {
+    test("creates change with fast_follow_of when parent_change_id valid", async () => {
+      // Create a parent change first
+      const parentResult = await changeTools.adv_change_create.execute(
+        { summary: "Parent change" },
+        store,
+      );
+      const parentParsed = parseToolOutput(parentResult);
+
+      const result = await changeTools.adv_change_create.execute(
+        {
+          summary: "Child follow-up",
+          parent_change_id: parentParsed.changeId,
+        },
+        store,
+      );
+      const parsed = parseToolOutput(result);
+
+      expect(parsed.changeId).toBe("childFollowUp");
+      expect(parsed.fast_follow_of).toBeDefined();
+      expect(parsed.fast_follow_of.parent_change_id).toBe(parentParsed.changeId);
+      expect(parsed.fast_follow_of.linked_at).toBeDefined();
+
+      // Verify persisted
+      const changeResult = await store.changes.get(parsed.changeId);
+      expect(changeResult.success).toBe(true);
+      expect(changeResult.data?.fast_follow_of?.parent_change_id).toBe(
+        parentParsed.changeId,
+      );
+    });
+
+    test("rejects mutual target_path + parent_change_id", async () => {
+      const result = await changeTools.adv_change_create.execute(
+        {
+          summary: "Should fail",
+          target_path: "/some/path",
+          parent_change_id: "someParent",
+        },
+        store,
+      );
+      const parsed = parseToolOutput(result);
+
+      expect(parsed.error).toMatch(/mutually exclusive/i);
+    });
+
+    test("rejects invalid parent_change_id with validParentIds hint", async () => {
+      const result = await changeTools.adv_change_create.execute(
+        {
+          summary: "Should fail",
+          parent_change_id: "nonExistentParent",
+        },
+        store,
+      );
+      const parsed = parseToolOutput(result);
+
+      expect(parsed.error).toMatch(/Parent change not found/i);
+      expect(parsed.validParentIds).toBeDefined();
+      expect(Array.isArray(parsed.validParentIds)).toBe(true);
+    });
+  });
+
   describe("adv_change_create — cross-project", () => {
     test("creates change in target project with origin metadata", async () => {
       // Set up a target project directory

--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -150,6 +150,14 @@ describe("Change Tools", () => {
       expect(parsed.changes).toHaveLength(1);
       expect(parsed.changes[0].parent_change_id).toBe("parentChange");
     });
+
+    test("omits parent_change_id when fast_follow_of not set", async () => {
+      const result = await changeTools.adv_change_list.execute({}, store);
+      const parsed = parseToolOutput(result);
+
+      expect(parsed.changes).toHaveLength(1);
+      expect(parsed.changes[0].parent_change_id).toBeUndefined();
+    });
   });
 
   describe("adv_change_close", () => {

--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -805,7 +805,9 @@ describe("Change Tools", () => {
 
       expect(parsed.changeId).toBe("childFollowUp");
       expect(parsed.fast_follow_of).toBeDefined();
-      expect(parsed.fast_follow_of.parent_change_id).toBe(parentParsed.changeId);
+      expect(parsed.fast_follow_of.parent_change_id).toBe(
+        parentParsed.changeId,
+      );
       expect(parsed.fast_follow_of.linked_at).toBeDefined();
 
       // Verify persisted

--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -532,6 +532,38 @@ describe("Change Tools", () => {
       expect(parsed._crossProjectOrigin).toBeUndefined();
     });
 
+    test("surfaces _fastFollowOrigin when fast_follow_of set", async () => {
+      // Add fast_follow_of to the change
+      const changeResult = await store.changes.get("addFeature");
+      expect(changeResult.success).toBe(true);
+      changeResult.data!.fast_follow_of = {
+        parent_change_id: "parentChange",
+        linked_at: "2026-01-01T01:00:00Z",
+      };
+      await store.changes.save(changeResult.data!);
+
+      const result = await changeTools.adv_change_show.execute(
+        { changeId: "addFeature" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed._fastFollowOrigin).toBeDefined();
+      expect(parsed._fastFollowOrigin.note).toContain("Fast-follow");
+      expect(parsed._fastFollowOrigin.parent_change_id).toBe("parentChange");
+      expect(parsed._fastFollowOrigin.linked_at).toBe("2026-01-01T01:00:00Z");
+    });
+
+    test("omits _fastFollowOrigin when no fast_follow_of set", async () => {
+      const result = await changeTools.adv_change_show.execute(
+        { changeId: "addFeature" },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed._fastFollowOrigin).toBeUndefined();
+    });
+
     test("includes _reflection for archived changes", async () => {
       // Archive the change and add a reflection
       const changeResult = await store.changes.get("addFeature");

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -922,6 +922,22 @@ export const changeTools = {
         output._duplicateWarning = result.duplicateWarning;
       }
 
+      // If parent_change_id set, attach fast-follow lineage
+      if (parent_change_id) {
+        const changeResult = await store.changes.get(result.changeId);
+        if (changeResult.success && changeResult.data) {
+          const updatedChange = {
+            ...changeResult.data,
+            fast_follow_of: {
+              parent_change_id: parent_change_id,
+              linked_at: new Date().toISOString(),
+            },
+          };
+          await store.changes.save(updatedChange);
+          output.fast_follow_of = updatedChange.fast_follow_of;
+        }
+      }
+
       await appendClarifyNeededForCreatedChange(store, result.changeId, output);
 
       return wrapWithBanner(

--- a/plugin/src/tools/status.test.ts
+++ b/plugin/src/tools/status.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Status Tool Tests
+ *
+ * Test adv_status lineage and recommendation behavior.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { statusTools } from "./status";
+import {
+  createTestProject,
+  createTempDir,
+  cleanupTempDir,
+  parseToolOutput,
+} from "../__tests__/setup";
+import { createLegacyStore } from "../storage/store";
+import type { Store } from "../storage/store";
+
+describe("Status Tools", () => {
+  let tempDir: string;
+  let store: Store;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    await createTestProject(tempDir);
+    store = await createLegacyStore(tempDir);
+  });
+
+  afterEach(async () => {
+    store.close();
+    await cleanupTempDir(tempDir);
+  });
+
+  describe("adv_status", () => {
+    test("shows ↳ prefix for fast-follow changes in formatted output", async () => {
+      // Create parent and child changes
+      const { changeTools } = await import("./change");
+      const parentResult = await changeTools.adv_change_create.execute(
+        { summary: "Parent change" },
+        store,
+      );
+      const parentParsed = parseToolOutput(parentResult);
+
+      await changeTools.adv_change_create.execute(
+        {
+          summary: "Child follow-up",
+          parent_change_id: parentParsed.changeId,
+        },
+        store,
+      );
+
+      const result = await statusTools.adv_status.execute({}, store);
+      const parsed = parseToolOutput(result);
+
+      expect(parsed.formatted.activeSection).toContain("↳ childFollowUp");
+    });
+
+    test("recommendation includes parent reference for fast-follow", async () => {
+      const { changeTools } = await import("./change");
+      const parentResult = await changeTools.adv_change_create.execute(
+        { summary: "Parent change" },
+        store,
+      );
+      const parentParsed = parseToolOutput(parentResult);
+
+      await changeTools.adv_change_create.execute(
+        {
+          summary: "Child follow-up",
+          parent_change_id: parentParsed.changeId,
+        },
+        store,
+      );
+
+      const result = await statusTools.adv_status.execute({}, store);
+      const parsed = parseToolOutput(result);
+
+      const followRec = parsed.recommendations.find((r: string) =>
+        r.includes("fast-follow"),
+      );
+      expect(followRec).toBeDefined();
+      expect(followRec).toContain("childFollowUp");
+      expect(followRec).toContain(parentParsed.changeId);
+    });
+
+    test("recommendation annotates terminal parent", async () => {
+      const { changeTools } = await import("./change");
+      const parentResult = await changeTools.adv_change_create.execute(
+        { summary: "Parent change" },
+        store,
+      );
+      const parentParsed = parseToolOutput(parentResult);
+
+      // Move parent to a terminal state (closed)
+      await store.changes.close(parentParsed.changeId, {
+        reason: "not_planned",
+        approved_by_user: true,
+        approval_evidence: "User cancelled",
+        approved_at: new Date().toISOString(),
+      });
+
+      await changeTools.adv_change_create.execute(
+        {
+          summary: "Child follow-up",
+          parent_change_id: parentParsed.changeId,
+        },
+        store,
+      );
+
+      const result = await statusTools.adv_status.execute({}, store);
+      const parsed = parseToolOutput(result);
+
+      const followRec = parsed.recommendations.find((r: string) =>
+        r.includes("fast-follow"),
+      );
+      expect(followRec).toBeDefined();
+      // Terminal parent (archived or closed) should be annotated with its state
+      expect(followRec).toMatch(/\((archived|closed)\)/);
+    });
+  });
+});

--- a/plugin/src/types.test.ts
+++ b/plugin/src/types.test.ts
@@ -11,6 +11,7 @@ import {
   ChangeStatusSchema,
   ChangeClosureSchema,
   CrossProjectOriginSchema,
+  FastFollowOfSchema,
   GATE_DEFS,
   GateIdSchema,
   GATE_ORDER,
@@ -602,6 +603,55 @@ describe("ChangeSchema", () => {
       CrossProjectOriginSchema.parse({
         source_project: "test",
         linked_at: "2026-01-01T01:00:00Z",
+      }),
+    ).toThrow();
+  });
+
+  test("parses change with fast_follow_of", () => {
+    const fastFollowChange = {
+      id: "addWebhookHandler",
+      title: "Add webhook handler",
+      status: "draft",
+      created_at: "2026-01-01T00:00:00Z",
+      tasks: [],
+      deltas: {},
+      fast_follow_of: {
+        parent_change_id: "addApiEndpoint",
+        linked_at: "2026-01-01T01:00:00Z",
+      },
+    };
+
+    const result = ChangeSchema.parse(fastFollowChange);
+    expect(result.fast_follow_of).toBeDefined();
+    expect(result.fast_follow_of?.parent_change_id).toBe("addApiEndpoint");
+    expect(result.fast_follow_of?.linked_at).toBe("2026-01-01T01:00:00Z");
+  });
+
+  test("accepts change without fast_follow_of (backwards compatible)", () => {
+    const localChange = {
+      id: "testChange",
+      title: "Test Change",
+      status: "draft",
+      created_at: "2026-01-01T00:00:00Z",
+      tasks: [],
+      deltas: {},
+    };
+    const result = ChangeSchema.parse(localChange);
+    expect(result.fast_follow_of).toBeUndefined();
+  });
+
+  test("fast_follow_of parent_change_id is required", () => {
+    expect(() =>
+      FastFollowOfSchema.parse({
+        linked_at: "2026-01-01T01:00:00Z",
+      }),
+    ).toThrow();
+  });
+
+  test("fast_follow_of linked_at is required", () => {
+    expect(() =>
+      FastFollowOfSchema.parse({
+        parent_change_id: "addApiEndpoint",
       }),
     ).toThrow();
   });

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1006,14 +1006,19 @@ export const CrossProjectOriginSchema = z.object({
 
 export type CrossProjectOrigin = z.infer<typeof CrossProjectOriginSchema>;
 
+// =============================================================================
+// Fast Follow (Same-Project Follow-up Lineage)
+// =============================================================================
+
 /**
- * Same-project lineage metadata for fast-follow changes.
- * Set when a change is split from a parent change in the same project.
+ * Provenance metadata for changes created as a fast-follow within the same
+ * project. Set when a child change is created with `parent_change_id` to
+ * establish same-project lineage.
  */
 export const FastFollowOfSchema = z.object({
-  /** Parent change ID that this fast-follow was split from */
+  /** Change ID of the parent change in the current project */
   parent_change_id: z.string(),
-  /** ISO8601 timestamp when the same-project link was established */
+  /** ISO8601 timestamp when the fast-follow link was established */
   linked_at: z.string(),
 });
 
@@ -1062,9 +1067,9 @@ export const ChangeSchema = z
      */
     cross_project_origin: CrossProjectOriginSchema.optional(),
     /**
-     * Same-project fast-follow provenance — set when this change was split
-     * from another change in the same project. Presence signals lineage
-     * validation and same-project parent surfacing.
+     * Same-project fast-follow lineage — set when this change was created
+     * as a follow-up to another change within the same project. Presence
+     * signals to /adv-discover that lineage validation is required.
      */
     fast_follow_of: FastFollowOfSchema.optional(),
     /**

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1287,7 +1287,9 @@ export interface ChangeListResponse {
     status: ChangeStatus;
     taskCount: number;
     completedTasks: number;
+    /** Same-project fast-follow lineage (optional) */
     fast_follow_of?: FastFollowOf;
+    /** Convenience top-level annotation when fast_follow_of is set (added by adv_change_list) */
     parent_change_id?: string;
   }>;
 }

--- a/plugin/src/utils/tool-formatters.test.ts
+++ b/plugin/src/utils/tool-formatters.test.ts
@@ -127,6 +127,26 @@ describe("tool-formatters", () => {
       expect(result.activeSection).toContain("🔥");
       expect(result.activeSection).toContain("testChange");
     });
+
+    it("prepends ↳ to active changes with parent_change_id", () => {
+      const result = formatStatusOutput({
+        specCount: 1,
+        requirementCount: 5,
+        activeChanges: [
+          {
+            id: "childChange",
+            title: "Child Change",
+            minutesSinceActivity: 2,
+            recency: "hot",
+            parent_change_id: "parentChange",
+          },
+        ],
+        archivedCount: 0,
+        recommendations: [],
+        temporalAlive: true,
+      });
+      expect(result.activeSection).toContain("↳ childChange");
+    });
   });
 
   describe("formatValidationOutput", () => {


### PR DESCRIPTION
## Summary

Archives `improveadvscopeandfollowupinte` (14/14 tasks done, all 7 ADV gates ✓). ADV-side archive bookkeeping is already committed; this PR brings the in-repo deliverables onto trunk.

Conflicts encountered during local fast-forward (9 files in `plugin/src/types.ts`, `tools/change.ts`, `tools/status.ts`, `storage/*`, `utils/tool-formatters.ts`, `adv-skill-backed-commands-assets.test.ts`) caused by trunk advancing with unrelated archives since this branch diverged. Resolving via PR workflow for reviewable diff context.

## Delivered

**Same-project fast-follow lineage:**
- `FastFollowOfSchema` + optional `fast_follow_of` field on `ChangeSchema` (`plugin/src/types.ts`)
- `adv_change_create` accepts `parent_change_id` arg with mutual exclusion vs `target_path` and parent-existence validation
- `adv_change_show` surfaces `_fastFollowOrigin` block parallel to `_crossProjectOrigin`
- `adv_change_list` annotates entries with `parent_change_id` when set
- `adv_status` shows `↳` lineage prefix and groups parents/children in recommendations

**Scope-discovery protocol (mid-execution scope handling):**
- New canonical doc `docs/scope-discovery-protocol.md` — Tier A inline prompt with `reenter`, `split`, `keep`, `cancel` options
- Cross-linked from `/adv-apply`, `/adv-review`, `/adv-harden` command files

**Large-Scope Validity guidance:**
- New subsection in `ADV_INSTRUCTIONS.md` forbidding size-based split-suggestions after prep-gate userApproval
- Routes size-triggered concerns through cost-governance Phase 1.5 only

## Verification

- 2027 tests pass (103 files) on acceptance run
- `pnpm run check` clean (typecheck + lint + format)
- `pnpm run build` clean
- `adv_change_validate strict: true` passes (2 advisory warnings: NO_DELTAS expected for additive feature, PROPOSAL_TASK_DRIFT on Problem section is metadata-only)
- Review verdict: APPROVED after remediation
- User accepted via Tier A inline approval

## Investment

14 tasks · 0 retries · 0 doom-loops · all gates clean. Tier classified `hardstop` purely on elapsed wall-clock (~24h calendar time, mostly idle between sessions) — informational only per cost-governance v1.

## Conflicts to resolve in PR

| File | Reason |
|------|--------|
| \`plugin/src/types.ts\` | Concurrent schema additions near \`ChangeSchema\` |
| \`plugin/src/tools/change.ts\` | Concurrent edits to \`adv_change_create/show/list\` (likely vs \`addChangeCloseOperations\`) |
| \`plugin/src/tools/change.test.ts\` | Test additions in overlapping regions |
| \`plugin/src/tools/status.ts\` | Concurrent \`enrichRecentChangeStatus\` edits |
| \`plugin/src/storage/store-types.ts\` | ChangeListResponse type additions |
| \`plugin/src/storage/store-disk.ts\` | List/save path edits |
| \`plugin/src/storage/store-temporal.ts\` | Same |
| \`plugin/src/utils/tool-formatters.ts\` | Concurrent formatter updates |
| \`plugin/src/adv-skill-backed-commands-assets.test.ts\` | Asset/manifest registration |

ADV change ID: \`improveadvscopeandfollowupinte\`
Archive path: \`~/.local/share/opencode/plugins/advance/{project-id}/archive/2026-04-27-improveadvscopeandfollowupinte/\`