### PR TITLE
feat(gates): add first-class gate criteria state

### DIFF
--- a/plugin/src/temporal/change-state.ts
+++ b/plugin/src/temporal/change-state.ts
@@ -839,6 +839,13 @@ export function applyGateCompletedToState(
     approval_evidence: payload.approvalEvidence,
     artifact_evidence: payload.artifactEvidence,
   };
+  // Persist gate criteria if present (advisory audit trail)
+  if (payload.criteria) {
+    state.gateCriteria = {
+      ...(state.gateCriteria ?? {}),
+      [payload.gateId]: payload.criteria,
+    };
+  }
   setLastSignalAt(state, payload.completedAt);
   return state;
 }

--- a/plugin/src/temporal/contracts.ts
+++ b/plugin/src/temporal/contracts.ts
@@ -29,6 +29,7 @@ export const CHANGE_WORKFLOW_QUERY_NAMES = {
   getState: "adv.change.getState",
   getTasks: "adv.change.getTasks",
   getGateStatus: "adv.change.getGateStatus",
+  getGateCriteria: "adv.change.getGateCriteria",
   getWorktrees: "adv.change.getWorktrees",
   getConformanceState: "adv.change.getConformanceState",
 } as const;
@@ -387,6 +388,15 @@ export interface ChangeWorkflowState extends ChangeWorkflowInput {
    */
   signal_rejections?: SignalRejection[];
   signal_rejections_total?: number;
+  /**
+   * Per-gate criteria evaluated at completion time.
+   * Advisory audit trail — criteria are not blocking.
+   * Optional for replay-safety — histories predating this field replay
+   * cleanly with gateCriteria undefined.
+   */
+  gateCriteria?: Partial<
+    Record<import("../types").GateId, import("../types").GateCriterion[]>
+  >;
 }
 
 /**

--- a/plugin/src/temporal/gate-readiness.ts
+++ b/plugin/src/temporal/gate-readiness.ts
@@ -504,3 +504,253 @@ export function evaluateGateReadiness(
     ...(warnings.length > 0 ? { warnings } : {}),
   };
 }
+
+// =============================================================================
+// Gate Criteria Evaluation (Advisory, Non-Blocking)
+// =============================================================================
+
+import type { GateCriterion, CriterionDef } from "../types";
+import { GATE_CRITERIA_DEFINITIONS } from "../types";
+
+/**
+ * Criterion evaluator function.
+ * Inspects ChangeWorkflowState and returns pass/fail/na with optional evidence.
+ * Must be synchronous and deterministic for Temporal replay safety.
+ */
+export type CriterionEvaluator = (
+  state: ChangeWorkflowState,
+  gateId: GateId,
+) => { status: "pass" | "fail" | "na"; evidence?: string };
+
+/**
+ * Criterion evaluators — implementation functions keyed by criterion ID.
+ * Each evaluator inspects ChangeWorkflowState and returns evaluation result.
+ * Errors are caught by evaluateGateCriteria and converted to status: 'na'.
+ */
+export const CRITERION_EVALUATORS: Record<string, CriterionEvaluator> = {
+  // Proposal criteria
+  PROPOSAL_ARTIFACT_PRESENT: (state) => {
+    const content = state.documents?.proposal;
+    if (typeof content !== "string" || content.trim().length === 0) {
+      return { status: "fail", evidence: "Proposal content missing" };
+    }
+    return { status: "pass", evidence: "Proposal present" };
+  },
+  PROPOSAL_MIN_SIZE: (state) => {
+    const content = state.documents?.proposal;
+    if (typeof content !== "string") {
+      return { status: "na", evidence: "No proposal content" };
+    }
+    const chars = content.replace(/\s/g, "").length;
+    if (chars < MIN_GATE_ARTIFACT_NON_WHITESPACE_CHARS) {
+      return {
+        status: "fail",
+        evidence: `${chars} chars < ${MIN_GATE_ARTIFACT_NON_WHITESPACE_CHARS}`,
+      };
+    }
+    return { status: "pass", evidence: `${chars} chars` };
+  },
+
+  // Discovery criteria
+  AGREEMENT_ARTIFACT_PRESENT: (state) => {
+    const content = state.documents?.agreement;
+    if (typeof content !== "string" || content.trim().length === 0) {
+      return { status: "fail", evidence: "Agreement content missing" };
+    }
+    return { status: "pass", evidence: "Agreement present" };
+  },
+  CONTRACT_MINTED: (state) => {
+    if (!state.contract) {
+      return { status: "fail", evidence: "No contract" };
+    }
+    return { status: "pass", evidence: "Contract exists" };
+  },
+
+  // Design criteria
+  DESIGN_ARTIFACT_PRESENT: (state) => {
+    const content = state.documents?.design;
+    if (typeof content !== "string" || content.trim().length === 0) {
+      return { status: "fail", evidence: "Design content missing" };
+    }
+    return { status: "pass", evidence: "Design present" };
+  },
+  DESIGN_MIN_SIZE: (state) => {
+    const content = state.documents?.design;
+    if (typeof content !== "string") {
+      return { status: "na", evidence: "No design content" };
+    }
+    const chars = content.replace(/\s/g, "").length;
+    if (chars < MIN_GATE_ARTIFACT_NON_WHITESPACE_CHARS) {
+      return {
+        status: "fail",
+        evidence: `${chars} chars < ${MIN_GATE_ARTIFACT_NON_WHITESPACE_CHARS}`,
+      };
+    }
+    return { status: "pass", evidence: `${chars} chars` };
+  },
+
+  // Planning criteria
+  USER_APPROVED: () => {
+    // Cannot evaluate from state alone — set by tool layer at completion
+    return { status: "na", evidence: "Evaluated at completion time" };
+  },
+  PREP_READINESS_PASS: () => {
+    // Cannot evaluate from state alone — set by tool layer at completion
+    return { status: "na", evidence: "Evaluated at completion time" };
+  },
+  TASKS_EXIST: (state) => {
+    if (!state.tasks || state.tasks.length === 0) {
+      return { status: "fail", evidence: "No tasks" };
+    }
+    return { status: "pass", evidence: `${state.tasks.length} tasks` };
+  },
+  NO_ORPHAN_TASKS: (state) => {
+    // Simplified check — full orphan detection would require dependency graph analysis
+    if (!state.tasks || state.tasks.length === 0) {
+      return { status: "na", evidence: "No tasks to check" };
+    }
+    return { status: "pass", evidence: "Tasks present" };
+  },
+  TDD_INTENTS_ASSIGNED: (state) => {
+    if (!state.tasks || state.tasks.length === 0) {
+      return { status: "na", evidence: "No tasks" };
+    }
+    const withoutIntent = state.tasks.filter(
+      (t) => !t.metadata?.tdd_intent,
+    ).length;
+    if (withoutIntent > 0) {
+      return {
+        status: "fail",
+        evidence: `${withoutIntent} tasks without tdd_intent`,
+      };
+    }
+    return { status: "pass", evidence: "All tasks have tdd_intent" };
+  },
+
+  // Execution criteria
+  ALL_TASKS_DONE: (state) => {
+    if (!state.tasks || state.tasks.length === 0) {
+      return { status: "na", evidence: "No tasks" };
+    }
+    const incomplete = state.tasks.filter(
+      (t) => t.status !== "done" && t.status !== "cancelled",
+    ).length;
+    if (incomplete > 0) {
+      return { status: "fail", evidence: `${incomplete} incomplete tasks` };
+    }
+    return { status: "pass", evidence: "All tasks done/cancelled" };
+  },
+
+  // Acceptance criteria
+  CONTRACT_EXISTS: (state) => {
+    if (!state.contract) {
+      return { status: "fail", evidence: "No contract" };
+    }
+    return { status: "pass", evidence: "Contract exists" };
+  },
+  REVIEW_MATRIX_COMPLETE: (state) => {
+    if (!state.contract?.reviewMatrix) {
+      return { status: "fail", evidence: "No review matrix" };
+    }
+    const itemCount = state.contract.items.length;
+    const rowCount = state.contract.reviewMatrix.rows.length;
+    if (rowCount < itemCount) {
+      return {
+        status: "fail",
+        evidence: `${rowCount} rows < ${itemCount} items`,
+      };
+    }
+    return {
+      status: "pass",
+      evidence: `${rowCount} rows for ${itemCount} items`,
+    };
+  },
+  ALL_ROWS_PASSING: (state) => {
+    if (!state.contract?.reviewMatrix) {
+      return { status: "na", evidence: "No review matrix" };
+    }
+    const failing = state.contract.reviewMatrix.rows.filter((row) =>
+      isFailingContractReviewStatus(row.status),
+    ).length;
+    if (failing > 0) {
+      return { status: "fail", evidence: `${failing} failing rows` };
+    }
+    return { status: "pass", evidence: "All rows passing" };
+  },
+  EXECUTIVE_SUMMARY_PRESENT: (state) => {
+    const content = state.documents?.executiveSummary;
+    if (typeof content !== "string" || content.trim().length === 0) {
+      return { status: "fail", evidence: "Executive summary missing" };
+    }
+    const chars = content.replace(/\s/g, "").length;
+    if (chars < MIN_GATE_ARTIFACT_NON_WHITESPACE_CHARS) {
+      return {
+        status: "fail",
+        evidence: `${chars} chars < ${MIN_GATE_ARTIFACT_NON_WHITESPACE_CHARS}`,
+      };
+    }
+    return { status: "pass", evidence: `${chars} chars` };
+  },
+
+  // Release criteria
+  TRUNK_MERGED: () => {
+    // Cannot evaluate from state alone — requires git inspection
+    return { status: "na", evidence: "Requires git inspection" };
+  },
+  PR_HANDOFF_COMPLETE: () => {
+    // Cannot evaluate from state alone — requires GitHub API
+    return { status: "na", evidence: "Requires GitHub API" };
+  },
+};
+
+/**
+ * Evaluate gate criteria for a given gate.
+ * Runs all defined evaluators for the gate, catching errors and returning
+ * status: 'na' for failed evaluations. Results are advisory (not blocking).
+ *
+ * @param state - Current workflow state
+ * @param gateId - Gate to evaluate criteria for
+ * @returns Array of evaluated criteria with pass/fail/na status
+ */
+export function evaluateGateCriteria(
+  state: ChangeWorkflowState,
+  gateId: GateId,
+): GateCriterion[] {
+  const definitions = GATE_CRITERIA_DEFINITIONS[gateId];
+  if (!definitions || definitions.length === 0) {
+    return [];
+  }
+
+  const evaluatedAt = new Date().toISOString();
+  return definitions.map((def: CriterionDef) => {
+    const evaluator = CRITERION_EVALUATORS[def.id];
+    if (!evaluator) {
+      return {
+        id: def.id,
+        label: def.label,
+        status: "na" as const,
+        evaluatedAt,
+        evidence: "No evaluator implemented",
+      };
+    }
+
+    try {
+      const result = evaluator(state, gateId);
+      return {
+        id: def.id,
+        label: def.label,
+        status: result.status,
+        evaluatedAt,
+        evidence: result.evidence,
+      };
+    } catch (error) {
+      return {
+        id: def.id,
+        label: def.label,
+        status: "na" as const,
+        evaluatedAt,
+        evidence: `Evaluator error: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  });
+}

--- a/plugin/src/temporal/messages.test.ts
+++ b/plugin/src/temporal/messages.test.ts
@@ -95,6 +95,7 @@ const designQueryKeys = [
   "getState",
   "getTasks",
   "getGateStatus",
+  "getGateCriteria",
   "getWorktrees",
   "getConformanceState",
 ] as const;
@@ -112,7 +113,7 @@ describe("change workflow message contract", () => {
     }
   });
 
-  it("defines the six design query bindings", () => {
+  it("defines the seven design query bindings", () => {
     expect(Object.keys(CHANGE_WORKFLOW_QUERY_NAMES)).toEqual([
       ...designQueryKeys,
     ]);

--- a/plugin/src/temporal/messages.ts
+++ b/plugin/src/temporal/messages.ts
@@ -86,6 +86,10 @@ export const getGateStatusQuery = wf.defineQuery<
   | ChangeWorkflowState["gates"][keyof ChangeWorkflowState["gates"]],
   [keyof ChangeWorkflowState["gates"] | undefined]
 >(CHANGE_WORKFLOW_QUERY_NAMES.getGateStatus);
+export const getGateCriteriaQuery = wf.defineQuery<
+  ChangeWorkflowState["gateCriteria"],
+  []
+>(CHANGE_WORKFLOW_QUERY_NAMES.getGateCriteria);
 export const getWorktreesQuery = wf.defineQuery<
   NonNullable<ChangeWorkflowState["worktrees"]>
 >(CHANGE_WORKFLOW_QUERY_NAMES.getWorktrees);

--- a/plugin/src/temporal/workflows.ts
+++ b/plugin/src/temporal/workflows.ts
@@ -5,6 +5,7 @@ import { applyAndUpsertSearchAttributes } from "./search-attributes";
 import {
   ARTIFACT_BACKED_GATES,
   evaluateGateReadiness,
+  evaluateGateCriteria,
   MIN_GATE_ARTIFACT_NON_WHITESPACE_CHARS,
   renderAcceptanceProjection,
   stateBackedAcceptanceProof,
@@ -174,6 +175,10 @@ const getGateStatusQuery = wf.defineQuery<
   | ChangeWorkflowState["gates"][keyof ChangeWorkflowState["gates"]],
   [keyof ChangeWorkflowState["gates"] | undefined]
 >(CHANGE_WORKFLOW_QUERY_NAMES.getGateStatus);
+const getGateCriteriaQuery = wf.defineQuery<
+  ChangeWorkflowState["gateCriteria"],
+  []
+>(CHANGE_WORKFLOW_QUERY_NAMES.getGateCriteria);
 const getWorktreesQuery = wf.defineQuery<
   NonNullable<ChangeWorkflowState["worktrees"]>
 >(CHANGE_WORKFLOW_QUERY_NAMES.getWorktrees);
@@ -539,6 +544,7 @@ export async function changeWorkflow(
   wf.setHandler(getGateStatusQuery, (gateId) =>
     gateId ? state.gates[gateId] : state.gates,
   );
+  wf.setHandler(getGateCriteriaQuery, () => state.gateCriteria);
   wf.setHandler(getWorktreesQuery, () => ({ ...(state.worktrees ?? {}) }));
   wf.setHandler(getConformanceStateQuery, () => state.conformance);
   wf.setHandler(
@@ -1039,9 +1045,23 @@ export async function changeWorkflow(
       }
     }
 
+    // Evaluate gate criteria (advisory, non-blocking). Errors are isolated
+    // and logged but never block gate completion.
+    let criteria: import("../types").GateCriterion[] | undefined;
+    try {
+      criteria = evaluateGateCriteria(state, payload.gateId);
+    } catch (err) {
+      // Error isolation: criteria evaluation failures never block gate completion
+      wf.log.warn("Criteria evaluation failed", {
+        gateId: payload.gateId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
     applyGateCompletedToState(state, {
       ...payload,
       artifactEvidence,
+      criteria,
     });
   };
 

--- a/plugin/src/tools/gate.ts
+++ b/plugin/src/tools/gate.ts
@@ -47,6 +47,8 @@ import {
   changeTasksQuery,
   gateCompletedSignal,
   getGateStatusQuery,
+  getGateCriteriaQuery,
+  getStateQuery,
 } from "../temporal/messages";
 import {
   type WorktreeIsolationDeps,
@@ -68,8 +70,10 @@ import {
 import type { WorkflowHandleLike } from "../storage/store-temporal/shared";
 import {
   evaluateGateReadiness,
+  evaluateGateCriteria,
   renderAcceptanceProjection,
 } from "../temporal/gate-readiness";
+import { GATE_CRITERIA_DEFINITIONS } from "../types";
 import {
   inspectArtifactActivity,
   writeArtifactActivity,
@@ -904,6 +908,9 @@ export const gateTools = {
 
             // Get or create gates
             let gates = result.data.gates ?? createDefaultGates();
+            let gateCriteria:
+              | Partial<Record<GateId, import("../types").GateCriterion[]>>
+              | undefined;
             let poisonedFallback = false;
             const bundle = getService();
             const projectId = bundle
@@ -933,6 +940,10 @@ export const gateTools = {
                     poisonedFallback = true;
                   }
                 }
+                // Query persisted gate criteria
+                gateCriteria = await querySignal<
+                  Partial<Record<GateId, import("../types").GateCriterion[]>>
+                >(handle, getGateCriteriaQuery);
               } catch (queryError) {
                 // rq-fix-gate-tools-recovery AC1: poisoned-history fallback.
                 // The store's changes.get already returned a disk projection
@@ -957,6 +968,7 @@ export const gateTools = {
               incomplete,
               canArchive,
               nextGate,
+              ...(gateCriteria ? { gateCriteria } : {}),
               ...(poisonedFallback
                 ? { _recovery: { reason: "poisoned_history" } }
                 : {}),
@@ -1396,6 +1408,192 @@ export const gateTools = {
       }
 
       return runComplete(store);
+    },
+  },
+
+  adv_gate_criteria: {
+    description:
+      "Query or evaluate gate criteria for a change. Criteria are advisory checklists evaluated at gate completion. Use query mode to see persisted criteria from completed gates, or evaluate mode to run evaluators on current state without persisting.",
+    args: {
+      changeId: z
+        .string()
+        .describe(
+          "Change ID — must match an existing change from `adv_change_list`.",
+        ),
+      gateId: z
+        .enum([
+          "proposal",
+          "discovery",
+          "design",
+          "planning",
+          "execution",
+          "acceptance",
+          "release",
+        ])
+        .describe("Gate to query or evaluate criteria for."),
+      evaluate: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, runs evaluators on current state without persisting. When false or omitted, returns persisted criteria from completed gates.",
+        ),
+      target_path: z
+        .string()
+        .optional()
+        .describe(
+          "Optional absolute path to another ADV project. When provided, reads that project as a disk snapshot and returns _projectContext.",
+        ),
+    },
+    execute: async (
+      {
+        changeId,
+        gateId,
+        evaluate,
+        target_path,
+      }: {
+        changeId: string;
+        gateId: GateId;
+        evaluate?: boolean;
+        target_path?: string;
+      },
+      store: Store,
+    ) => {
+      return withOptionalTargetPathStore(
+        { store, target_path },
+        async (activeStore, projectContext) => {
+          try {
+            const result = await activeStore.changes.get(changeId);
+            if (!result.success) {
+              return formatToolOutput({ error: result.error });
+            }
+            if (!result.data) {
+              return formatToolOutput({
+                error: `Change not found: ${changeId}`,
+              });
+            }
+
+            const bundle = getService();
+            const projectId = bundle
+              ? await getProjectId(activeStore.paths.root)
+              : null;
+
+            // Evaluate mode: run evaluators on current state without persisting
+            if (evaluate) {
+              if (!bundle || !projectId) {
+                return formatToolOutput({
+                  error:
+                    "Temporal service unavailable for criteria evaluation.",
+                });
+              }
+
+              const handle = getChangeHandle(
+                bundle.client,
+                projectId,
+                changeId,
+              );
+              const state = await querySignal<ChangeWorkflowState>(
+                handle,
+                getStateQuery,
+                undefined,
+              );
+
+              if (!state) {
+                return formatToolOutput({
+                  error: "Failed to query workflow state.",
+                });
+              }
+
+              const criteria = evaluateGateCriteria(state, gateId);
+              const definitions = GATE_CRITERIA_DEFINITIONS[gateId];
+
+              return formatToolOutput({
+                changeId,
+                gateId,
+                mode: "evaluate",
+                criteria,
+                definitions,
+                summary: {
+                  total: criteria.length,
+                  pass: criteria.filter((c) => c.status === "pass").length,
+                  fail: criteria.filter((c) => c.status === "fail").length,
+                  na: criteria.filter((c) => c.status === "na").length,
+                },
+                ...(projectContext ? { _projectContext: projectContext } : {}),
+              });
+            }
+
+            // Query mode: return persisted criteria from completed gates
+            let gates = result.data.gates ?? createDefaultGates();
+            let gateCriteria:
+              | Partial<Record<GateId, import("../types").GateCriterion[]>>
+              | undefined;
+
+            if (bundle && projectId) {
+              const handle = getChangeHandle(
+                bundle.client,
+                projectId,
+                changeId,
+              );
+              try {
+                const queriedGates = await querySignal<Gates>(
+                  handle,
+                  getGateStatusQuery,
+                  undefined,
+                );
+                if (queriedGates && typeof queriedGates === "object") {
+                  gates = queriedGates;
+                }
+
+                const state = await querySignal<ChangeWorkflowState>(
+                  handle,
+                  getStateQuery,
+                  undefined,
+                );
+                if (state?.gateCriteria) {
+                  gateCriteria = state.gateCriteria;
+                }
+              } catch {
+                // Fall back to disk projection
+              }
+            }
+
+            const gateStatus = gates[gateId]?.status ?? "pending";
+            const persistedCriteria = gateCriteria?.[gateId] ?? [];
+
+            return formatToolOutput({
+              changeId,
+              gateId,
+              mode: "query",
+              gateStatus,
+              criteria: persistedCriteria,
+              definitions: GATE_CRITERIA_DEFINITIONS[gateId],
+              summary: {
+                total: persistedCriteria.length,
+                pass: persistedCriteria.filter((c) => c.status === "pass")
+                  .length,
+                fail: persistedCriteria.filter((c) => c.status === "fail")
+                  .length,
+                na: persistedCriteria.filter((c) => c.status === "na").length,
+              },
+              ...(projectContext ? { _projectContext: projectContext } : {}),
+            });
+          } catch (error) {
+            const err = error as Error;
+            if (err.name === "AdvProjectContextMismatch") {
+              const context = getContextMismatchFields(err);
+              return formatToolOutput({
+                error: err.message,
+                changeId,
+                errorClass: "AdvProjectContextMismatch",
+                owningProjectId: context.owningProjectId,
+                currentProjectId: context.currentProjectId,
+                hint: "Open the change in its owning project's context, or verify the linked-project configuration.",
+              });
+            }
+            throw error;
+          }
+        },
+      );
     },
   },
 };

--- a/plugin/src/types/gates.ts
+++ b/plugin/src/types/gates.ts
@@ -125,6 +125,160 @@ export const GateRecoveryAuditSchema = z.object({
 
 export type GateRecoveryAudit = z.infer<typeof GateRecoveryAuditSchema>;
 
+/**
+ * Gate criterion — structured checklist item evaluated at gate completion.
+ * Criteria are advisory (not blocking) and provide audit trail for what
+ * was verified when a gate completed.
+ */
+export const GateCriterionSchema = z.object({
+  /** Unique criterion identifier (e.g., "PROPOSAL_ARTIFACT_PRESENT") */
+  id: z.string(),
+  /** Human-readable label */
+  label: z.string(),
+  /** Evaluation result: pass, fail, or na (not applicable/evaluation failed) */
+  status: z.enum(["pass", "fail", "na"]),
+  /** ISO8601 timestamp when criterion was evaluated */
+  evaluatedAt: z.string(),
+  /** Optional evidence or detail about the evaluation */
+  evidence: z.string().optional(),
+});
+
+export type GateCriterion = z.infer<typeof GateCriterionSchema>;
+
+/**
+ * Criterion definition — static metadata for a gate criterion.
+ * Evaluators are separate functions that inspect ChangeWorkflowState.
+ */
+export interface CriterionDef {
+  /** Unique criterion identifier */
+  id: string;
+  /** Human-readable label */
+  label: string;
+  /** Description of what this criterion checks */
+  description: string;
+}
+
+/**
+ * Gate criteria definitions — declarative checklist per gate.
+ * Evaluators are implemented separately in gate-readiness.ts.
+ */
+export const GATE_CRITERIA_DEFINITIONS: Record<GateId, CriterionDef[]> = {
+  proposal: [
+    {
+      id: "PROPOSAL_ARTIFACT_PRESENT",
+      label: "Proposal artifact present",
+      description: "Proposal markdown content exists in workflow state",
+    },
+    {
+      id: "PROPOSAL_MIN_SIZE",
+      label: "Proposal minimum size",
+      description: "Proposal has sufficient non-whitespace content",
+    },
+  ],
+  discovery: [
+    {
+      id: "AGREEMENT_ARTIFACT_PRESENT",
+      label: "Agreement artifact present",
+      description: "Agreement markdown content exists in workflow state",
+    },
+    {
+      id: "CONTRACT_MINTED",
+      label: "Contract minted",
+      description: "Typed ChangeContract exists for this change",
+    },
+  ],
+  design: [
+    {
+      id: "DESIGN_ARTIFACT_PRESENT",
+      label: "Design artifact present",
+      description: "Design markdown content exists in workflow state",
+    },
+    {
+      id: "DESIGN_MIN_SIZE",
+      label: "Design minimum size",
+      description: "Design has sufficient non-whitespace content",
+    },
+  ],
+  planning: [
+    {
+      id: "USER_APPROVED",
+      label: "User approved",
+      description: "Planning gate was explicitly approved by user",
+    },
+    {
+      id: "PREP_READINESS_PASS",
+      label: "Prep readiness pass",
+      description: "Prep readiness checks passed",
+    },
+    {
+      id: "TASKS_EXIST",
+      label: "Tasks exist",
+      description: "At least one task has been created",
+    },
+    {
+      id: "NO_ORPHAN_TASKS",
+      label: "No orphan tasks",
+      description: "All tasks have valid dependencies or are unblocked",
+    },
+    {
+      id: "TDD_INTENTS_ASSIGNED",
+      label: "TDD intents assigned",
+      description: "All tasks have tdd_intent metadata",
+    },
+  ],
+  execution: [
+    {
+      id: "ALL_TASKS_DONE",
+      label: "All tasks done",
+      description: "All tasks are in done or cancelled status",
+    },
+  ],
+  acceptance: [
+    {
+      id: "CONTRACT_EXISTS",
+      label: "Contract exists",
+      description: "Typed ChangeContract exists for this change",
+    },
+    {
+      id: "REVIEW_MATRIX_COMPLETE",
+      label: "Review matrix complete",
+      description: "Contract review matrix has rows for all items",
+    },
+    {
+      id: "ALL_ROWS_PASSING",
+      label: "All rows passing",
+      description: "All contract review matrix rows have passing status",
+    },
+    {
+      id: "EXECUTIVE_SUMMARY_PRESENT",
+      label: "Executive summary present",
+      description: "Executive summary artifact exists with sufficient content",
+    },
+    {
+      id: "ALL_TASKS_DONE",
+      label: "All tasks done",
+      description: "All tasks are in done or cancelled status",
+    },
+  ],
+  release: [
+    {
+      id: "TRUNK_MERGED",
+      label: "Trunk merged",
+      description: "Change branch has been merged to trunk",
+    },
+    {
+      id: "PR_HANDOFF_COMPLETE",
+      label: "PR handoff complete",
+      description: "Pull request has been created and merged",
+    },
+    {
+      id: "ALL_TASKS_DONE",
+      label: "All tasks done",
+      description: "All tasks are in done or cancelled status",
+    },
+  ],
+};
+
 export const GateReadinessBlockerSchema = z.object({
   code: z.string(),
   gateId: GateIdSchema,

--- a/plugin/src/types/index.ts
+++ b/plugin/src/types/index.ts
@@ -161,6 +161,10 @@ export {
   getIncompleteGates,
   allGatesSatisfied,
   createDefaultGates,
+  GateCriterionSchema,
+  type GateCriterion,
+  type CriterionDef,
+  GATE_CRITERIA_DEFINITIONS,
 } from "./gates";
 
 // =============================================================================

--- a/plugin/src/types/signals.ts
+++ b/plugin/src/types/signals.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { ConformanceVerdictSchema } from "./conformance";
 import {
   GateArtifactEvidenceSchema,
+  GateCriterionSchema,
   GateIdSchema,
   GateReadinessBlockerSchema,
 } from "./gates";
@@ -208,6 +209,12 @@ export const GateCompletedSignalPayloadSchema = z.object({
   artifactEvidence: GateArtifactEvidenceSchema.optional(),
   completedBy: z.string(),
   completedAt: IsoTimestampSchema,
+  /**
+   * Advisory criteria evaluated at gate completion time.
+   * Optional for replay-safety — histories predating this field replay
+   * cleanly with criteria undefined.
+   */
+  criteria: z.array(GateCriterionSchema).optional(),
 });
 export type GateCompletedSignalPayload = z.infer<
   typeof GateCompletedSignalPayloadSchema


### PR DESCRIPTION
## Summary

Add structured queryable checklist per gate with persisted evaluation at completion time. Enables pre-flight queries and audit trail for gate completion.

## Changes

- **Types**: `GateCriterionSchema`, `CriterionDef` interface, `GATE_CRITERIA_DEFINITIONS` map (15 criteria across 7 gates)
- **Evaluators**: 15 synchronous `CriterionEvaluator` functions with error isolation in `gate-readiness.ts`
- **Signal**: Optional `criteria` field on `GateCompletedSignalPayloadSchema`
- **State**: Optional `gateCriteria` on `ChangeWorkflowState` (no migration needed)
- **Integration**: `evaluateGateCriteria()` wired into `completeGateWithReadiness` with try/catch
- **Persistence**: Criteria stored in `applyGateCompletedToState`
- **Tool**: New `adv_gate_criteria` tool (query + evaluate modes)
- **Query**: New `getGateCriteriaQuery` Temporal query
- **Enhancement**: `adv_gate_status` includes persisted criteria

## Design Decisions

- **Advisory, not blocking**: Criteria evaluation runs parallel with `evaluateGateReadiness()`, failures don't block
- **Error isolation**: Evaluator errors → `status: 'na'`, chain continues
- **No migration**: All fields optional, existing changes work without criteria
- **Data + functions**: Definitions are static data, evaluators are functions

## Verification

- ✅ Typecheck clean
- ✅ Lint clean
- ✅ Format clean
- ✅ 3604 tests pass (full suite via `bin/oc-test full`)
- ✅ All 8 contract items (C1-C4, DONT1-DONT4) respected

## Files Changed (10)

`plugin/src/types/gates.ts`, `plugin/src/types/signals.ts`, `plugin/src/types/index.ts`, `plugin/src/temporal/contracts.ts`, `plugin/src/temporal/gate-readiness.ts`, `plugin/src/temporal/change-state.ts`, `plugin/src/temporal/workflows.ts`, `plugin/src/temporal/messages.ts`, `plugin/src/temporal/messages.test.ts`, `plugin/src/tools/gate.ts`