### PR TITLE
Update terminal title: Epic | change context rendering

### DIFF
--- a/plugin/src/events/events.test.ts
+++ b/plugin/src/events/events.test.ts
@@ -441,6 +441,28 @@ describe("buildTabTitle", () => {
       "Security | fixAuth",
     );
   });
+
+  it("sanitizes control characters in epic title and change label", () => {
+    // C0 control chars (0x01-0x1f) should be replaced by sanitizer
+    const title = buildTabTitle("🟩", "Jester", "fix\x01Auth", "Sec\x1burity");
+    // buildTabTitle itself does not sanitize — the OSC writer does.
+    // But the title should still render with the pipe separator.
+    expect(title).toContain("|");
+    expect(title).toContain("fix");
+    expect(title).toContain("Auth");
+  });
+
+  it("does not produce dangling separator when epic title is whitespace-only", () => {
+    const title = buildTabTitle("🟩", "Jester", "fixAuth", "   ");
+    expect(title).not.toContain("|");
+    expect(title).toBe("fixAuth");
+  });
+
+  it("renders exactly one separator when both epic and change are present", () => {
+    const title = buildTabTitle("🟩", "Jester", "fixAuth", "Security");
+    const separatorCount = (title.match(/\|/g) || []).length;
+    expect(separatorCount).toBe(1);
+  });
 });
 
 // =============================================================================

--- a/plugin/src/events/events.test.ts
+++ b/plugin/src/events/events.test.ts
@@ -401,16 +401,45 @@ describe("buildTabTitle", () => {
     expect(title).not.toMatch(/\[\d+\/\d+\]/);
   });
 
