### PR TITLE
feat(ci): bump runtime to Node 24 LTS + fix auto-release branch protection

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,12 +88,12 @@ jobs:
           echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
           echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
 
-      - name: Generate CHANGELOG
+      - name: Generate release notes
+        id: notes
         if: steps.bump.outputs.skip != 'true'
         run: |
+          set -euo pipefail
           LAST_TAG="${{ steps.last_tag.outputs.tag }}"
-          NEW_TAG="${{ steps.bump.outputs.new_tag }}"
-          TODAY=$(date +%Y-%m-%d)
 
           FEAT_ENTRIES=""
           FIX_ENTRIES=""
@@ -106,7 +106,6 @@ jobs:
           ARCHIVE_FILES=$(git diff --name-only "${LAST_TAG}..HEAD" -- '.adv/archive/*/executive-summary.md' 2>/dev/null || true)
           if [ -n "$ARCHIVE_FILES" ]; then
             while IFS= read -r archive_file; do
-              # Extract change title from bundle directory name: <timestamp>-<changeId>
               BUNDLE_NAME=$(dirname "$archive_file" | xargs basename)
               CHANGE_TITLE=$(echo "$BUNDLE_NAME" | sed -E 's/^[0-9]+-//')
               CONTENT=$(git show "HEAD:$archive_file" 2>/dev/null | head -20 || true)
@@ -138,46 +137,46 @@ jobs:
             fi
           done <<< "$COMMITS"
 
-          ENTRY="## ${TODAY} (${NEW_TAG})
-          "
-          [ -n "$FEAT_ENTRIES" ] && ENTRY="${ENTRY}
+          BODY=""
+          [ -n "$FEAT_ENTRIES" ] && BODY="${BODY}
           ### Added
-          ${FEAT_ENTRIES}"
-          [ -n "$FIX_ENTRIES" ] && ENTRY="${ENTRY}
+          ${FEAT_ENTRIES}
+          "
+          [ -n "$FIX_ENTRIES" ] && BODY="${BODY}
           ### Fixed
-          ${FIX_ENTRIES}"
-          [ -n "$OTHER_ENTRIES" ] && ENTRY="${ENTRY}
+          ${FIX_ENTRIES}
+          "
+          [ -n "$OTHER_ENTRIES" ] && BODY="${BODY}
           ### Changed
-          ${OTHER_ENTRIES}"
-          [ -n "$HIGHLIGHTS" ] && ENTRY="${ENTRY}
-
+          ${OTHER_ENTRIES}
+          "
+          [ -n "$HIGHLIGHTS" ] && BODY="${BODY}
           ### Change Highlights
-          ${HIGHLIGHTS}"
+          ${HIGHLIGHTS}
+          "
 
-          if [ -f CHANGELOG.md ]; then
-            EXISTING=$(cat CHANGELOG.md)
-            printf '%s\n\n%s\n' "$ENTRY" "$EXISTING" > CHANGELOG.md
-          else
-            printf '%s\n' "$ENTRY" > CHANGELOG.md
-          fi
+          {
+            echo "body<<NOTES_EOF"
+            echo "$BODY"
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Commit CHANGELOG and push tag
+      - name: Push tag
         if: steps.bump.outputs.skip != 'true'
         run: |
           NEW_TAG="${{ steps.bump.outputs.new_tag }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "docs: update changelog for ${NEW_TAG}"
           git tag -a "$NEW_TAG" -m "Release ${NEW_TAG}"
-          git push origin HEAD:"${{ github.event.workflow_run.head_branch }}"
+          # Tags only — CHANGELOG.md updates land via normal PRs (avoids
+          # bypassing branch protection's required status checks on trunk).
           git push origin "$NEW_TAG"
 
       - name: Setup Node.js
         if: steps.bump.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Install pnpm
         if: steps.bump.outputs.skip != 'true'
@@ -258,6 +257,7 @@ jobs:
             dist/install.sh
             dist/SHA256SUMS.txt
           generate_release_notes: true
+          body: ${{ steps.notes.outputs.body }}
 
       - name: Summary
         if: steps.bump.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -25,7 +25,7 @@ jobs:
           version: 11
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -78,9 +78,9 @@ jobs:
           version: 11
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'pnpm'
           cache-dependency-path: plugin/pnpm-lock.yaml
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -61,7 +61,7 @@
     "typescript": "^5.0.0 || ^6.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Two coupled changes per adoptV0SecurityGates ADV change.

## Runtime: Node 22 -> 24
- engines.node bumped (>= 24)
- ci.yml matrix [24.x], setup-node@v6, checkout@v6
- auto-release.yml setup-node@v6, checkout@v6

Node 22 is Maintenance LTS (EOL Apr 2027); Node 24 is Active LTS (EOL Apr 2028). Node 25 is never-LTS (EOL Jun 1 2026). All key deps verified Node 24 compatible. Local: 3032 tests pass on Node 24.

## Auto-release fix
Branch protection on trunk (added 2026-05-23) blocks github-actions[bot] CHANGELOG.md push. Fix: emit release notes via softprops body instead of committing the file. Tags don't flow through branch protection.

Pilot promotion to required check will be a follow-up gh api PATCH once this CI cycle confirms green.