### PR TITLE
feat(skills): vendor codebase-design and improve-codebase-architecture

### DIFF
--- a/ADV_INSTRUCTIONS.md
+++ b/ADV_INSTRUCTIONS.md
@@ -926,6 +926,15 @@ Pocock overlap skills remain excluded from ADV skill selection:
 | `triage`          | Superseded by `/adv-triage`; WSJF + ROADMAP mirror already gate-aware.           |
 | `tdd`             | Superseded by RSTC TDD Protocol; task metadata and verification own correctness. |
 
+### Adopted Skills (Open-Zone Resolutions)
+
+The following Pocock skills were not excluded but adopted as ADV vendored skills. They supplement ADV methodology without conflicting with the gate-bound model.
+
+| Skill                          | Adopted as                  | Rationale                                                                                                                                                              |
+| ------------------------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `codebase-design`              | `adv-codebase-design`       | Adopted 2026-07-08 for change `adoptCodebaseDesignImprove`. Vocabulary reference (deep-module terms + deletion test + dependency categories). License: MIT.             |
+| `improve-codebase-architecture`| `adv-improve-codebase-architecture` | Adopted 2026-07-08 for change `adoptCodebaseDesignImprove`. Procedural organic-exploration + HTML-report workflow (`disable-model-invocation: true` preserved). License: MIT. |
+
 ## Skill Creation Protocol
 
 Enabled in `/adv-discover` and `/adv-research`. Conservative — only triggers for the change's core problem domain.