-  it("ignores BLOCKED/status prefix for the simple identity title", () => {
-    expect(buildTabTitle("🟥", "Jester", "changeX", "💀")).toBe("changeX");
+  it("ignores BLOCKED/status emoji for the simple identity title", () => {
+    expect(buildTabTitle("🟥", "Jester", "changeX")).toBe("changeX");
   });
 
-  it("shows project only when BLOCKED/status prefix is provided without active change", () => {
-    expect(buildTabTitle("🟥", "Jester", undefined, "💀")).toBe("Jester");
+  it("shows project only when BLOCKED status emoji is provided without active change", () => {
+    expect(buildTabTitle("🟥", "Jester", undefined)).toBe("Jester");
   });
 
   it("ignores status emoji in the tab title", () => {
     expect(buildTabTitle("🟩", "Jester", "changeX")).toBe("changeX");
+  });
+
+  it("renders Epic title | change label when both provided", () => {
+    expect(buildTabTitle("🟩", "Jester", "fixAuth", "Security Epic")).toBe(
+      "Security Epic | fixAuth",
+    );
+  });
+
+  it("renders change label only when no epic title", () => {
+    expect(buildTabTitle("🟩", "Jester", "fixAuth", undefined)).toBe("fixAuth");
+  });
+
+  it("renders change label only when epic title is empty", () => {
+    expect(buildTabTitle("🟩", "Jester", "fixAuth", "")).toBe("fixAuth");
+  });
+
+  it("renders change label only when epic title is whitespace", () => {
+    expect(buildTabTitle("🟩", "Jester", "fixAuth", "   ")).toBe("fixAuth");
+  });
+
+  it("does not produce dangling separator when epic title missing", () => {
+    const title = buildTabTitle("🟩", "Jester", "fixAuth", undefined);
+    expect(title).not.toContain("|");
+  });
+
+  it("trims whitespace in epic title and change label", () => {
+    expect(buildTabTitle("🟩", "Jester", "  fixAuth  ", "  Security  ")).toBe(
+      "Security | fixAuth",
+    );
   });
 });
 

--- a/plugin/src/events/events.test.ts
+++ b/plugin/src/events/events.test.ts
@@ -181,6 +181,33 @@ describe("Status State Management", () => {
       setActiveChange(null);
       expect(getStatus().activeChangeId).toBeNull();
     });
+
+    it("accepts structured context with label and epic title", () => {
+      initializeStatus("test-project");
+      setActiveChange("my-change", { label: "Fix auth bug", epicTitle: "Security Epic" });
+      const status = getStatus();
+      expect(status.activeChangeId).toBe("my-change");
+      expect(status.activeChangeLabel).toBe("Fix auth bug");
+      expect(status.activeEpicTitle).toBe("Security Epic");
+    });
+
+    it("defaults label to changeId when context not provided", () => {
+      initializeStatus("test-project");
+      setActiveChange("my-change");
+      const status = getStatus();
+      expect(status.activeChangeLabel).toBe("my-change");
+      expect(status.activeEpicTitle).toBeNull();
+    });
+
+    it("clears structured context when change set to null", () => {
+      initializeStatus("test-project");
+      setActiveChange("my-change", { label: "Fix auth bug", epicTitle: "Security Epic" });
+      setActiveChange(null);
+      const status = getStatus();
+      expect(status.activeChangeId).toBeNull();
+      expect(status.activeChangeLabel).toBeNull();
+      expect(status.activeEpicTitle).toBeNull();
+    });
   });
 
   describe("setTaskProgress", () => {

--- a/plugin/src/events/status.ts
+++ b/plugin/src/events/status.ts
@@ -156,7 +156,8 @@ const updateTerminal = (): void => {
   updateTerminalStatus(
     state.currentStatus,
     state.projectName,
-    state.activeChangeId ?? undefined,
+    state.activeChangeLabel ?? undefined,
+    state.activeEpicTitle ?? undefined,
     state.taskProgress ?? undefined,
   );
 };

--- a/plugin/src/events/status.ts
+++ b/plugin/src/events/status.ts
@@ -16,6 +16,8 @@ interface StatusState {
   currentStatus: StatusMarker;
   projectName: string;
   activeChangeId: string | null;
+  activeChangeLabel: string | null;
+  activeEpicTitle: string | null;
   taskProgress: string | null;
   lastUpdated: number;
 }
@@ -24,6 +26,8 @@ let state: StatusState = {
   currentStatus: "IDLE",
   projectName: "Unknown",
   activeChangeId: null,
+  activeChangeLabel: null,
+  activeEpicTitle: null,
   taskProgress: null,
   lastUpdated: Date.now(),
 };
@@ -83,6 +87,8 @@ export const initializeStatus = (projectName: string): void => {
     currentStatus: "IDLE",
     projectName,
     activeChangeId: null,
+    activeChangeLabel: null,
+    activeEpicTitle: null,
     taskProgress: null,
     lastUpdated: Date.now(),
   };
@@ -100,6 +106,8 @@ export const resetStatusForTest = (): void => {
     currentStatus: "IDLE",
     projectName: "Unknown",
     activeChangeId: null,
+    activeChangeLabel: null,
+    activeEpicTitle: null,
     taskProgress: null,
     lastUpdated: Date.now(),
   };
@@ -118,9 +126,18 @@ export const setStatus = (status: StatusMarker): void => {
 
 /**
  * Set the active change being worked on.
+ *
+ * Accepts optional structured context (label and epicTitle) for pane title
+ * rendering. When context is not provided, label defaults to changeId and
+ * epicTitle defaults to null. Passing null for changeId clears all context.
  */
-export const setActiveChange = (changeId: string | null): void => {
+export const setActiveChange = (
+  changeId: string | null,
+  context?: { label?: string; epicTitle?: string },
+): void => {
   state.activeChangeId = changeId;
+  state.activeChangeLabel = changeId ? (context?.label ?? changeId) : null;
+  state.activeEpicTitle = changeId ? (context?.epicTitle ?? null) : null;
   updateTerminal();
 };
 
@@ -159,6 +176,8 @@ export const resetStatus = (): void => {
     ...state,
     currentStatus: "IDLE",
     activeChangeId: null,
+    activeChangeLabel: null,
+    activeEpicTitle: null,
     taskProgress: null,
     lastUpdated: Date.now(),
   };
@@ -176,6 +195,8 @@ export const cleanup = (): void => {
     currentStatus: "IDLE",
     projectName: "Unknown",
     activeChangeId: null,
+    activeChangeLabel: null,
+    activeEpicTitle: null,
     taskProgress: null,
     lastUpdated: Date.now(),
   };

--- a/plugin/src/events/terminal.ts
+++ b/plugin/src/events/terminal.ts
@@ -259,30 +259,34 @@ const cleanTitlePart = (value: string | undefined): string =>
   (value ?? "").trim();
 
 /**
- * Build tab title from raw project name and raw change ID.
+ * Build tab title from project name, change label, and optional epic title.
+ *
+ * Title priority:
+ *   - Active change with Epic: "Epic title | change label"
+ *   - Active change without Epic: "change label"
+ *   - No active change: project name
  *
  * Deliberately avoids semantic normalization, shortname generation, acronym
- * generation, verb stripping, or AI/agent-driven naming. The terminal title is
- * a direct reflection of the active ADV change ID, falling back to the initial
- * project basename when no ADV change is active:
- *
- *   Project
- *   change-id
+ * generation, verb stripping, or AI/agent-driven naming.
  */
 export const buildTabTitle = (
   _emoji: string,
   projectName: string,
-  changeId: string | undefined,
-  _prefix?: string,
+  changeLabel: string | undefined,
+  epicTitle?: string,
 ): string => {
-  const projectLabel = cleanTitlePart(projectName);
-  const changeLabel = cleanTitlePart(changeId);
+  const projectPart = cleanTitlePart(projectName);
+  const changePart = cleanTitlePart(changeLabel);
+  const epicPart = cleanTitlePart(epicTitle);
 
-  if (changeLabel) {
-    return changeLabel;
+  if (changePart && epicPart) {
+    return `${epicPart} | ${changePart}`;
   }
-  if (projectLabel) {
-    return projectLabel;
+  if (changePart) {
+    return changePart;
+  }
+  if (projectPart) {
+    return projectPart;
   }
   return "";
 };
@@ -292,25 +296,18 @@ let lastTitle: string | null = null;
 /**
  * Update terminal based on status.
  * Title format:
- *   - Active change: "<change-id>"
+ *   - Active change with Epic: "Epic title | change label"
+ *   - Active change without Epic: "change label"
  *   - No active change: "<project>"
- *
- * Title policy: identity-only. Do not encode status/progress or repeatedly
- * rewrite the tab title during normal status churn. The simple identity title
- * is updated only when the identity string changes.
- *
- * Notification policy: ADV core does not emit audible terminal bells for
- * status transitions. Attention/completion notifications are handled by the
- * host/tool integration layer (for example Warp/OpenCode notifications) or by
- * user terminal settings outside this module.
  */
 export const updateTerminalStatus = (
   status: StatusMarker,
   projectName: string,
-  changeId?: string,
+  changeLabel?: string,
+  epicTitle?: string,
   _progress?: string,
 ): void => {
-  const title = buildTabTitle(getStatusEmoji(status), projectName, changeId);
+  const title = buildTabTitle(getStatusEmoji(status), projectName, changeLabel, epicTitle);
 
   if (title !== lastTitle) {
     if (setTitle(title)) {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -618,7 +618,8 @@ const advancePluginImpl: Plugin = async (input) => {
           );
           if (reachable) {
             state.activeChange.id = String(args.changeId);
-            setActiveChange(state.activeChange.id);
+            const ctx = await resolveChangeContext(state.activeChange.id);
+            setActiveChange(state.activeChange.id, ctx);
             debugLog(`handleToolExecuteBefore: re-pointed to ${args.changeId}`);
           } else {
             debugLog(
@@ -816,11 +817,35 @@ const advancePluginImpl: Plugin = async (input) => {
     handleLongRunningToolStart(toolName);
   };
 
-  const recordCreatedChange = (rawOutput: string) => {
+  /**
+   * Resolve change label and parent Epic title from the project store.
+   * Used at active-change pointer transitions to feed structured context to
+   * the terminal title renderer. Falls back gracefully — never blocks or
+   * fails the tool operation.
+   */
+  const resolveChangeContext = async (
+    changeId: string,
+  ): Promise<{ label?: string; epicTitle?: string }> => {
+    if (!store) return {};
+    try {
+      const result = await store.changes.get(changeId);
+      if (!result.success || !result.data) return {};
+      const change = result.data;
+      return {
+        label: change.title,
+        epicTitle: change.epic_membership?.title,
+      };
+    } catch {
+      return {};
+    }
+  };
+
+  const recordCreatedChange = async (rawOutput: string) => {
     const newChangeId = extractCreatedChangeId(rawOutput);
     if (!newChangeId) return;
     state.activeChange.id = newChangeId;
-    setActiveChange(newChangeId);
+    const ctx = await resolveChangeContext(newChangeId);
+    setActiveChange(newChangeId, ctx);
     debugLog(`adv_change_create: set activeChange to ${newChangeId}`);
   };
 
@@ -955,7 +980,7 @@ const advancePluginImpl: Plugin = async (input) => {
         // Track new change creation (changeId only in output, not input args)
         if (input.tool === "adv_change_create" && output.output) {
           try {
-            recordCreatedChange(output.output);
+            await recordCreatedChange(output.output);
           } catch (err) {
             // Outer parse error — unexpected if banner format changes
             hooksLogger.warn(


### PR DESCRIPTION
## What Changes
- `buildTabTitle` renders `Epic title | change label` with structured context fallbacks
- `StatusState` extended with `activeChangeLabel` and `activeEpicTitle`
- `setActiveChange` accepts optional `{ label, epicTitle }` context
- `resolveChangeContext` helper resolves `epic_membership.title` from store at pointer transitions

## Files
- `plugin/src/events/terminal.ts`: buildTabTitle + updateTerminalStatus structured context
- `plugin/src/events/status.ts`: StatusState fields + setActiveChange signature
- `plugin/src/index.ts`: resolveChangeContext + async pointer hooks
- `plugin/src/events/events.test.ts`: comprehensive title state tests

## Verification
- Events 65/65 PASS
- Integration 30/30 PASS