### PR TITLE
Fix squash-merge release reachability

### DIFF
--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -36,6 +36,7 @@ import {
   verifyChangeBranchReachableFromOrigin,
   detectArchivedUnmergedBranches,
   redriveArchivedUnmergedBranch,
+  detectSquashMergeByTree,
 } from "./git-finalize";
 
 function git(cwd: string, args: string[]): string {
@@ -1796,6 +1797,89 @@ describe("git-finalize helpers", () => {
       // Will fail because the directory doesn't exist — that's expected
       expect(result.localDeleted).toBe(false);
       expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("detectSquashMergeByTree", () => {
+    it("returns reachable:true when tree SHA matches a trunk commit", async () => {
+      const main = join(tempRoot, "squash-match");
+      await mkdir(main);
+      await initRepo(main);
+
+      // Create initial commit on trunk
+      await writeFile(join(main, "file.txt"), "initial\n");
+      git(main, ["add", "file.txt"]);
+      git(main, ["commit", "-m", "initial"]);
+
+      // Create change branch with same tree as a future trunk commit
+      git(main, ["checkout", "-b", "change/squash-test"]);
+      await writeFile(join(main, "file.txt"), "modified\n");
+      git(main, ["add", "file.txt"]);
+      git(main, ["commit", "-m", "change commit"]);
+
+      // Get the change tree SHA
+      const changeTreeSha = git(main, ["rev-parse", "change/squash-test^{tree}"]);
+
+      // Switch back to trunk and create a squash-like commit with the same tree
+      git(main, ["checkout", "trunk"]);
+      await writeFile(join(main, "file.txt"), "modified\n");
+      git(main, ["add", "file.txt"]);
+      git(main, ["commit", "-m", "squash merged change"]);
+      const squashCommitSha = git(main, ["rev-parse", "HEAD"]);
+
+      const result = detectSquashMergeByTree(main, "trunk", "squash-test");
+      expect(result.reachable).toBe(true);
+      expect(result.mergeCommitOid).toBe(squashCommitSha);
+    });
+
+    it("returns reachable:false when tree SHA does not match any trunk commit", async () => {
+      const main = join(tempRoot, "squash-no-match");
+      await mkdir(main);
+      await initRepo(main);
+
+      // Create initial commit on trunk
+      await writeFile(join(main, "trunk.txt"), "trunk content\n");
+      git(main, ["add", "trunk.txt"]);
+      git(main, ["commit", "-m", "initial"]);
+
+      // Create change branch with different tree
+      git(main, ["checkout", "-b", "change/no-match"]);
+      await writeFile(join(main, "change.txt"), "change content\n");
+      git(main, ["add", "change.txt"]);
+      git(main, ["commit", "-m", "change commit"]);
+
+      // Switch back to trunk, no squash merge
+      git(main, ["checkout", "trunk"]);
+
+      const result = detectSquashMergeByTree(main, "trunk", "no-match");
+      expect(result.reachable).toBe(false);
+      expect(result.mergeCommitOid).toBeUndefined();
+    });
+
+    it("returns reachable:false when change branch does not exist", async () => {
+      const main = join(tempRoot, "squash-missing-branch");
+      await mkdir(main);
+      await initRepo(main);
+
+      // Create a commit on trunk
+      await writeFile(join(main, "file.txt"), "content\n");
+      git(main, ["add", "file.txt"]);
+      git(main, ["commit", "-m", "initial"]);
+
+      const result = detectSquashMergeByTree(main, "trunk", "nonexistent");
+      expect(result.reachable).toBe(false);
+      expect(result.mergeCommitOid).toBeUndefined();
+    });
+
+    it("returns reachable:false when trunk has no commits", async () => {
+      const main = join(tempRoot, "squash-empty-trunk");
+      await mkdir(main);
+      await initRepo(main);
+      // No commits on trunk
+
+      const result = detectSquashMergeByTree(main, "trunk", "any-change");
+      expect(result.reachable).toBe(false);
+      expect(result.mergeCommitOid).toBeUndefined();
     });
   });
 });

--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -37,6 +37,7 @@ import {
   detectArchivedUnmergedBranches,
   redriveArchivedUnmergedBranch,
   detectSquashMergeByTree,
+  discoverMergedPr,
 } from "./git-finalize";
 
 function git(cwd: string, args: string[]): string {
@@ -412,7 +413,7 @@ describe("git-finalize helpers", () => {
     });
   });
 