--- a/LICENSE-THIRD-PARTY.md
+++ b/LICENSE-THIRD-PARTY.md
@@ -7,8 +7,8 @@ This repository vendors content from external projects under their original lice
 **Source:** https://github.com/mattpocock/skills
 **Author:** Matt Pocock <https://github.com/mattpocock>
 **License:** MIT (see [LICENSE](#mit-license-mattpocockskills) below)
-**Imported SHA:** `9f2e0bd0ea776eb6372eb81fa8a4a47814a8404a`
-**Imported at:** 2026-05-11 (change `adoptMattpocockSkills`)
+**Imported SHA:** `d574778f94cf620fcc8ce741584093bc650a61d3`
+**Imported at:** 2026-05-11 (change `adoptMattpocockSkills`); 2026-07-08 (change `adoptCodebaseDesignImprove`)
 
 ### Vendored skills
 
@@ -21,6 +21,11 @@ This repository vendors content from external projects under their original lice
 | `skills/adv-prototype/LOGIC.md` | `skills/engineering/prototype/LOGIC.md` | (same name) |
 | `skills/adv-prototype/UI.md` | `skills/engineering/prototype/UI.md` | (same name) |
 | `skills/adv-skill-author/SKILL.md` | `skills/productivity/write-a-skill/SKILL.md` | `adv-skill-author` (renamed) |
+| `skills/adv-codebase-design/SKILL.md` | `skills/engineering/codebase-design/SKILL.md` | `adv-codebase-design` |
+| `skills/adv-codebase-design/DEEPENING.md` | `skills/engineering/codebase-design/DEEPENING.md` | (same name) |
+| `skills/adv-codebase-design/DESIGN-IT-TWICE.md` | `skills/engineering/codebase-design/DESIGN-IT-TWICE.md` | (same name) |
+| `skills/adv-improve-codebase-architecture/SKILL.md` | `skills/engineering/improve-codebase-architecture/SKILL.md` | `adv-improve-codebase-architecture` |
+| `skills/adv-improve-codebase-architecture/HTML-REPORT.md` | `skills/engineering/improve-codebase-architecture/HTML-REPORT.md` | (same name) |
 
 The `skills/adv-skill-author/SKILL.md` content was minimally adapted: description field updated for ADV context and an ADV-Specific Guidance section appended. Pocock's original content preserved verbatim.
 

--- a/skills/adv-codebase-design/DEEPENING.md
+++ b/skills/adv-codebase-design/DEEPENING.md
@@ -1,0 +1,43 @@
+<!-- Vendored from mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3:skills/engineering/codebase-design/DEEPENING.md
+     Author: Matt Pocock <https://github.com/mattpocock>
+     License: MIT (see LICENSE-THIRD-PARTY.md)
+     Renamed per ADR-001 (docs/adr/0001-adv-prefix-vendored-skills.md).
+     Imported: 2026-07-08 for change adoptCodebaseDesignImprove. -->
+
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [SKILL.md](SKILL.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/skills/adv-codebase-design/DESIGN-IT-TWICE.md
+++ b/skills/adv-codebase-design/DESIGN-IT-TWICE.md
@@ -1,0 +1,50 @@
+<!-- Vendored from mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3:skills/engineering/codebase-design/DESIGN-IT-TWICE.md
+     Author: Matt Pocock <https://github.com/mattpocock>
+     License: MIT (see LICENSE-THIRD-PARTY.md)
+     Renamed per ADR-001 (docs/adr/0001-adv-prefix-vendored-skills.md).
+     Imported: 2026-07-08 for change adoptCodebaseDesignImprove. -->
+
+# Design It Twice
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [SKILL.md](SKILL.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [SKILL.md](SKILL.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/skills/adv-codebase-design/SKILL.md
+++ b/skills/adv-codebase-design/SKILL.md
@@ -1,0 +1,121 @@
+<!-- Vendored from mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3:skills/engineering/codebase-design/SKILL.md
+     Author: Matt Pocock <https://github.com/mattpocock>
+     License: MIT (see LICENSE-THIRD-PARTY.md)
+     Renamed to adv-codebase-design per ADR-001 (docs/adr/0001-adv-prefix-vendored-skills.md).
+     Imported: 2026-07-08 for change adoptCodebaseDesignImprove. -->
+
+---
+name: adv-codebase-design
+description: Shared vocabulary for designing deep modules. Use when the user wants to design or improve a module's interface, find deepening opportunities, decide where a seam goes, make code more testable or AI-navigable, or when another skill needs the deep-module vocabulary.
+keywords: ["module-design", "deep-module", "interface", "seam", "adapter"]
+---
+
+# Codebase Design
+
+Design **deep modules**: a lot of behaviour behind a small interface, placed at a clean seam, testable through that interface. Use this language and these principles wherever code is being designed or restructured. The aim is leverage for callers, locality for maintainers, and testability for everyone.
+
+## Glossary
+
+Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+**Module** — anything with an interface and an implementation. Deliberately scale-agnostic: a function, class, package, or tier-spanning slice. _Avoid_: unit, component, service.
+
+**Interface** — everything a caller must know to use the module correctly: the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics. _Avoid_: API, signature (too narrow — they refer only to the type-level surface).
+
+**Implementation** — what's inside a module, its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth** — leverage at the interface: the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface, **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(Michael Feathers)_ — a place where you can alter behaviour without editing in that place; the *location* at which a module's interface lives. Where to put the seam is its own design decision, distinct from what goes behind it. _Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter** — a concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage** — what callers get from depth: more capability per unit of interface they learn. One implementation pays back across N call sites and M tests.
+
+**Locality** — what maintainers get from depth: change, bugs, knowledge, and verification concentrate in one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Deep vs shallow
+
+**Deep module** = small interface + lots of implementation:
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid):
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing an interface, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Designing for testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them.**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects.**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area.** Fewer methods = fewer tests needed. Fewer params = simpler test setup.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.
+
+## Going deeper
+
+- **Deepening a cluster given its dependencies** — see [DEEPENING.md](DEEPENING.md): dependency categories, seam discipline, and replace-don't-layer testing.
+- **Exploring alternative interfaces** — see [DESIGN-IT-TWICE.md](DESIGN-IT-TWICE.md): spin up parallel sub-agents to design the interface several radically different ways, then compare on depth, locality, and seam placement.

--- a/skills/adv-improve-codebase-architecture/HTML-REPORT.md
+++ b/skills/adv-improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,129 @@
+<!-- Vendored from mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3:skills/engineering/improve-codebase-architecture/HTML-REPORT.md
+     Author: Matt Pocock <https://github.com/mattpocock>
+     License: MIT (see LICENSE-THIRD-PARTY.md)
+     Renamed per ADR-001 (docs/adr/0001-adv-prefix-vendored-skills.md).
+     Imported: 2026-07-08 for change adoptCodebaseDesignImprove. -->
+
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms (from the `/codebase-design` skill) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from the `/codebase-design` skill. Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in the `/codebase-design` glossary, reach for one that is before inventing a new one.

--- a/skills/adv-improve-codebase-architecture/SKILL.md
+++ b/skills/adv-improve-codebase-architecture/SKILL.md
@@ -1,0 +1,73 @@
+<!-- Vendored from mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3:skills/engineering/improve-codebase-architecture/SKILL.md
+     Author: Matt Pocock <https://github.com/mattpocock>
+     License: MIT (see LICENSE-THIRD-PARTY.md)
+     Renamed to adv-improve-codebase-architecture per ADR-001 (docs/adr/0001-adv-prefix-vendored-skills.md).
+     Imported: 2026-07-08 for change adoptCodebaseDesignImprove. -->
+
+---
+name: adv-improve-codebase-architecture
+description: Scan a codebase for deepening opportunities, present them as a visual HTML report, then grill through whichever one you pick.
+disable-model-invocation: true
+keywords: ["architecture", "refactoring", "deepening"]
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+This command is _informed_ by the project's domain model and built on a shared design vocabulary:
+
+- Run the `/codebase-design` skill for the architecture vocabulary (**module**, **interface**, **depth**, **seam**, **adapter**, **leverage**, **locality**) and its principles (the deletion test, "the interface is the test surface", "one adapter = hypothetical seam, two = real"). Use these terms exactly in every suggestion — don't drift into "component," "service," "API," or "boundary."
+- The domain language in `CONTEXT.md` gives names to good seams; ADRs in `docs/adr/` record decisions this command should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary (`CONTEXT.md`) and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates as an HTML report
+
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, render a card with:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and the `/codebase-design` vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, run the `/grilling` skill to walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize — run the `/domain-modeling` skill to keep the domain model current as you go:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md`. Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones.
+- **Want to explore alternative interfaces for the deepened module?** Run the `/codebase-design` skill and use its design-it-twice parallel sub-agent pattern.


### PR DESCRIPTION
## Summary

Adopt two open-zone `mattpocock/skills` into ADV's `skills/` directory:

- **`codebase-design`** (renamed `adv-codebase-design`): deep-module vocabulary reference (module/interface/depth/seam/adapter/leverage/locality + deletion test + dependency categories). MIT licensed.
- **`improve-codebase-architecture`** (renamed `adv-improve-codebase-architecture`): procedural organic-exploration + HTML-report workflow. Preserves `disable-model-invocation: true` (user-invoked only). MIT licensed.

## Motivation

ADV's `/adv-design` and `/adv-discover` discovery output had no shared deep-module vocabulary. The two skills land in the open zone of mattpocock/skills adoption (not yet excluded, not yet adopted). Resolving the open zone unblocks design-phase conversations about seams, adapters, leverage, and locality that previously relied on prose without shared terms.

## Changes

| Path | Change |
|---|---|
| `skills/adv-codebase-design/SKILL.md` | Vendor + minimal frontmatter adapt (renamed, keywords added) |
| `skills/adv-codebase-design/DEEPENING.md` | Vendor verbatim |
| `skills/adv-codebase-design/DESIGN-IT-TWICE.md` | Vendor verbatim |
| `skills/adv-improve-codebase-architecture/SKILL.md` | Vendor + minimal frontmatter adapt (renamed, keywords added, `disable-model-invocation: true` preserved) |
| `skills/adv-improve-codebase-architecture/HTML-REPORT.md` | Vendor verbatim |
| `LICENSE-THIRD-PARTY.md` | Bump `Imported SHA` to `d574778f94cf620fcc8ce741584093bc650a61d3`; add 5 vendored rows; extend `Imported at` line |
| `ADV_INSTRUCTIONS.md` | Add "Adopted Skills (Open-Zone Resolutions)" table under § Excluded Skills |

## Out of scope (per agreement)

- No wholesale rename of `boundary`/`service`/`component` in P-rules or repo docs (Matt's vocabulary bans) — documented as non-adoption
- No JSON → HTML migration (`adv-arch-scan` / `adv-slop-scan` output schemas unchanged)
- No grill-loop replacement of 7-gate lifecycle (`/adv-clarify` continues to own Socratic clarification)
- No auto-load of `improve-codebase-architecture` (`disable-model-invocation: true` preserved)
- No new ADR (ADR-001 reuse)

## Verification

- `pnpm run check` (via `bin/oc-test smoke`): schemas:check + typecheck + check-test-isolation + check-lockfile-policy + lint + format:check all pass
- `pnpm test` (full suite): 4772/4773 pass; 1 Temporal integration test (`concurrent-signaling.itest.ts` SC1/SC9) flakes on full-suite run but PASSES in isolation — confirmed pre-existing flake, not a regression (this change is docs-only with zero `src/` impact)
- `scripts/deploy-local.sh --check`: line 29 glob (`skills/adv-*/SKILL.md`) covers both new skills; pre-existing tool-drift issue (`adv_backlog_*` not in adv.md allowlist) is unrelated to this change
- Skill Discovery: `keywords` field correctly added to both new SKILL.md frontmatter; `/adv-discover` Phase 1.5 will match against trusted skill dirs after deploy

## Artifacts

- `proposal.md`: problem, goal, scope, approach, error handling, out-of-scope
- `agreement.md`: 7 AC, 2 SC, 7 constraints, 5 avoidances; 3 clarifying questions resolved (CQ1: keywords added; CQ2: ADR-001 reuse; CQ3: SHA bump to current HEAD)
- `design.md`: 7-phase implementation strategy, 5 design-derived criteria, 8 risks with mitigations; validator marked INCONCLUSIVE (independent validator worker unavailable in this session — orchestrator self-validated all 4 dimensions)

Closes no issue; origin: adhoc.