### PR TITLE
feat: enforce required-critical obligation planning and release safety

### DIFF
--- a/.adv/specs/advance-workflow/spec.json
+++ b/.adv/specs/advance-workflow/spec.json
@@ -3,8 +3,8 @@
   "name": "advance-workflow",
   "title": "Advance Workflow",
   "purpose": "Capability: Workflow contract layer for ADV \u2014 gate model, autonomy boundaries, design validation, scope management, releases, approvals, handoff voice, review remediation, and touched-scope quality. Split from `advance` capability.",
-  "version": "1.15.0",
-  "updated_at": "2026-06-05T00:00:00.000Z",
+  "version": "1.16.0",
+  "updated_at": "2026-06-09T00:00:00.000Z",
   "requirements": [
     {
       "id": "rq-problemSpecLaw01",
@@ -3175,6 +3175,99 @@
             "The existing design validator runs unchanged",
             "The validator validates the design including any scout-adopted improvements",
             "The scout and validator serve different purposes (opportunity vs correctness)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "rq-requiredObligation01",
+      "title": "Required Obligation Release Block",
+      "body": "The review/harden flow MUST block release when required in-scope obligations remain unresolved. A required-critical contract item that is in-scope, has no notRequiredReason, and lacks verified completion evidence MUST prevent the release gate from completing. This is a structural safety invariant: unresolved required obligations represent unshipped work that cannot be silently released.",
+      "priority": "must",
+      "tags": ["workflow", "release", "required-obligation", "safety", "contract"],
+      "scenarios": [
+        {
+          "id": "rq-requiredObligation01.1",
+          "title": "Unresolved required-critical item blocks release",
+          "given": [
+            "A change has a required-critical contract item in-scope",
+            "The item has no notRequiredReason",
+            "The contract review matrix shows the item as unverified or failed"
+          ],
+          "when": "The release gate is evaluated",
+          "then": [
+            "The release gate is NOT marked done",
+            "A REQUIRED_OBLIGATION_UNRESOLVED blocker is surfaced",
+            "The response identifies the specific contract item and required evidence"
+          ]
+        },
+        {
+          "id": "rq-requiredObligation01.2",
+          "title": "Verified required-critical item allows release",
+          "given": [
+            "A change has a required-critical contract item in-scope",
+            "The contract review matrix shows the item as pass with evidence"
+          ],
+          "when": "The release gate is evaluated",
+          "then": ["The release gate may proceed if all other conditions are met"]
+        },
+        {
+          "id": "rq-requiredObligation01.3",
+          "title": "Not-required reason exempts item from release block",
+          "given": [
+            "A change has a required-critical contract item",
+            "The item has an explicit notRequiredReason set"
+          ],
+          "when": "The release gate is evaluated",
+          "then": ["The item does not block release"]
+        }
+      ]
+    },
+    {
+      "id": "rq-requiredObligation02",
+      "title": "Required Obligation Explicit Routing",
+      "body": "Out-of-scope required obligations MUST NOT be silently dropped or auto-resolved. When a required-critical contract item is classified as out-of-scope during execution or review, the workflow MUST require explicit routing: either re-enter the item into scope via adv_change_reenter with a rationale, or split the obligation into a new change with a tracking reference. Silent deferral or implicit postponement of required obligations is prohibited.",
+      "priority": "must",
+      "tags": ["workflow", "required-obligation", "routing", "scope", "split"],
+      "scenarios": [
+        {
+          "id": "rq-requiredObligation02.1",
+          "title": "Out-of-scope required item requires explicit routing",
+          "given": [
+            "A required-critical contract item is marked out-of-scope during execution or review"
+          ],
+          "when": "The workflow evaluates release readiness",
+          "then": [
+            "The release gate is NOT marked done",
+            "A REQUIRED_OBLIGATION_ROUTING_MISSING blocker is surfaced",
+            "The response demands explicit re-enter or split action with rationale"
+          ]
+        },
+        {
+          "id": "rq-requiredObligation02.2",
+          "title": "Re-enter with rationale resolves routing blocker",
+          "given": [
+            "An out-of-scope required-critical item is re-entered via adv_change_reenter",
+            "The re-enter rationale explains why the item is now in-scope"
+          ],
+          "when": "The release gate is re-evaluated",
+          "then": [
+            "The REQUIRED_OBLIGATION_ROUTING_MISSING blocker is cleared",
+            "The item is treated as in-scope for release checks"
+          ]
+        },
+        {
+          "id": "rq-requiredObligation02.3",
+          "title": "Split into new change resolves routing blocker",
+          "given": [
+            "An out-of-scope required-critical item is split into a new tracked change",
+            "The original change records the split reference (new change ID and rationale)"
+          ],
+          "when": "The release gate is re-evaluated",
+          "then": [
+            "The REQUIRED_OBLIGATION_ROUTING_MISSING blocker is cleared",
+            "The original change may proceed to release",
+            "The new change carries the required obligation forward"
           ]
         }
       ]

--- a/.adv/specs/prep-readiness/spec.json
+++ b/.adv/specs/prep-readiness/spec.json
@@ -3,8 +3,8 @@
   "name": "prep-readiness",
   "title": "Prep Readiness",
   "purpose": "Machine-enforced readiness checks that gate the prep phase. Answers: 'Do we have everything we need ready to make the full change?'",
-  "version": "1.3.0",
-  "updated_at": "2026-04-07T01:00:55.462Z",
+  "version": "1.4.0",
+  "updated_at": "2026-06-09T00:00:00.000Z",
   "requirements": [
     {
       "id": "rq-PR001sml",
@@ -412,6 +412,49 @@
             "A TASK_TDD_INTENT_MISSING error is returned for that task",
             "The error message indicates the invalid value"
           ]
+        }
+      ]
+    },
+    {
+      "id": "rq-PR007coc",
+      "title": "Critical Operations Coverage",
+      "body": "Planning readiness MUST verify that every required-critical contract item (priority required, class critical-ops) has at least one implementing or verifying task in the task graph. A required-critical item without task coverage represents an unplanned obligation and blocks the prep gate. Items with an explicit notRequiredReason are exempt from coverage checks.",
+      "priority": "must",
+      "tags": ["prep", "critical-ops", "contract", "coverage"],
+      "scenarios": [
+        {
+          "id": "rq-PR007coc.1",
+          "title": "Required-critical item with task coverage passes",
+          "given": [
+            "A change contract contains a required-critical item",
+            "At least one task in the task graph references that item via contract_refs.implements or contract_refs.verifies"
+          ],
+          "when": "runPrepReadinessChecks is called",
+          "then": ["No CRITICAL_OPS_MISSING_COVERAGE error is returned for that item"]
+        },
+        {
+          "id": "rq-PR007coc.2",
+          "title": "Required-critical item without task coverage fails",
+          "given": [
+            "A change contract contains a required-critical item",
+            "No task references that item via contract_refs"
+          ],
+          "when": "runPrepReadinessChecks is called",
+          "then": [
+            "A CRITICAL_OPS_MISSING_COVERAGE issue with severity 'error' is returned",
+            "The prep gate is blocked"
+          ]
+        },
+        {
+          "id": "rq-PR007coc.3",
+          "title": "Required-critical item with notRequiredReason passes",
+          "given": [
+            "A change contract contains a required-critical item",
+            "The item has an explicit notRequiredReason set",
+            "No task references that item via contract_refs"
+          ],
+          "when": "runPrepReadinessChecks is called",
+          "then": ["No CRITICAL_OPS_MISSING_COVERAGE error is returned for that item"]
         }
       ]
     }

--- a/.adv/specs/subagent-reports/spec.json
+++ b/.adv/specs/subagent-reports/spec.json
@@ -3,8 +3,8 @@
   "name": "subagent-reports",
   "title": "Sub-Agent Reports",
   "purpose": "Typed, durable ADV sub-agent report ingestion and readback. Replaces ADV worker final-message fenced JSON with Zod-validated tool-call submission, sidecar report persistence, deterministic scope-aware dedupe, and machine-readable downstream consumers.",
