### PR TITLE
chore(sonar): suppress remaining S7739 BDD then-field false-positives

### DIFF
--- a/plugin/src/__tests__/setup.ts
+++ b/plugin/src/__tests__/setup.ts
@@ -109,14 +109,14 @@ export const SAMPLE_SPEC = {
           title: "Basic scenario",
           given: ["the system is initialized", "a user exists"],
           when: "the user performs an action",
-          then: ["the action succeeds", "the result is recorded"],
+          then: ["the action succeeds", "the result is recorded"], // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
         },
         {
           id: "rq-test0001.2",
           title: "Error scenario",
           given: ["the system is initialized", "no user exists"],
           when: "an anonymous action is attempted",
-          then: ["the action fails", "an error is returned"],
+          then: ["the action fails", "an error is returned"], // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
         },
       ],
     },

--- a/plugin/src/types/specs.ts
+++ b/plugin/src/types/specs.ts
@@ -36,7 +36,7 @@ export const ScenarioSchema = z
     title: z.string(),
     given: z.array(z.string()),
     when: z.string(),
-    then: z.array(z.string()),
+    then: z.array(z.string()), // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
   })
   .passthrough(); // Allow extra fields for forward/backward compatibility
 

--- a/plugin/src/validator/clarify-readiness.e2e.test.ts
+++ b/plugin/src/validator/clarify-readiness.e2e.test.ts
@@ -150,6 +150,7 @@ mechanisms introduced.
                 title: "Rejects over-limit requests",
                 given: ["rate limiter is configured at 100 req/min"],
                 when: "client sends 101st request within 1 minute",
+                // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
                 then: [
                   "response status is 429",
                   "Retry-After header is present",
@@ -160,7 +161,7 @@ mechanisms introduced.
                 title: "Allows under-limit requests",
                 given: ["rate limiter is configured at 100 req/min"],
                 when: "client sends 50th request within 1 minute",
-                then: ["response status is 200"],
+                then: ["response status is 200"], // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
               },
             ],
           },

--- a/plugin/src/validator/clarify-readiness.test.ts
+++ b/plugin/src/validator/clarify-readiness.test.ts
@@ -160,7 +160,7 @@ describe("checkMissingScenarios", () => {
                   id: "rq-test2.1",
                   given: "user sends 101st request",
                   when: "rate limit is 100/min",
-                  then: "return 429",
+                  then: "return 429", // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
                 },
               ],
             },
@@ -349,7 +349,7 @@ describe("runClarifyReadinessChecks", () => {
                   id: "rq-clean.1",
                   given: "user sends 101st request",
                   when: "limit is 100/min",
-                  then: "return 429",
+                  then: "return 429", // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
                 },
               ],
             },

--- a/scripts/migrate-openspec.ts
+++ b/scripts/migrate-openspec.ts
@@ -225,7 +225,7 @@ function parseScenario(content: string): ParsedScenario | null {
     title: "", // Will be set by caller
     given,
     when: when || "the action is performed",
-    then: then.length > 0 ? then : ["the expected outcome occurs"],
+    then: then.length > 0 ? then : ["the expected outcome occurs"], // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
   };
 }
 
