### PR TITLE
style(plugin): fix Prettier formatting in git-finalize.test.ts

### DIFF
--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -1808,6 +1808,3 @@ function defaultRunGit(cwd: string, args: string[]) {
     stderr: result.stderr ?? "",
   };
 }
-
-
-


### PR DESCRIPTION
Trailing blank lines at EOF in `git-finalize.test.ts` caused CI format check failure after PR #160 squash merge.

`pnpm run format` applied the fix. No logic changes.