### PR TITLE
fix: reconcile recovered close visibility

### DIFF
--- a/plugin/src/adv-skill-backed-commands-assets.test.ts
+++ b/plugin/src/adv-skill-backed-commands-assets.test.ts
@@ -313,7 +313,7 @@ describe("ambiguity taxonomy spec assets", () => {
     expect(prepSpec.requirements.map((rq) => rq.id)).toEqual(
       expect.arrayContaining(["rq-stagePrepNoCriteriaFirming01"]),
     );
-    expect(workflowSpec.version).toBe("1.21.0");
+    expect(workflowSpec.version).toBe("1.22.0");
     expect(workflowSpec.requirements.map((rq) => rq.id)).toEqual(
       expect.arrayContaining([
         "rq-stageDesignCriteriaBoundary01",

--- a/plugin/src/deploy-local.test.ts
+++ b/plugin/src/deploy-local.test.ts
@@ -782,6 +782,8 @@ describe("deploy-local.sh", () => {
 
     test("canonical ADV prompt stays under the safe compression ceiling", () => {
       const lines = advAgent.split(/\r?\n/).length;
+      // Ceiling raised from 368 → 371 after documenting the change-lifecycle
+      // state invariant in the canonical ADV prompt.
       // Ceiling raised from 365 → 368 after adding compact adv-temporal-repair
       // routing markers and packet anchors.
       // Ceiling raised from 363 → 365 after adding adv_archive_repair and
@@ -794,7 +796,7 @@ describe("deploy-local.sh", () => {
       // refactor exposed `adv_worktree_resume` and we added it to the
       // canonical allowlist to clear deploy-local tool-drift checks.
       // Re-ratchet here once the prompt has been audited for excess.
-      expect(lines).toBeLessThanOrEqual(368);
+      expect(lines).toBeLessThanOrEqual(371);
     });
 
     test("canonical ADV prompt keeps safety-critical markers", () => {

--- a/plugin/src/ops-follow-up-assets.test.ts
+++ b/plugin/src/ops-follow-up-assets.test.ts
@@ -91,9 +91,9 @@ describe("ops-follow-up traceability spec law", () => {
 });
 
 describe("ops-follow-up spec versions bumped", () => {
-  test("advance-workflow version is at least 1.19.0", () => {
+  test("advance-workflow version is at least 1.22.0", () => {
     const spec = loadSpec("advance-workflow");
-    expect(spec.version).toBe("1.21.0");
+    expect(spec.version).toBe("1.22.0");
   });
 
   test("subagent-reports version is at least 1.3.0", () => {
@@ -101,8 +101,8 @@ describe("ops-follow-up spec versions bumped", () => {
     expect(spec.version).toBe("1.4.0");
   });
 
-  test("backlog-coordination version is at least 1.3.0", () => {
+  test("backlog-coordination version is at least 1.4.0", () => {
     const spec = loadSpec("backlog-coordination");
-    expect(spec.version).toBe("1.3.0");
+    expect(spec.version).toBe("1.4.0");
   });
 });

--- a/plugin/src/storage/store-temporal/index.test.ts
+++ b/plugin/src/storage/store-temporal/index.test.ts
@@ -503,7 +503,7 @@ describe("createTemporalStoreBackend change projection fallback", () => {
       expect.objectContaining({ changeId: "activeDiskOnlyList" }),
     ]);
     expect(queryCount("archivedDiskOnlyList")).toBe(1);
-    expect(queryCount("closedDiskOnlyList")).toBe(1);
+    expect(queryCount("closedDiskOnlyList")).toBe(0);
   });
 
   it("seeds contract proof fields when recovering a poisoned non-terminal change", async () => {
@@ -922,6 +922,69 @@ describe("listResolvedChanges memo fast path", () => {
     expect(listed).toBeDefined();
     expect(listed!.taskCount).toBe(2);
     expect(listed!.completedTasks).toBe(1);
+  });
+
+  it("lets closed disk projection dominate stale active Temporal state", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+
+    await legacy.changes.save(closedChange("staleClosedChange"));
+
+    const temporal = {
+      client: {
+        workflow: {
+          getHandle: () => ({
+            query: async () => ({
+              id: "staleClosedChange",
+              changeId: "staleClosedChange",
+              title: "Stale active staleClosedChange",
+              status: "active",
+              createdAt: "2026-05-07T00:00:00.000Z",
+              initializedAt: "2026-05-07T00:00:00.000Z",
+              projectId: "project-1",
+              tasks: [],
+              deltas: {},
+              wisdom: [],
+              gates: createDefaultGates(),
+              reentry_history: [],
+              artifacts: {},
+              documents: {},
+              reflections: [],
+              worktrees: {},
+              conformance: { lockedSpecs: [], overrides: [] },
+            }),
+          }),
+          list: async function* () {
+            yield {
+              workflowId: "adv/change/project-1/staleClosedChange",
+            };
+          },
+          start: async () => {
+            throw new Error("start should not be called");
+          },
+        },
+      },
+    };
+
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const getResult = await store.changes.get("staleClosedChange");
+    expect(getResult.success).toBe(true);
+    expect(getResult.data?.status).toBe("closed");
+
+    const activeList = await store.changes.list();
+    expect(activeList.changes.map((change) => change.id)).not.toContain(
+      "staleClosedChange",
+    );
+
+    const closedList = await store.changes.list({ status: "closed" });
+    expect(closedList.changes.map((change) => change.id)).toContain(
+      "staleClosedChange",
+    );
   });
 });
 

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -551,6 +551,12 @@ export function createTemporalStoreBackend(
   const getTemporalChange = async (
     changeId: string,
   ): Promise<ReturnType<Store["changes"]["get"]>> => {
+    const terminalDiskProjection = await loadDiskTerminalProjection(changeId);
+    if (terminalDiskProjection) {
+      indexTasksFromChange(terminalDiskProjection);
+      return { success: true, data: terminalDiskProjection };
+    }
+
     const cached = changeCache.get(changeId);
     if (cached) {
       if (cached.status !== "archived" && cached.status !== "closed") {
@@ -620,6 +626,21 @@ export function createTemporalStoreBackend(
       }
       throw error;
     }
+  };
+
+  const loadDiskTerminalProjection = async (
+    changeId: string,
+  ): Promise<Change | null> => {
+    try {
+      const result = await legacy.changes.get(changeId);
+      if (result.success && result.data && result.data.status === "closed") {
+        return result.data;
+      }
+    } catch {
+      // Disk projection is only a terminal-state dominance check. Missing or
+      // unreadable disk state falls through to Temporal/missing-workflow logic.
+    }
+    return null;
   };
 
   /**

--- a/plugin/src/temporal/change-state.ts
+++ b/plugin/src/temporal/change-state.ts
@@ -79,6 +79,8 @@ export interface StateMutationContext {
 export function normalizeChangeLifecycleState(
   status: ChangeStatus | ChangeLifecycleState | undefined,
 ): ChangeLifecycleState {
+  // rq-changeLifecycleState01: lifecycle state is the durable open/terminal
+  // claim, separate from compatibility `status` values such as draft/active.
   if (status === "archived" || status === "closed") return status;
   return "open";
 }

--- a/plugin/src/temporal/observability.test.ts
+++ b/plugin/src/temporal/observability.test.ts
@@ -10,6 +10,7 @@ import {
 const SIGNAL_SEARCH_ATTRIBUTE_NAMES = [
   "AdvChangeId",
   "AdvChangeStatus",
+  "AdvLifecycleState",
   "AdvChangeTitle",
   "AdvAffectedProjects",
   "AdvCurrentGate",
@@ -26,6 +27,7 @@ const SIGNAL_SEARCH_ATTRIBUTE_NAMES = [
 const SIGNAL_REQUIRED_SEARCH_ATTRIBUTES = [
   { name: "AdvChangeId", type: "Keyword", typeCode: 2 },
   { name: "AdvChangeStatus", type: "Keyword", typeCode: 2 },
+  { name: "AdvLifecycleState", type: "Keyword", typeCode: 2 },
   { name: "AdvChangeTitle", type: "Keyword", typeCode: 2 },
   { name: "AdvAffectedProjects", type: "KeywordList", typeCode: 7 },
   { name: "AdvCurrentGate", type: "Keyword", typeCode: 2 },
@@ -127,6 +129,7 @@ describe("temporal observability helpers", () => {
       "AdvCurrentGate",
     ]);
     expect(result.missing.map((attr) => attr.name)).toEqual([
+      "AdvLifecycleState",
       "AdvChangeTitle",
       "AdvAffectedProjects",
       "AdvCurrentBucket",
@@ -203,6 +206,7 @@ describe("temporal observability helpers", () => {
     expect(addSearchAttributes).toHaveBeenCalledWith({
       namespace: "default",
       searchAttributes: {
+        AdvLifecycleState: 2,
         AdvChangeTitle: 2,
         AdvAffectedProjects: 7,
         AdvCurrentBucket: 2,
@@ -218,6 +222,7 @@ describe("temporal observability helpers", () => {
       method: "operatorService.addSearchAttributes",
       verificationStatus: "verified",
       created: [
+        { name: "AdvLifecycleState", type: "Keyword", typeCode: 2 },
         { name: "AdvChangeTitle", type: "Keyword", typeCode: 2 },
         { name: "AdvAffectedProjects", type: "KeywordList", typeCode: 7 },
         { name: "AdvCurrentBucket", type: "Keyword", typeCode: 2 },

--- a/plugin/src/temporal/service-reconnect.test.ts
+++ b/plugin/src/temporal/service-reconnect.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => {
   const ADV_SA_FULL_PRESENT = {
     AdvChangeId: { indexedValueType: 2 },
     AdvChangeStatus: { indexedValueType: 2 },
+    AdvLifecycleState: { indexedValueType: 2 },
     AdvChangeTitle: { indexedValueType: 2 },
     AdvAffectedProjects: { indexedValueType: 7 },
     AdvCurrentGate: { indexedValueType: 2 },

--- a/plugin/src/temporal/service.test.ts
+++ b/plugin/src/temporal/service.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => {
   const ADV_SA_FULL_PRESENT = {
     AdvChangeId: { indexedValueType: 2 },
     AdvChangeStatus: { indexedValueType: 2 },
+    AdvLifecycleState: { indexedValueType: 2 },
     AdvChangeTitle: { indexedValueType: 2 },
     AdvAffectedProjects: { indexedValueType: 7 },
     AdvCurrentGate: { indexedValueType: 2 },
@@ -114,6 +115,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
       searchAttributes: {
         AdvChangeId: 2,
         AdvChangeStatus: 2,
+        AdvLifecycleState: 2,
         AdvChangeTitle: 2,
         AdvAffectedProjects: 7,
         AdvCurrentGate: 2,

--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -1488,7 +1488,7 @@ describe("change tools — signal-driven lifecycle", () => {
       expect(mocks.saveRecoveredChangeStatus).not.toHaveBeenCalled();
     });
 
-    test("recovers completed-workflow close failure with audited disk projection", async () => {
+    test("recovers completed-workflow close failure with audited disk projection and keeps projection readable", async () => {
       const store = createMockStore();
       mocks.fireSignalAndRefresh.mockRejectedValueOnce(
         Object.assign(new Error("workflow execution already completed"), {
@@ -1528,10 +1528,7 @@ describe("change tools — signal-driven lifecycle", () => {
           }),
         }),
       );
-      expect(mocks.removeChangeDir).toHaveBeenCalledWith(
-        store.paths.changes,
-        "test-change",
-      );
+      expect(mocks.removeChangeDir).not.toHaveBeenCalled();
     });
   });
 
@@ -1778,7 +1775,7 @@ describe("change tools — signal-driven lifecycle", () => {
       });
       expect(mocks.saveRecoveredChangeStatus).toHaveBeenCalledTimes(1);
       expect(mocks.sweepClosedChangesFromDisk).toHaveBeenCalledWith(
-        ["chg-1", "chg-2"],
+        ["chg-2"],
         store.paths.changes,
       );
     });

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -3481,22 +3481,13 @@ export const changeTools = {
           signalError: error,
         });
         if (recovery.recovered) {
-          let cleanupWarning: string | undefined;
-          if (store.paths?.changes) {
-            try {
-              await removeChangeDir(store.paths.changes, changeId);
-            } catch (err) {
-              cleanupWarning = `Source cleanup warning: failed to remove changes/${changeId}: ${err instanceof Error ? err.message : String(err)}`;
-            }
-          }
           return formatToolOutput({
             success: true,
             _recoveryMutation: true,
+            diskProjectionRetained: true,
             changeId,
             reason,
-            message: cleanupWarning
-              ? `Closed change ${changeId} as ${reason} via completed-workflow recovery. ${cleanupWarning}`
-              : `Closed change ${changeId} as ${reason} via completed-workflow recovery.`,
+            message: `Closed change ${changeId} as ${reason} via completed-workflow recovery. Retained closed disk projection for stale-visibility reconciliation.`,
           });
         }
         const contextMismatch = extractContextMismatch(error);
@@ -3704,7 +3695,7 @@ export const changeTools = {
         let diskRemoved: string[] = [];
         let diskFailed: Array<{ id: string; error: string }> = [];
         const successfulIds = results
-          .filter((r) => r.success)
+          .filter((r) => r.success && !r.recovered)
           .map((r) => r.changeId);
         if (successfulIds.length > 0 && store.paths?.changes) {
           const sweep = await sweepClosedChangesFromDisk(


### PR DESCRIPTION
## Summary
- retain closed disk projections for completed-workflow close recovery
- let closed disk projection dominate stale active Temporal state in list/show reads
- avoid sweeping recovered bulk-close projections that are needed for reconciliation

## Verification
- bin/oc-test targeted -- src/tools/change.test.ts src/storage/store-temporal/index.test.ts
- bin/oc-test smoke
- pnpm --dir plugin run build