### PR TITLE
fix(adv): query full epic workflow state

### DIFF
--- a/plugin/src/storage/store-temporal/epics.test.ts
+++ b/plugin/src/storage/store-temporal/epics.test.ts
@@ -17,7 +17,7 @@ import {
   changeLinkedSignal,
   changeUnlinkedSignal,
   entriesReorderedSignal,
-  getEpicQuery,
+  getEpicStateQuery,
 } from "../../temporal/messages";
 import type { Epic, EpicWorkflowState } from "../../types";
 
@@ -102,7 +102,21 @@ describe("createEpicOps", () => {
     const result = await ops.get("addAuthEpic");
     expect(result.success).toBe(true);
     expect(result.data?.title).toBe("Add Auth Epic");
-    expect(queryMock).toHaveBeenCalledWith(getEpicQuery);
+    expect(queryMock).toHaveBeenCalledWith(getEpicStateQuery);
+  });
+
+  test("get treats an Epic-only query response as unreadable state", async () => {
+    const { deps, queryMock } = setup();
+    queryMock.mockResolvedValue(makeEpic());
+
+    const ops = createEpicOps(deps);
+    const result = await ops.get("addAuthEpic");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.type).toBe("read_error");
+    }
+    expect(queryMock).toHaveBeenCalledWith(getEpicStateQuery);
   });
 
   test("update fires epicUpdated with expected version", async () => {

--- a/plugin/src/storage/store-temporal/epics.ts
+++ b/plugin/src/storage/store-temporal/epics.ts
@@ -10,7 +10,7 @@ import {
   changeProjectionStatusUpdatedSignal,
   changeUnlinkedSignal,
   entriesReorderedSignal,
-  getEpicQuery,
+  getEpicStateQuery,
 } from "../../temporal/messages";
 import { runTemporal, runTemporalQuery, type StoreDeps } from "./shared";
 
@@ -61,9 +61,23 @@ function extractMutationRejection(
 async function queryEpicState(
   handle: EpicHandleLike,
 ): Promise<import("../../temporal/contracts").EpicWorkflowState> {
-  return runTemporalQuery(() => handle.query(getEpicQuery)) as Promise<
-    import("../../temporal/contracts").EpicWorkflowState
-  >;
+  const state = await runTemporalQuery(() => handle.query(getEpicStateQuery));
+  if (!isEpicWorkflowState(state)) {
+    throw new Error("Epic workflow state query returned malformed state");
+  }
+  return state;
+}
+
+function isEpicWorkflowState(
+  value: unknown,
+): value is import("../../temporal/contracts").EpicWorkflowState {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "epic" in value &&
+    typeof (value as { epic?: unknown }).epic === "object" &&
+    (value as { epic?: unknown }).epic !== null
+  );
 }
 
 function isWorkflowNotFoundError(error: unknown): boolean {


### PR DESCRIPTION
## Summary
- Query full Epic workflow state from Temporal store reads
- Add malformed-state guard so Epic-only query responses fail loudly
- Update Epic store tests for state query behavior

## Verification
- pnpm run check
- pnpm vitest run src/storage/store-temporal/epics.test.ts src/tools/epic.test.ts
- pnpm run typecheck
- pnpm run build