### PR TITLE
fix: add missing adv_change_status_repair title and CLI surface matrix row

### DIFF
--- a/docs/cli-surface-matrix.md
+++ b/docs/cli-surface-matrix.md
@@ -84,6 +84,7 @@
 | `adv_change_bulk_close` | `no-cli-dangerous` | Change mutation |
 | `adv_change_archive` | `no-cli-dangerous` | Archive mutation + spec delta |
 | `adv_archive_repair` | `no-cli-dangerous` | Archive release repair mutation |
+| `adv_change_status_repair` | `no-cli-dangerous` | Change status repair mutation |
 | `adv_change_update_issues` | `no-cli-dangerous` | Issue linkage mutation |
 | `adv_change_reenter` | `no-cli-dangerous` | Change state mutation |
 | `adv_task_add` | `no-cli-dangerous` | Task mutation |

--- a/plugin/src/utils/tool-title.ts
+++ b/plugin/src/utils/tool-title.ts
@@ -84,6 +84,8 @@ const TITLE_BUILDERS: Record<string, TitleBuilder> = {
     write(`Archive change${suffix(args, "changeId")}`),
   adv_archive_repair: (args) =>
     operator(`Repair archive${suffix(args, "changeId", "action")}`),
+  adv_change_status_repair: (args) =>
+    operator(`Repair change status${suffix(args, "changeId")}`),
   adv_change_update_issues: (args) =>
     write(`Update change issues${suffix(args, "changeId")}`),
   adv_change_reenter: (args) =>


### PR DESCRIPTION
Two tests fail on trunk:
- `tool-registry.test.ts:104` — `hasExplicitAdvToolTitle` returns false for `adv_change_status_repair`
- `cli-surface-matrix.test.ts:39` — missing matrix row

Added TITLE_BUILDERS entry and matrix row.