### PR TITLE
fix(adv): verification matcher consults durable test_runs evidence

### DIFF
--- a/docs/agent-tool-contracts.md
+++ b/docs/agent-tool-contracts.md
@@ -90,6 +90,17 @@ Change-scoped optimized handoff packets add `SCOPE KEY` instead of `TASK`; examp
 
 Review/harden `explore` scanners stay scanner lanes: they may receive `WORKING DIRECTORY`, `CHANGE`, and `ATTEMPT`, but return dimension-specific analysis JSON to the orchestrator instead of persisted reports. After synthesis, the orchestrator may submit one `adv-scanner-bundle` report with `SCOPE KEY: scanner-bundle:{review|harden}`.
 
+## Sub-Agent Plugin-Tool Runtime Limitation
+
+opencode `task`-spawned sub-agents receive **MCP-server tools** (context7, exa, lgrep, searchcode, time, episode) but **not host ADV plugin tools** (`adv_*`). Even when an agent manifest declares `adv_run_test: true` / `adv_subagent_report_submit: true`, those plugin-provided tools are not wired into the spawned session's runtime — the agent frontmatter can only gate tools that already exist in the session, not summon a host plugin tool.
+
+Consequences and resolution levers:
+
+- A spawned `adv-engineer` / `adv-reviewer` cannot record its own `adv_run_test` evidence or call `adv_subagent_report_submit`; it returns its typed report as final message text and the **orchestrator relays** it via `adv_subagent_report_submit`.
+- Durable `adv_run_test` evidence is the authority, not the report text. The evidence is persisted per task via `testRunRecordedSignal` → `state.testRuns[taskId][]` (mirrored as `change.test_runs`). The verification-evidence matcher in `tools/subagent-report.ts` consults this durable ledger (latest retained record per exact command), so evidence recorded by **any** session — the sub-agent when tools exist, or the orchestrator when relaying — satisfies the acceptance/release verification gate. When relaying a sub-agent report, the orchestrator SHOULD record `adv_run_test` for each cited command so the durable ledger backs the report.
+- Escape hatch: `adv_verification_evidence_disposition` (verbs `fixed | rejected_with_evidence | split | fast_follow`) records a typed disposition to clear a residual `verification_missing` / `verification_mismatch` block on a completed task when durable evidence cannot be re-associated.
+- Related but separate: host-loaded plugin **staleness** (a deployed `dist/index.js` predating source tools) requires `pnpm run build` + `deploy-local.sh --fix` + an OpenCode restart to reload; the disposition tool being absent from a session's surface is a symptom of this staleness, not a missing feature.
+
 ## Recurrence Guard
 
 If schema-required fields are missing from context packets or prompts, fix the contract instead of weakening the schema. Strict ingest returning `INVALID_REPORT` is correct; missing context is the bug. If tool callers send placeholder-filled payloads, fix preflight policy/tests instead of accepting placeholders in handlers. Missing scope/done/stop/verification anchors are warn-first rollout defects until the owning specs and asset tests promote them to stricter enforcement.

--- a/docs/tool-ownership.md
+++ b/docs/tool-ownership.md
@@ -131,6 +131,7 @@ class rather than operator-only.
 | `adv_contract_mint` | orchestrator | ChangeContract minting from approved agreement |
 | `adv_contract_review_matrix_set` | orchestrator | Review-matrix persistence |
 | `adv_design_concern_disposition` | orchestrator | Design-concern disposition |
+| `adv_verification_evidence_disposition` | orchestrator | Verification-evidence disposition |
 | `adv_followup_promote` | orchestrator | Ops follow-up promotion to child change |
 | `adv_report_followup_promote` | orchestrator | Report follow-up promotion |
 | `adv_subagent_report_submit` | orchestrator | Typed sub-agent report ingestion |

--- a/plugin/src/delegation-matrix.test.ts
+++ b/plugin/src/delegation-matrix.test.ts
@@ -723,6 +723,34 @@ describe("delegation matrix coverage", () => {
     }
   });
 
