### PR TITLE
chore(sonar): fix line-scoped NOSONAR for clarify-readiness e2e BDD scenario

### DIFF
--- a/plugin/src/validator/clarify-readiness.e2e.test.ts
+++ b/plugin/src/validator/clarify-readiness.e2e.test.ts
@@ -150,11 +150,8 @@ mechanisms introduced.
                 title: "Rejects over-limit requests",
                 given: ["rate limiter is configured at 100 req/min"],
                 when: "client sends 101st request within 1 minute",
-                // NOSONAR(typescript:S7739): BDD scenario field, not a thenable
-                then: [
-                  "response status is 429",
-                  "Retry-After header is present",
-                ],
+                then /* NOSONAR(typescript:S7739): BDD scenario field, not a thenable */:
+                  ["response status is 429", "Retry-After header is present"],
               },
               {
                 id: "rq-rate0001.2",


### PR DESCRIPTION
## Summary

Final fix to land the last `typescript:S7739` BDD `then`-field bug. After PR #76, project bugs dropped 9 → 1. The 1 remaining was at `clarify-readiness.e2e.test.ts:154` where the NOSONAR comment was placed on the line BEFORE the multi-line `then: [...]` array; SonarCloud's NOSONAR is line-scoped.

Switches to a block-comment between property name and colon: `then /* NOSONAR(...) */: [...]`. Prettier preserves it on the same line as `then`, so suppression stays attached to the line Sonar flags.

## Verified

\`\`\`
pnpm run typecheck       # clean
pnpm run lint            # clean
pnpm run format:check    # clean
pnpm exec vitest run src/validator/clarify-readiness.e2e.test.ts  # 3/3 pass
\`\`\`

## Expected Sonar state after merge

- bugs: **0** (was 32 at start of cleanup)
- vulnerabilities: **0** (held; was 14)
- security_rating: **A** (was D)
- Tier A+B+C scope complete