@@ -400,7 +400,7 @@ function convertToADV(parsed: ParsedSpec): ADVSpec {
         title: s.title,
         given: s.given,
         when: s.when,
-        then: s.then,
+        then: s.then, // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
       })),
     };
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,26 +13,14 @@ sonar.exclusions=**/dist/**,**/node_modules/**,**/coverage/**
 # Rule exclusions
 # ----------------------------------------------------------------------------
 #
-# typescript:S7739 ("Do not add `then` to an object") fires on legitimate BDD
-# Given/When/Then scenario fields. ADV's spec format models scenarios as
-# `{ given, when, then }` per the canonical Gherkin vocabulary; the resulting
-# objects are never used as thenables. Excluded at file scope rather than
-# scattered NOSONAR comments to keep the BDD vocabulary visible and uncluttered.
+# Per-rule suppressions are inline via `// NOSONAR(typescript:Sxxxx): reason`
+# comments rather than file-level exclusions here. SonarCloud's Automatic
+# Analysis (used by this repo's GitHub integration) does NOT honor
+# `sonar.issue.ignore.multicriteria` from this file. Switching to a
+# CI-driven `sonar-scanner` action is the proper way to apply file-scoped
+# exclusions; until then NOSONAR comments are the working mechanism.
 #
-sonar.issue.ignore.multicriteria=bddthen1,bddthen2,bddthen3,bddthen4,bddthen5
-
-sonar.issue.ignore.multicriteria.bddthen1.ruleKey=typescript:S7739
-sonar.issue.ignore.multicriteria.bddthen1.resourceKey=plugin/src/types/specs.ts
-
-sonar.issue.ignore.multicriteria.bddthen2.ruleKey=typescript:S7739
-sonar.issue.ignore.multicriteria.bddthen2.resourceKey=plugin/src/__tests__/setup.ts
-
-sonar.issue.ignore.multicriteria.bddthen3.ruleKey=typescript:S7739
-sonar.issue.ignore.multicriteria.bddthen3.resourceKey=plugin/src/validator/clarify-readiness*.test.ts
-
-sonar.issue.ignore.multicriteria.bddthen4.ruleKey=typescript:S7739
-sonar.issue.ignore.multicriteria.bddthen4.resourceKey=scripts/migrate-openspec.ts
-
-# Reserved slot for future BDD scenario test fixtures.
-sonar.issue.ignore.multicriteria.bddthen5.ruleKey=typescript:S7739
-sonar.issue.ignore.multicriteria.bddthen5.resourceKey=plugin/src/**/*scenario*.ts
+# Currently suppressed via inline NOSONAR:
+#   - typescript:S7739 ("Do not add `then` to an object") on BDD Given/When/Then
+#     scenario fields. The `then` field is the canonical Gherkin scenario
+#     vocabulary, never used as a thenable.


### PR DESCRIPTION
## Summary

- Replaces the non-functional `sonar.issue.ignore.multicriteria` block in `sonar-project.properties` with inline `// NOSONAR(typescript:S7739)` comments at the 9 BDD-scenario `then:` sites
- Reason: SonarCloud's Automatic Analysis (used by this repo) ignores file-level multi-criteria exclusions; only inline NOSONAR is honored
- Net 19 added / 30 removed; touches 5 source files + the properties file

## Why

After PR #75 + the trunk sonar-cleanup commit, project bugs dropped from **32 → 9** and vulnerabilities from **14 → 0**. The 9 remaining bugs are all `typescript:S7739` ("Do not add `then` to an object") on legitimate BDD Given/When/Then scenario fields. The trunk attempt to suppress them via `sonar-project.properties` didn't work because Automatic Analysis ignores that file's rule-exclusion sections.

## Sites covered (9 total)

| File | Count | Context |
|---|---|---|
| `plugin/src/types/specs.ts` | 1 | `ScenarioSchema` Zod definition |
| `plugin/src/__tests__/setup.ts` | 2 | sample scenario fixtures |
| `plugin/src/validator/clarify-readiness.test.ts` | 2 | clarify scenarios |
| `plugin/src/validator/clarify-readiness.e2e.test.ts` | 2 | e2e scenarios |
| `scripts/migrate-openspec.ts` | 2 | OpenSpec migration scenarios |

## Verification

\`\`\`
pnpm run typecheck   # clean
pnpm run lint        # clean
pnpm run format:check # clean
pnpm exec vitest run src/validator/clarify-readiness.test.ts \\
                     src/validator/clarify-readiness.e2e.test.ts \\
                     src/__tests__/setup.ts
# 37/37 pass
\`\`\`

After the SonarCloud Automatic Analysis runs on this branch, project `bugs` should be **0** and the Quality Gate should pass.

## Future improvement (out of scope)

Add a CI workflow using \`sonarsource/sonarcloud-github-action\` so \`sonar-project.properties\` rule-exclusion sections are honored. That would let us drop NOSONAR comments in favor of file-level config. Tracked via the documentation in the updated properties file; can be a follow-up issue if desired.