### PR TITLE
fix(release): treat private-repo 403 on branch-rules API as direct route

### DIFF
--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -406,6 +406,36 @@ describe("git-finalize helpers", () => {
     });
   });
 
+  it("classifyFinalizationRoute treats private-repo 403 as direct (no rules)", () => {
+    const result = classifyFinalizationRoute("/repo", "trunk", {
+      runGit: (_cwd, args) => {
+        if (args.join(" ") === "remote get-url origin") {
+          return {
+            status: 0,
+            stdout: "https://github.com/User/private-repo.git\n",
+            stderr: "",
+          };
+        }
+        return { status: 1, stdout: "", stderr: "unexpected" };
+      },
+      runGh: (_cwd, args) => {
+        if (args[0] === "api" && args[1].includes("/rules/branches/")) {
+          return {
+            status: 1,
+            stdout: "",
+            stderr:
+              "gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)",
+          };
+        }
+        return { status: 1, stdout: "", stderr: "unexpected" };
+      },
+    });
+    expect(result).toMatchObject({
+      route: "direct",
+      protected: false,
+    });
+  });
+
   it("coercePrWorkflowRoute passes merge_queue through unchanged", () => {
     const route = coercePrWorkflowRoute({
       route: "merge_queue",

--- a/plugin/src/tools/archive-helpers/git-finalize.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.ts
@@ -425,6 +425,26 @@ export function classifyFinalizationRoute(
     `repos/${origin.repo}/rules/branches/${encodeURIComponent(defaultBranch)}`,
   ]);
   if (rules.status !== 0) {
+    const rulesErrText = (rules.stderr || rules.stdout || "").toLowerCase();
+    // Private repos without GitHub Pro return 403 on the branch-rules API.
+    // The rules API is unavailable on this plan — not a policy detection
+    // failure. Treat as "no rules detectable → direct route" so the release
+    // gate can proceed with git-based reachability verification.
+    const isPlanRestriction =
+      rulesErrText.includes("upgrade to github pro") ||
+      rulesErrText.includes("make this repository public");
+    if (isPlanRestriction) {
+      return {
+        route: "direct",
+        repo: origin.repo,
+        remoteUrl: origin.remoteUrl,
+        protected: false,
+        parsedRules: [],
+        details: [
+          "branch-rules API unavailable on private repo (GitHub Pro required); treating as unprotected",
+        ],
+      };
+    }
     return {
       route: "blocked",
       repo: origin.repo,


### PR DESCRIPTION
## Problem

Private repos without GitHub Pro return HTTP 403 on the branch-rules API endpoint (`repos/{owner}/{repo}/rules/branches/{branch}`). The `classifyFinalizationRoute` function treated any non-zero exit as `POLICY_DETECTION_FAILED → blocked route`, which poisoned the entire release gate: blocked route → reachability false → gate rejected with `RELEASE_REQUIRES_TRUNK_MERGE`, even when the merge was real and pushed.

## Fix

Detect the plan-restriction 403 pattern ('Upgrade to GitHub Pro' or 'make this repository public') and treat it as 'no rules detectable → direct route', allowing git-based reachability verification to proceed normally.

## Test

`classifyFinalizationRoute treats private-repo 403 as direct (no rules)` — verifies the 403 plan-restriction error returns `route: "direct", protected: false` instead of `route: "blocked"`.

All 72 git-finalize tests + 8 release-enforcement tests pass.