### PR TITLE
fix(adv): add adv_design_concern_disposition to canonical agent allowlists

### DIFF
--- a/.opencode/agents/adv-atc.md
+++ b/.opencode/agents/adv-atc.md
@@ -52,6 +52,7 @@ tools:
   adv_change_update_issues: true
   adv_change_reenter: true
   adv_change_forget: true
+  adv_design_concern_disposition: true
   adv_archive_repair: true
   adv_change_status_repair: true
   # Tasks

--- a/.opencode/agents/adv.md
+++ b/.opencode/agents/adv.md
@@ -55,6 +55,7 @@ tools:
   adv_archive_repair: true
   adv_change_status_repair: true
   adv_change_forget: true
+  adv_design_concern_disposition: true
   # Tasks
   adv_task_list: true
   adv_task_show: true

--- a/plugin/src/deploy-local.test.ts
+++ b/plugin/src/deploy-local.test.ts
@@ -797,8 +797,10 @@ describe("deploy-local.sh", () => {
       // canonical allowlist to clear deploy-local tool-drift checks.
       // Ceiling raised from 368 → 371 to match trunk (branch base was stale;
       // adv.md is identical to trunk, which already accepts 371).
+      // Ceiling raised from 371 → 372 after addDesignQualityGates shipped
+      // adv_design_concern_disposition and we added it to the allowlists.
       // Re-ratchet here once the prompt has been audited for excess.
-      expect(lines).toBeLessThanOrEqual(371);
+      expect(lines).toBeLessThanOrEqual(372);
     });
 
     test("canonical ADV prompt keeps safety-critical markers", () => {


### PR DESCRIPTION
## Summary

Follow-up to #179 (Add design quality gates (structural)). The new tool `adv_design_concern_disposition` was registered and the gate-readiness evaluator wired, but the canonical agent allowlists in `.opencode/agents/adv.md` and `.opencode/agents/adv-atc.md` were not updated. `deploy-local.sh --check` flags this as tool drift — the agent cannot call the tool it just shipped.

## Diff

- `.opencode/agents/adv.md`: add `adv_design_concern_disposition: true` to the tools allowlist (line 55).
- `.opencode/agents/adv-atc.md`: add `adv_design_concern_disposition: true` to the tools allowlist (line 55).
- `plugin/src/deploy-local.test.ts`: bump canonical-prompt compression ceiling 371 → 372 (one line added per agent file).

## Verification

- `bin/oc-test targeted -- src/deploy-local.test.ts`: 66/66 passed.
- `pnpm run check` (from `plugin/`): schemas/check, typecheck, test-isolation, lockfile, lint, format:check — all green.
- `scripts/deploy-local.sh --check`: tool drift cleared; both allowlists match the plugin registry (59 tools).

## Out of scope

- No spec or workflow change. Pure allowlist/asset-test fix.