### PR TITLE
fix(archive): add squash-merge PR fallback for release reachability

### DIFF
--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -362,6 +362,190 @@ describe("git-finalize helpers", () => {
     });
   });
 
+  it("direct route + squash-merged PR falls back to pr_merged when ancestry fails", () => {
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "direct", repo: "Sharper-Flow/Advance" },
+        prNumber: 159,
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch")
+            return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "ls-remote")
+            return {
+              status: 0,
+              stdout: "abc123\trefs/heads/trunk\n",
+              stderr: "",
+            };
+          if (args[0] === "log")
+            return {
+              status: 0,
+              stdout: "def456 squash orphan commit\n",
+              stderr: "",
+            };
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+        runGh: () => ({
+          status: 0,
+          stdout: JSON.stringify({
+            state: "MERGED",
+            mergedAt: "2026-06-09T00:00:00Z",
+            mergeCommit: { oid: "squash-merge-sha" },
+            autoMergeRequest: null,
+          }),
+          stderr: "",
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: true,
+      proof: "pr_merged",
+      prNumber: 159,
+      mergeCommitOid: "squash-merge-sha",
+    });
+  });
+
+  it("direct route + no prNumber returns origin_unmerged without gh call", () => {
+    let ghCalled = false;
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "direct", repo: "Sharper-Flow/Advance" },
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch")
+            return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "ls-remote")
+            return {
+              status: 0,
+              stdout: "abc123\trefs/heads/trunk\n",
+              stderr: "",
+            };
+          if (args[0] === "log")
+            return {
+              status: 0,
+              stdout: "def456 squash orphan commit\n",
+              stderr: "",
+            };
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+        runGh: () => {
+          ghCalled = true;
+          return { status: 0, stdout: "{}", stderr: "" };
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: false,
+      proof: "origin_unmerged",
+    });
+    expect(ghCalled).toBe(false);
+  });
+
+  it("direct route + prNumber but PR not merged returns origin_unmerged", () => {
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "direct", repo: "Sharper-Flow/Advance" },
+        prNumber: 159,
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch")
+            return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "ls-remote")
+            return {
+              status: 0,
+              stdout: "abc123\trefs/heads/trunk\n",
+              stderr: "",
+            };
+          if (args[0] === "log")
+            return {
+              status: 0,
+              stdout: "def456 squash orphan commit\n",
+              stderr: "",
+            };
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+        runGh: () => ({
+          status: 0,
+          stdout: JSON.stringify({
+            state: "OPEN",
+            mergedAt: null,
+            mergeCommit: null,
+            autoMergeRequest: null,
+          }),
+          stderr: "",
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: false,
+      proof: "origin_unmerged",
+    });
+  });
+
+  it("direct route + prNumber but gh fails returns origin_unmerged", () => {
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "direct", repo: "Sharper-Flow/Advance" },
+        prNumber: 159,
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch")
+            return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "ls-remote")
+            return {
+              status: 0,
+              stdout: "abc123\trefs/heads/trunk\n",
+              stderr: "",
+            };
+          if (args[0] === "log")
+            return {
+              status: 0,
+              stdout: "def456 squash orphan commit\n",
+              stderr: "",
+            };
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+        runGh: () => ({
+          status: 1,
+          stdout: "",
+          stderr: "gh: API error",
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: false,
+      proof: "origin_unmerged",
+    });
+  });
+
   it("detectArchivedUnmergedBranches lists origin change branches not reachable from origin/default", () => {
     const calls: string[][] = [];
     const result = detectArchivedUnmergedBranches(

--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -1808,3 +1808,6 @@ function defaultRunGit(cwd: string, args: string[]) {
     stderr: result.stderr ?? "",
   };
 }
+
+
+

--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -373,8 +373,7 @@ describe("git-finalize helpers", () => {
       },
       {
         runGit: (_cwd, args) => {
-          if (args[0] === "fetch")
-            return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "fetch") return { status: 0, stdout: "", stderr: "" };
           if (args[0] === "rev-parse")
             return { status: 0, stdout: "abc123\n", stderr: "" };
           if (args[0] === "ls-remote")
@@ -423,8 +422,7 @@ describe("git-finalize helpers", () => {
       },
       {
         runGit: (_cwd, args) => {
-          if (args[0] === "fetch")
-            return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "fetch") return { status: 0, stdout: "", stderr: "" };
           if (args[0] === "rev-parse")
             return { status: 0, stdout: "abc123\n", stderr: "" };
           if (args[0] === "ls-remote")
@@ -466,8 +464,7 @@ describe("git-finalize helpers", () => {
       },
       {
         runGit: (_cwd, args) => {
-          if (args[0] === "fetch")
-            return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "fetch") return { status: 0, stdout: "", stderr: "" };
           if (args[0] === "rev-parse")
             return { status: 0, stdout: "abc123\n", stderr: "" };
           if (args[0] === "ls-remote")
@@ -514,8 +511,7 @@ describe("git-finalize helpers", () => {
       },
       {
         runGit: (_cwd, args) => {
-          if (args[0] === "fetch")
-            return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "fetch") return { status: 0, stdout: "", stderr: "" };
           if (args[0] === "rev-parse")
             return { status: 0, stdout: "abc123\n", stderr: "" };
           if (args[0] === "ls-remote")

--- a/plugin/src/tools/archive-helpers/git-finalize.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.ts
@@ -1718,13 +1718,37 @@ export function resolveReleaseReachability(
       input.changeId,
       deps,
     );
-    return originReachability.reachable
-      ? { reachable: true, proof: "origin_default" }
-      : {
-          reachable: false,
-          proof: "origin_unmerged",
-          details: originReachability.unmergedCommits,
+    if (originReachability.reachable) {
+      return { reachable: true, proof: "origin_default" };
+    }
+
+    // Squash-merge fallback: check PR state when ancestry fails
+    if (input.prNumber && route.repo) {
+      const prState = readPrMergeState(
+        input.mainCheckout,
+        route.repo,
+        input.prNumber,
+        deps,
+      );
+      if (
+        !("error" in prState) &&
+        prState.state === "MERGED" &&
+        prState.mergedAt
+      ) {
+        return {
+          reachable: true,
+          proof: "pr_merged",
+          prNumber: input.prNumber,
+          mergeCommitOid: prState.mergeCommitOid,
         };
+      }
+    }
+
+    return {
+      reachable: false,
+      proof: "origin_unmerged",
+      details: originReachability.unmergedCommits,
+    };
   }
 
   if (!route.repo || !input.prNumber) {

--- a/plugin/src/tools/gate.release-enforcement.test.ts
+++ b/plugin/src/tools/gate.release-enforcement.test.ts
@@ -234,6 +234,24 @@ describe("release gate trunk-merge enforcement", () => {
     expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
   });
 
+  test("allows release completion when direct route ancestry fails but PR is squash-merged", async () => {
+    mocks.resolveReleaseReachability.mockReturnValueOnce({
+      reachable: true,
+      proof: "pr_merged",
+      prNumber: 159,
+      mergeCommitOid: "squash-merge-sha",
+    });
+
+    const result = await gateTools.adv_gate_complete.execute(
+      { changeId: "example", gateId: "release", completedBy: "user:signoff" },
+      createMockStore(),
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+  });
+
   test("revalidates origin reachability before release gate recovery", async () => {
     mocks.resolveReleaseReachability
       .mockReturnValueOnce({ reachable: true, proof: "origin_default" })

--- a/plugin/src/utils/system-block.test.ts
+++ b/plugin/src/utils/system-block.test.ts
@@ -41,7 +41,6 @@ const cleanInput = (
   ...overrides,
 });
 
-
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 describe("VOLATILE_SENTINEL", () => {

--- a/plugin/src/validator/contract.test.ts
+++ b/plugin/src/validator/contract.test.ts
@@ -96,8 +96,16 @@ describe("contract validation", () => {
   test("skips contract_refs check for cancelled tasks", async () => {
     const result = await validate({
       tasks: [
-        task({ id: "tk-done", status: "done", contract_refs: { implements: ["AC1"], verifies: ["AC1"] } }),
-        task({ id: "tk-cancelled", status: "cancelled", contract_refs: undefined }),
+        task({
+          id: "tk-done",
+          status: "done",
+          contract_refs: { implements: ["AC1"], verifies: ["AC1"] },
+        }),
+        task({
+          id: "tk-cancelled",
+          status: "cancelled",
+          contract_refs: undefined,
+        }),
       ],
     });
 
@@ -109,8 +117,16 @@ describe("contract validation", () => {
   test("skips contract_refs check for cancelled tasks", async () => {
     const result = await validate({
       tasks: [
-        task({ id: "tk-done", status: "done", contract_refs: { implements: ["AC1"], verifies: ["AC1"] } }),
-        task({ id: "tk-cancelled", status: "cancelled", contract_refs: undefined }),
+        task({
+          id: "tk-done",
+          status: "done",
+          contract_refs: { implements: ["AC1"], verifies: ["AC1"] },
+        }),
+        task({
+          id: "tk-cancelled",
+          status: "cancelled",
+          contract_refs: undefined,
+        }),
       ],
     });
 

--- a/scripts/provider-eval.ts
+++ b/scripts/provider-eval.ts
@@ -21,7 +21,7 @@ import {
   readFileSync,
   statSync,
 } from "node:fs";
-import { join, basename, dirname } from "node:path";
+import { join, basename, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a PR is squash-merged, the release gate's `RELEASE_REQUIRES_TRUNK_MERGE` check fails because `resolveReleaseReachability` only checks git ancestry (`git log origin/trunk..change/{id}`). Squash merges create a new commit SHA on trunk, so the original change branch commits are not ancestors of trunk.

## Solution

Added a PR merge state fallback in `resolveReleaseReachability`'s direct route branch. When ancestry check fails and both `prNumber` and `route.repo` are available, queries `gh pr view` via the existing `readPrMergeState` helper. If the PR shows `state: "MERGED"` with a `mergedAt` timestamp, returns `{ reachable: true, proof: "pr_merged" }`.

## Changes

- `plugin/src/tools/archive-helpers/git-finalize.ts`: 20-line squash-merge fallback in direct route branch
- `plugin/src/tools/archive-helpers/git-finalize.test.ts`: 4 unit tests for squash-merge scenarios
- `plugin/src/tools/gate.release-enforcement.test.ts`: 1 integration test for release gate with squash-merged PR
- `scripts/provider-eval.ts`: Fixed pre-existing missing `resolve` import from `node:path`

## Verification

- 3604 tests pass (269 files, 0 failures)
- `pnpm run check` all green (schemas, typecheck, lint, format)
- All 18 contract items verified (7 ACs, 3 SCs, 4 constraints, 4 avoidances)