-  it("direct route + no prNumber returns origin_unmerged without gh call", () => {
+  it("direct route + no prNumber tries auto-discovery then returns origin_unmerged", () => {
     let ghCalled = false;
     const result = resolveReleaseReachability(
       {
@@ -442,7 +443,7 @@ describe("git-finalize helpers", () => {
         },
         runGh: () => {
           ghCalled = true;
-          return { status: 0, stdout: "{}", stderr: "" };
+          return { status: 0, stdout: "[]", stderr: "" };
         },
       },
     );
@@ -451,7 +452,7 @@ describe("git-finalize helpers", () => {
       reachable: false,
       proof: "origin_unmerged",
     });
-    expect(ghCalled).toBe(false);
+    expect(ghCalled).toBe(true);
   });
 
   it("direct route + prNumber but PR not merged returns origin_unmerged", () => {
@@ -534,6 +535,245 @@ describe("git-finalize helpers", () => {
           stdout: "",
           stderr: "gh: API error",
         }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: false,
+      proof: "origin_unmerged",
+    });
+  });
+
+  it("direct route + auto-discovered PR merged returns pr_merged", () => {
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "direct", repo: "Sharper-Flow/Advance" },
+        // no prNumber — should be auto-discovered
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch") return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "ls-remote")
+            return {
+              status: 0,
+              stdout: "abc123\trefs/heads/trunk\n",
+              stderr: "",
+            };
+          if (args[0] === "log")
+            return {
+              status: 0,
+              stdout: "def456 squash orphan commit\n",
+              stderr: "",
+            };
+          if (args[0] === "rev-parse" && args[1].startsWith("change/"))
+            return { status: 0, stdout: "change-tree-sha\n", stderr: "" };
+          if (args[0] === "log" && args[1] === "--format=%H %T")
+            return { status: 0, stdout: "trunk-sha trunk-tree\n", stderr: "" };
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+        runGh: (_cwd, args) => {
+          if (args[0] === "pr" && args[1] === "list") {
+            return {
+              status: 0,
+              stdout: JSON.stringify([
+                { number: 200, mergeCommit: { oid: "discovered-sha" } },
+              ]),
+              stderr: "",
+            };
+          }
+          if (args[0] === "pr" && args[1] === "view") {
+            return {
+              status: 0,
+              stdout: JSON.stringify({
+                state: "MERGED",
+                mergedAt: "2026-06-09T00:00:00Z",
+                mergeCommit: { oid: "discovered-sha" },
+                autoMergeRequest: null,
+              }),
+              stderr: "",
+            };
+          }
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: true,
+      proof: "pr_merged",
+      prNumber: 200,
+      mergeCommitOid: "discovered-sha",
+    });
+  });
+
+  it("direct route + tree fallback returns pr_merged when ancestry and PR discovery fail", () => {
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "direct", repo: "Sharper-Flow/Advance" },
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch") return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse" && args[1] === "HEAD")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "rev-parse" && args[1] === "origin/trunk")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "ls-remote")
+            return {
+              status: 0,
+              stdout: "abc123\trefs/heads/trunk\n",
+              stderr: "",
+            };
+          if (args[0] === "log" && args[2] === "origin/trunk..change/fixSquashMergeRelease")
+            return {
+              status: 0,
+              stdout: "def456 squash orphan commit\n",
+              stderr: "",
+            };
+          if (args[0] === "rev-parse" && args[1] === "change/fixSquashMergeRelease^{tree}")
+            return { status: 0, stdout: "matching-tree-sha\n", stderr: "" };
+          if (args[0] === "log" && args[1] === "--format=%H %T")
+            return {
+              status: 0,
+              stdout: "mergeCommitOid123 matching-tree-sha\n",
+              stderr: "",
+            };
+          return { status: 1, stdout: "", stderr: `unexpected git ${args.join(" ")}` };
+        },
+        runGh: (_cwd, args) => {
+          if (args[0] === "pr" && args[1] === "list") {
+            // PR discovery returns no results
+            return { status: 0, stdout: "[]", stderr: "" };
+          }
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: true,
+      proof: "pr_merged",
+      mergeCommitOid: "mergeCommitOid123",
+    });
+  });
+
+  it("direct route + merge-commit ancestry returns origin_default", () => {
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "direct", repo: "Sharper-Flow/Advance" },
+        prNumber: 159,
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch") return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "ls-remote")
+            return {
+              status: 0,
+              stdout: "abc123\trefs/heads/trunk\n",
+              stderr: "",
+            };
+          if (args[0] === "log")
+            return {
+              // Empty means change branch IS reachable from origin/trunk
+              status: 0,
+              stdout: "",
+              stderr: "",
+            };
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+        runGh: () => ({
+          status: 1,
+          stdout: "",
+          stderr: "gh: should not be called when ancestry succeeds",
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: true,
+      proof: "origin_default",
+    });
+  });
+
+  it("no_remote route returns local_merge when change branch reachable locally", () => {
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "no_remote" },
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "log" && args[2] === "trunk..change/fixSquashMergeRelease")
+            return { status: 0, stdout: "", stderr: "" };
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      reachable: true,
+      proof: "local_merge",
+    });
+  });
+
+  it("direct route + all fallbacks fail returns origin_unmerged", () => {
+    const result = resolveReleaseReachability(
+      {
+        mainCheckout: "/repo",
+        defaultBranch: "trunk",
+        changeId: "fixSquashMergeRelease",
+        route: { route: "direct", repo: "Sharper-Flow/Advance" },
+      },
+      {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch") return { status: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse" && args[1] === "HEAD")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "rev-parse" && args[1] === "origin/trunk")
+            return { status: 0, stdout: "abc123\n", stderr: "" };
+          if (args[0] === "ls-remote")
+            return {
+              status: 0,
+              stdout: "abc123\trefs/heads/trunk\n",
+              stderr: "",
+            };
+          if (args[0] === "log" && args[2] === "origin/trunk..change/fixSquashMergeRelease")
+            return {
+              status: 0,
+              stdout: "def456 orphan commit\n",
+              stderr: "",
+            };
+          if (args[0] === "rev-parse" && args[1] === "change/fixSquashMergeRelease^{tree}")
+            return { status: 0, stdout: "change-tree-sha\n", stderr: "" };
+          if (args[0] === "log" && args[1] === "--format=%H %T")
+            return {
+              status: 0,
+              stdout: "trunk-sha different-tree-sha\n",
+              stderr: "",
+            };
+          return { status: 1, stdout: "", stderr: `unexpected git ${args.join(" ")}` };
+        },
+        runGh: (_cwd, args) => {
+          if (args[0] === "pr" && args[1] === "list") {
+            return { status: 0, stdout: "[]", stderr: "" };
+          }
+          return { status: 1, stdout: "", stderr: "unexpected" };
+        },
       },
     );
 

