### PR TITLE
fix(agents): add adv_archive_repair and adv_change_status_repair to tool allowlists

### DIFF
--- a/.opencode/agents/adv-atc.md
+++ b/.opencode/agents/adv-atc.md
@@ -51,6 +51,8 @@ tools:
   adv_change_archive: true
   adv_change_update_issues: true
   adv_change_reenter: true
+  adv_archive_repair: true
+  adv_change_status_repair: true
   # Tasks
   adv_task_list: true
   adv_task_show: true

--- a/.opencode/agents/adv.md
+++ b/.opencode/agents/adv.md
@@ -52,6 +52,8 @@ tools:
   adv_change_archive: true
   adv_change_update_issues: true
   adv_change_reenter: true
+  adv_archive_repair: true
+  adv_change_status_repair: true
   # Tasks
   adv_task_list: true
   adv_task_show: true

--- a/plugin/src/deploy-local.test.ts
+++ b/plugin/src/deploy-local.test.ts
@@ -801,6 +801,8 @@ describe("deploy-local.sh", () => {
 
     test("canonical ADV prompt stays under the safe compression ceiling", () => {
       const lines = advAgent.split(/\r?\n/).length;
+      // Ceiling raised from 363 → 365 after adding adv_archive_repair and
+      // adv_change_status_repair to adv.md and adv-atc.md allowlists.
       // Ceiling raised from 362 → 363 after adding the release-stage
       // adv-reviewer phase mapping needed for typed worker packets.
       // Ceiling raised from 361 → 362 after adding explicit typed worker
@@ -809,7 +811,7 @@ describe("deploy-local.sh", () => {
       // refactor exposed `adv_worktree_resume` and we added it to the
       // canonical allowlist to clear deploy-local tool-drift checks.
       // Re-ratchet here once the prompt has been audited for excess.
-      expect(lines).toBeLessThanOrEqual(363);
+      expect(lines).toBeLessThanOrEqual(365);
     });
 
     test("canonical ADV prompt keeps safety-critical markers", () => {


### PR DESCRIPTION
Two tools registered in tool-registry but missing from `adv.md` and `adv-atc.md` allowlists. Deploy script `--check` flags them as invisible to the agent.

```check_tool_drift
adv_archive_repair
adv_change_status_repair
```