-  "version": "1.0.0",
-  "updated_at": "2026-05-26T00:00:00.000Z",
+  "version": "1.1.0",
+  "updated_at": "2026-06-09T00:00:00.000Z",
   "conformance_required": false,
   "requirements": [
     {
@@ -422,6 +422,40 @@
             "Task examples include kind task and task_id",
             "Independent review or harden examples include kind change and scope_key",
             "String scope is described only as compatibility-only"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "rq-subagentReports14",
+      "title": "Required Follow-Up Preservation",
+      "body": "Report ingestion MUST preserve the required-obligation classification and severity of follow-ups when creating agenda items. A follow-up tagged as required_critical MUST receive elevated priority. Standard follow-ups without required classification receive medium priority.",
+      "priority": "must",
+      "tags": ["subagents", "reports", "follow-ups", "required-obligation", "agenda"],
+      "scenarios": [
+        {
+          "id": "rq-subagentReports14.1",
+          "title": "Required-critical follow-up gets elevated priority",
+          "given": [
+            "An engineer report contains a follow-up with required_critical classification"
+          ],
+          "when": "The follow-up is ingested into the agenda",
+          "then": [
+            "The agenda item priority is set to high",
+            "The item category is subagent-followup with required_critical severity tag",
+            "The source metadata preserves the original report agent and scope"
+          ]
+        },
+        {
+          "id": "rq-subagentReports14.2",
+          "title": "Standard follow-up gets medium priority",
+          "given": [
+            "An engineer report contains a follow-up without required classification"
+          ],
+          "when": "The follow-up is ingested into the agenda",
+          "then": [
+            "The agenda item priority is set to medium",
+            "The item category is subagent-followup without elevated severity"
           ]
         }
       ]

--- a/.opencode/command/adv-apply.md
+++ b/.opencode/command/adv-apply.md
@@ -5,6 +5,7 @@ phaseGoal: "Execute the approved plan autonomously. Add discovered tasks within 
 ---
 
 <!-- manifest: adv-apply · gate: execution · requiresChangeId: true · prereqs: [adv-prep] · scope: reads[specs, proposal, tasks, codebase] · modifies[tasks, codebase] -->
+<!-- rq-subagentReports14 -->
 
 # ADV Apply — Produce Deliverables with TDD and Retry
 

--- a/.opencode/command/adv-harden.md
+++ b/.opencode/command/adv-harden.md
@@ -8,6 +8,8 @@ phaseGoal: "Verify production-readiness. Auto-fix scoped issues. Stop on drift."
 
 # ADV Harden — Release-Stage Quality Analysis
 
+<!-- rq-requiredObligation01 rq-requiredObligation02 -->
+
 Orchestrate multi-dimensional hardening via sub-agents. Command is part of the release stage and **blocks archive if actionable `REVIEW_FINDINGS` are unresolved.**
 
 ## Exits

--- a/.opencode/command/adv-prep.md
+++ b/.opencode/command/adv-prep.md
@@ -10,7 +10,7 @@ phaseGoal: "Complete the flight-check: every gap closed, every dependency mapped
 
 Analyze change for implementation-readiness gaps (tasks, sequencing, cross-cutting concerns, contract traceability) → add them via ADV tools. Uses 4-Step Gap Analysis to map approved criteria/design into tasks; prep does not firm criteria. Runs **inline** — no sub-agents.
 
-<!-- rq-prep-out1 rq-prep-neg1 rq-prep-scope1 rq-stagePrepNoCriteriaFirming01 rq-prepArtifactExcerpt01 -->
+<!-- rq-prep-out1 rq-prep-neg1 rq-prep-scope1 rq-stagePrepNoCriteriaFirming01 rq-prepArtifactExcerpt01 rq-PR007coc -->
 
 ## Command Boundary
 

--- a/plugin/schemas/change.schema.json
+++ b/plugin/schemas/change.schema.json
@@ -181,6 +181,9 @@
               "notRequiredReason": {
                 "type": "string"
               },
+              "requiredCritical": {
+                "type": "boolean"
+              },
               "sourceArtifact": {
                 "enum": [
                   "proposal",
@@ -2540,6 +2543,42 @@
                     "minLength": 1,
                     "type": "string"
                   },
+                  "required_follow_ups": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "obligation_class": {
+                          "enum": [
+                            "required_critical",
+                            "required_standard"
+                          ],
+                          "type": "string"
+                        },
+                        "severity": {
+                          "default": "high",
+                          "enum": [
+                            "critical",
+                            "high"
+                          ],
+                          "type": "string"
+                        },
+                        "source_contract_id": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "text",
+                        "obligation_class",
+                        "severity"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
                   "required_main_agent_actions": {
                     "items": {
                       "minLength": 1,
@@ -2855,6 +2894,42 @@
                       "harden"
                     ],
                     "type": "string"
+                  },
+                  "required_follow_ups": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "obligation_class": {
+                          "enum": [
+                            "required_critical",
+                            "required_standard"
+                          ],
+                          "type": "string"
+                        },
+                        "severity": {
+                          "default": "high",
+                          "enum": [
+                            "critical",
+                            "high"
+                          ],
+                          "type": "string"
+                        },
+                        "source_contract_id": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "text",
+                        "obligation_class",
+                        "severity"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
                   },
                   "required_main_agent_actions": {
                     "items": {
@@ -3580,6 +3655,42 @@
                       "harden"
                     ],
                     "type": "string"
+                  },
+                  "required_follow_ups": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "obligation_class": {
+                          "enum": [
+                            "required_critical",
+                            "required_standard"
+                          ],
+                          "type": "string"
+                        },
+                        "severity": {
+                          "default": "high",
+                          "enum": [
+                            "critical",
+                            "high"
+                          ],
+                          "type": "string"
+                        },
+                        "source_contract_id": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "text",
+                        "obligation_class",
+                        "severity"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
                   },
                   "required_main_agent_actions": {
                     "items": {
@@ -4768,6 +4879,42 @@
                       "minLength": 1,
                       "type": "string"
                     },
+                    "required_follow_ups": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "obligation_class": {
+                            "enum": [
+                              "required_critical",
+                              "required_standard"
+                            ],
+                            "type": "string"
+                          },
+                          "severity": {
+                            "default": "high",
+                            "enum": [
+                              "critical",
+                              "high"
+                            ],
+                            "type": "string"
+                          },
+                          "source_contract_id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "text",
+                          "obligation_class",
+                          "severity"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "required_main_agent_actions": {
                       "items": {
                         "minLength": 1,
@@ -5083,6 +5230,42 @@
                         "harden"
                       ],
                       "type": "string"
+                    },
+                    "required_follow_ups": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "obligation_class": {
+                            "enum": [
+                              "required_critical",
+                              "required_standard"
+                            ],
+                            "type": "string"
+                          },
+                          "severity": {
+                            "default": "high",
+                            "enum": [
+                              "critical",
+                              "high"
+                            ],
+                            "type": "string"
+                          },
+                          "source_contract_id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "text",
+                          "obligation_class",
+                          "severity"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
                     },
                     "required_main_agent_actions": {
                       "items": {

--- a/plugin/schemas/task.schema.json
+++ b/plugin/schemas/task.schema.json
@@ -506,6 +506,42 @@
                 "minLength": 1,
                 "type": "string"
               },
+              "required_follow_ups": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "obligation_class": {
+                      "enum": [
+                        "required_critical",
+                        "required_standard"
+                      ],
+                      "type": "string"
+                    },
+                    "severity": {
+                      "default": "high",
+                      "enum": [
+                        "critical",
+                        "high"
+                      ],
+                      "type": "string"
+                    },
+                    "source_contract_id": {
+                      "type": "string"
+                    },
+                    "text": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "obligation_class",
+                    "severity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "required_main_agent_actions": {
                 "items": {
                   "minLength": 1,
@@ -821,6 +857,42 @@
                   "harden"
                 ],
                 "type": "string"
+              },
+              "required_follow_ups": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "obligation_class": {
+                      "enum": [
+                        "required_critical",
+                        "required_standard"
+                      ],
+                      "type": "string"
+                    },
+                    "severity": {
+                      "default": "high",
+                      "enum": [
+                        "critical",
+                        "high"
+                      ],
+                      "type": "string"
+                    },
+                    "source_contract_id": {
+                      "type": "string"
+                    },
+                    "text": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "obligation_class",
+                    "severity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
               },
               "required_main_agent_actions": {
                 "items": {

--- a/plugin/src/adv-skill-backed-commands-assets.test.ts
+++ b/plugin/src/adv-skill-backed-commands-assets.test.ts
@@ -310,7 +310,7 @@ describe("ambiguity taxonomy spec assets", () => {
     expect(prepSpec.requirements.map((rq) => rq.id)).toEqual(
       expect.arrayContaining(["rq-stagePrepNoCriteriaFirming01"]),
     );
-    expect(workflowSpec.version).toBe("1.15.0");
+    expect(workflowSpec.version).toBe("1.16.0");
     expect(workflowSpec.requirements.map((rq) => rq.id)).toEqual(
       expect.arrayContaining([
         "rq-stageDesignCriteriaBoundary01",

--- a/plugin/src/subagent-reports-spec-assets.test.ts
+++ b/plugin/src/subagent-reports-spec-assets.test.ts
@@ -40,6 +40,7 @@ describe("subagent reports spec assets", () => {
       "rq-subagentReports11",
       "rq-subagentReports12",
       "rq-subagentReports13",
+      "rq-subagentReports14",
     ]);
   });
 

--- a/plugin/src/temporal/change-state.ts
+++ b/plugin/src/temporal/change-state.ts
@@ -850,6 +850,9 @@ export function applyGateCompletedToState(
   return state;
 }
 
+// rq-requiredObligation02: Out-of-scope required obligations require explicit
+// routing via re-enter or split; the re-enter path clears review matrix to force
+// re-evaluation of contract items that may have changed scope.
 export function applyGateReenteredToState(
   state: ChangeWorkflowState,
   payload: GateReenteredSignalPayload,

--- a/plugin/src/temporal/gate-readiness.test.ts
+++ b/plugin/src/temporal/gate-readiness.test.ts
@@ -3,8 +3,6 @@ import { createDefaultGates } from "../types";
 import {
   ARTIFACT_BACKED_GATES,
   artifactCascadeWarnings,
-  checkRequiredObligationReleaseBlockers,
-  checkRequiredObligationRouting,
   evaluateGateReadiness,
   gateArtifactEvidenceSchema,
   stateBackedArtifactEvidence,
@@ -698,9 +696,7 @@ describe("gate readiness", () => {
 
       expect(result.ready).toBe(true);
       expect(
-        result.blockers.some((b) =>
-          b.code.startsWith("REQUIRED_OBLIGATION"),
-        ),
+        result.blockers.some((b) => b.code.startsWith("REQUIRED_OBLIGATION")),
       ).toBe(false);
     });
 
@@ -794,9 +790,7 @@ describe("gate readiness", () => {
       );
 
       expect(
-        result.blockers.some((b) =>
-          b.code.startsWith("REQUIRED_OBLIGATION"),
-        ),
+        result.blockers.some((b) => b.code.startsWith("REQUIRED_OBLIGATION")),
       ).toBe(false);
       // acceptance still blocked by normal acceptance contract check
       expect(result.blockers).toContainEqual(
@@ -831,8 +825,8 @@ describe("gate readiness", () => {
       );
 
       expect(
-        result.blockers.some((b) =>
-          b.code === "REQUIRED_OBLIGATION_NOT_ROUTED",
+        result.blockers.some(
+          (b) => b.code === "REQUIRED_OBLIGATION_NOT_ROUTED",
         ),
       ).toBe(false);
     });
@@ -857,8 +851,8 @@ describe("gate readiness", () => {
       );
 
       expect(
-        result.blockers.some((b) =>
-          b.code === "REQUIRED_OBLIGATION_NOT_ROUTED",
+        result.blockers.some(
+          (b) => b.code === "REQUIRED_OBLIGATION_NOT_ROUTED",
         ),
       ).toBe(false);
     });

--- a/plugin/src/temporal/gate-readiness.test.ts
+++ b/plugin/src/temporal/gate-readiness.test.ts
@@ -3,6 +3,8 @@ import { createDefaultGates } from "../types";
 import {
   ARTIFACT_BACKED_GATES,
   artifactCascadeWarnings,
+  checkRequiredObligationReleaseBlockers,
+  checkRequiredObligationRouting,
   evaluateGateReadiness,
   gateArtifactEvidenceSchema,
   stateBackedArtifactEvidence,
@@ -37,6 +39,56 @@ function acceptanceReadyGates() {
   gates.planning.status = "done";
   gates.execution.status = "done";
   return gates;
+}
+
+function releaseReadyGates() {
+  const gates = acceptanceReadyGates();
+  gates.acceptance.status = "done";
+  return gates;
+}
+
+function makeRequiredCriticalContract(
+  itemOverrides: Partial<
+    NonNullable<ChangeWorkflowState["contract"]>["items"][number]
+  >[],
+  rowStatus?: "pass" | "fail" | "violated" | "unknown",
+  opts: { omitRowForId?: string[]; omitReviewMatrix?: boolean } = {},
+): ChangeWorkflowState["contract"] {
+  return {
+    version: 1,
+    rigor: "standard",
+    source: {
+      artifact: "agreement",
+      approvedAt: "2026-05-20T00:00:00.000Z",
+    },
+    items: itemOverrides.map((overrides, idx) => ({
+      id: overrides.id ?? `RC-${idx + 1}`,
+      kind: overrides.kind ?? "acceptance_criterion",
+      text: overrides.text ?? "Required-critical obligation.",
+      sourceArtifact: "agreement",
+      verificationRequired: true,
+      evidencePolicy: "test",
+      status: "approved",
+      ...overrides,
+    })),
+    ...(opts.omitReviewMatrix
+      ? {}
+      : {
+          reviewMatrix: {
+            reviewedAt: "2026-05-20T00:00:00.000Z",
+            rows: itemOverrides
+              .filter((it) => !opts.omitRowForId?.includes(it.id ?? ""))
+              .map((it) => ({
+                contractId: it.id ?? "",
+                kind: it.kind ?? "acceptance_criterion",
+                status: rowStatus ?? "pass",
+                evidencePolicy: "test",
+                evidence: "reviewed",
+              })),
+          },
+        }),
+    amendments: [],
+  };
 }
 
 function passingContract(): ChangeWorkflowState["contract"] {
@@ -628,6 +680,187 @@ describe("gate readiness", () => {
       );
 
       expect(result.warnings).toBeUndefined();
+    });
+  });
+
+  describe("required-critical obligation release checks", () => {
+    it("release gate is ready when all requiredCritical items pass review", () => {
+      const result = evaluateGateReadiness(
+        makeState({
+          gates: releaseReadyGates(),
+          contract: makeRequiredCriticalContract(
+            [{ id: "RC-1", requiredCritical: true }],
+            "pass",
+          ),
+        }),
+        "release",
+      );
+
+      expect(result.ready).toBe(true);
+      expect(
+        result.blockers.some((b) =>
+          b.code.startsWith("REQUIRED_OBLIGATION"),
+        ),
+      ).toBe(false);
+    });
+
+    it("blocks release when a requiredCritical item has failing review status", () => {
+      const result = evaluateGateReadiness(
+        makeState({
+          gates: releaseReadyGates(),
+          contract: makeRequiredCriticalContract(
+            [{ id: "RC-1", requiredCritical: true }],
+            "fail",
+          ),
+        }),
+        "release",
+      );
+
+      expect(result.ready).toBe(false);
+      expect(result.blockers).toContainEqual(
+        expect.objectContaining({
+          code: "REQUIRED_OBLIGATION_UNRESOLVED",
+          gateId: "release",
+          contractId: "RC-1",
+        }),
+      );
+    });
+
+    it("blocks release when a requiredCritical item is silently deferred", () => {
+      const result = evaluateGateReadiness(
+        makeState({
+          gates: releaseReadyGates(),
+          contract: makeRequiredCriticalContract(
+            [{ id: "RC-1", requiredCritical: true }],
+            "pass",
+            { omitRowForId: ["RC-1"], omitReviewMatrix: false },
+          ),
+        }),
+        "release",
+      );
+
+      expect(result.ready).toBe(false);
+      expect(result.blockers).toContainEqual(
+        expect.objectContaining({
+          code: "REQUIRED_OBLIGATION_NOT_ROUTED",
+          gateId: "release",
+          contractId: "RC-1",
+          remediation: expect.stringContaining("adv_change_reenter"),
+        }),
+      );
+    });
+
+    it("does not block release for non-requiredCritical failing items", () => {
+      const result = evaluateGateReadiness(
+        makeState({
+          gates: releaseReadyGates(),
+          contract: makeRequiredCriticalContract(
+            [
+              { id: "RC-1", requiredCritical: false },
+              { id: "RC-2", requiredCritical: true },
+            ],
+            "pass",
+          ),
+        }),
+        "release",
+      );
+
+      // Flip RC-1 to fail manually (helper set all rows to pass)
+      const contract = result.blockers.some((b) =>
+        b.code.startsWith("REQUIRED_OBLIGATION"),
+      );
+      expect(contract).toBe(false);
+      expect(result.ready).toBe(true);
+    });
+
+    it("does not affect acceptance gate", () => {
+      const result = evaluateGateReadiness(
+        makeState({
+          gates: acceptanceReadyGates(),
+          projectionChangesDir: "/tmp/changes",
+          contract: makeRequiredCriticalContract(
+            [{ id: "RC-1", requiredCritical: true }],
+            "fail",
+          ),
+          artifacts: {
+            executiveSummary: {
+              path: "/tmp/changes/change-1/executive-summary.md",
+              updatedAt: "2026-05-20T00:00:00.000Z",
+              contentHash: "a".repeat(64),
+            },
+          },
+        }),
+        "acceptance",
+      );
+
+      expect(
+        result.blockers.some((b) =>
+          b.code.startsWith("REQUIRED_OBLIGATION"),
+        ),
+      ).toBe(false);
+      // acceptance still blocked by normal acceptance contract check
+      expect(result.blockers).toContainEqual(
+        expect.objectContaining({
+          code: "ACCEPTANCE_REVIEW_ROW_FAILING",
+          contractId: "RC-1",
+        }),
+      );
+    });
+
+    it("routing check respects task coverage", () => {
+      const result = evaluateGateReadiness(
+        makeState({
+          gates: releaseReadyGates(),
+          tasks: [
+            {
+              id: "tk-cover",
+              title: "Cover RC-1",
+              status: "done",
+              createdAt: "2026-05-20T00:00:00.000Z",
+              updatedAt: "2026-05-20T00:00:00.000Z",
+              contract_refs: { verifies: ["RC-1"] },
+            },
+          ],
+          contract: makeRequiredCriticalContract(
+            [{ id: "RC-1", requiredCritical: true }],
+            "pass",
+            { omitRowForId: ["RC-1"], omitReviewMatrix: false },
+          ),
+        }),
+        "release",
+      );
+
+      expect(
+        result.blockers.some((b) =>
+          b.code === "REQUIRED_OBLIGATION_NOT_ROUTED",
+        ),
+      ).toBe(false);
+    });
+
+    it("routing check respects notRequiredReason alternate route", () => {
+      const result = evaluateGateReadiness(
+        makeState({
+          gates: releaseReadyGates(),
+          contract: makeRequiredCriticalContract(
+            [
+              {
+                id: "RC-1",
+                requiredCritical: true,
+                notRequiredReason: "Handled by upstream dependency.",
+              },
+            ],
+            "pass",
+            { omitRowForId: ["RC-1"], omitReviewMatrix: false },
+          ),
+        }),
+        "release",
+      );
+
+      expect(
+        result.blockers.some((b) =>
+          b.code === "REQUIRED_OBLIGATION_NOT_ROUTED",
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/plugin/src/temporal/gate-readiness.ts
+++ b/plugin/src/temporal/gate-readiness.ts
@@ -428,6 +428,80 @@ function acceptanceContractBlockers(
   );
 }
 
+function contractItemsCoveredByTasks(state: ChangeWorkflowState): Set<string> {
+  const covered = new Set<string>();
+  for (const task of state.tasks) {
+    if (task.status === "cancelled") continue;
+    const refs = task.contract_refs;
+    if (!refs) continue;
+    for (const id of refs.implements ?? []) covered.add(id);
+    for (const id of refs.verifies ?? []) covered.add(id);
+  }
+  return covered;
+}
+
+export function checkRequiredObligationReleaseBlockers(
+  state: ChangeWorkflowState,
+  gateId: GateId,
+): GateReadinessBlocker[] {
+  if (gateId !== "release") return [];
+  if (!state.contract) return [];
+
+  const rowsByContractId = new Map(
+    state.contract.reviewMatrix?.rows.map((row) => [row.contractId, row]) ?? [],
+  );
+
+  return state.contract.items
+    .filter((item) => item.requiredCritical === true)
+    .flatMap((item) => {
+      const row = rowsByContractId.get(item.id);
+      if (row && isFailingContractReviewStatus(row.status)) {
+        return [
+          makeBlocker({
+            code: "REQUIRED_OBLIGATION_UNRESOLVED",
+            gateId,
+            contractId: item.id,
+            message: `Required-critical obligation ${item.id} has failing review status ${row.status}.`,
+            remediation:
+              "Resolve the failing required-critical contract review row before releasing.",
+          }),
+        ];
+      }
+      return [];
+    });
+}
+
+export function checkRequiredObligationRouting(
+  state: ChangeWorkflowState,
+  gateId: GateId,
+): GateReadinessBlocker[] {
+  if (gateId !== "release") return [];
+  if (!state.contract) return [];
+
+  const rowsByContractId = new Map(
+    state.contract.reviewMatrix?.rows.map((row) => [row.contractId, row]) ?? [],
+  );
+  const coveredIds = contractItemsCoveredByTasks(state);
+
+  return state.contract.items
+    .filter((item) => item.requiredCritical === true)
+    .flatMap((item) => {
+      if (item.notRequiredReason) return [];
+      if (rowsByContractId.has(item.id)) return [];
+      if (coveredIds.has(item.id)) return [];
+      return [
+        makeBlocker({
+          code: "REQUIRED_OBLIGATION_NOT_ROUTED",
+          gateId,
+          contractId: item.id,
+          message: `Required-critical obligation ${item.id} has no task coverage and no review matrix row.`,
+          remediation:
+            "Route via adv_change_reenter or fast-follow split, or add task coverage and complete review.",
+        }),
+      ];
+    });
+}
+
 export function renderAcceptanceProjection(state: ChangeWorkflowState): string {
   const contract = state.contract;
   if (!contract?.reviewMatrix) {
@@ -493,6 +567,11 @@ export function evaluateGateReadiness(
     } else {
       blockers.push(...acceptanceContractBlockers(state, gateId));
     }
+  }
+
+  if (gateId === "release") {
+    blockers.push(...checkRequiredObligationReleaseBlockers(state, gateId));
+    blockers.push(...checkRequiredObligationRouting(state, gateId));
   }
 
   const warnings = artifactCascadeWarnings(state, gateId);

--- a/plugin/src/temporal/gate-readiness.ts
+++ b/plugin/src/temporal/gate-readiness.ts
@@ -693,6 +693,9 @@ export const CRITERION_EVALUATORS: Record<string, CriterionEvaluator> = {
   },
 
   // Release criteria
+  // rq-requiredObligation01: Required-critical contract items without verified
+  // completion evidence block release. Evaluated via acceptance contract blockers
+  // and release gate readiness checks.
   TRUNK_MERGED: () => {
     // Cannot evaluate from state alone — requires git inspection
     return { status: "na", evidence: "Requires git inspection" };

--- a/plugin/src/tools/subagent-report.test.ts
+++ b/plugin/src/tools/subagent-report.test.ts
@@ -555,6 +555,124 @@ describe("subagentReportTools", () => {
     );
   });
 
+  test("required_follow_ups with obligation_class required_critical creates agenda item with priority critical", async () => {
+    const store = storeFor(change());
+    const report = engineerReport({
+      follow_ups: [],
+      required_follow_ups: [
+        {
+          text: "Fix security vulnerability",
+          obligation_class: "required_critical",
+          severity: "critical",
+          source_contract_id: "contract-sec-1",
+        },
+      ],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Fix security vulnerability",
+      expect.objectContaining({
+        priority: "critical",
+        category: "required-obligation",
+        description: expect.stringContaining("Obligation: required_critical"),
+        agendaPath: "/state/agenda.jsonl",
+      }),
+    );
+    expect(
+      mocks.addAgendaItem.mock.calls[0][2].description,
+    ).toContain("Contract: contract-sec-1");
+  });
+
+  test("required_follow_ups with severity high creates agenda item with priority high", async () => {
+    const store = storeFor(change());
+    const report = engineerReport({
+      follow_ups: [],
+      required_follow_ups: [
+        {
+          text: "Update documentation",
+          obligation_class: "required_standard",
+          severity: "high",
+        },
+      ],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Update documentation",
+      expect.objectContaining({
+        priority: "high",
+        category: "required-obligation",
+      }),
+    );
+  });
+
+  test("report without required_follow_ups creates no required agenda items", async () => {
+    const store = storeFor(change());
+    const report = engineerReport({ follow_ups: ["Regular follow-up"] });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Regular follow-up",
+      expect.objectContaining({
+        category: "subagent-followup",
+      }),
+    );
+  });
+
+  test("existing follow_ups still get priority medium (backward compat)", async () => {
+    const store = storeFor(change());
+    const report = engineerReport({
+      follow_ups: ["Backward compat follow-up"],
+      required_follow_ups: [],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Backward compat follow-up",
+      expect.objectContaining({
+        priority: "medium",
+        category: "subagent-followup",
+      }),
+    );
+  });
+
   test("rejects malformed reports at the Zod boundary and records task error_recovery", async () => {
     const store = storeFor(change());
 
@@ -770,5 +888,131 @@ describe("subagentReportTools", () => {
       expect.any(Function),
     );
     expect(mocks.fireSignalAndRefresh.mock.calls[0][1]).toBe(targetStore);
+  });
+
+  test("required_follow_ups with obligation_class required_critical creates agenda item with priority critical", async () => {
+    const store = storeFor(change());
+    const report = engineerReport({
+      follow_ups: [],
+      required_follow_ups: [
+        {
+          text: "Fix contract coverage",
+          obligation_class: "required_critical",
+          severity: "critical",
+          source_contract_id: "contract-1",
+        },
+      ],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(output.consumerResults.requiredFollowUps.previewCount).toBe(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Fix contract coverage",
+      expect.objectContaining({
+        priority: "critical",
+        category: "required-obligation",
+        description: expect.stringContaining("Obligation: required_critical"),
+      }),
+    );
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Fix contract coverage",
+      expect.objectContaining({
+        description: expect.stringContaining("Contract: contract-1"),
+      }),
+    );
+  });
+
+  test("required_follow_ups with severity high creates agenda item with priority high", async () => {
+    const store = storeFor(change());
+    const report = engineerReport({
+      follow_ups: [],
+      required_follow_ups: [
+        {
+          text: "Update tests",
+          obligation_class: "required_standard",
+          severity: "high",
+        },
+      ],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(output.consumerResults.requiredFollowUps.previewCount).toBe(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Update tests",
+      expect.objectContaining({
+        priority: "high",
+        category: "required-obligation",
+      }),
+    );
+  });
+
+  test("report without required_follow_ups produces no required agenda items", async () => {
+    const store = storeFor(change());
+    const report = engineerReport({
+      follow_ups: ["Regular follow-up"],
+      required_follow_ups: undefined,
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(output.consumerResults.requiredFollowUps.previewCount).toBe(0);
+    expect(output.consumerResults.requiredFollowUps.created).toEqual([]);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Regular follow-up",
+      expect.objectContaining({
+        category: "subagent-followup",
+      }),
+    );
+  });
+
+  test("existing follow_ups still get priority medium", async () => {
+    const store = storeFor(change());
+    const report = engineerReport({
+      follow_ups: ["Regular follow-up"],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Regular follow-up",
+      expect.objectContaining({
+        priority: "medium",
+        category: "subagent-followup",
+      }),
+    );
   });
 });

--- a/plugin/src/tools/subagent-report.test.ts
+++ b/plugin/src/tools/subagent-report.test.ts
@@ -588,9 +588,9 @@ describe("subagentReportTools", () => {
         agendaPath: "/state/agenda.jsonl",
       }),
     );
-    expect(
-      mocks.addAgendaItem.mock.calls[0][2].description,
-    ).toContain("Contract: contract-sec-1");
+    expect(mocks.addAgendaItem.mock.calls[0][2].description).toContain(
+      "Contract: contract-sec-1",
+    );
   });
 
   test("required_follow_ups with severity high creates agenda item with priority high", async () => {

--- a/plugin/src/tools/subagent-report.ts
+++ b/plugin/src/tools/subagent-report.ts
@@ -301,8 +301,12 @@ function reportFollowUps(report: ScopedSubagentReport): string[] {
   return "follow_ups" in report ? report.follow_ups : [];
 }
 
-function reportRequiredFollowUps(report: ScopedSubagentReport): RequiredFollowUp[] {
-  return "required_follow_ups" in report ? (report.required_follow_ups ?? []) : [];
+function reportRequiredFollowUps(
+  report: ScopedSubagentReport,
+): RequiredFollowUp[] {
+  return "required_follow_ups" in report
+    ? (report.required_follow_ups ?? [])
+    : [];
 }
 
 /** Build the human-readable source token used on report-created agenda items. */

--- a/plugin/src/tools/subagent-report.ts
+++ b/plugin/src/tools/subagent-report.ts
@@ -16,6 +16,7 @@ import {
   type ErrorRecovery,
   type ScopedSubagentReport,
   type Task,
+  type RequiredFollowUp,
 } from "../types";
 import { getProjectId } from "../utils/project-id";
 import { formatToolOutput } from "../utils/tool-output";
@@ -300,6 +301,10 @@ function reportFollowUps(report: ScopedSubagentReport): string[] {
   return "follow_ups" in report ? report.follow_ups : [];
 }
 
+function reportRequiredFollowUps(report: ScopedSubagentReport): RequiredFollowUp[] {
+  return "required_follow_ups" in report ? (report.required_follow_ups ?? []) : [];
+}
+
 /** Build the human-readable source token used on report-created agenda items. */
 function reportSourceDescription(report: ScopedSubagentReport): string {
   const taskId = reportTaskId(report);
@@ -507,6 +512,62 @@ async function consumeFollowUps(input: {
   };
 }
 
+// rq-subagentReports14: Required Follow-Up Preservation
+async function consumeRequiredFollowUps(input: {
+  store: Store;
+  report: ScopedSubagentReport;
+  dryRun?: boolean;
+}): Promise<{
+  previewCount: number;
+  created: unknown[];
+  warnings: ConsumerWarning[];
+}> {
+  const requiredFollowUps = reportRequiredFollowUps(input.report);
+  if (input.dryRun) {
+    return {
+      previewCount: requiredFollowUps.length,
+      created: [],
+      warnings: [],
+    };
+  }
+
+  const created: unknown[] = [];
+  const warnings: ConsumerWarning[] = [];
+  for (const followUp of requiredFollowUps) {
+    try {
+      const description = [
+        reportSourceDescription(input.report),
+        `Obligation: ${followUp.obligation_class}`,
+        ...(followUp.source_contract_id
+          ? [`Contract: ${followUp.source_contract_id}`]
+          : []),
+      ].join("\n");
+      created.push(
+        await addAgendaItem(input.store.paths.root, followUp.text, {
+          description,
+          priority: followUp.severity,
+          category: "required-obligation",
+          agendaPath: input.store.paths.agenda,
+        }),
+      );
+    } catch (error) {
+      warnings.push({
+        kind: "consumer_failure",
+        message:
+          error instanceof Error
+            ? `Failed to add required-obligation agenda item: ${error.message}`
+            : "Failed to add required-obligation agenda item",
+      });
+    }
+  }
+
+  return {
+    previewCount: requiredFollowUps.length,
+    created,
+    warnings: validateConsumerWarnings(warnings),
+  };
+}
+
 function appendProjectContext(
   output: string,
   projectContext?: TargetProjectOutputContext,
@@ -569,6 +630,7 @@ async function executeSubmit(
         reportId: id,
         consumerResults: {
           followUps: { previewCount: 0, created: [] },
+          requiredFollowUps: { previewCount: 0, created: [] },
           verification: { warnings: [] },
         },
       }),
@@ -621,7 +683,16 @@ async function executeSubmit(
     report,
     dryRun: args.dryRun,
   });
-  const warnings = [...initialWarnings, ...followUps.warnings];
+  const requiredFollowUps = await consumeRequiredFollowUps({
+    store,
+    report,
+    dryRun: args.dryRun,
+  });
+  const warnings = [
+    ...initialWarnings,
+    ...followUps.warnings,
+    ...requiredFollowUps.warnings,
+  ];
 
   return appendProjectContext(
     formatToolOutput({
@@ -634,6 +705,10 @@ async function executeSubmit(
         followUps: {
           previewCount: followUps.previewCount,
           created: followUps.created,
+        },
+        requiredFollowUps: {
+          previewCount: requiredFollowUps.previewCount,
+          created: requiredFollowUps.created,
         },
         verification: { warnings },
       },

--- a/plugin/src/types/changes.ts
+++ b/plugin/src/types/changes.ts
@@ -379,6 +379,7 @@ export const ContractItemSchema = z.object({
   evidencePolicy: ContractEvidencePolicySchema,
   status: ContractItemStatusSchema.default("draft"),
   notRequiredReason: z.string().optional(),
+  requiredCritical: z.boolean().optional(),
 });
 export type ContractItem = z.infer<typeof ContractItemSchema>;
 

--- a/plugin/src/types/contract.test.ts
+++ b/plugin/src/types/contract.test.ts
@@ -119,4 +119,33 @@ describe("change contract schemas", () => {
 
     expect(contract.version).toBe(1);
   });
+
+  test("accepts requiredCritical on contract item", () => {
+    const item = ContractItemSchema.parse({
+      id: "RC1",
+      kind: "success_criterion",
+      text: "Must preserve backward compatibility.",
+      sourceArtifact: "agreement",
+      verificationRequired: true,
+      evidencePolicy: "test",
+      status: "approved",
+      requiredCritical: true,
+    });
+
+    expect(item.requiredCritical).toBe(true);
+  });
+
+  test("preserves backward compat without requiredCritical", () => {
+    const item = ContractItemSchema.parse({
+      id: "RC2",
+      kind: "acceptance_criterion",
+      text: "No required-critical flag.",
+      sourceArtifact: "agreement",
+      verificationRequired: true,
+      evidencePolicy: "review",
+      status: "draft",
+    });
+
+    expect(item.requiredCritical).toBeUndefined();
+  });
 });

--- a/plugin/src/types/index.ts
+++ b/plugin/src/types/index.ts
@@ -88,6 +88,8 @@ export {
   SubagentDecisionSchema,
   SubagentBlockerSchema,
   SubagentConsumerWarningSchema,
+  RequiredFollowUpSchema,
+  type RequiredFollowUp,
   EngineerSubagentReportSchema,
   DesignerDesignDimensionSchema,
   DesignerDesignDimensionsSchema,

--- a/plugin/src/types/subagent-reports.test.ts
+++ b/plugin/src/types/subagent-reports.test.ts
@@ -8,6 +8,7 @@ import {
   getSubagentReportPacketAnchors,
   normalizePersistedSubagentReportState,
   type PersistedSubagentReportAgent,
+  RequiredFollowUpSchema,
   ResearcherSubagentReportSchema,
   ReviewerSubagentReportSchema,
   ScannerBundleSubagentReportSchema,
@@ -417,6 +418,62 @@ describe("Subagent report schemas", () => {
       "harden:release",
     );
     expect(() => ChangeReportScopeKeySchema.parse("freeform")).toThrow();
+  });
+
+  it("parses engineer report with required_follow_ups", () => {
+    const parsed = EngineerSubagentReportSchema.parse({
+      ...engineerReport,
+      required_follow_ups: [
+        {
+          text: "Add acceptance test for required-critical defaulting",
+          obligation_class: "required_critical",
+          severity: "critical",
+          source_contract_id: "AC1",
+        },
+      ],
+    });
+
+    expect(parsed.required_follow_ups).toHaveLength(1);
+    expect(parsed.required_follow_ups![0].obligation_class).toBe(
+      "required_critical",
+    );
+    expect(parsed.required_follow_ups![0].severity).toBe("critical");
+  });
+
+  it("parses reviewer report with required_follow_ups", () => {
+    const parsed = ReviewerSubagentReportSchema.parse({
+      ...reviewerReport,
+      required_follow_ups: [
+        {
+          text: "Harden boundary validation before release",
+          obligation_class: "required_standard",
+          severity: "high",
+        },
+      ],
+    });
+
+    expect(parsed.required_follow_ups).toHaveLength(1);
+    expect(parsed.required_follow_ups![0].obligation_class).toBe(
+      "required_standard",
+    );
+    expect(parsed.required_follow_ups![0].severity).toBe("high");
+  });
+
+  it("defaults required_follow_up severity to high", () => {
+    const followUp = RequiredFollowUpSchema.parse({
+      text: "Update docs",
+      obligation_class: "required_standard",
+    });
+
+    expect(followUp.severity).toBe("high");
+  });
+
+  it("preserves backward compat without required_follow_ups", () => {
+    const parsedEngineer = EngineerSubagentReportSchema.parse(engineerReport);
+    const parsedReviewer = ReviewerSubagentReportSchema.parse(reviewerReport);
+
+    expect(parsedEngineer.required_follow_ups).toBeUndefined();
+    expect(parsedReviewer.required_follow_ups).toBeUndefined();
   });
 
   describe("context packet anchor contract", () => {

--- a/plugin/src/types/subagent-reports.ts
+++ b/plugin/src/types/subagent-reports.ts
@@ -110,6 +110,16 @@ export const ReviewerScopeDriftSchema = z
 
 export const EngineerScopeDriftSchema = ReviewerScopeDriftSchema;
 
+export const RequiredFollowUpSchema = z
+  .object({
+    text: z.string().min(1),
+    obligation_class: z.enum(["required_critical", "required_standard"]),
+    severity: z.enum(["critical", "high"]).default("high"),
+    source_contract_id: z.string().optional(),
+  })
+  .strict();
+export type RequiredFollowUp = z.infer<typeof RequiredFollowUpSchema>;
+
 export const SubagentConsumerWarningSchema = z
   .object({
     kind: z.enum([
@@ -131,6 +141,7 @@ export const EngineerSubagentReportSchema =
     blockers: z.array(SubagentBlockerSchema),
     scope_drift: EngineerScopeDriftSchema.nullable(),
     follow_ups: z.array(z.string().min(1)),
+    required_follow_ups: z.array(RequiredFollowUpSchema).optional(),
     required_main_agent_actions: z.array(z.string().min(1)),
     related_scan: z.string().min(1),
     context_update_for_adv: z
@@ -242,6 +253,7 @@ const ReviewerReportFields = {
   scope_drift: ReviewerScopeDriftSchema.nullable(),
   risks: z.array(z.string().min(1)),
   required_main_agent_actions: z.array(z.string().min(1)),
+  required_follow_ups: z.array(RequiredFollowUpSchema).optional(),
   consumer_warnings: z.array(SubagentConsumerWarningSchema).optional(),
 };
 

--- a/plugin/src/validator/prep-readiness.test.ts
+++ b/plugin/src/validator/prep-readiness.test.ts
@@ -10,7 +10,10 @@
  */
 
 import { describe, expect, test } from "vitest";
-import { runPrepReadinessChecks, checkCriticalOpsCoverage } from "./prep-readiness";
+import {
+  runPrepReadinessChecks,
+  checkCriticalOpsCoverage,
+} from "./prep-readiness";
 import type { Change } from "../types";
 
 /**
@@ -117,8 +120,12 @@ function buildChangeWithContract(
         sourceArtifact: "agreement",
         evidencePolicy: "test",
         verificationRequired: it.verificationRequired !== false,
-        ...(it.requiredCritical !== undefined && { requiredCritical: it.requiredCritical }),
-        ...(it.notRequiredReason !== undefined && { notRequiredReason: it.notRequiredReason }),
+        ...(it.requiredCritical !== undefined && {
+          requiredCritical: it.requiredCritical,
+        }),
+        ...(it.notRequiredReason !== undefined && {
+          notRequiredReason: it.notRequiredReason,
+        }),
       })),
     },
     tasks: tasks.map((t) => ({
@@ -136,7 +143,13 @@ describe("checkCriticalOpsCoverage", () => {
   test("requiredCritical item with task coverage produces no issues", () => {
     const change = buildChangeWithContract(
       [{ id: "AC-1", requiredCritical: true }],
-      [{ id: "tk-1", status: "pending", contract_refs: { implements: ["AC-1"] } }],
+      [
+        {
+          id: "tk-1",
+          status: "pending",
+          contract_refs: { implements: ["AC-1"] },
+        },
+      ],
     );
     const issues = checkCriticalOpsCoverage(change);
     expect(issues).toHaveLength(0);
@@ -155,7 +168,13 @@ describe("checkCriticalOpsCoverage", () => {
 
   test("requiredCritical item with notRequiredReason is exempt (alternate route)", () => {
     const change = buildChangeWithContract(
-      [{ id: "AC-1", requiredCritical: true, notRequiredReason: "Covered by upstream contract" }],
+      [
+        {
+          id: "AC-1",
+          requiredCritical: true,
+          notRequiredReason: "Covered by upstream contract",
+        },
+      ],
       [],
     );
     const issues = checkCriticalOpsCoverage(change);
@@ -174,7 +193,13 @@ describe("checkCriticalOpsCoverage", () => {
   test("requiredCritical item with cancelled task coverage is still uncovered", () => {
     const change = buildChangeWithContract(
       [{ id: "AC-1", requiredCritical: true }],
-      [{ id: "tk-1", status: "cancelled", contract_refs: { verifies: ["AC-1"] } }],
+      [
+        {
+          id: "tk-1",
+          status: "cancelled",
+          contract_refs: { verifies: ["AC-1"] },
+        },
+      ],
     );
     const issues = checkCriticalOpsCoverage(change);
     expect(issues).toHaveLength(1);
@@ -185,7 +210,13 @@ describe("checkCriticalOpsCoverage", () => {
   test("requiredCritical item with verifies coverage produces no issues", () => {
     const change = buildChangeWithContract(
       [{ id: "SC-1", requiredCritical: true, kind: "success_criterion" }],
-      [{ id: "tk-1", status: "pending", contract_refs: { verifies: ["SC-1"] } }],
+      [
+        {
+          id: "tk-1",
+          status: "pending",
+          contract_refs: { verifies: ["SC-1"] },
+        },
+      ],
     );
     const issues = checkCriticalOpsCoverage(change);
     expect(issues).toHaveLength(0);

--- a/plugin/src/validator/prep-readiness.test.ts
+++ b/plugin/src/validator/prep-readiness.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, test } from "vitest";
-import { runPrepReadinessChecks } from "./prep-readiness";
+import { runPrepReadinessChecks, checkCriticalOpsCoverage } from "./prep-readiness";
 import type { Change } from "../types";
 
 /**
@@ -76,5 +76,138 @@ describe("checkTaskGraphIntegrity — TDD inversion severity (rq-PR003tdd.1, AC4
       expect(inversion).toHaveLength(1);
       expect(inversion[0].severity).toBe("warning");
     }
+  });
+});
+
+// =============================================================================
+// Critical-Ops Coverage (rq-PR007cro)
+// =============================================================================
+
+function buildChangeWithContract(
+  items: Array<{
+    id: string;
+    requiredCritical?: boolean;
+    notRequiredReason?: string;
+    kind?: string;
+    verificationRequired?: boolean;
+  }>,
+  tasks: Array<{
+    id: string;
+    status: string;
+    contract_refs?: {
+      implements?: string[];
+      verifies?: string[];
+    };
+  }>,
+): Change {
+  return {
+    id: "c-critical",
+    title: "Critical ops fixture",
+    status: "active",
+    created_at: "2026-06-02T00:00:00.000Z",
+    deltas: {},
+    contract: {
+      version: 1,
+      rigor: "standard",
+      source: { artifact: "agreement", approvedAt: "2026-06-02T00:00:00.000Z" },
+      items: items.map((it) => ({
+        id: it.id,
+        kind: (it.kind as any) ?? "acceptance_criterion",
+        text: it.id,
+        sourceArtifact: "agreement",
+        evidencePolicy: "test",
+        verificationRequired: it.verificationRequired !== false,
+        ...(it.requiredCritical !== undefined && { requiredCritical: it.requiredCritical }),
+        ...(it.notRequiredReason !== undefined && { notRequiredReason: it.notRequiredReason }),
+      })),
+    },
+    tasks: tasks.map((t) => ({
+      id: t.id,
+      title: t.id,
+      status: t.status,
+      deps: [],
+      metadata: {},
+      ...(t.contract_refs && { contract_refs: t.contract_refs }),
+    })),
+  } as unknown as Change;
+}
+
+describe("checkCriticalOpsCoverage", () => {
+  test("requiredCritical item with task coverage produces no issues", () => {
+    const change = buildChangeWithContract(
+      [{ id: "AC-1", requiredCritical: true }],
+      [{ id: "tk-1", status: "pending", contract_refs: { implements: ["AC-1"] } }],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("requiredCritical item without task coverage produces CRITICAL_OPS_UNCOVERED error", () => {
+    const change = buildChangeWithContract(
+      [{ id: "AC-1", requiredCritical: true }],
+      [],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("CRITICAL_OPS_UNCOVERED");
+    expect(issues[0].severity).toBe("error");
+  });
+
+  test("requiredCritical item with notRequiredReason is exempt (alternate route)", () => {
+    const change = buildChangeWithContract(
+      [{ id: "AC-1", requiredCritical: true, notRequiredReason: "Covered by upstream contract" }],
+      [],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("non-requiredCritical item without coverage produces no error from this check", () => {
+    const change = buildChangeWithContract(
+      [{ id: "AC-1", requiredCritical: false }],
+      [],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("requiredCritical item with cancelled task coverage is still uncovered", () => {
+    const change = buildChangeWithContract(
+      [{ id: "AC-1", requiredCritical: true }],
+      [{ id: "tk-1", status: "cancelled", contract_refs: { verifies: ["AC-1"] } }],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("CRITICAL_OPS_UNCOVERED");
+    expect(issues[0].severity).toBe("error");
+  });
+
+  test("requiredCritical item with verifies coverage produces no issues", () => {
+    const change = buildChangeWithContract(
+      [{ id: "SC-1", requiredCritical: true, kind: "success_criterion" }],
+      [{ id: "tk-1", status: "pending", contract_refs: { verifies: ["SC-1"] } }],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("requiredCritical item with verificationRequired:false still needs coverage", () => {
+    const change = buildChangeWithContract(
+      [{ id: "AC-1", requiredCritical: true, verificationRequired: false }],
+      [],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("CRITICAL_OPS_UNCOVERED");
+    expect(issues[0].severity).toBe("error");
+  });
+
+  test("runPrepReadinessChecks includes checkCriticalOpsCoverage in checksPerformed", () => {
+    const change = buildChangeWithContract(
+      [{ id: "AC-1", requiredCritical: true }],
+      [],
+    );
+    const result = runPrepReadinessChecks(change, "strict");
+    expect(result.checksPerformed).toContain("checkCriticalOpsCoverage");
   });
 });

--- a/plugin/src/validator/prep-readiness.ts
+++ b/plugin/src/validator/prep-readiness.ts
@@ -43,6 +43,10 @@ const PrepReadinessCodes = {
   // Cross-repo routing
   CROSS_REPO_MISSING_METADATA: "CROSS_REPO_MISSING_METADATA", // must (error)
   CROSS_REPO_HINT_UNROUTED: "CROSS_REPO_HINT_UNROUTED", // warning
+
+  // Critical-ops coverage (rq-PR007cro)
+  CRITICAL_OPS_UNCOVERED: "CRITICAL_OPS_UNCOVERED", // must (error)
+  CRITICAL_OPS_DEFERRED: "CRITICAL_OPS_DEFERRED", // must (error)
 } as const;
 
 type _PrepReadinessCode =
@@ -412,6 +416,55 @@ export function checkTddIntentAssigned(
 }
 
 // =============================================================================
+// Check: Critical-Ops Coverage (rq-PR007coc)
+// =============================================================================
+
+/**
+ * Ensure every contract item marked `requiredCritical: true` has active task
+ * coverage (implements or verifies) by a non-cancelled task, or an explicit
+ * policy-approved alternate route via `notRequiredReason`.
+ *
+ * Items with `verificationRequired: false` are NOT exempt — requiredCritical
+ * is a correctness/release-safety obligation that must not be silently deferred.
+ */
+export function checkCriticalOpsCoverage(change: Change): ValidationIssue[] {
+  const contract = change.contract;
+  if (!contract) return [];
+
+  const issues: ValidationIssue[] = [];
+
+  // Collect IDs covered by non-cancelled tasks
+  const coveredIds = new Set<string>();
+  for (const task of change.tasks ?? []) {
+    if (task.status === "cancelled") continue;
+    const refs = task.contract_refs;
+    if (!refs) continue;
+    for (const id of refs.implements ?? []) coveredIds.add(id);
+    for (const id of refs.verifies ?? []) coveredIds.add(id);
+  }
+
+  for (const item of contract.items) {
+    if (item.requiredCritical !== true) continue;
+    if (item.notRequiredReason) continue; // policy-approved alternate route
+    if (!coveredIds.has(item.id)) {
+      issues.push({
+        code: PrepReadinessCodes.CRITICAL_OPS_UNCOVERED,
+        severity: "error",
+        message: `Required-critical contract item "${item.id}" has no active task coverage (implements or verifies)`,
+        path: `contract.items.${item.id}`,
+        details: {
+          contractId: item.id,
+          remediation:
+            "Add a non-cancelled task that implements or verifies this contract item, or set notRequiredReason to document an approved alternate route.",
+        },
+      });
+    }
+  }
+
+  return issues;
+}
+
+// =============================================================================
 // runPrepReadinessChecks
 // =============================================================================
 
@@ -439,6 +492,7 @@ export function runPrepReadinessChecks(
     ...checkScenarioAdequacy(change),
     ...checkTaskGraphIntegrity(change),
     ...checkCrossRepoRouting(change),
+    ...checkCriticalOpsCoverage(change),
     ...(tddEnforcement !== "off"
       ? checkTddIntentAssigned(
           change,
@@ -459,6 +513,7 @@ export function runPrepReadinessChecks(
       "checkScenarioAdequacy",
       "checkTaskGraphIntegrity",
       "checkCrossRepoRouting",
+      "checkCriticalOpsCoverage",
       "checkTddIntentAssigned",
     ],
     checkedAt: new Date().toISOString(),

--- a/plugin/src/validator/required-obligation-regression.test.ts
+++ b/plugin/src/validator/required-obligation-regression.test.ts
@@ -1,0 +1,888 @@
+/**
+ * Required-Obligation Regression Tests
+ *
+ * End-to-end integration tests for the required-obligation enforcement pipeline
+ * across contract typing, prep readiness, report ingestion, and release safety.
+ *
+ * Coverage:
+ * - Typed model: requiredCritical field on ContractItem
+ * - Prep readiness: checkCriticalOpsCoverage blocks planning for uncovered items
+ * - Report ingestion: consumeRequiredFollowUps preserves obligation_class/severity
+ * - Release safety: checkRequiredObligationReleaseBlockers + checkRequiredObligationRouting
+ * - Backward compatibility: contracts without requiredCritical work as before
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createDefaultGates } from "../types";
+import type {
+  Change,
+  ChangeWorkflowState,
+  EngineerSubagentReport,
+} from "../types";
+import type { Store } from "../storage/store-types";
+import {
+  checkCriticalOpsCoverage,
+  runPrepReadinessChecks,
+} from "./prep-readiness";
+import {
+  checkRequiredObligationReleaseBlockers,
+  checkRequiredObligationRouting,
+  evaluateGateReadiness,
+} from "../temporal/gate-readiness";
+
+// =============================================================================
+// Mocks (mirrors subagent-report.test.ts pattern for tool-layer ingestion)
+// =============================================================================
+
+const mocks = vi.hoisted(() => {
+  const fireSignalAndRefresh = vi.fn(async () => undefined);
+  const workflowHandle = { signal: vi.fn(), query: vi.fn() };
+  const addAgendaItem = vi.fn(async (_root: string, title: string) => ({
+    id: `ag-${title.length}`,
+    title,
+    status: "pending",
+  }));
+
+  return {
+    fireSignalAndRefresh,
+    workflowHandle,
+    addAgendaItem,
+  };
+});
+
+vi.mock("../tools/_adapters", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../tools/_adapters")>()),
+  fireSignalAndRefresh: mocks.fireSignalAndRefresh,
+  getChangeHandle: () => mocks.workflowHandle,
+}));
+
+vi.mock("../temporal/service", () => ({
+  getService: () => ({ client: { workflow: { getHandle: vi.fn() } } }),
+}));
+
+vi.mock("../utils/project-id", () => ({
+  getProjectId: async () => "project-1",
+}));
+
+vi.mock("../storage/agenda", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../storage/agenda")>()),
+  addAgendaItem: mocks.addAgendaItem,
+}));
+
+// Import tool layer AFTER mocks are established
+import { subagentReportTools } from "../tools/subagent-report";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeChangeWorkflowState(
+  overrides: Partial<ChangeWorkflowState> = {},
+): ChangeWorkflowState {
+  return {
+    projectId: "project-1",
+    changeId: "change-1",
+    title: "Test change",
+    initializedAt: "2026-05-20T00:00:00.000Z",
+    id: "change-1",
+    status: "draft",
+    createdAt: "2026-05-20T00:00:00.000Z",
+    tasks: [],
+    deltas: {},
+    wisdom: [],
+    gates: createDefaultGates(),
+    artifacts: {},
+    ...overrides,
+  };
+}
+
+function releaseReadyGates() {
+  const gates = createDefaultGates();
+  gates.proposal.status = "done";
+  gates.discovery.status = "done";
+  gates.design.status = "done";
+  gates.planning.status = "done";
+  gates.execution.status = "done";
+  gates.acceptance.status = "done";
+  return gates;
+}
+
+function makeContract(
+  items: Array<
+    Partial<NonNullable<ChangeWorkflowState["contract"]>["items"][number]> & {
+      id: string;
+    }
+  >,
+  reviewMatrixRows?: Array<{
+    contractId: string;
+    status: string;
+    evidencePolicy?: string;
+  }>,
+): NonNullable<ChangeWorkflowState["contract"]> {
+  return {
+    version: 1,
+    rigor: "standard",
+    source: { artifact: "agreement", approvedAt: "2026-05-20T00:00:00.000Z" },
+    items: items.map((it) => ({
+      kind: "acceptance_criterion",
+      text: it.id,
+      sourceArtifact: "agreement",
+      verificationRequired: true,
+      evidencePolicy: "test",
+      status: "approved",
+      ...it,
+    })),
+    ...(reviewMatrixRows
+      ? {
+          reviewMatrix: {
+            reviewedAt: "2026-05-20T00:00:00.000Z",
+            rows: reviewMatrixRows.map((r) => ({
+              contractId: r.contractId,
+              kind: "acceptance_criterion",
+              status: r.status,
+              evidencePolicy: r.evidencePolicy ?? "test",
+              evidence: "reviewed",
+            })),
+          },
+        }
+      : {}),
+    amendments: [],
+  };
+}
+
+function buildChangeWithContract(
+  items: Array<{
+    id: string;
+    requiredCritical?: boolean;
+    notRequiredReason?: string;
+    kind?: string;
+    verificationRequired?: boolean;
+  }>,
+  tasks: Array<{
+    id: string;
+    status: string;
+    contract_refs?: {
+      implements?: string[];
+      verifies?: string[];
+    };
+  }>,
+): Change {
+  return {
+    id: "c-critical",
+    title: "Critical ops fixture",
+    status: "active",
+    created_at: "2026-06-02T00:00:00.000Z",
+    deltas: {},
+    contract: {
+      version: 1,
+      rigor: "standard",
+      source: { artifact: "agreement", approvedAt: "2026-06-02T00:00:00.000Z" },
+      items: items.map((it) => ({
+        id: it.id,
+        kind: (it.kind as any) ?? "acceptance_criterion",
+        text: it.id,
+        sourceArtifact: "agreement",
+        evidencePolicy: "test",
+        verificationRequired: it.verificationRequired !== false,
+        ...(it.requiredCritical !== undefined && {
+          requiredCritical: it.requiredCritical,
+        }),
+        ...(it.notRequiredReason !== undefined && {
+          notRequiredReason: it.notRequiredReason,
+        }),
+      })),
+    },
+    tasks: tasks.map((t) => ({
+      id: t.id,
+      title: t.id,
+      status: t.status,
+      deps: [],
+      metadata: {},
+      ...(t.contract_refs && { contract_refs: t.contract_refs }),
+    })),
+  } as unknown as Change;
+}
+
+function engineerReport(
+  overrides: Partial<EngineerSubagentReport> = {},
+): EngineerSubagentReport {
+  return {
+    schema_version: "1.0",
+    change_id: "change-1",
+    task_id: "tk-1",
+    attempt: 1,
+    agent: "adv-engineer",
+    status: "complete",
+    scope: { kind: "task", task_id: "tk-1" },
+    workdir_used: "/repo",
+    files_touched: ["src/a.ts"],
+    verification: [{ command: "pnpm test", exit_code: 0, summary: "passed" }],
+    decisions: [{ what: "Used typed tool", why: "Durable state" }],
+    blockers: [],
+    scope_drift: null,
+    follow_ups: [],
+    required_main_agent_actions: [],
+    related_scan: "No same-pattern issues",
+    context_update_for_adv: {
+      what_ads_needs_to_know: "Report submitted",
+      suggested_next_action: "Continue",
+    },
+    ...overrides,
+  };
+}
+
+function storeFor(baseChange: Change): Store {
+  return {
+    paths: {
+      root: "/repo",
+      agenda: "/state/agenda.jsonl",
+    } as Store["paths"],
+    config: null,
+    init: vi.fn(),
+    sync: vi.fn(),
+    close: vi.fn(),
+    flush: vi.fn(),
+    changes: {
+      get: vi.fn(async () => ({ success: true, data: baseChange })),
+      refresh: vi.fn(async () => undefined),
+    },
+  } as unknown as Store;
+}
+
+function parse(output: string): Record<string, any> {
+  return JSON.parse(output) as Record<string, any>;
+}
+
+// =============================================================================
+// Full Pipeline Tests
+// =============================================================================
+
+describe("required-obligation end-to-end pipeline", () => {
+  describe("happy path: requiredCritical → coverage → review → release", () => {
+    test("prep blocks when requiredCritical item has no task coverage", () => {
+      const change = buildChangeWithContract(
+        [{ id: "RC-1", requiredCritical: true }],
+        [],
+      );
+      const result = runPrepReadinessChecks(change, "strict");
+
+      expect(result.passed).toBe(false);
+      expect(result.mustFailures).toContainEqual(
+        expect.objectContaining({
+          code: "CRITICAL_OPS_UNCOVERED",
+          severity: "error",
+          details: expect.objectContaining({ contractId: "RC-1" }),
+        }),
+      );
+    });
+
+    test("prep passes after task coverage is added", () => {
+      const change = buildChangeWithContract(
+        [{ id: "RC-1", requiredCritical: true }],
+        [
+          {
+            id: "tk-1",
+            status: "pending",
+            contract_refs: { implements: ["RC-1"] },
+          },
+        ],
+      );
+      const result = runPrepReadinessChecks(change, "strict");
+
+      expect(
+        result.mustFailures.some((i) => i.code === "CRITICAL_OPS_UNCOVERED"),
+      ).toBe(false);
+    });
+
+    test("release passes when requiredCritical item has passing review matrix", () => {
+      const result = evaluateGateReadiness(
+        makeChangeWorkflowState({
+          gates: releaseReadyGates(),
+          contract: makeContract(
+            [{ id: "RC-1", requiredCritical: true }],
+            [{ contractId: "RC-1", status: "pass" }],
+          ),
+        }),
+        "release",
+      );
+
+      expect(result.ready).toBe(true);
+      expect(
+        result.blockers.some((b) => b.code.startsWith("REQUIRED_OBLIGATION")),
+      ).toBe(false);
+    });
+  });
+
+  describe("negative path: silently deferred requiredCritical", () => {
+    test("prep blocks for uncovered requiredCritical", () => {
+      const change = buildChangeWithContract(
+        [{ id: "RC-1", requiredCritical: true }],
+        [],
+      );
+      const prepResult = runPrepReadinessChecks(change, "strict");
+      expect(prepResult.passed).toBe(false);
+      expect(prepResult.mustFailures).toContainEqual(
+        expect.objectContaining({ code: "CRITICAL_OPS_UNCOVERED" }),
+      );
+    });
+
+    test("release blocks for silently deferred requiredCritical (no row, no coverage)", () => {
+      const result = evaluateGateReadiness(
+        makeChangeWorkflowState({
+          gates: releaseReadyGates(),
+          contract: makeContract(
+            [{ id: "RC-1", requiredCritical: true }],
+            // review matrix present but missing RC-1 row
+            [{ contractId: "RC-2", status: "pass" }],
+          ),
+        }),
+        "release",
+      );
+
+      expect(result.ready).toBe(false);
+      expect(result.blockers).toContainEqual(
+        expect.objectContaining({
+          code: "REQUIRED_OBLIGATION_NOT_ROUTED",
+          gateId: "release",
+          contractId: "RC-1",
+        }),
+      );
+    });
+
+    test("release also blocks for requiredCritical with failing review status", () => {
+      const result = evaluateGateReadiness(
+        makeChangeWorkflowState({
+          gates: releaseReadyGates(),
+          contract: makeContract(
+            [{ id: "RC-1", requiredCritical: true }],
+            [{ contractId: "RC-1", status: "fail" }],
+          ),
+        }),
+        "release",
+      );
+
+      expect(result.ready).toBe(false);
+      expect(result.blockers).toContainEqual(
+        expect.objectContaining({
+          code: "REQUIRED_OBLIGATION_UNRESOLVED",
+          gateId: "release",
+          contractId: "RC-1",
+        }),
+      );
+    });
+  });
+});
+
+// =============================================================================
+// Cross-Cutting Enforcement Tests
+// =============================================================================
+
+describe("checkCriticalOpsCoverage", () => {
+  test("identifies uncovered requiredCritical items", () => {
+    const change = buildChangeWithContract(
+      [
+        { id: "RC-1", requiredCritical: true },
+        { id: "RC-2", requiredCritical: true },
+      ],
+      [
+        {
+          id: "tk-1",
+          status: "pending",
+          contract_refs: { implements: ["RC-1"] },
+        },
+      ],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("CRITICAL_OPS_UNCOVERED");
+    expect(issues[0].details).toMatchObject({ contractId: "RC-2" });
+  });
+
+  test("ignores non-requiredCritical items without coverage", () => {
+    const change = buildChangeWithContract(
+      [
+        { id: "AC-1", requiredCritical: false },
+        { id: "AC-2" }, // requiredCritical undefined
+      ],
+      [],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("checkRequiredObligationReleaseBlockers", () => {
+  test("blocks release for failing requiredCritical review row", () => {
+    const state = makeChangeWorkflowState({
+      contract: makeContract(
+        [{ id: "RC-1", requiredCritical: true }],
+        [{ contractId: "RC-1", status: "fail" }],
+      ),
+    });
+    const blockers = checkRequiredObligationReleaseBlockers(state, "release");
+
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].code).toBe("REQUIRED_OBLIGATION_UNRESOLVED");
+  });
+
+  test("blocks release for 'unknown' review status", () => {
+    const state = makeChangeWorkflowState({
+      contract: makeContract(
+        [{ id: "RC-1", requiredCritical: true }],
+        [{ contractId: "RC-1", status: "unknown" }],
+      ),
+    });
+    const blockers = checkRequiredObligationReleaseBlockers(state, "release");
+
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].code).toBe("REQUIRED_OBLIGATION_UNRESOLVED");
+  });
+
+  test("does not block for 'violated' non-requiredCritical items", () => {
+    const state = makeChangeWorkflowState({
+      contract: makeContract(
+        [
+          { id: "RC-1", requiredCritical: false },
+          { id: "RC-2", requiredCritical: true },
+        ],
+        [
+          { contractId: "RC-1", status: "violated" },
+          { contractId: "RC-2", status: "pass" },
+        ],
+      ),
+    });
+    const blockers = checkRequiredObligationReleaseBlockers(state, "release");
+    expect(blockers).toHaveLength(0);
+  });
+
+  test("no-op for non-release gates", () => {
+    const state = makeChangeWorkflowState({
+      contract: makeContract(
+        [{ id: "RC-1", requiredCritical: true }],
+        [{ contractId: "RC-1", status: "fail" }],
+      ),
+    });
+    for (const gateId of [
+      "proposal",
+      "discovery",
+      "design",
+      "planning",
+      "execution",
+      "acceptance",
+    ] as const) {
+      expect(
+        checkRequiredObligationReleaseBlockers(state, gateId),
+      ).toHaveLength(0);
+    }
+  });
+});
+
+describe("checkRequiredObligationRouting", () => {
+  test("blocks release for requiredCritical with no row and no task coverage", () => {
+    const state = makeChangeWorkflowState({
+      contract: makeContract(
+        [{ id: "RC-1", requiredCritical: true }],
+        [], // no review matrix rows at all
+      ),
+    });
+    const blockers = checkRequiredObligationRouting(state, "release");
+
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].code).toBe("REQUIRED_OBLIGATION_NOT_ROUTED");
+  });
+
+  test("allows release when task coverage exists even without review row", () => {
+    const state = makeChangeWorkflowState({
+      tasks: [
+        {
+          id: "tk-cover",
+          title: "Cover RC-1",
+          status: "done",
+          createdAt: "2026-05-20T00:00:00.000Z",
+          updatedAt: "2026-05-20T00:00:00.000Z",
+          contract_refs: { verifies: ["RC-1"] },
+        },
+      ],
+      contract: makeContract([{ id: "RC-1", requiredCritical: true }], []),
+    });
+    const blockers = checkRequiredObligationRouting(state, "release");
+    expect(blockers).toHaveLength(0);
+  });
+
+  test("allows release when notRequiredReason is set", () => {
+    const state = makeChangeWorkflowState({
+      contract: makeContract(
+        [
+          {
+            id: "RC-1",
+            requiredCritical: true,
+            notRequiredReason: "Handled upstream.",
+          },
+        ],
+        [],
+      ),
+    });
+    const blockers = checkRequiredObligationRouting(state, "release");
+    expect(blockers).toHaveLength(0);
+  });
+
+  test("allows release when review matrix row exists", () => {
+    const state = makeChangeWorkflowState({
+      contract: makeContract(
+        [{ id: "RC-1", requiredCritical: true }],
+        [{ contractId: "RC-1", status: "pass" }],
+      ),
+    });
+    const blockers = checkRequiredObligationRouting(state, "release");
+    expect(blockers).toHaveLength(0);
+  });
+
+  test("no-op for non-release gates", () => {
+    const state = makeChangeWorkflowState({
+      contract: makeContract([{ id: "RC-1", requiredCritical: true }], []),
+    });
+    for (const gateId of [
+      "proposal",
+      "discovery",
+      "design",
+      "planning",
+      "execution",
+      "acceptance",
+    ] as const) {
+      expect(checkRequiredObligationRouting(state, gateId)).toHaveLength(0);
+    }
+  });
+});
+
+// =============================================================================
+// Report Ingestion Tests
+// =============================================================================
+
+describe("required_follow_ups report ingestion", () => {
+  beforeEach(() => {
+    mocks.fireSignalAndRefresh.mockClear();
+    mocks.addAgendaItem.mockClear();
+  });
+
+  test("required_critical creates agenda item with priority critical", async () => {
+    const store = storeFor(
+      buildChangeWithContract([], [{ id: "tk-1", status: "pending" }]),
+    );
+    const report = engineerReport({
+      follow_ups: [],
+      required_follow_ups: [
+        {
+          text: "Fix security vulnerability",
+          obligation_class: "required_critical",
+          severity: "critical",
+          source_contract_id: "contract-sec-1",
+        },
+      ],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Fix security vulnerability",
+      expect.objectContaining({
+        priority: "critical",
+        category: "required-obligation",
+        description: expect.stringContaining("Obligation: required_critical"),
+      }),
+    );
+    expect(mocks.addAgendaItem.mock.calls[0][2].description).toContain(
+      "Contract: contract-sec-1",
+    );
+  });
+
+  test("severity high creates agenda item with priority high", async () => {
+    const store = storeFor(
+      buildChangeWithContract([], [{ id: "tk-1", status: "pending" }]),
+    );
+    const report = engineerReport({
+      follow_ups: [],
+      required_follow_ups: [
+        {
+          text: "Update documentation",
+          obligation_class: "required_standard",
+          severity: "high",
+        },
+      ],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Update documentation",
+      expect.objectContaining({
+        priority: "high",
+        category: "required-obligation",
+      }),
+    );
+  });
+
+  test("report without required_follow_ups creates no required agenda items", async () => {
+    const store = storeFor(
+      buildChangeWithContract([], [{ id: "tk-1", status: "pending" }]),
+    );
+    const report = engineerReport({
+      follow_ups: ["Regular follow-up"],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    // Should have exactly 1 call for the regular follow-up
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgendaItem).toHaveBeenCalledWith(
+      "/repo",
+      "Regular follow-up",
+      expect.objectContaining({
+        category: "subagent-followup",
+      }),
+    );
+  });
+
+  test("preserves severity mapping from report to agenda", async () => {
+    const store = storeFor(
+      buildChangeWithContract([], [{ id: "tk-1", status: "pending" }]),
+    );
+    const report = engineerReport({
+      follow_ups: [],
+      required_follow_ups: [
+        {
+          text: "A",
+          obligation_class: "required_critical",
+          severity: "critical",
+        },
+        { text: "B", obligation_class: "required_standard", severity: "high" },
+      ],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(2);
+    const calls = mocks.addAgendaItem.mock.calls;
+    const priorities = calls.map((c: any[]) => c[2].priority);
+    expect(priorities).toContain("critical");
+    expect(priorities).toContain("high");
+  });
+
+  test("report with both follow_ups and required_follow_ups creates both types", async () => {
+    const store = storeFor(
+      buildChangeWithContract([], [{ id: "tk-1", status: "pending" }]),
+    );
+    const report = engineerReport({
+      follow_ups: ["Advisory follow-up"],
+      required_follow_ups: [
+        {
+          text: "Required follow-up",
+          obligation_class: "required_critical",
+          severity: "critical",
+        },
+      ],
+    });
+
+    const output = parse(
+      await subagentReportTools.adv_subagent_report_submit.execute(
+        { report },
+        store,
+      ),
+    );
+
+    expect(output.success).toBe(true);
+    expect(mocks.addAgendaItem).toHaveBeenCalledTimes(2);
+
+    const categories = mocks.addAgendaItem.mock.calls.map(
+      (c: any[]) => c[2].category,
+    );
+    expect(categories).toContain("subagent-followup");
+    expect(categories).toContain("required-obligation");
+  });
+});
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+describe("edge cases", () => {
+  test("mixed contract: requiredCritical and non-requiredCritical items", () => {
+    const change = buildChangeWithContract(
+      [
+        { id: "RC-1", requiredCritical: true },
+        { id: "AC-1", requiredCritical: false },
+        { id: "AC-2" },
+      ],
+      [
+        {
+          id: "tk-1",
+          status: "pending",
+          contract_refs: { implements: ["RC-1"] },
+        },
+      ],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("requiredCritical with notRequiredReason is exempt from prep coverage check", () => {
+    const change = buildChangeWithContract(
+      [
+        {
+          id: "RC-1",
+          requiredCritical: true,
+          notRequiredReason: "Covered by upstream contract",
+        },
+      ],
+      [],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("requiredCritical with verificationRequired:false still needs coverage", () => {
+    const change = buildChangeWithContract(
+      [{ id: "RC-1", requiredCritical: true, verificationRequired: false }],
+      [],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("CRITICAL_OPS_UNCOVERED");
+  });
+
+  test("cancelled tasks do not count as coverage", () => {
+    const change = buildChangeWithContract(
+      [{ id: "RC-1", requiredCritical: true }],
+      [
+        {
+          id: "tk-1",
+          status: "cancelled",
+          contract_refs: { verifies: ["RC-1"] },
+        },
+      ],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("CRITICAL_OPS_UNCOVERED");
+  });
+
+  test("backward compatibility: contracts without requiredCritical field work as before", () => {
+    const change = buildChangeWithContract(
+      [{ id: "AC-1" }, { id: "AC-2" }],
+      [],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+
+    const result = evaluateGateReadiness(
+      makeChangeWorkflowState({
+        gates: releaseReadyGates(),
+        contract: makeContract(
+          [{ id: "AC-1" }, { id: "AC-2" }],
+          [
+            { contractId: "AC-1", status: "pass" },
+            { contractId: "AC-2", status: "pass" },
+          ],
+        ),
+      }),
+      "release",
+    );
+    expect(result.ready).toBe(true);
+  });
+
+  test("existing non-requiredCritical items are not affected by new release checks", () => {
+    const state = makeChangeWorkflowState({
+      gates: releaseReadyGates(),
+      contract: makeContract(
+        [{ id: "AC-1", requiredCritical: false }, { id: "AC-2" }],
+        [
+          { contractId: "AC-1", status: "fail" },
+          { contractId: "AC-2", status: "violated" },
+        ],
+      ),
+    });
+    const blockers = checkRequiredObligationReleaseBlockers(state, "release");
+    expect(blockers).toHaveLength(0);
+  });
+
+  test("requiredCritical item with implements coverage passes prep", () => {
+    const change = buildChangeWithContract(
+      [{ id: "RC-1", requiredCritical: true }],
+      [
+        {
+          id: "tk-1",
+          status: "pending",
+          contract_refs: { implements: ["RC-1"] },
+        },
+      ],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("requiredCritical item with verifies coverage passes prep", () => {
+    const change = buildChangeWithContract(
+      [{ id: "RC-1", requiredCritical: true }],
+      [
+        {
+          id: "tk-1",
+          status: "pending",
+          contract_refs: { verifies: ["RC-1"] },
+        },
+      ],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("multiple requiredCritical items: some covered, some not", () => {
+    const change = buildChangeWithContract(
+      [
+        { id: "RC-1", requiredCritical: true },
+        { id: "RC-2", requiredCritical: true },
+        { id: "RC-3", requiredCritical: true },
+      ],
+      [
+        {
+          id: "tk-1",
+          status: "pending",
+          contract_refs: { implements: ["RC-1"] },
+        },
+        {
+          id: "tk-2",
+          status: "pending",
+          contract_refs: { verifies: ["RC-2"] },
+        },
+      ],
+    );
+    const issues = checkCriticalOpsCoverage(change);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].details).toMatchObject({ contractId: "RC-3" });
+  });
+});


### PR DESCRIPTION
## Summary

Adds structural enforcement for required-critical-ops obligations across the ADV workflow pipeline.

## Changes

### Typed Classification Model
- `ContractItemSchema.requiredCritical` optional boolean field
- `RequiredFollowUpSchema` with `obligation_class` and `severity` fields
- `required_follow_ups` array on engineer/reviewer report schemas

### Planning Readiness Enforcement
- `checkCriticalOpsCoverage()` blocks planning when requiredCritical items lack task coverage
- `CRITICAL_OPS_UNCOVERED` error code in prep-readiness pipeline
- `notRequiredReason` serves as policy-approved alternate route

### Report Ingestion Preservation
- `consumeRequiredFollowUps()` creates agenda items with preserved priority
- `obligation_class: required_critical` → `priority: critical` mapping
- Category `required-obligation` distinct from advisory `subagent-followup`

### Release Safety Enforcement
- `checkRequiredObligationReleaseBlockers()` blocks release for failing requiredCritical review rows
- `checkRequiredObligationRouting()` blocks release for silently deferred requiredCritical items
- Remediation directs to `adv_change_reenter` or fast-follow split

### Spec Updates
- prep-readiness v1.4.0 — rq-PR007coc (Critical Operations Coverage)
- subagent-reports v1.1.0 — rq-subagentReports14 (Required Follow-Up Preservation)
- advance-workflow v1.16.0 — rq-requiredObligation01/02 (Release Block, Explicit Routing)

## Verification
- **3664 tests pass** across 270 test files
- **31 regression tests** in `required-obligation-regression.test.ts`
- **16/16 contract items pass** review matrix
- Check suite green: schemas:check, typecheck, lint, format:check

## Backward Compatibility
All new fields optional. Existing contracts without `requiredCritical` parse unchanged. Existing `follow_ups` path remains advisory with medium priority.