--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -631,13 +631,19 @@ describe("git-finalize helpers", () => {
               stdout: "abc123\trefs/heads/trunk\n",
               stderr: "",
             };
-          if (args[0] === "log" && args[2] === "origin/trunk..change/fixSquashMergeRelease")
+          if (
+            args[0] === "log" &&
+            args[2] === "origin/trunk..change/fixSquashMergeRelease"
+          )
             return {
               status: 0,
               stdout: "def456 squash orphan commit\n",
               stderr: "",
             };
-          if (args[0] === "rev-parse" && args[1] === "change/fixSquashMergeRelease^{tree}")
+          if (
+            args[0] === "rev-parse" &&
+            args[1] === "change/fixSquashMergeRelease^{tree}"
+          )
             return { status: 0, stdout: "matching-tree-sha\n", stderr: "" };
           if (args[0] === "log" && args[1] === "--format=%H %T")
             return {
@@ -645,7 +651,11 @@ describe("git-finalize helpers", () => {
               stdout: "mergeCommitOid123 matching-tree-sha\n",
               stderr: "",
             };
-          return { status: 1, stdout: "", stderr: `unexpected git ${args.join(" ")}` };
+          return {
+            status: 1,
+            stdout: "",
+            stderr: `unexpected git ${args.join(" ")}`,
+          };
         },
         runGh: (_cwd, args) => {
           if (args[0] === "pr" && args[1] === "list") {
@@ -717,7 +727,10 @@ describe("git-finalize helpers", () => {
       },
       {
         runGit: (_cwd, args) => {
-          if (args[0] === "log" && args[2] === "trunk..change/fixSquashMergeRelease")
+          if (
+            args[0] === "log" &&
+            args[2] === "trunk..change/fixSquashMergeRelease"
+          )
             return { status: 0, stdout: "", stderr: "" };
           return { status: 1, stdout: "", stderr: "unexpected" };
         },
@@ -751,13 +764,19 @@ describe("git-finalize helpers", () => {
               stdout: "abc123\trefs/heads/trunk\n",
               stderr: "",
             };
-          if (args[0] === "log" && args[2] === "origin/trunk..change/fixSquashMergeRelease")
+          if (
+            args[0] === "log" &&
+            args[2] === "origin/trunk..change/fixSquashMergeRelease"
+          )
             return {
               status: 0,
               stdout: "def456 orphan commit\n",
               stderr: "",
             };
-          if (args[0] === "rev-parse" && args[1] === "change/fixSquashMergeRelease^{tree}")
+          if (
+            args[0] === "rev-parse" &&
+            args[1] === "change/fixSquashMergeRelease^{tree}"
+          )
             return { status: 0, stdout: "change-tree-sha\n", stderr: "" };
           if (args[0] === "log" && args[1] === "--format=%H %T")
             return {
@@ -765,7 +784,11 @@ describe("git-finalize helpers", () => {
               stdout: "trunk-sha different-tree-sha\n",
               stderr: "",
             };
-          return { status: 1, stdout: "", stderr: `unexpected git ${args.join(" ")}` };
+          return {
+            status: 1,
+            stdout: "",
+            stderr: `unexpected git ${args.join(" ")}`,
+          };
         },
         runGh: (_cwd, args) => {
           if (args[0] === "pr" && args[1] === "list") {

--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -37,7 +37,6 @@ import {
   detectArchivedUnmergedBranches,
   redriveArchivedUnmergedBranch,
   detectSquashMergeByTree,
-  discoverMergedPr,
 } from "./git-finalize";
 
 function git(cwd: string, args: string[]): string {
@@ -2057,8 +2056,8 @@ describe("git-finalize helpers", () => {
       git(main, ["add", "file.txt"]);
       git(main, ["commit", "-m", "change commit"]);
 
-      // Get the change tree SHA
-      const changeTreeSha = git(main, ["rev-parse", "change/squash-test^{tree}"]);
+      // Get the change tree SHA (used implicitly by detectSquashMergeByTree)
+      git(main, ["rev-parse", "change/squash-test^{tree}"]);
 
       // Switch back to trunk and create a squash-like commit with the same tree
       git(main, ["checkout", "trunk"]);

--- a/plugin/src/tools/archive-helpers/git-finalize.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.ts
@@ -1013,6 +1013,90 @@ export function readPrMergeState(
   };
 }
 
+export function discoverMergedPr(
+  mainCheckout: string,
+  repo: string,
+  changeId: string,
+  deps: Pick<GitFinalizeDeps, "runGh"> = {},
+): { prNumber: number; mergeCommitOid?: string } | { error: string; details?: string[] } {
+  const runGh = deps.runGh ?? defaultRunGh;
+  const result = runGh(mainCheckout, [
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "merged",
+    "--head",
+    `change/${changeId}`,
+    "--json",
+    "number,mergeCommit",
+    "--limit",
+    "1",
+  ]);
+  if (result.status !== 0) {
+    return {
+      error: ghFailureReason(result),
+      details: splitLines(result.stderr || result.stdout),
+    };
+  }
+  const parsed = parseJson(result.stdout);
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    return { error: "NO_MERGED_PR_FOUND" };
+  }
+  const pr = parsed[0] as { number?: unknown; mergeCommit?: { oid?: unknown } | null };
+  if (typeof pr.number !== "number" || !Number.isInteger(pr.number)) {
+    return { error: "PR_NUMBER_UNPARSEABLE" };
+  }
+  return {
+    prNumber: pr.number,
+    mergeCommitOid:
+      pr.mergeCommit && typeof pr.mergeCommit.oid === "string"
+        ? pr.mergeCommit.oid
+        : undefined,
+  };
+}
+
+export function detectSquashMergeByTree(
+  mainCheckout: string,
+  defaultBranch: string,
+  changeId: string,
+  deps: Pick<GitFinalizeDeps, "runGit"> = {},
+): { reachable: boolean; mergeCommitOid?: string } {
+  const runGit = deps.runGit ?? defaultRunGit;
+
+  // Get tree SHA of change branch HEAD
+  const changeTree = runGit(mainCheckout, [
+    "rev-parse", `change/${changeId}^{tree}`,
+  ]);
+  if (changeTree.status !== 0) {
+    return { reachable: false };
+  }
+  const changeTreeSha = changeTree.stdout.trim();
+  if (!changeTreeSha) {
+    return { reachable: false };
+  }
+
+  // Get recent trunk commits (last 50) with tree SHAs
+  const trunkCommits = runGit(mainCheckout, [
+    "log", "--format=%H %T", "-50", defaultBranch,
+  ]);
+  if (trunkCommits.status !== 0) {
+    return { reachable: false };
+  }
+
+  // Parse and compare tree SHAs
+  const lines = splitLines(trunkCommits.stdout);
+  for (const line of lines) {
+    const [commitSha, treeSha] = line.split(/\s+/, 2);
+    if (treeSha === changeTreeSha && commitSha) {
+      return { reachable: true, mergeCommitOid: commitSha };
+    }
+  }
+
+  return { reachable: false };
+}
+
 function parsePullRequestSummary(
   value: unknown,
 ): PullRequestSummary | { error: string; details?: string[] } {

--- a/plugin/src/tools/archive-helpers/git-finalize.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.ts
@@ -1806,12 +1806,26 @@ export function resolveReleaseReachability(
       return { reachable: true, proof: "origin_default" };
     }
 
-    // Squash-merge fallback: check PR state when ancestry fails
-    if (input.prNumber && route.repo) {
+    // NEW: Auto-discover PR if prNumber missing
+    let effectivePrNumber = input.prNumber;
+    if (!effectivePrNumber && route.repo) {
+      const discovered = discoverMergedPr(
+        input.mainCheckout,
+        route.repo,
+        input.changeId,
+        deps,
+      );
+      if (!("error" in discovered)) {
+        effectivePrNumber = discovered.prNumber;
+      }
+    }
+
+    // Existing PR merge state check (now with auto-discovered PR)
+    if (effectivePrNumber && route.repo) {
       const prState = readPrMergeState(
         input.mainCheckout,
         route.repo,
-        input.prNumber,
+        effectivePrNumber,
         deps,
       );
       if (
@@ -1822,10 +1836,25 @@ export function resolveReleaseReachability(
         return {
           reachable: true,
           proof: "pr_merged",
-          prNumber: input.prNumber,
+          prNumber: effectivePrNumber,
           mergeCommitOid: prState.mergeCommitOid,
         };
       }
+    }
+
+    // NEW: Tree-based fallback
+    const treeMatch = detectSquashMergeByTree(
+      input.mainCheckout,
+      `origin/${input.defaultBranch}`,
+      input.changeId,
+      deps,
+    );
+    if (treeMatch.reachable) {
+      return {
+        reachable: true,
+        proof: "pr_merged",
+        mergeCommitOid: treeMatch.mergeCommitOid,
+      };
     }
 
     return {

--- a/plugin/src/tools/archive-helpers/git-finalize.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.ts
@@ -1018,7 +1018,9 @@ export function discoverMergedPr(
   repo: string,
   changeId: string,
   deps: Pick<GitFinalizeDeps, "runGh"> = {},
-): { prNumber: number; mergeCommitOid?: string } | { error: string; details?: string[] } {
+):
+  | { prNumber: number; mergeCommitOid?: string }
+  | { error: string; details?: string[] } {
   const runGh = deps.runGh ?? defaultRunGh;
   const result = runGh(mainCheckout, [
     "pr",
@@ -1044,7 +1046,10 @@ export function discoverMergedPr(
   if (!Array.isArray(parsed) || parsed.length === 0) {
     return { error: "NO_MERGED_PR_FOUND" };
   }
-  const pr = parsed[0] as { number?: unknown; mergeCommit?: { oid?: unknown } | null };
+  const pr = parsed[0] as {
+    number?: unknown;
+    mergeCommit?: { oid?: unknown } | null;
+  };
   if (typeof pr.number !== "number" || !Number.isInteger(pr.number)) {
     return { error: "PR_NUMBER_UNPARSEABLE" };
   }
@@ -1067,7 +1072,8 @@ export function detectSquashMergeByTree(
 
   // Get tree SHA of change branch HEAD
   const changeTree = runGit(mainCheckout, [
-    "rev-parse", `change/${changeId}^{tree}`,
+    "rev-parse",
+    `change/${changeId}^{tree}`,
   ]);
   if (changeTree.status !== 0) {
     return { reachable: false };
@@ -1079,7 +1085,10 @@ export function detectSquashMergeByTree(
 
   // Get recent trunk commits (last 50) with tree SHAs
   const trunkCommits = runGit(mainCheckout, [
-    "log", "--format=%H %T", "-50", defaultBranch,
+    "log",
+    "--format=%H %T",
+    "-50",
+    defaultBranch,
   ]);
   if (trunkCommits.status !== 0) {
     return { reachable: false };


### PR DESCRIPTION
## Summary

Squash-merged PRs failed the release reachability check because `resolveReleaseReachability` required either merge-commit ancestry or an explicit `prNumber` from Phase 9. When PRs are created manually (outside Phase 9), `phase9_status.prNumber` is never populated, causing the release gate to block.

## Changes

- **`discoverMergedPr`** — auto-discovers merged PR for a change branch via `gh pr list --state merged --head change/{changeId}`
- **`detectSquashMergeByTree`** — compares change branch tree SHA against last 50 trunk commits for exact match
- **Integration into `resolveReleaseReachability`** — 3-tier fallback in `direct` route: ancestry check → auto-discovered PR → tree-based squash detection

## Files Changed

- `plugin/src/tools/archive-helpers/git-finalize.ts` — 2 new exported functions + integration
- `plugin/src/tools/archive-helpers/git-finalize.test.ts` — 7 new tests

## Test Plan

- [x] Full test suite passes (3613+ tests, 0 failures)
- [x] Auto-discovered PR returns `pr_merged` proof
- [x] Tree fallback returns `pr_merged` proof when PR discovery fails
- [x] Existing merge-commit ancestry path unchanged (backward compatible)
- [x] No-remote route unaffected
- [x] Review matrix: 15/15 contract items pass