### PR TITLE
fix: allow stale epic shell removal

### DIFF
--- a/plugin/src/tools/epic.test.ts
+++ b/plugin/src/tools/epic.test.ts
@@ -1530,6 +1530,74 @@ describe("adv_epic_repair_membership", () => {
     expect(store.changes.clearEpicMembership).not.toHaveBeenCalled();
   });
 
+  test("remove_stale_entry dry-run previews shell entry removal", async () => {
+    const store = makeStore({
+      entries: [
+        makeShellEntry({
+          entry_id: "shell-stale",
+          title: "Stale Shell",
+        }),
+      ],
+    });
+
+    const output = await epicTools.adv_epic_repair_membership.execute(
+      {
+        epic_id: "addAuthEpic",
+        entry_id: "shell-stale",
+        mode: "remove_stale_entry",
+        evidence: "Operator verified duplicate shell should be removed.",
+        dryRun: true,
+      },
+      store,
+    );
+    const parsed = parseToolOutput(output);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.action).toBe("remove_stale_entry");
+    expect(parsed.entry_id).toBe("shell-stale");
+    expect(parsed.entry_kind).toBe("shell");
+    expect(parsed.change_id).toBeUndefined();
+    expect(store.epics.unlinkChange).not.toHaveBeenCalled();
+    expect(store.changes.get).not.toHaveBeenCalled();
+  });
+
+  test("remove_stale_entry removes shell entry without child mutation", async () => {
+    const store = makeStore({
+      entries: [
+        makeShellEntry({
+          entry_id: "shell-stale",
+          title: "Stale Shell",
+        }),
+      ],
+    });
+
+    const output = await epicTools.adv_epic_repair_membership.execute(
+      {
+        epic_id: "addAuthEpic",
+        entry_id: "shell-stale",
+        mode: "remove_stale_entry",
+        evidence: "Operator verified duplicate shell should be removed.",
+      },
+      store,
+    );
+    const parsed = parseToolOutput(output);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.repaired).toBe(true);
+    expect(parsed.removed).toBe(true);
+    expect(parsed.entry_id).toBe("shell-stale");
+    expect(parsed.entry_kind).toBe("shell");
+    expect(parsed.change_id).toBeUndefined();
+    expect(store.epics.unlinkChange).toHaveBeenCalledWith(
+      "addAuthEpic",
+      "shell-stale",
+      "Operator verified duplicate shell should be removed.",
+    );
+    expect(store.changes.get).not.toHaveBeenCalled();
+    expect(store.changes.clearEpicMembership).not.toHaveBeenCalled();
+  });
+
   test("retarget_stale_entry dry-run previews retarget without mutation", async () => {
     const store = makeStore({
       entries: [

--- a/plugin/src/tools/epic.ts
+++ b/plugin/src/tools/epic.ts
@@ -444,6 +444,19 @@ function findChangeEntry(
   }) as Extract<EpicEntry, { kind: "change" }> | undefined;
 }
 
+function findEpicEntry(
+  epic: import("../types").Epic,
+  input: { entryId?: string; changeId?: string },
+) {
+  return epic.entries.find((entry) => {
+    if (input.entryId && entry.entry_id === input.entryId) return true;
+    if (entry.kind === "change" && input.changeId) {
+      return getEpicEntryChangeId(entry) === input.changeId;
+    }
+    return false;
+  });
+}
+
 function requireChangeEntry(
   entry: EpicEntry,
 ): Extract<EpicEntry, { kind: "change" }> {
@@ -1826,6 +1839,46 @@ export const epicTools = {
           }
           return epicNotFound(epic_id);
         }
+        if (mode === "remove_stale_entry") {
+          const entry = findEpicEntry(epic, {
+            entryId: entry_id,
+            changeId: change_id,
+          });
+          if (!entry) {
+            return formatToolOutput({
+              error: `Entry not found in Epic ${epic_id}`,
+              code: "ENTRY_NOT_FOUND",
+            });
+          }
+          const finalChangeId =
+            entry.kind === "change" ? getEpicEntryChangeId(entry) : undefined;
+          if (entry.kind === "change" && !finalChangeId) {
+            return formatToolOutput({
+              error: `Entry has no change reference: ${entry.entry_id}`,
+              code: "PROJECTION_MISSING",
+            });
+          }
+          if (dryRun) {
+            return formatToolOutput({
+              success: true,
+              dryRun: true,
+              entry_id: entry.entry_id,
+              entry_kind: entry.kind,
+              ...(finalChangeId ? { change_id: finalChangeId } : {}),
+              action: "remove_stale_entry",
+            });
+          }
+          await store.epics.unlinkChange(epic_id, entry.entry_id, evidence);
+          return formatToolOutput({
+            success: true,
+            repaired: true,
+            entry_id: entry.entry_id,
+            entry_kind: entry.kind,
+            ...(finalChangeId ? { change_id: finalChangeId } : {}),
+            removed: true,
+          });
+        }
+
         const entry = findChangeEntry(epic, {
           entryId: entry_id,
           changeId: change_id,
@@ -1836,31 +1889,12 @@ export const epicTools = {
             code: "ENTRY_NOT_FOUND",
           });
         }
+
         const finalChangeId = getEpicEntryChangeId(entry);
         if (!finalChangeId) {
           return formatToolOutput({
             error: `Entry has no change reference: ${entry.entry_id}`,
             code: "PROJECTION_MISSING",
-          });
-        }
-
-        if (mode === "remove_stale_entry") {
-          if (dryRun) {
-            return formatToolOutput({
-              success: true,
-              dryRun: true,
-              entry_id: entry.entry_id,
-              change_id: finalChangeId,
-              action: "remove_stale_entry",
-            });
-          }
-          await store.epics.unlinkChange(epic_id, entry.entry_id, evidence);
-          return formatToolOutput({
-            success: true,
-            repaired: true,
-            entry_id: entry.entry_id,
-            change_id: finalChangeId,
-            removed: true,
           });
         }
 


### PR DESCRIPTION
## Summary
- allow adv_epic_repair_membership remove_stale_entry to resolve shell entries by entry_id
- keep existing change-entry removal behavior
- add dry-run and execute tests for shell removal

## Verification
- pnpm test src/tools/epic.test.ts
- pnpm run typecheck
- pnpm exec prettier --check src/tools/epic.ts src/tools/epic.test.ts
- pnpm run build
