### PR TITLE
fix(cli): flush stdout before process.exit to prevent pipe truncation

### DIFF
--- a/bin/adv
+++ b/bin/adv
@@ -761,5 +761,12 @@ async function main(argv: string[]): Promise<number> {
 }
 
 main(process.argv.slice(2)).then((code) => {
-  process.exit(code);
+  // Flush stdout before force-exiting. process.exit() immediately terminates
+  // the event loop, which truncates piped output (e.g. `adv status --json |
+  // wc`) when data is still in the async pipe write queue. stdout.end()
+  // flushes pending writes then calls back, at which point we can safely exit.
+  // Force exit (not exitCode) because error paths leave dangling gRPC handles
+  // that prevent natural event-loop termination.
+  // See: https://github.com/nodejs/node/issues/6456
+  process.stdout.end(() => process.exit(code));
 });


### PR DESCRIPTION
## Problem

`adv status --json` truncates piped output at ~8KB. Root cause: `bin/adv` line 764 calls `process.exit(code)` immediately after `main()` resolves, which kills the Bun event loop before async stdout pipe writes complete.

When stdout is a **pipe** (bash `$(...)`, `| wc`, etc.), large payloads (>8KB) get truncated. When stdout is a **file** or TTY, writes are synchronous and complete.

## Impact

Any consumer that pipes `adv status --json` loses data once the payload exceeds ~8KB. The `zellij-project-launcher` epic heatmap captures status via bash `$(...)` (a pipe); for projects with large active-change sets (e.g. 33 changes → 17KB JSON), the truncated JSON fails to parse and the launcher falls back to grey/idle rendering with no timestamps.

## Proof

```
adv status --json | wc -c   →  8192  (truncated)
adv status --json > file    →  17170 (complete)
```

## Fix

Replace `process.exit(code)` with `process.stdout.end(() => process.exit(code))`. `stdout.end()` signals end-of-stream, flushes pending writes, then invokes the callback — at which point force-exit is safe.

Force exit (not `exitCode`) is still needed because error paths leave dangling gRPC handles from the Temporal client that prevent natural event-loop termination.

## Verification

- All 16 `bin/adv.test.ts` tests pass (including the error-path timeout test)
- All 18 `bin/lib/live-status.test.ts` tests pass
- Piped and file-redirected output now match byte-for-byte
- `zellij-project-launcher --adv-changes` now renders correct heatmap colors + timestamps for projects with >8KB status JSON

🤖 Generated with [opencode](https://opencode.ai)