### PR TITLE
chore: remove todowrite from agent frontmatters and apply workflow

### DIFF
--- a/.opencode/agents/adv-atc.md
+++ b/.opencode/agents/adv-atc.md
@@ -16,7 +16,7 @@ tools:
   morph_edit: true
   task: true
   # question: false — ATC never prompts inline; defers all HITL to GitHub
-  todowrite: true
+
   # Local code intelligence
   lgrep_search_semantic: true
   lgrep_index_semantic: true

--- a/.opencode/agents/adv-designer.md
+++ b/.opencode/agents/adv-designer.md
@@ -11,7 +11,7 @@ tools:
   patch: true
   morph_edit: true
   bash: true
-  todowrite: true
+
   question: true
   skill: true
   glob: true

--- a/.opencode/agents/adv-engineer.md
+++ b/.opencode/agents/adv-engineer.md
@@ -11,7 +11,7 @@ tools:
   patch: true
   morph_edit: true
   bash: true
-  todowrite: true
+
   question: true
   glob: true
   grep: true

--- a/.opencode/agents/adv-researcher.md
+++ b/.opencode/agents/adv-researcher.md
@@ -43,7 +43,7 @@ tools:
   bash: false
   morph_edit: false
   task: false
-  todowrite: false
+
 ---
 
 You are a specialized architectural research agent for the ADV (Advance) spec-driven development system.

--- a/.opencode/agents/adv-reviewer.md
+++ b/.opencode/agents/adv-reviewer.md
@@ -11,7 +11,7 @@ tools:
   patch: true
   morph_edit: true
   bash: true
-  todowrite: true
+
   question: true
   skill: true
   glob: true

--- a/.opencode/agents/adv-tron.md
+++ b/.opencode/agents/adv-tron.md
@@ -34,7 +34,7 @@ tools:
   bash: false
   morph_edit: false
   task: false
-  todowrite: false
+
   # Disabled - no ADV orchestration mutations beyond own optimized report submit
   adv_change_create: false
   adv_task_add: false

--- a/.opencode/agents/adv.md
+++ b/.opencode/agents/adv.md
@@ -16,7 +16,7 @@ tools:
   morph_edit: true
   task: true
   question: true
-  todowrite: true
+
   # Local code intelligence
   lgrep_search_semantic: true
   lgrep_index_semantic: true

--- a/.opencode/agents/build.md
+++ b/.opencode/agents/build.md
@@ -12,7 +12,7 @@ tools:
   morph_edit: true
   bash: true
   task: true
-  todowrite: true
+
   question: true
   glob: true
   grep: true
@@ -130,7 +130,7 @@ Once scope is locked, work in short cycles:
 4. **Apply** — Implement the fix. Write code, edit files — whatever the scope requires.
 5. **Verify** — Run relevant checks. Fix anything that breaks.
 
-Repeat until verification passes and scope is complete. Non-ADV multi-step work: use `todowrite` + tasks.
+Repeat until verification passes and scope is complete.
 
 ## Prune-First Heuristic
 

--- a/.opencode/agents/plan.md
+++ b/.opencode/agents/plan.md
@@ -15,7 +15,7 @@ tools:
   glob: true
   grep: true
   task: true
-  todowrite: true
+
   question: true
   # ADV tools for proposal creation and gate completion
   adv_change_list: true

--- a/.opencode/command/adv-apply.md
+++ b/.opencode/command/adv-apply.md
@@ -548,8 +548,6 @@ The Designer Apply Context Packet uses the same identity anchors as the Apply Co
 
 **3a. Start:** Refresh context (MANDATORY) → `adv_task_update status: "in_progress"` fires `taskAssignedSignal`. On resume, query change workflow state and continue from the active task without adding a user pause.
 
-**3a.1. Seed TodoWrite:** Call `todowrite` with the `_todoProjection.rows` from the most recent `adv_task_ready` or `adv_change_show include.readyTasks:true` response. Map each row to a todo entry: `{ content: row.content, status: row.status }`. This gives the user a live at-a-glance view of the task graph. Copy `content` values exactly — do not invent prose descriptions.
-
 **3a.5. Route:** Evaluate delegation routing (above). If delegated and verified → skip to 3d.
 
 **3a.6. Clean Baseline Capture:** Verify `git status --porcelain` is clean and capture `baselineHeadSha = git rev-parse HEAD` and `baselineBranch = git branch --show-current`. If dirty → stop and remediate before Red Phase.
@@ -580,8 +578,6 @@ The Designer Apply Context Packet uses the same identity anchors as the Apply Co
 **3c.55. Post-delegation P23 diff-scan:** If task was delegated to a sub-agent, diff the sub-agent's touched files against the pre-delegation baseline. For each touched file, check same-pattern local subsystem for identical defect/quality patterns (P23 campsite-rule scan). If same-pattern issues found and fix is small/safe/local → apply inline. If fix would expand scope → document in `follow_ups`, do NOT auto-fix. Skip this step for inline tasks.
 
 **3d. Complete:** assert `adv_task_checkpoint` returned `checkpointRecorded:true`; do not call `adv_task_update status: "done"` in normal apply flow. Show evidence from the checkpoint result and continue.
-
-**3d.1. Refresh TodoWrite:** Call `adv_task_ready` → use the returned `_todoProjection.rows` to update `todowrite` with the new ready queue. Mark the just-completed task as `completed`, keep remaining rows as `pending`/`in_progress`.
 
 **3e. Loop:** `adv_task_ready` → if ready tasks remain, **GOTO 3a**. REPEAT until the ready queue is empty.
 


### PR DESCRIPTION
Remove explicit `todowrite` tool declarations from all agent frontmatters so the default behavior applies — agents decide whether to use it.

Remove forced Seed TodoWrite (3a.1) and Refresh TodoWrite (3d.1) steps from adv-apply command workflow. ADV tasks (`adv_task_ready`/`adv_task_list`) remain the sole structured task-tracking surface.

**Changes:**
- Removed `todowrite: true/false` from 10 agent frontmatters
- Removed `todowrite` seed/refresh steps from adv-apply.md
- Removed `todowrite` prose reference from build.md