### PR TITLE
chore(deps): adopt org Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>Sharper-Flow/sharperflow-security-gates"],
+  "automerge": false,
   "packageRules": [
     {
       "description": "Group pnpm subpackage (plugin/, acp-mux/) updates",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>Sharper-Flow/sharperflow-security-gates"],
+  "packageRules": [
+    {
+      "description": "Group pnpm subpackage (plugin/, acp-mux/) updates",
+      "matchManagers": ["npm"],
+      "groupName": "pnpm packages"
+    }
+  ]
+}


### PR DESCRIPTION
Part of adoptRenovateOrgWide. Adds `renovate.json` extending the org preset (`github>Sharper-Flow/sharperflow-security-gates`). Takes effect once the Renovate App is installed + the preset is on security-gates' default branch.