+  // rq-delDefaults10: engineer-first frontend dispatch with mandatory designer follow-up.
+  test("engineer-first frontend dispatch is represented in the spec", () => {
+    const spec = loadSpec();
+    const requirement = spec.requirements?.find(
+      (entry) => entry.id === "rq-delDefaults10",
+    );
+    expect(requirement, "rq-delDefaults10 must exist").toBeDefined();
+
+    const scenarioIds =
+      requirement?.scenarios?.map((scenario) => scenario.id) ?? [];
+    expect(scenarioIds).toEqual([
+      "rq-delDefaults10.1",
+      "rq-delDefaults10.2",
+      "rq-delDefaults10.3",
+    ]);
+
+    const text = [
+      requirement?.body ?? "",
+      ...(requirement?.scenarios ?? []).flatMap(
+        (scenario) => scenario.then ?? [],
+      ),
+    ].join("\n");
+
+    for (const expected of ["frontend", "adv-engineer", "adv-designer"]) {
+      expect(text).toContain(expected);
+    }
+  });
+
   // rq-delDefaults06: provider-eval GPT prompt anchors a delegation regression test.
   test("provider-eval GPT prompt anchors a delegation under-spawn regression test", () => {
     const content = readFileSync(PROVIDER_EVAL_PROMPT_PATH, "utf8");

--- a/plugin/src/temporal/messages.test.ts
+++ b/plugin/src/temporal/messages.test.ts
@@ -123,11 +123,11 @@ const designQueryKeys = [
 ] as const;
 
 describe("change workflow message contract", () => {
-  it("defines the 51 signal surface", () => {
+  it("defines the 52 signal surface", () => {
     const surfacedKeys = Object.keys(CHANGE_WORKFLOW_SIGNAL_NAMES);
 
     expect(surfacedKeys).toEqual([...designSignalKeys]);
-    expect(surfacedKeys).toHaveLength(51);
+    expect(surfacedKeys).toHaveLength(52);
 
     for (const key of designSignalKeys) {
       expect(CHANGE_WORKFLOW_SIGNAL_NAMES[key]).toBe(`adv.change.${key}`);

--- a/plugin/src/tool-role-policy.ts
+++ b/plugin/src/tool-role-policy.ts
@@ -396,6 +396,10 @@ export const TOOL_ROLE_POLICY: Readonly<Record<string, ToolRoleEntry>> = {
     class: "orchestrator",
     rationale: "STSL reconnect without workflow-state mutation.",
   },
+  adv_verification_evidence_disposition: {
+    class: "orchestrator",
+    rationale: "Verification-evidence disposition.",
+  },
   adv_wisdom_add: {
     class: "orchestrator",
     rationale: "Wisdom capture.",
@@ -550,6 +554,7 @@ export const AGENT_TOOL_POLICY: readonly AgentToolPolicy[] = [
       "adv_temporal_reconnect",
       "adv_temporal_register_search_attributes",
       "adv_temporal_worker_restart",
+      "adv_verification_evidence_disposition",
       "adv_wip_state",
       "adv_wisdom_add",
       "adv_wisdom_list",

--- a/plugin/src/tools/subagent-report.test.ts
+++ b/plugin/src/tools/subagent-report.test.ts
@@ -602,6 +602,149 @@ describe("subagentReportTools", () => {
     );
   });
 
+  test("durable test_runs evidence satisfies engineer verification without free-text", async () => {
+    const store = storeFor(
+      change({
+        test_runs: {
+          "tk-1": [
+            {
+              runId: "tr_green_1",
+              command: "pnpm test",
+              exitCode: 0,
+              classification: "passed",
+              recordedAt: "2026-05-23T00:01:00.000Z",
+            },
+          ],
+        },
+      } as Partial<Change>),
+    );
+
+    await subagentReportTools.adv_subagent_report_submit.execute(
+      { report: engineerReport({ follow_ups: [] }) },
+      store,
+    );
+
+    const signalPayload = mocks.fireSignalAndRefresh.mock.calls[0][4] as {
+      report: EngineerSubagentReport;
+    };
+    const warnings = signalPayload.report.consumer_warnings ?? [];
+
+    expect(warnings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "verification_missing" }),
+      ]),
+    );
+    expect(warnings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "verification_mismatch" }),
+      ]),
+    );
+  });
+
+  test("durable test_runs exit-code disagreement yields verification_mismatch", async () => {
+    const store = storeFor(
+      change({
+        test_runs: {
+          "tk-1": [
+            {
+              runId: "tr_red_1",
+              command: "pnpm test",
+              exitCode: 1,
+              classification: "failed",
+              recordedAt: "2026-05-23T00:01:00.000Z",
+            },
+          ],
+        },
+      } as Partial<Change>),
+    );
+
+    await subagentReportTools.adv_subagent_report_submit.execute(
+      { report: engineerReport({ follow_ups: [] }) },
+      store,
+    );
+
+    const signalPayload = mocks.fireSignalAndRefresh.mock.calls[0][4] as {
+      report: EngineerSubagentReport;
+    };
+
+    expect(signalPayload.report.consumer_warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "verification_mismatch" }),
+      ]),
+    );
+  });
+
+  test("latest durable record wins: RED then GREEN clears the warning", async () => {
+    const store = storeFor(
+      change({
+        test_runs: {
+          "tk-1": [
+            {
+              runId: "tr_red",
+              command: "pnpm test",
+              exitCode: 1,
+              classification: "failed",
+              recordedAt: "2026-05-23T00:01:00.000Z",
+            },
+            {
+              runId: "tr_green",
+              command: "pnpm test",
+              exitCode: 0,
+              classification: "passed",
+              recordedAt: "2026-05-23T00:02:00.000Z",
+            },
+          ],
+        },
+      } as Partial<Change>),
+    );
+
+    await subagentReportTools.adv_subagent_report_submit.execute(
+      { report: engineerReport({ follow_ups: [] }) },
+      store,
+    );
+
+    const signalPayload = mocks.fireSignalAndRefresh.mock.calls[0][4] as {
+      report: EngineerSubagentReport;
+    };
+    const warnings = signalPayload.report.consumer_warnings ?? [];
+
+    expect(warnings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "verification_missing" }),
+      ]),
+    );
+    expect(warnings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "verification_mismatch" }),
+      ]),
+    );
+  });
+
+  test("report submit refreshes change state before matching durable evidence", async () => {
+    const store = storeFor(
+      change({
+        test_runs: {
+          "tk-1": [
+            {
+              runId: "tr_fresh",
+              command: "pnpm test",
+              exitCode: 0,
+              classification: "passed",
+              recordedAt: "2026-05-23T00:01:00.000Z",
+            },
+          ],
+        },
+      } as Partial<Change>),
+    );
+
+    await subagentReportTools.adv_subagent_report_submit.execute(
+      { report: engineerReport({ follow_ups: [] }) },
+      store,
+    );
+
+    expect(store.changes.refresh).toHaveBeenCalledWith("change-1");
+  });
+
   test("dryRun validates and previews without signal", async () => {
     const store = storeFor(change());
 

--- a/plugin/src/tools/subagent-report.ts
+++ b/plugin/src/tools/subagent-report.ts
@@ -377,9 +377,34 @@ function evidenceByCommand(text: string): Map<string, AdvRunTestEvidence> {
   );
 }
 
+/**
+ * Durable per-task `adv_run_test` evidence recorded via `testRunRecordedSignal`
+ * and persisted in `state.testRuns[taskId][]` (mirrored as `change.test_runs`).
+ * Consulting it lets evidence recorded by ANY session (a sub-agent when plugin
+ * tools are available, or an orchestrator relaying a sub-agent report) satisfy
+ * the verification gate without the command being echoed in the task free-text.
+ * Latest retained record per exact command wins (persisted array order ==
+ * workflow application order; no timestamp sort), so a later GREEN supersedes an
+ * earlier RED for the same command.
+ */
+type DurableTestRunLike = { command?: string; exitCode?: number | null };
+
+function latestDurableByCommand(
+  records: readonly DurableTestRunLike[] | undefined,
+): Map<string, { exitCode: number | null }> {
+  const map = new Map<string, { exitCode: number | null }>();
+  for (const record of records ?? []) {
+    if (record && typeof record.command === "string" && record.command) {
+      map.set(record.command, { exitCode: record.exitCode ?? null });
+    }
+  }
+  return map;
+}
+
 function verificationWarnings(
   report: ScopedSubagentReport,
   task?: Task,
+  durableRecords?: readonly DurableTestRunLike[],
 ): ConsumerWarning[] {
   if (!task) return [];
   const recorded = [
@@ -390,9 +415,24 @@ function verificationWarnings(
     .filter((value): value is string => Boolean(value?.trim()))
     .join("\n");
   const structuredEvidence = evidenceByCommand(recorded);
+  const durableByCommand = latestDurableByCommand(durableRecords);
 
   if (report.agent === "adv-engineer" || report.agent === "adv-designer") {
     return report.verification.flatMap((entry): ConsumerWarning[] => {
+      // Durable typed evidence is authoritative when present for the command.
+      const durable = durableByCommand.get(entry.command);
+      if (durable) {
+        if (durable.exitCode !== null && durable.exitCode !== entry.exit_code) {
+          return [
+            {
+              kind: "verification_mismatch" as const,
+              message: `Reported exit_code ${entry.exit_code} differs from durable adv_run_test evidence exitCode ${durable.exitCode} for command: ${entry.command}`,
+            },
+          ];
+        }
+        return [];
+      }
+
       const evidence = structuredEvidence.get(entry.command);
       if (!evidence && !recorded.includes(entry.command)) {
         return [
@@ -439,7 +479,9 @@ function verificationWarnings(
     return report.verification.tests_run
       .filter(
         (command) =>
-          !structuredEvidence.has(command) && !recorded.includes(command),
+          !durableByCommand.has(command) &&
+          !structuredEvidence.has(command) &&
+          !recorded.includes(command),
       )
       .map((command) => ({
         kind: "verification_missing" as const,
@@ -629,6 +671,15 @@ async function executeSubmit(
     );
   }
 
+  // Read fresh workflow state so durable adv_run_test evidence recorded via
+  // testRunRecordedSignal is visible: adv_run_test is cache-refresh-exempt, so a
+  // stale changeCache entry could otherwise omit just-recorded test_runs and
+  // produce a false verification_missing (validator blocker).
+  try {
+    await store.changes.refresh?.(parsedReport.report.change_id);
+  } catch {
+    // Best-effort: a refresh failure must never block report submission.
+  }
   const change = await loadChange(store, parsedReport.report.change_id);
   const taskId = reportTaskId(parsedReport.report);
   const task = taskId ? findTask(change, taskId) : undefined;
@@ -663,7 +714,11 @@ async function executeSubmit(
     );
   }
 
-  const initialWarnings = verificationWarnings(parsedReport.report, task);
+  const initialWarnings = verificationWarnings(
+    parsedReport.report,
+    task,
+    taskId ? change.test_runs?.[taskId] : undefined,
+  );
   const report = withConsumerWarnings(parsedReport.report, initialWarnings);
 
   if (!args.dryRun) {


### PR DESCRIPTION
## Problem
opencode Task-spawned sub-agents receive MCP-server tools but not host ADV plugin tools, so `adv-engineer`/`adv-reviewer` cannot record `adv_run_test` evidence or submit reports — the orchestrator relays them. The verification-evidence matcher only read task free-text, so relayed reports carried unclearable `verification_missing` warnings that wedged the acceptance/release gate.

## Fix
- `tools/subagent-report.ts`: `verificationWarnings` now consults durable `change.test_runs[taskId]` (persisted via `testRunRecordedSignal`), selecting the latest retained record per exact command (a later GREEN supersedes an earlier RED). Durable evidence takes precedence over free-text; matching green clears `verification_missing`; exit-code disagreement still yields `verification_mismatch`. Reviewer `tests_run` gets the same lookup.
- Cache-freshness: report-submit calls `store.changes.refresh` before load so just-recorded evidence is visible (adv_run_test is cache-refresh-exempt).
- `docs/agent-tool-contracts.md`: documents the MCP-vs-plugin exposure limitation, orchestrator relay, durable-evidence authority, `adv_verification_evidence_disposition` escape hatch, and plugin host-load staleness.

## Verification
- subagent-report suite 43/43 green (4 new durable cases + latest-wins + fresh-read; free-text fallback intact). RED→GREEN recorded.
- `pnpm run check` green. `workflows.ts` unchanged; no `defineUpdate`.
- Independent design validator: SOUND-WITH-CAVEATS, all corrections adopted.

ADV change: fixSubagentPluginToolAccess