### PR TITLE
fix: sync adv overlay and add ship to manifest

### DIFF
--- a/.opencode/overlays/adv.overlay.md
+++ b/.opencode/overlays/adv.overlay.md
@@ -1,12 +1,19 @@
 <!-- ADV_SYNC:START adv -->
+
 ## ADV Overlay
 
 - NEVER invoke `/adv-*` from inside ADV; execute ADV workflows inline with tools instead of slash-command dispatch
 - Only the top-level orchestrator may spawn sub-agents
 - Spawned workers must complete inline and must not spawn additional sub-agents; nesting depth is hard-limited to `1`
-- Voice: user-facing prose terse and direct; keep JSON/code/commits/safety text normal — see `docs/command-voice-standard.md` § Voice Contract
-- **Due diligence first:** Unknown architecture/platform/capability questions require source-appropriate evidence before answering, recommending, or deciding. Evidence may come from any appropriate mix: `lgrep`/`read` on local code, repo history / repo examples, GitHub examples, official docs, or web research — chosen to fit the question. Use `explore` + `adv-researcher` in parallel when the question spans multiple dimensions; inline evidence gathering is fine when a single source is clearly sufficient. **quick-answer requests change brevity only**, not the evidence bar. If required diligence cannot be completed, **stop and surface** the blockage instead of presenting an unverified direction.
-- Canonical TDD path is documented here only, not enforced here: use editing tools for test-file changes and `adv_run_test` for red/green; primary enforcement lives in plugin/runtime + spec.
-- Tool names are exact schema identifiers. Never normalize MCP names: use `searchcode_code_search`, not `code_search`; use `context7_resolve-library-id`, not `context7_resolve_library_id`.
 - Structural correctness (P33): prefer types/schemas/parsers/state machines/validators/tests over heuristic inference; heuristics may assist discovery/ranking/triage, never own correctness, security, persistence, gate completion, or spec compliance.
+
+## Voice Contract
+
+User-facing prose: terse, concrete, low-fluff. Prefer bullets/tables/fragments. Keep technical terms and quoted errors exact. See `docs/command-voice-standard.md` § Voice Contract.
+Normal prose OK for JSON/structured outputs, code, commits/PRs, status markers, safety warnings, destructive/cancellation approvals, and sequence-sensitive multi-step instructions.
+
+## Scope Validity
+
+- × NEVER suggest splitting a change based on size, complexity, or task count alone. Trust the prep gate. Real concerns surface as judgment calls, not split-suggestions. See `ADV_INSTRUCTIONS.md § Large-Scope Validity`.
+
 <!-- ADV_SYNC:END adv -->


### PR DESCRIPTION
## Changes
- **adv.overlay.md**: Removed 4 lines (Voice one-liner, Due Diligence, TDD note, MCP tool-name) already covered by richer sections in adv.md body. Overlay now matches adv.md sync block exactly — `deploy-local.sh --fix` is a clean no-op diff.
- **manifest.ts**: Added `ship` command entry (phase: utility, no gate) so the manifest covers all command files.

## Audit Context
Post-v1.0.0 alignment audit found overlay drift between adv.overlay.md and adv.md sync block. No functional impact (deploy script handles the merge), but the drift was a maintenance hazard. Build/plan overlays left per user preference.

## Verification
- `pnpm run typecheck` clean
- Overlay diff confirmed MATCH after change
- 3343 tests pass on trunk