### PR TITLE
fix(adv): list epics by workflow type

### DIFF
--- a/plugin/src/temporal/list-epic-workflows.test.ts
+++ b/plugin/src/temporal/list-epic-workflows.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildEpicVisibilityQuery,
+  listEpicWorkflowIds,
+} from "./list-epic-workflows";
+
+function makeClient(results: Array<{ workflowId: string }>): {
+  workflow: {
+    list: ReturnType<typeof vi.fn>;
+  };
+} {
+  const list = vi.fn(({ query: _query }: { query: string }) => {
+    return (async function* iterate() {
+      for (const r of results) yield r;
+    })();
+  });
+  return { workflow: { list } };
+}
+
+describe("listEpicWorkflowIds", () => {
+  it("uses workflow type only and filters project scope by workflow ID prefix", async () => {
+    const client = makeClient([
+      { workflowId: "adv/epic/pid-abc/cardIdentity" },
+      { workflowId: "adv/epic/other-pid/providerArchitecture" },
+      { workflowId: "adv/change/pid-abc/notAnEpic" },
+      { workflowId: "adv/epic/pid-abc/simplifiedChineseCardData" },
+    ]);
+
+    const ids = await listEpicWorkflowIds(client, { projectId: "pid-abc" });
+
+    expect(ids).toEqual(["cardIdentity", "simplifiedChineseCardData"]);
+    expect(client.workflow.list).toHaveBeenCalledWith({
+      query: 'WorkflowType = "epicWorkflow"',
+    });
+  });
+
+  it("does not use WorkflowId LIKE in visibility query", () => {
+    expect(buildEpicVisibilityQuery("pid-abc")).toBe(
+      'WorkflowType = "epicWorkflow"',
+    );
+  });
+});

--- a/plugin/src/temporal/list-epic-workflows.ts
+++ b/plugin/src/temporal/list-epic-workflows.ts
@@ -1,10 +1,10 @@
 /**
  * Visibility-API-backed Epic enumeration.
  *
- * Mirrors list-change-workflows.ts but scopes to the Epic workflow type
- * and the `adv/epic/{projectId}/` workflow ID prefix. Epic workflows do
- * not use custom search attributes; `WorkflowType = "epicWorkflow"` is
- * sufficient because the workflow ID carries the project scope.
+ * Mirrors list-change-workflows.ts but scopes to the Epic workflow type.
+ * Epic workflows do not use custom search attributes; the workflow ID carries
+ * project scope, so we enumerate by workflow type and filter the canonical
+ * `adv/epic/{projectId}/` prefix in-process.
  */
 
 export interface ListEpicWorkflowIdsOptions {
@@ -24,16 +24,11 @@ export interface ListEpicClient {
   };
 }
 
-function escapeQueryValue(value: string): string {
-  return value.replace(/"/g, '\\"');
-}
-
 /**
  * Build the visibility-API query string for epic-workflow enumeration.
  */
-export function buildEpicVisibilityQuery(projectId: string): string {
-  const safeProjectId = escapeQueryValue(projectId);
-  return `WorkflowType = "epicWorkflow" AND WorkflowId LIKE "adv/epic/${safeProjectId}/%"`;
+export function buildEpicVisibilityQuery(_projectId: string): string {
+  return `WorkflowType = "epicWorkflow"`;
 }
 
 const EPIC_WORKFLOW_PREFIX = "adv/epic/";


### PR DESCRIPTION
## Summary
- Stop using WorkflowId LIKE in Epic visibility query
- Enumerate Epic workflows by WorkflowType and filter project prefix in-process
- Add listEpicWorkflowIds coverage for project-prefix filtering

## Verification
- pnpm run check
- pnpm vitest run src/temporal/list-epic-workflows.test.ts src/storage/store-temporal/epics.test.ts src/tools/epic.test.ts
- pnpm run typecheck