### PR TITLE
fix(adv): auto-roll stale OOP worker bundle on redeploy

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -16,7 +16,7 @@
   "author": "Anomaly",
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts && pnpm run build:worker",
-    "build:worker": "tsup src/temporal/worker.ts src/temporal/workflows.ts --format esm --out-dir dist/temporal",
+    "build:worker": "tsup src/temporal/worker.ts src/temporal/workflows.ts --format esm --out-dir dist/temporal && tsx scripts/write-worker-bundle-manifest.ts",
     "dev": "tsup src/index.ts --format esm --watch",
     "check": "pnpm run schemas:check && pnpm run typecheck && tsx scripts/check-test-isolation.ts && tsx scripts/check-lockfile-policy.ts && pnpm run lint && pnpm run format:check",
     "prepublishOnly": "pnpm run build",

--- a/plugin/scripts/write-worker-bundle-manifest.ts
+++ b/plugin/scripts/write-worker-bundle-manifest.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * build:worker finalizer — writes the worker bundle generation manifest.
+ *
+ * Runs as the LAST step of `pnpm run build:worker` (after tsup has written
+ * both dist/temporal/worker.js and dist/temporal/workflows.js). The
+ * manifest pins the bundle generation (SHA-256 over both files) so the
+ * plugin host can detect when a running out-of-process worker child is
+ * stale relative to the on-disk bundle. See
+ * src/temporal/worker-bundle-manifest.ts for the generation contract.
+ */
+
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+import { writeWorkerBundleManifest } from "../src/temporal/worker-bundle-manifest";
+
+const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const bundleDir = join(pluginRoot, "dist", "temporal");
+
+try {
+  const manifest = await writeWorkerBundleManifest(bundleDir);
+  console.log(
+    `worker bundle manifest written: generation=${manifest.generation.slice(0, 12)}… (${bundleDir})`,
+  );
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/plugin/src/deploy-local-worker-refresh.test.ts
+++ b/plugin/src/deploy-local-worker-refresh.test.ts
@@ -66,6 +66,8 @@ printf '// fake build\\n' > "$PWD/dist/index.js"
 printf '// fake worker\\n' > "$PWD/dist/temporal/worker.js"
 printf '// fake workflows\\n' > "$PWD/dist/temporal/workflows.js"
 touch "$PWD/dist/index.js" "$PWD/dist/temporal/worker.js" "$PWD/dist/temporal/workflows.js"
+printf '{"schema_version":1,"generation":"fake","files":{"worker.js":"fake","workflows.js":"fake"},"built_at":"2026-01-01T00:00:00.000Z"}
+' > "$PWD/dist/temporal/bundle-manifest.json"
 `,
     { mode: 0o755 },
   );

--- a/plugin/src/overlay-sync-assets.test.ts
+++ b/plugin/src/overlay-sync-assets.test.ts
@@ -51,6 +51,7 @@ describe("overlay sync script support", () => {
     expect(content).toContain("tsup.config.ts");
     expect(content).toContain("dist/temporal/worker.js");
     expect(content).toContain("dist/temporal/workflows.js");
+    expect(content).toContain("dist/temporal/bundle-manifest.json");
     expect(content).toContain(
       '(cd "$ADV_SOURCE_PLUGIN_PATH" && pnpm run build)',
     );
@@ -126,6 +127,16 @@ describe("overlay sync script support", () => {
         join(tempWorktree, "plugin", "dist", "temporal", "workflows.js"),
         "// fresh workflows\n",
       );
+      writeFileSync(
+        join(
+          tempWorktree,
+          "plugin",
+          "dist",
+          "temporal",
+          "bundle-manifest.json",
+        ),
+        '{"schema_version":1}\n',
+      );
       utimesSync(
         distPath,
         new Date("2030-01-01T00:00:00Z"),
@@ -138,6 +149,17 @@ describe("overlay sync script support", () => {
       );
       utimesSync(
         join(tempWorktree, "plugin", "dist", "temporal", "workflows.js"),
+        new Date("2030-01-01T00:00:00Z"),
+        new Date("2030-01-01T00:00:00Z"),
+      );
+      utimesSync(
+        join(
+          tempWorktree,
+          "plugin",
+          "dist",
+          "temporal",
+          "bundle-manifest.json",
+        ),
         new Date("2030-01-01T00:00:00Z"),
         new Date("2030-01-01T00:00:00Z"),
       );
@@ -200,9 +222,11 @@ mkdir -p "$PWD/dist/temporal"
 printf '// fake build\n' > "$PWD/dist/index.js"
 printf '// fake worker\n' > "$PWD/dist/temporal/worker.js"
 printf '// fake workflows\n' > "$PWD/dist/temporal/workflows.js"
+printf '{"schema_version":1}\n' > "$PWD/dist/temporal/bundle-manifest.json"
 touch "$PWD/dist/index.js"
 touch "$PWD/dist/temporal/worker.js"
 touch "$PWD/dist/temporal/workflows.js"
+touch "$PWD/dist/temporal/bundle-manifest.json"
 `,
         { mode: 0o755 },
       );
@@ -637,10 +661,27 @@ cp -a "$src/." "$dest/"
         join(tempWorktree, "plugin", "dist", "temporal", "workflows.js"),
         "// test workflows is fresh\n",
       );
+      writeFileSync(
+        join(
+          tempWorktree,
+          "plugin",
+          "dist",
+          "temporal",
+          "bundle-manifest.json",
+        ),
+        '{"schema_version":1}\n',
+      );
       for (const distFile of [
         join(tempWorktree, "plugin", "dist", "index.js"),
         join(tempWorktree, "plugin", "dist", "temporal", "worker.js"),
         join(tempWorktree, "plugin", "dist", "temporal", "workflows.js"),
+        join(
+          tempWorktree,
+          "plugin",
+          "dist",
+          "temporal",
+          "bundle-manifest.json",
+        ),
       ]) {
         utimesSync(
           distFile,

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -33,6 +33,7 @@ import {
 } from "./temporal/health-monitor";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
+import { dirname } from "node:path";
 import { performance } from "node:perf_hooks";
 import { cleanup as cleanupTerminal } from "./events";
 import {
@@ -52,6 +53,10 @@ import {
   startWorkerLockHeartbeat,
   type WorkerLockHeartbeatController,
 } from "./temporal/worker-heartbeat";
+import {
+  initWorkerBundleRoll,
+  type WorkerBundleRollMonitor,
+} from "./temporal/worker-roll";
 
 const debugLog = (msg: string): void => appendDebugLog("plugin-init", msg);
 const logger = createLogger("plugin-init");
@@ -162,6 +167,7 @@ export async function tryInitStore(
   const initStartedAt = performance.now();
   let worker: InProcessWorker | undefined;
   let workerHeartbeat: WorkerLockHeartbeatController | undefined;
+  let workerBundleRollMonitor: WorkerBundleRollMonitor | undefined;
 
   try {
     const projectIdStartedAt = performance.now();
@@ -230,6 +236,11 @@ export async function tryInitStore(
               spawnedWorker
                 ? isWorkerServiceable(spawnedWorker, expectedQueue)
                 : true,
+            // Fire-and-forget: the drift check single-flights internally;
+            // beats must never block on a roll.
+            onBeat: () => {
+              void workerBundleRollMonitor?.checkNow().catch(() => undefined);
+            },
           });
           registerWorkerLockHeartbeat(workerHeartbeat);
         }
@@ -266,15 +277,36 @@ export async function tryInitStore(
             );
           }
           const workerStartedAt = performance.now();
-          spawnedWorker = await createOutOfProcessWorker({
+          const workerScriptPath = resolveWorkerScriptPath();
+          const outOfProcessWorker = await createOutOfProcessWorker({
             address: runtime.address,
             namespace: runtime.namespace,
             queues: [expectedQueue],
-            workerScript: resolveWorkerScriptPath(),
+            workerScript: workerScriptPath,
             projectId,
             onWorkerExhausted,
           });
+          spawnedWorker = outOfProcessWorker;
           worker = spawnedWorker;
+
+          // OOP-only bundle drift self-roll (owner-driven). The child was
+          // just spawned from the current bundle and passed its ready
+          // handshake — stamp the lock generation post-readiness, then
+          // converge on every heartbeat beat. In-process workers share
+          // the host's bundle and never drift, so they skip this.
+          workerBundleRollMonitor = await initWorkerBundleRoll({
+            projectStateDir,
+            bundleDir: dirname(workerScriptPath),
+            restartChild: () => outOfProcessWorker.restartChild(),
+            onRollError: (err) =>
+              debugLog(`worker bundle roll failed: ${err.message}`),
+          }).catch((err) => {
+            debugLog(
+              `worker bundle roll monitor unavailable: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            return undefined;
+          });
+
           profilePluginInit("worker_started", {
             duration_ms: Number(
               (performance.now() - workerStartedAt).toFixed(3),

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -291,13 +291,17 @@ export async function tryInitStore(
 
           // OOP-only bundle drift self-roll (owner-driven). The child was
           // just spawned from the current bundle and passed its ready
-          // handshake — stamp the lock generation post-readiness, then
-          // converge on every heartbeat beat. In-process workers share
-          // the host's bundle and never drift, so they skip this.
+          // handshake — hand the current generation to the heartbeat (the
+          // sole worker.lock writer) so it is stamped post-readiness on
+          // the next beat, then converge on every heartbeat beat.
+          // In-process workers share the host's bundle and never drift,
+          // so they skip this.
           workerBundleRollMonitor = await initWorkerBundleRoll({
             projectStateDir,
             bundleDir: dirname(workerScriptPath),
             restartChild: () => outOfProcessWorker.restartChild(),
+            setBundleGeneration: (generation) =>
+              workerHeartbeat?.setBundleGeneration(generation),
             onRollError: (err) =>
               debugLog(`worker bundle roll failed: ${err.message}`),
           }).catch((err) => {

--- a/plugin/src/temporal/out-of-process-worker.test.ts
+++ b/plugin/src/temporal/out-of-process-worker.test.ts
@@ -522,4 +522,33 @@ describe("createOutOfProcessWorker restart policy", () => {
 
     await worker.shutdown();
   });
+
+  it("restartChild rolls the shared child without touching crash counters", async () => {
+    const first = makeFakeChild();
+    const replacement = makeFakeChild();
+    spawnWithReady(first);
+    spawnWithReady(replacement);
+
+    const { createOutOfProcessWorker } =
+      await import("./out-of-process-worker");
+
+    const worker = await createOutOfProcessWorker({
+      address: "127.0.0.1:7233",
+      namespace: "default",
+      queues: ["advance-q"],
+      workerScript: "/plugin/dist/temporal/worker.js",
+      projectId: "q",
+    });
+
+    await worker.restartChild();
+
+    expect(first.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+    expect(worker.isAlive()).toBe(true);
+    for (const diag of worker.getDiagnostics()) {
+      expect(diag.restartCount).toBe(0);
+    }
+
+    await worker.shutdown();
+  });
 });

--- a/plugin/src/temporal/out-of-process-worker.ts
+++ b/plugin/src/temporal/out-of-process-worker.ts
@@ -29,6 +29,15 @@ export interface OutOfProcessWorkerInput {
 
 export interface OutOfProcessWorker extends InProcessWorker {
   isAlive(): boolean;
+  /**
+   * First-class bundle-roll lifecycle (see `worker-multi.ts`
+   * `restartChild`). Distinct from crash-respawn and `shutdown()`:
+   * gracefully retires the current child (SIGTERM, hard-kill deadline
+   * exceeding the child Temporal shutdownGraceTime), spawns a
+   * replacement, and resolves after the replacement's ready handshake.
+   * Single-flight; never increments the crash restartCount.
+   */
+  restartChild(): Promise<void>;
   getDiagnostics(): Array<{
     queue: string;
     dead: boolean;
@@ -68,6 +77,10 @@ export async function createOutOfProcessWorker(
 
     isAlive(): boolean {
       return multi.isAlive();
+    },
+
+    async restartChild(): Promise<void> {
+      return multi.restartChild();
     },
 
     getDiagnostics() {

--- a/plugin/src/temporal/worker-bundle-manifest.test.ts
+++ b/plugin/src/temporal/worker-bundle-manifest.test.ts
@@ -1,0 +1,115 @@
+import { readdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { cleanupTempDir, createTempDir } from "../__tests__/setup";
+import {
+  WORKER_BUNDLE_MANIFEST_FILENAME,
+  readWorkerBundleGeneration,
+  readWorkerBundleManifest,
+  writeWorkerBundleManifest,
+} from "./worker-bundle-manifest";
+
+const NOW = new Date("2026-07-15T00:00:00.000Z");
+
+describe("worker bundle manifest", () => {
+  let tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => cleanupTempDir(dir)));
+    tempDirs = [];
+  });
+
+  const tempBundleDir = async (withBundles = true) => {
+    const dir = await createTempDir("worker-bundle-manifest-");
+    tempDirs.push(dir);
+    if (withBundles) {
+      await writeFile(join(dir, "worker.js"), "// worker bundle v1\n");
+      await writeFile(join(dir, "workflows.js"), "// workflows bundle v1\n");
+    }
+    return dir;
+  };
+
+  test("write produces a manifest with sha256 hashes and a generation", async () => {
+    const dir = await tempBundleDir();
+
+    const manifest = await writeWorkerBundleManifest(dir, { now: () => NOW });
+
+    expect(manifest.schema_version).toBe(1);
+    expect(manifest.built_at).toBe(NOW.toISOString());
+    expect(manifest.files["worker.js"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(manifest.files["workflows.js"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(manifest.generation).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("write is atomic via temp+rename and leaves no temp files", async () => {
+    const dir = await tempBundleDir();
+
+    await writeWorkerBundleManifest(dir, { now: () => NOW });
+
+    const entries = await readdir(dir);
+    expect(entries).toContain(WORKER_BUNDLE_MANIFEST_FILENAME);
+    expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([]);
+  });
+
+  test("generation covers BOTH worker.js and workflows.js", async () => {
+    const dir = await tempBundleDir();
+    const first = await writeWorkerBundleManifest(dir, { now: () => NOW });
+
+    // Change only workflows.js — generation must change (worker.js alone
+    // is never sufficient to define the generation).
+    await writeFile(join(dir, "workflows.js"), "// workflows bundle v2\n");
+    const second = await writeWorkerBundleManifest(dir, { now: () => NOW });
+    expect(second.generation).not.toBe(first.generation);
+    expect(second.files["worker.js"]).toBe(first.files["worker.js"]);
+
+    await writeFile(join(dir, "worker.js"), "// worker bundle v2\n");
+    const third = await writeWorkerBundleManifest(dir, { now: () => NOW });
+    expect(third.generation).not.toBe(second.generation);
+  });
+
+  test("same bundle contents produce the same generation", async () => {
+    const dir = await tempBundleDir();
+    const first = await writeWorkerBundleManifest(dir, {
+      now: () => new Date("2026-07-15T00:00:00.000Z"),
+    });
+    const second = await writeWorkerBundleManifest(dir, {
+      now: () => new Date("2026-07-15T01:00:00.000Z"),
+    });
+
+    expect(second.generation).toBe(first.generation);
+  });
+
+  test("write refuses when worker.js or workflows.js is missing", async () => {
+    const dir = await tempBundleDir(false);
+    await writeFile(join(dir, "worker.js"), "// worker only\n");
+
+    await expect(writeWorkerBundleManifest(dir)).rejects.toThrow(
+      /workflows\.js/,
+    );
+    await expect(readWorkerBundleGeneration(dir)).resolves.toBeNull();
+  });
+
+  test("read round-trips a written manifest", async () => {
+    const dir = await tempBundleDir();
+    const written = await writeWorkerBundleManifest(dir, { now: () => NOW });
+
+    await expect(readWorkerBundleManifest(dir)).resolves.toEqual(written);
+    await expect(readWorkerBundleGeneration(dir)).resolves.toBe(
+      written.generation,
+    );
+  });
+
+  test("read returns null for missing or malformed manifests", async () => {
+    const missingDir = await tempBundleDir();
+    await expect(readWorkerBundleManifest(missingDir)).resolves.toBeNull();
+
+    const malformedDir = await tempBundleDir();
+    await writeFile(
+      join(malformedDir, WORKER_BUNDLE_MANIFEST_FILENAME),
+      JSON.stringify({ schema_version: 1, generation: 42 }),
+    );
+    await expect(readWorkerBundleManifest(malformedDir)).resolves.toBeNull();
+    await expect(readWorkerBundleGeneration(malformedDir)).resolves.toBeNull();
+  });
+});

--- a/plugin/src/temporal/worker-bundle-manifest.ts
+++ b/plugin/src/temporal/worker-bundle-manifest.ts
@@ -1,0 +1,162 @@
+/**
+ * Worker bundle generation manifest.
+ *
+ * The OOP Temporal worker child loads `dist/temporal/worker.js`, which in
+ * turn loads the workflow bundle `dist/temporal/workflows.js`. Together
+ * those two files define the *bundle generation* a running worker was
+ * started from. This module writes and reads an atomic manifest that pins
+ * the generation so the plugin host can detect when the on-disk bundle has
+ * drifted from the bundle its worker child is running (see
+ * `worker-roll.ts`).
+ *
+ * Generation contract:
+ *   - SHA-256 is computed over BOTH `worker.js` and `workflows.js`.
+ *   - `generation` is the SHA-256 of the two file hashes concatenated with
+ *     their names, so a change to either file changes the generation.
+ *   - The manifest is written LAST (after both bundles exist) via a
+ *     temp-file + rename in the same directory, so a concurrent reader
+ *     never observes a partially written manifest.
+ */
+
+import { createHash, randomUUID } from "crypto";
+import { readFile, rename, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const WORKER_BUNDLE_MANIFEST_FILENAME = "bundle-manifest.json";
+export const WORKER_BUNDLE_MANIFEST_SCHEMA_VERSION = 1;
+
+/** Files that define the bundle generation. Both are required. */
+export const WORKER_BUNDLE_FILES = ["worker.js", "workflows.js"] as const;
+export type WorkerBundleFile = (typeof WORKER_BUNDLE_FILES)[number];
+
+export interface WorkerBundleManifest {
+  schema_version: typeof WORKER_BUNDLE_MANIFEST_SCHEMA_VERSION;
+  /** SHA-256 hex digest over both bundle file hashes. */
+  generation: string;
+  /** Per-file SHA-256 hex digests keyed by bundle file name. */
+  files: Record<WorkerBundleFile, string>;
+  /** ISO timestamp of when the manifest was written. */
+  built_at: string;
+}
+
+export interface WriteWorkerBundleManifestOptions {
+  now?: () => Date;
+}
+
+async function hashFileSha256(path: string): Promise<string> {
+  const contents = await readFile(path);
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+/**
+ * Compute the generation digest from the per-file hashes. The file names
+ * are part of the hashed payload so a hash cannot shift between files
+ * without changing the generation.
+ */
+export function computeWorkerBundleGeneration(
+  files: Record<WorkerBundleFile, string>,
+): string {
+  const hash = createHash("sha256");
+  for (const name of WORKER_BUNDLE_FILES) {
+    hash.update(`${name}:${files[name]}\n`);
+  }
+  return hash.digest("hex");
+}
+
+/**
+ * Hash both bundle files and atomically write the manifest into
+ * `bundleDir`. Must run AFTER the bundler has finished writing both
+ * `worker.js` and `workflows.js` (the manifest is the LAST write of the
+ * build). Throws when either bundle file is missing — a build that cannot
+ * produce both bundles must not produce a manifest.
+ */
+export async function writeWorkerBundleManifest(
+  bundleDir: string,
+  options: WriteWorkerBundleManifestOptions = {},
+): Promise<WorkerBundleManifest> {
+  const files = {} as Record<WorkerBundleFile, string>;
+  for (const name of WORKER_BUNDLE_FILES) {
+    files[name] = await hashFileSha256(join(bundleDir, name)).catch(
+      (err: NodeJS.ErrnoException) => {
+        throw new Error(
+          `Cannot write worker bundle manifest: ${name} is missing from ${bundleDir} (${err.code ?? err.message}).`,
+        );
+      },
+    );
+  }
+
+  const builtAt = (options.now ?? (() => new Date()))().toISOString();
+  const manifest: WorkerBundleManifest = {
+    schema_version: WORKER_BUNDLE_MANIFEST_SCHEMA_VERSION,
+    generation: computeWorkerBundleGeneration(files),
+    files,
+    built_at: builtAt,
+  };
+
+  const manifestPath = join(bundleDir, WORKER_BUNDLE_MANIFEST_FILENAME);
+  const tmpPath = `${manifestPath}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(manifest, null, 2));
+  await rename(tmpPath, manifestPath);
+
+  return manifest;
+}
+
+/**
+ * Read and validate the bundle manifest. Returns null when the manifest is
+ * absent, unparsable, or fails schema validation — callers treat an
+ * unreadable manifest as "generation unknown" and never roll on it.
+ */
+export async function readWorkerBundleManifest(
+  bundleDir: string,
+): Promise<WorkerBundleManifest | null> {
+  const manifestPath = join(bundleDir, WORKER_BUNDLE_MANIFEST_FILENAME);
+  const raw = await readFile(manifestPath, "utf8").catch(() => null);
+  if (!raw || !raw.trim()) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const candidate = parsed as Partial<WorkerBundleManifest>;
+  if (candidate.schema_version !== WORKER_BUNDLE_MANIFEST_SCHEMA_VERSION) {
+    return null;
+  }
+  if (
+    typeof candidate.generation !== "string" ||
+    !/^[0-9a-f]{64}$/.test(candidate.generation)
+  ) {
+    return null;
+  }
+  if (
+    !candidate.files ||
+    typeof candidate.files !== "object" ||
+    WORKER_BUNDLE_FILES.some(
+      (name) =>
+        typeof (candidate.files as Record<string, unknown>)[name] !==
+          "string" ||
+        !/^[0-9a-f]{64}$/.test(
+          (candidate.files as Record<string, string>)[name],
+        ),
+    )
+  ) {
+    return null;
+  }
+  if (typeof candidate.built_at !== "string") return null;
+
+  return candidate as WorkerBundleManifest;
+}
+
+/**
+ * Convenience reader for the common case where only the generation digest
+ * is needed. Returns null when the manifest is missing or invalid.
+ */
+export async function readWorkerBundleGeneration(
+  bundleDir: string,
+): Promise<string | null> {
+  const manifest = await readWorkerBundleManifest(bundleDir);
+  return manifest?.generation ?? null;
+}

--- a/plugin/src/temporal/worker-heartbeat.test.ts
+++ b/plugin/src/temporal/worker-heartbeat.test.ts
@@ -99,6 +99,64 @@ describe("worker lock heartbeat", () => {
     expect(clearIntervalFn).toHaveBeenCalledWith(timer);
   });
 
+  test("heartbeat preserves bundle_generation", async () => {
+    const dir = await tempDir();
+    let now = new Date("2026-05-12T00:00:00.000Z");
+    const lock = await acquireWorkerLock(dir, {
+      pid: 4000,
+      schemaVersion: 2,
+      bundleGeneration: "gen-pinned",
+      now: () => now,
+    });
+
+    const heartbeat = startWorkerLockHeartbeat(dir, { now: () => now });
+    now = new Date("2026-05-12T00:00:12.000Z");
+    await heartbeat.beatNow();
+
+    await expect(readLockContents(lock.lockPath)).resolves.toMatchObject({
+      pid: 4000,
+      bundle_generation: "gen-pinned",
+      last_heartbeat: "2026-05-12T00:00:12.000Z",
+    });
+
+    await heartbeat.stop();
+  });
+
+  test("invokes onBeat after each successful beat (fire-and-forget safe)", async () => {
+    const dir = await tempDir();
+    const now = new Date("2026-05-12T00:00:00.000Z");
+    await acquireWorkerLock(dir, {
+      pid: 5000,
+      schemaVersion: 2,
+      now: () => now,
+    });
+
+    const onBeat = vi.fn();
+    const heartbeat = startWorkerLockHeartbeat(dir, {
+      now: () => now,
+      onBeat,
+    });
+
+    await heartbeat.beatNow();
+    await heartbeat.beatNow();
+
+    expect(onBeat).toHaveBeenCalledTimes(2);
+
+    await heartbeat.stop();
+  });
+
+  test("does not invoke onBeat when the beat has no v2 lock to renew", async () => {
+    const dir = await tempDir();
+    const onBeat = vi.fn();
+    const heartbeat = startWorkerLockHeartbeat(dir, { onBeat });
+
+    await heartbeat.beatNow();
+
+    expect(onBeat).not.toHaveBeenCalled();
+
+    await heartbeat.stop();
+  });
+
   test("stops renewing after serviceability grace expires", async () => {
     const dir = await tempDir();
     let now = new Date("2026-05-12T00:00:00.000Z");

--- a/plugin/src/temporal/worker-heartbeat.test.ts
+++ b/plugin/src/temporal/worker-heartbeat.test.ts
@@ -157,6 +157,89 @@ describe("worker lock heartbeat", () => {
     await heartbeat.stop();
   });
 
+  test("writes a handed-off bundle_generation together with the heartbeat on every beat", async () => {
+    const dir = await tempDir();
+    let now = new Date("2026-05-12T00:00:00.000Z");
+    const lock = await acquireWorkerLock(dir, {
+      pid: 7000,
+      schemaVersion: 2,
+      expectedQueue: "adv-test-queue",
+      bundleGeneration: "gen-old",
+      now: () => now,
+    });
+
+    const heartbeat = startWorkerLockHeartbeat(dir, { now: () => now });
+    // Roll handoff: the generation is applied at write time, not read
+    // from the beat's lock snapshot.
+    heartbeat.setBundleGeneration("gen-new");
+
+    now = new Date("2026-05-12T00:00:10.000Z");
+    await heartbeat.beatNow();
+
+    await expect(readLockContents(lock.lockPath)).resolves.toMatchObject({
+      pid: 7000,
+      expected_queue: "adv-test-queue",
+      bundle_generation: "gen-new",
+      last_heartbeat: "2026-05-12T00:00:10.000Z",
+    });
+
+    // The override persists: later beats keep stamping it alongside the
+    // renewed heartbeat.
+    now = new Date("2026-05-12T00:00:20.000Z");
+    await heartbeat.beatNow();
+
+    await expect(readLockContents(lock.lockPath)).resolves.toMatchObject({
+      bundle_generation: "gen-new",
+      last_heartbeat: "2026-05-12T00:00:20.000Z",
+    });
+
+    await heartbeat.stop();
+  });
+
+  test("a generation handed off mid-beat is not lost to the beat's stale snapshot", async () => {
+    const dir = await tempDir();
+    let now = new Date("2026-05-12T00:00:00.000Z");
+    const lock = await acquireWorkerLock(dir, {
+      pid: 6000,
+      schemaVersion: 2,
+      bundleGeneration: "gen-old",
+      now: () => now,
+    });
+
+    // Park the beat inside its read-modify-write window: the lock read
+    // has resolved (snapshot holds gen-old), the rewrite has not run.
+    let releaseRead!: () => void;
+    let readReached!: () => void;
+    const readParked = new Promise<void>((resolve) => (readReached = resolve));
+    const readGate = new Promise<void>((resolve) => (releaseRead = resolve));
+    const heartbeat = startWorkerLockHeartbeat(dir, {
+      now: () => now,
+      onBeatLockRead: async () => {
+        readReached();
+        await readGate;
+      },
+    });
+
+    now = new Date("2026-05-12T00:00:10.000Z");
+    const beat = heartbeat.beatNow();
+    await readParked;
+
+    // The roll hands the new generation to the heartbeat (the sole lock
+    // writer) while the beat is parked on a stale snapshot.
+    heartbeat.setBundleGeneration("gen-new");
+    releaseRead();
+    await beat;
+
+    // AC5: the handed-off generation is applied at write time, so the
+    // interleaved beat cannot lose it.
+    await expect(readLockContents(lock.lockPath)).resolves.toMatchObject({
+      bundle_generation: "gen-new",
+      last_heartbeat: "2026-05-12T00:00:10.000Z",
+    });
+
+    await heartbeat.stop();
+  });
+
   test("stops renewing after serviceability grace expires", async () => {
     const dir = await tempDir();
     let now = new Date("2026-05-12T00:00:00.000Z");

--- a/plugin/src/temporal/worker-heartbeat.ts
+++ b/plugin/src/temporal/worker-heartbeat.ts
@@ -28,12 +28,30 @@ export interface WorkerLockHeartbeatOptions {
    * be cheap and non-blocking (e.g. `void monitor.checkNow()`).
    */
   onBeat?: () => void;
+  /**
+   * Testing seam: invoked after the lock is read and before the renewed
+   * contents are constructed and atomically rewritten. Lets interleaving
+   * tests park a beat inside its read-modify-write window to inject a
+   * concurrent generation handoff. Not used in production.
+   */
+  onBeatLockRead?: () => void | Promise<void>;
   setIntervalFn?: (handler: () => void, timeout: number) => IntervalHandle;
   clearIntervalFn?: (timer: IntervalHandle) => void;
 }
 
 export interface WorkerLockHeartbeatController {
   beatNow: () => Promise<void>;
+  /**
+   * Record the bundle generation the worker child is now running. The
+   * heartbeat is the SOLE writer of worker.lock after acquire: the
+   * handed-off generation is written together with `last_heartbeat` in
+   * the same atomic rewrite on the next beat (and every beat after).
+   * Because the roll path (`worker-roll.ts`) never writes the lock
+   * directly and this override is applied at write time — not read from
+   * the beat's lock snapshot — a roll can never lose its generation to
+   * an interleaved beat (AC5 no-lost-updates).
+   */
+  setBundleGeneration: (generation: string) => void;
   stop: () => Promise<void>;
   isStopped: () => boolean;
 }
@@ -60,6 +78,10 @@ export function startWorkerLockHeartbeat(
 
   let stopped = false;
   let firstUnserviceableAt: number | null = null;
+  // Generation handed off by the roll path. Applied at write time on
+  // every subsequent beat, so the value persisted never depends on how
+  // stale the beat's lock snapshot is.
+  let bundleGenerationOverride: string | null = null;
 
   const stopRenewing = () => {
     if (stopped) return;
@@ -83,9 +105,15 @@ export function startWorkerLockHeartbeat(
 
     const contents = await readLockContents(lockPath).catch(() => null);
     if (!contents || contents.schema_version !== 2) return;
+    if (options.onBeatLockRead) {
+      await options.onBeatLockRead();
+    }
     const next: WorkerLockContentsV2 = {
       ...contents,
       last_heartbeat: current.toISOString(),
+      ...(bundleGenerationOverride !== null
+        ? { bundle_generation: bundleGenerationOverride }
+        : {}),
     };
     await writeLockContentsAtomically(lockPath, next);
 
@@ -105,6 +133,9 @@ export function startWorkerLockHeartbeat(
 
   return {
     beatNow,
+    setBundleGeneration: (generation: string) => {
+      bundleGenerationOverride = generation;
+    },
     stop: async () => {
       stopRenewing();
       await releaseWorkerLock(projectStateDir, { lockFilename });

--- a/plugin/src/temporal/worker-heartbeat.ts
+++ b/plugin/src/temporal/worker-heartbeat.ts
@@ -20,6 +20,14 @@ export interface WorkerLockHeartbeatOptions {
   serviceabilityGraceMs?: number;
   now?: () => Date;
   isServiceable?: () => boolean;
+  /**
+   * Fire-and-forget hook invoked synchronously after each SUCCESSFUL beat
+   * (v2 lock renewed). Not invoked when the beat early-returns (stopped,
+   * unserviceable past grace, or no v2 lock). Used by plugin-init to run
+   * the worker bundle drift check on the heartbeat cadence; the hook must
+   * be cheap and non-blocking (e.g. `void monitor.checkNow()`).
+   */
+  onBeat?: () => void;
   setIntervalFn?: (handler: () => void, timeout: number) => IntervalHandle;
   clearIntervalFn?: (timer: IntervalHandle) => void;
 }
@@ -73,13 +81,21 @@ export function startWorkerLockHeartbeat(
       firstUnserviceableAt = null;
     }
 
-    const contents = await readLockContents(lockPath);
+    const contents = await readLockContents(lockPath).catch(() => null);
     if (!contents || contents.schema_version !== 2) return;
     const next: WorkerLockContentsV2 = {
       ...contents,
       last_heartbeat: current.toISOString(),
     };
     await writeLockContentsAtomically(lockPath, next);
+
+    if (options.onBeat) {
+      try {
+        options.onBeat();
+      } catch {
+        // Fire-and-forget hook must never break the heartbeat cadence.
+      }
+    }
   };
 
   const timer = setIntervalFn(() => {

--- a/plugin/src/temporal/worker-lock.test.ts
+++ b/plugin/src/temporal/worker-lock.test.ts
@@ -1,4 +1,4 @@
-import { readdir, writeFile } from "fs/promises";
+import { writeFile } from "fs/promises";
 import { join } from "path";
 import { afterEach, describe, expect, test } from "vitest";
 
@@ -8,7 +8,6 @@ import {
   acquireWorkerLock,
   readLockContents,
   tryReclaimStaleLock,
-  updateWorkerLockBundleGeneration,
 } from "./worker-lock";
 
 const NOW = new Date("2026-05-12T00:00:00.000Z");
@@ -194,93 +193,6 @@ describe("worker lock", () => {
       });
 
       await expect(readLockContents(lockPath)).resolves.toBeNull();
-    });
-
-    test("updateWorkerLockBundleGeneration updates the generation and validates via readback", async () => {
-      const dir = await tempDir();
-      const lock = await acquireWorkerLock(dir, {
-        pid: 4321,
-        schemaVersion: 2,
-        bundleGeneration: "gen-old",
-        now: () => NOW,
-      });
-
-      const result = await updateWorkerLockBundleGeneration(dir, {
-        bundleGeneration: "gen-new",
-      });
-
-      expect(result).toEqual({ updated: true, generation: "gen-new" });
-      await expect(readLockContents(lock.lockPath)).resolves.toMatchObject({
-        pid: 4321,
-        bundle_generation: "gen-new",
-      });
-    });
-
-    test("updateWorkerLockBundleGeneration preserves other lock fields", async () => {
-      const dir = await tempDir();
-      const lock = await acquireWorkerLock(dir, {
-        pid: 4321,
-        schemaVersion: 2,
-        expectedQueue: "adv-test-queue",
-        now: () => NOW,
-      });
-
-      await updateWorkerLockBundleGeneration(dir, {
-        bundleGeneration: "gen-new",
-      });
-
-      await expect(readLockContents(lock.lockPath)).resolves.toMatchObject({
-        pid: 4321,
-        worker_id: lock.workerId,
-        acquired_at: NOW.toISOString(),
-        last_heartbeat: NOW.toISOString(),
-        expected_queue: "adv-test-queue",
-      });
-    });
-
-    test("updateWorkerLockBundleGeneration refuses when the lock is missing", async () => {
-      const dir = await tempDir();
-
-      const result = await updateWorkerLockBundleGeneration(dir, {
-        bundleGeneration: "gen-new",
-      });
-
-      expect(result).toEqual({
-        updated: false,
-        reason: "lock_missing",
-        generation: null,
-      });
-    });
-
-    test("updateWorkerLockBundleGeneration refuses a v1 lock", async () => {
-      const dir = await tempDir();
-      await writeLock(dir, {
-        pid: 1111,
-        worker_id: "v1-worker",
-        acquired_at: NOW.toISOString(),
-      });
-
-      const result = await updateWorkerLockBundleGeneration(dir, {
-        bundleGeneration: "gen-new",
-      });
-
-      expect(result).toEqual({
-        updated: false,
-        reason: "lock_not_v2",
-        generation: null,
-      });
-    });
-
-    test("updateWorkerLockBundleGeneration leaves no temp files behind", async () => {
-      const dir = await tempDir();
-      await acquireWorkerLock(dir, { pid: 4321, schemaVersion: 2 });
-
-      await updateWorkerLockBundleGeneration(dir, {
-        bundleGeneration: "gen-new",
-      });
-
-      const entries = await readdir(dir);
-      expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([]);
     });
   });
 });

--- a/plugin/src/temporal/worker-lock.test.ts
+++ b/plugin/src/temporal/worker-lock.test.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "fs/promises";
+import { readdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { afterEach, describe, expect, test } from "vitest";
 
@@ -8,6 +8,7 @@ import {
   acquireWorkerLock,
   readLockContents,
   tryReclaimStaleLock,
+  updateWorkerLockBundleGeneration,
 } from "./worker-lock";
 
 const NOW = new Date("2026-05-12T00:00:00.000Z");
@@ -144,6 +145,142 @@ describe("worker lock", () => {
       owned: false,
       ownerPid: 7777,
       reason: "lock_held_by_alive_pid",
+    });
+  });
+
+  describe("bundle_generation", () => {
+    test("acquire writes bundle_generation and read round-trips it", async () => {
+      const dir = await tempDir();
+
+      const result = await acquireWorkerLock(dir, {
+        pid: 1234,
+        schemaVersion: 2,
+        expectedQueue: "adv-test-queue",
+        bundleGeneration: "gen-aaa",
+        now: () => NOW,
+      });
+
+      expect(result.owned).toBe(true);
+      await expect(readLockContents(result.lockPath)).resolves.toMatchObject({
+        schema_version: 2,
+        bundle_generation: "gen-aaa",
+      });
+    });
+
+    test("read tolerates a v2 lock without bundle_generation", async () => {
+      const dir = await tempDir();
+      const lockPath = await writeLock(dir, {
+        pid: 2222,
+        worker_id: "pre-roll-worker",
+        acquired_at: NOW.toISOString(),
+        schema_version: 2,
+        last_heartbeat: NOW.toISOString(),
+      });
+
+      const contents = await readLockContents(lockPath);
+      expect(contents).toMatchObject({ schema_version: 2 });
+      expect(contents).not.toHaveProperty("bundle_generation");
+    });
+
+    test("read rejects a v2 lock with a malformed bundle_generation", async () => {
+      const dir = await tempDir();
+      const lockPath = await writeLock(dir, {
+        pid: 2222,
+        worker_id: "bad-gen-worker",
+        acquired_at: NOW.toISOString(),
+        schema_version: 2,
+        last_heartbeat: NOW.toISOString(),
+        bundle_generation: 42,
+      });
+
+      await expect(readLockContents(lockPath)).resolves.toBeNull();
+    });
+
+    test("updateWorkerLockBundleGeneration updates the generation and validates via readback", async () => {
+      const dir = await tempDir();
+      const lock = await acquireWorkerLock(dir, {
+        pid: 4321,
+        schemaVersion: 2,
+        bundleGeneration: "gen-old",
+        now: () => NOW,
+      });
+
+      const result = await updateWorkerLockBundleGeneration(dir, {
+        bundleGeneration: "gen-new",
+      });
+
+      expect(result).toEqual({ updated: true, generation: "gen-new" });
+      await expect(readLockContents(lock.lockPath)).resolves.toMatchObject({
+        pid: 4321,
+        bundle_generation: "gen-new",
+      });
+    });
+
+    test("updateWorkerLockBundleGeneration preserves other lock fields", async () => {
+      const dir = await tempDir();
+      const lock = await acquireWorkerLock(dir, {
+        pid: 4321,
+        schemaVersion: 2,
+        expectedQueue: "adv-test-queue",
+        now: () => NOW,
+      });
+
+      await updateWorkerLockBundleGeneration(dir, {
+        bundleGeneration: "gen-new",
+      });
+
+      await expect(readLockContents(lock.lockPath)).resolves.toMatchObject({
+        pid: 4321,
+        worker_id: lock.workerId,
+        acquired_at: NOW.toISOString(),
+        last_heartbeat: NOW.toISOString(),
+        expected_queue: "adv-test-queue",
+      });
+    });
+
+    test("updateWorkerLockBundleGeneration refuses when the lock is missing", async () => {
+      const dir = await tempDir();
+
+      const result = await updateWorkerLockBundleGeneration(dir, {
+        bundleGeneration: "gen-new",
+      });
+
+      expect(result).toEqual({
+        updated: false,
+        reason: "lock_missing",
+        generation: null,
+      });
+    });
+
+    test("updateWorkerLockBundleGeneration refuses a v1 lock", async () => {
+      const dir = await tempDir();
+      await writeLock(dir, {
+        pid: 1111,
+        worker_id: "v1-worker",
+        acquired_at: NOW.toISOString(),
+      });
+
+      const result = await updateWorkerLockBundleGeneration(dir, {
+        bundleGeneration: "gen-new",
+      });
+
+      expect(result).toEqual({
+        updated: false,
+        reason: "lock_not_v2",
+        generation: null,
+      });
+    });
+
+    test("updateWorkerLockBundleGeneration leaves no temp files behind", async () => {
+      const dir = await tempDir();
+      await acquireWorkerLock(dir, { pid: 4321, schemaVersion: 2 });
+
+      await updateWorkerLockBundleGeneration(dir, {
+        bundleGeneration: "gen-new",
+      });
+
+      const entries = await readdir(dir);
+      expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([]);
     });
   });
 });

--- a/plugin/src/temporal/worker-lock.ts
+++ b/plugin/src/temporal/worker-lock.ts
@@ -1,4 +1,4 @@
-import { open, readFile, rm } from "fs/promises";
+import { open, readFile, rename, rm, writeFile } from "fs/promises";
 import { randomUUID } from "crypto";
 import { join } from "path";
 import { isProcessAlive } from "../utils/process-liveness";
@@ -20,6 +20,14 @@ export interface WorkerLockContentsV2 {
   schema_version: 2;
   last_heartbeat: string;
   expected_queue?: string;
+  /**
+   * Generation of the worker bundle (`dist/temporal/bundle-manifest.json`)
+   * the owning worker child was started from. Optional: locks written
+   * before bundle manifests existed simply omit it. The bundle roll
+   * monitor (`worker-roll.ts`) compares this against the on-disk manifest
+   * generation to detect stale workers; heartbeats preserve it verbatim.
+   */
+  bundle_generation?: string;
 }
 
 export type WorkerLockContents = WorkerLockContentsV1 | WorkerLockContentsV2;
@@ -39,6 +47,7 @@ export interface AcquireWorkerLockOptions {
   lockFilename?: string;
   schemaVersion?: 1 | 2;
   expectedQueue?: string;
+  bundleGeneration?: string;
   now?: () => Date;
 }
 
@@ -71,6 +80,9 @@ export async function acquireWorkerLock(
           last_heartbeat: acquiredAt,
           ...(options.expectedQueue
             ? { expected_queue: options.expectedQueue }
+            : {}),
+          ...(options.bundleGeneration
+            ? { bundle_generation: options.bundleGeneration }
             : {}),
         }
       : { schema_version: 1 }),
@@ -137,6 +149,75 @@ export async function releaseWorkerLock(
   await rm(lockPath, { force: true }).catch(() => undefined);
 }
 
+export interface UpdateWorkerLockBundleGenerationOptions {
+  bundleGeneration: string;
+  lockFilename?: string;
+}
+
+export type UpdateWorkerLockBundleGenerationResult =
+  | { updated: true; generation: string }
+  | {
+      updated: false;
+      reason: "lock_missing" | "lock_not_v2" | "readback_mismatch";
+      generation: string | null;
+    };
+
+/**
+ * Stamp the lock with the bundle generation the owning worker child is now
+ * running. Called by the lock owner ONLY after the child has confirmed
+ * readiness (see `worker-roll.ts`) — never before, so the generation claim
+ * always reflects a worker that is actually up.
+ *
+ * The write is atomic (temp file + rename in the same directory) and
+ * validated by readback: after the rename the lock is re-read and the
+ * persisted generation must match the requested one. A readback mismatch
+ * (corrupt write, lost race with a lock rewrite) is reported rather than
+ * silently accepted.
+ */
+export async function updateWorkerLockBundleGeneration(
+  projectStateDir: string,
+  options: UpdateWorkerLockBundleGenerationOptions,
+): Promise<UpdateWorkerLockBundleGenerationResult> {
+  const lockPath = join(
+    projectStateDir,
+    options.lockFilename ?? WORKER_LOCK_FILENAME,
+  );
+
+  const current = await readLockContents(lockPath).catch(() => null);
+  if (!current) {
+    return { updated: false, reason: "lock_missing", generation: null };
+  }
+  if (current.schema_version !== 2) {
+    return { updated: false, reason: "lock_not_v2", generation: null };
+  }
+
+  const next: WorkerLockContentsV2 = {
+    ...current,
+    bundle_generation: options.bundleGeneration,
+  };
+  const tmpPath = `${lockPath}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(next, null, 2));
+  await rename(tmpPath, lockPath);
+
+  const readback = await readLockContents(lockPath).catch(() => null);
+  if (
+    !readback ||
+    readback.schema_version !== 2 ||
+    readback.bundle_generation !== options.bundleGeneration
+  ) {
+    return {
+      updated: false,
+      reason: "readback_mismatch",
+      generation:
+        readback?.schema_version === 2
+          ? (readback.bundle_generation ?? null)
+          : null,
+    };
+  }
+
+  return { updated: true, generation: options.bundleGeneration };
+}
+
 export async function readLockContents(
   lockPath: string,
 ): Promise<WorkerLockContents | null> {
@@ -154,7 +235,9 @@ export async function readLockContents(
     if (
       typeof parsed.last_heartbeat !== "string" ||
       (parsed.expected_queue !== undefined &&
-        typeof parsed.expected_queue !== "string")
+        typeof parsed.expected_queue !== "string") ||
+      (parsed.bundle_generation !== undefined &&
+        typeof parsed.bundle_generation !== "string")
     ) {
       return null;
     }
@@ -166,6 +249,9 @@ export async function readLockContents(
       last_heartbeat: parsed.last_heartbeat,
       ...(parsed.expected_queue
         ? { expected_queue: parsed.expected_queue }
+        : {}),
+      ...(parsed.bundle_generation
+        ? { bundle_generation: parsed.bundle_generation }
         : {}),
     };
   }

--- a/plugin/src/temporal/worker-lock.ts
+++ b/plugin/src/temporal/worker-lock.ts
@@ -1,4 +1,4 @@
-import { open, readFile, rename, rm, writeFile } from "fs/promises";
+import { open, readFile, rm } from "fs/promises";
 import { randomUUID } from "crypto";
 import { join } from "path";
 import { isProcessAlive } from "../utils/process-liveness";
@@ -23,9 +23,12 @@ export interface WorkerLockContentsV2 {
   /**
    * Generation of the worker bundle (`dist/temporal/bundle-manifest.json`)
    * the owning worker child was started from. Optional: locks written
-   * before bundle manifests existed simply omit it. The bundle roll
-   * monitor (`worker-roll.ts`) compares this against the on-disk manifest
-   * generation to detect stale workers; heartbeats preserve it verbatim.
+   * before bundle manifests existed simply omit it. Written on acquire,
+   * then renewed ONLY by the worker.lock heartbeat — the sole
+   * post-acquire lock writer — after the roll monitor hands off a new
+   * generation (`worker-heartbeat.ts` `setBundleGeneration`). There is
+   * deliberately no direct "stamp the generation" writer here: a second
+   * read-modify-write path races the heartbeat and loses updates (AC5).
    */
   bundle_generation?: string;
 }
@@ -147,75 +150,6 @@ export async function releaseWorkerLock(
     options.lockFilename ?? WORKER_LOCK_FILENAME,
   );
   await rm(lockPath, { force: true }).catch(() => undefined);
-}
-
-export interface UpdateWorkerLockBundleGenerationOptions {
-  bundleGeneration: string;
-  lockFilename?: string;
-}
-
-export type UpdateWorkerLockBundleGenerationResult =
-  | { updated: true; generation: string }
-  | {
-      updated: false;
-      reason: "lock_missing" | "lock_not_v2" | "readback_mismatch";
-      generation: string | null;
-    };
-
-/**
- * Stamp the lock with the bundle generation the owning worker child is now
- * running. Called by the lock owner ONLY after the child has confirmed
- * readiness (see `worker-roll.ts`) — never before, so the generation claim
- * always reflects a worker that is actually up.
- *
- * The write is atomic (temp file + rename in the same directory) and
- * validated by readback: after the rename the lock is re-read and the
- * persisted generation must match the requested one. A readback mismatch
- * (corrupt write, lost race with a lock rewrite) is reported rather than
- * silently accepted.
- */
-export async function updateWorkerLockBundleGeneration(
-  projectStateDir: string,
-  options: UpdateWorkerLockBundleGenerationOptions,
-): Promise<UpdateWorkerLockBundleGenerationResult> {
-  const lockPath = join(
-    projectStateDir,
-    options.lockFilename ?? WORKER_LOCK_FILENAME,
-  );
-
-  const current = await readLockContents(lockPath).catch(() => null);
-  if (!current) {
-    return { updated: false, reason: "lock_missing", generation: null };
-  }
-  if (current.schema_version !== 2) {
-    return { updated: false, reason: "lock_not_v2", generation: null };
-  }
-
-  const next: WorkerLockContentsV2 = {
-    ...current,
-    bundle_generation: options.bundleGeneration,
-  };
-  const tmpPath = `${lockPath}.${process.pid}.${randomUUID()}.tmp`;
-  await writeFile(tmpPath, JSON.stringify(next, null, 2));
-  await rename(tmpPath, lockPath);
-
-  const readback = await readLockContents(lockPath).catch(() => null);
-  if (
-    !readback ||
-    readback.schema_version !== 2 ||
-    readback.bundle_generation !== options.bundleGeneration
-  ) {
-    return {
-      updated: false,
-      reason: "readback_mismatch",
-      generation:
-        readback?.schema_version === 2
-          ? (readback.bundle_generation ?? null)
-          : null,
-    };
-  }
-
-  return { updated: true, generation: options.bundleGeneration };
 }
 
 export async function readLockContents(

--- a/plugin/src/temporal/worker-multi.test.ts
+++ b/plugin/src/temporal/worker-multi.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { createMultiWorker, MULTI_SHUTDOWN_GRACE_MS } from "./worker-multi";
+import {
+  createMultiWorker,
+  MULTI_SHUTDOWN_GRACE_MS,
+  RESTART_HARD_KILL_DEADLINE_MS,
+} from "./worker-multi";
 import {
   getLastWorkerRunError,
   resetTemporalRetryTelemetry,
@@ -539,6 +543,154 @@ describe("Multi-queue worker host", () => {
       const result = await settled;
       expect(result).toBeInstanceOf(Error);
       expect((result as Error).message).toMatch(/exit|crash|never became/i);
+    });
+  });
+
+  // Bundle-roll lifecycle (restartChild).
+  //
+  // restartChild is a FIRST-CLASS lifecycle distinct from crash-respawn and
+  // from shutdown(): it retires the current child gracefully (SIGTERM, with
+  // a hard-kill deadline that exceeds the child-side Temporal
+  // shutdownGraceTime), spawns a replacement, and resolves only after the
+  // replacement sends its ready handshake. It must NOT set shuttingDown
+  // (that is terminal) and must NOT touch the crash restartCount.
+  describe("restartChild (bundle roll)", () => {
+    it("retires the old child via SIGTERM and spawns a ready replacement", async () => {
+      const worker = await createMultiWorker(baseInput);
+      const oldChild = lastMockChild!;
+
+      await worker.restartChild();
+
+      expect(oldChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(mockChildren.length).toBe(2);
+      expect(worker.isAlive()).toBe(true);
+      expect(worker.getDiagnostics().childPid).toBe(mockChildren[1].pid);
+
+      await worker.shutdown();
+    });
+
+    it("does not increment the crash restartCount", async () => {
+      const worker = await createMultiWorker(baseInput);
+
+      await worker.restartChild();
+
+      expect(worker.getDiagnostics().restartCount).toBe(0);
+
+      await worker.shutdown();
+    });
+
+    it("resolves only after the replacement child sends ready", async () => {
+      const worker = await createMultiWorker(baseInput);
+
+      // The replacement child will NOT auto-ready.
+      autoEmitReady = false;
+      let resolved = false;
+      const rollPromise = worker.restartChild().then(() => {
+        resolved = true;
+      });
+
+      // Let the old child exit and the replacement spawn.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockChildren.length).toBe(2);
+      expect(resolved).toBe(false);
+
+      mockChildren[1].sendReady();
+      await rollPromise;
+      expect(resolved).toBe(true);
+
+      await worker.shutdown();
+    });
+
+    it("single-flights concurrent restartChild calls", async () => {
+      const worker = await createMultiWorker(baseInput);
+      const oldChild = lastMockChild!;
+
+      await Promise.all([worker.restartChild(), worker.restartChild()]);
+
+      // One roll: old child SIGTERMed once, exactly one replacement spawned.
+      expect(
+        oldChild.kill.mock.calls.filter(([sig]) => sig === "SIGTERM").length,
+      ).toBe(1);
+      expect(mockChildren.length).toBe(2);
+
+      await worker.shutdown();
+    });
+
+    it("rejects while shutting down", async () => {
+      const worker = await createMultiWorker(baseInput);
+      await worker.shutdown();
+
+      await expect(worker.restartChild()).rejects.toThrow(/shutting down/);
+    });
+
+    it("escalates to SIGKILL only after the hard-kill deadline, never before grace expires", async () => {
+      vi.useFakeTimers();
+      const worker = await createMultiWorker(baseInput);
+      const oldChild = lastMockChild!;
+
+      // Stuck child: SIGTERM does not produce an exit; SIGKILL does.
+      (oldChild.kill as ReturnType<typeof vi.fn>).mockImplementation(
+        (signal?: string) => {
+          oldChild.killed = true;
+          if (signal === "SIGKILL") {
+            oldChild.exitCode = 137;
+            queueMicrotask(() => oldChild.emit("exit", 137, "SIGKILL"));
+          }
+        },
+      );
+
+      const rollPromise = worker.restartChild();
+
+      // SIGTERM is sent immediately at the start of the roll.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(oldChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(
+        oldChild.kill.mock.calls.filter(([sig]) => sig === "SIGKILL").length,
+      ).toBe(0);
+
+      // Just before the deadline: still no SIGKILL, no replacement.
+      await vi.advanceTimersByTimeAsync(RESTART_HARD_KILL_DEADLINE_MS - 100);
+      expect(
+        oldChild.kill.mock.calls.filter(([sig]) => sig === "SIGKILL").length,
+      ).toBe(0);
+      expect(mockChildren.length).toBe(1);
+
+      // Past the deadline: SIGKILL fires, then the replacement spawns.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(oldChild.kill).toHaveBeenCalledWith("SIGKILL");
+
+      // SIGTERM strictly precedes SIGKILL.
+      const termOrder =
+        oldChild.kill.mock.invocationCallOrder[
+          oldChild.kill.mock.calls.findIndex(([sig]) => sig === "SIGTERM")
+        ];
+      const killOrder =
+        oldChild.kill.mock.invocationCallOrder[
+          oldChild.kill.mock.calls.findIndex(([sig]) => sig === "SIGKILL")
+        ];
+      expect(termOrder).toBeLessThan(killOrder);
+
+      await rollPromise;
+      expect(mockChildren.length).toBe(2);
+      expect(worker.getDiagnostics().restartCount).toBe(0);
+
+      // Return to real timers before shutdown — the replacement child's
+      // mock SIGTERM exit is scheduled via setImmediate.
+      vi.useRealTimers();
+      await worker.shutdown();
+    });
+
+    it("keeps the worker shut-downable after a completed roll", async () => {
+      const worker = await createMultiWorker(baseInput);
+      await worker.restartChild();
+
+      const replacement = mockChildren[1];
+      const shutdownPromise = worker.shutdown();
+      setTimeout(() => replacement.emit("exit", 0, null), 10);
+      await shutdownPromise;
+
+      expect(replacement.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(worker.isAlive()).toBe(false);
     });
   });
 });

--- a/plugin/src/temporal/worker-multi.ts
+++ b/plugin/src/temporal/worker-multi.ts
@@ -56,6 +56,16 @@ const MAX_RESTARTS = RESTART_BACKOFF_MS.length;
 export const MULTI_SHUTDOWN_GRACE_MS = 5_000;
 
 /**
+ * Parent-side hard-kill deadline for a first-class bundle roll
+ * (`restartChild`). After SIGTERM the child drains in-flight work for up
+ * to its explicit Temporal `shutdownGraceTime`
+ * (`TEMPORAL_WORKER_SHUTDOWN_GRACE_MS` = 5s in worker.ts). This deadline
+ * MUST strictly exceed that child grace so a draining child always gets
+ * its full window before the parent escalates to SIGKILL.
+ */
+export const RESTART_HARD_KILL_DEADLINE_MS = 10_000;
+
+/**
  * Maximum time the parent waits for the child to send
  * `{"type":"ready"}` after spawn. If this elapses, parent kills the
  * orphan child and rejects `createMultiWorker`. 30s covers Worker.create
@@ -146,6 +156,19 @@ export interface MultiWorkerInput {
 
 export interface MultiWorker extends InProcessWorker {
   isAlive(): boolean;
+  /**
+   * First-class bundle-roll lifecycle — distinct from BOTH crash-respawn
+   * (which increments `restartCount` and backs off) and `shutdown()`
+   * (which sets `shuttingDown` and suppresses respawn). Retires the
+   * current child gracefully (SIGTERM; SIGKILL only after
+   * `RESTART_HARD_KILL_DEADLINE_MS`), spawns a replacement, and resolves
+   * only after the replacement's ready handshake — callers gate the
+   * worker.lock `bundle_generation` stamp on that readiness.
+   *
+   * Single-flight: concurrent calls share one in-flight roll. Rejects
+   * when the worker is shutting down. Never touches `restartCount`.
+   */
+  restartChild(): Promise<void>;
   getDiagnostics(): {
     queues: string[];
     restartCount: number;
@@ -179,6 +202,15 @@ export async function createMultiWorker(
   let child: ChildProcess | null = null;
   let restartCount = 0;
   let shuttingDown = false;
+  /** In-flight bundle roll, if any — restartChild single-flights on this. */
+  let rollInFlight: Promise<void> | null = null;
+  /**
+   * Children retired by a bundle roll. The exit handler skips ALL crash
+   * accounting (restartCount, backoff respawn, exhaustion) and does not
+   * resolve the shutdown exitPromise for these — a roll exit is expected,
+   * not a crash and not a shutdown.
+   */
+  const expectedRollExits = new Set<ChildProcess>();
   const pendingRegistrations = new Map<
     string,
     {
@@ -190,9 +222,22 @@ export async function createMultiWorker(
   const registerErrors = new Map<string, string>();
   let exhaustedNotified = false;
   let resolveExit: () => void = () => {};
-  const exitPromise = new Promise<void>((resolve) => {
-    resolveExit = resolve;
-  });
+  const exitPromiseState: { promise: Promise<void> } = {
+    promise: new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    }),
+  };
+
+  /**
+   * Re-arm the shutdown exit promise for a new child generation. A bundle
+   * roll retires one child and spawns another; the shutdown waiter must
+   * track the CURRENT generation, not the retired one.
+   */
+  function rearmExitPromise(): void {
+    exitPromiseState.promise = new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    });
+  }
 
   /**
    * Handle a parsed JSON-line message from the child. Returns true if a
@@ -399,6 +444,15 @@ export async function createMultiWorker(
           );
         }
 
+        if (expectedRollExits.has(newChild)) {
+          // Bundle-roll retirement: expected exit. No crash accounting,
+          // no respawn, no shutdown-promise resolution — the roll owns
+          // the replacement spawn.
+          expectedRollExits.delete(newChild);
+          if (child === newChild) child = null;
+          return;
+        }
+
         if (shuttingDown || code === 0) {
           child = null;
           resolveExit();
@@ -433,6 +487,67 @@ export async function createMultiWorker(
     );
 
     return readyPromise;
+  }
+
+  async function restartChild(): Promise<void> {
+    if (shuttingDown) {
+      throw new Error(
+        "Cannot restart multi-queue Temporal worker child — worker is shutting down",
+      );
+    }
+    if (rollInFlight) return rollInFlight;
+
+    const roll = (async () => {
+      const oldChild = child;
+      if (oldChild && oldChild.exitCode === null) {
+        expectedRollExits.add(oldChild);
+        const oldExit = new Promise<void>((resolve) => {
+          oldChild.once("exit", () => resolve());
+        });
+        try {
+          oldChild.kill("SIGTERM");
+        } catch (e) {
+          debugLog(`roll SIGTERM threw: ${(e as Error).message}`);
+        }
+
+        // The child gets its full Temporal shutdownGraceTime to drain;
+        // only past the hard-kill deadline (which exceeds that grace) do
+        // we escalate to SIGKILL.
+        const timedOut = await Promise.race([
+          oldExit.then(() => false),
+          new Promise<boolean>((resolve) => {
+            setTimeout(
+              () => resolve(true),
+              RESTART_HARD_KILL_DEADLINE_MS,
+            ).unref();
+          }),
+        ]);
+        if (timedOut && oldChild.exitCode === null) {
+          debugLog("roll drain deadline exceeded — escalating to SIGKILL");
+          try {
+            oldChild.kill("SIGKILL");
+          } catch {
+            // best-effort
+          }
+          await oldExit;
+        }
+      }
+
+      // The retired child's exit must not satisfy future shutdown()
+      // waiters — re-arm for the replacement generation, then block on
+      // the replacement's ready handshake so callers only proceed (e.g.
+      // stamping worker.lock bundle_generation) once the new child is
+      // actually serving.
+      rearmExitPromise();
+      await spawnChild();
+    })();
+
+    rollInFlight = roll;
+    try {
+      await roll;
+    } finally {
+      rollInFlight = null;
+    }
   }
 
   function sendToChild(msg: ParentToChildMessage): boolean {
@@ -497,6 +612,12 @@ export async function createMultiWorker(
       if (shuttingDown) return;
       shuttingDown = true;
 
+      // A bundle roll in flight gets to finish (its deadlines are
+      // bounded) so shutdown then retires the CURRENT child generation.
+      if (rollInFlight) {
+        await rollInFlight.catch(() => undefined);
+      }
+
       for (const [queue, pending] of pendingRegistrations) {
         pending.reject(
           new Error(
@@ -515,7 +636,7 @@ export async function createMultiWorker(
       }
 
       const timedOut = await Promise.race([
-        exitPromise.then(() => false),
+        exitPromiseState.promise.then(() => false),
         new Promise<boolean>((resolve) => {
           setTimeout(() => resolve(true), MULTI_SHUTDOWN_GRACE_MS).unref();
         }),
@@ -530,13 +651,15 @@ export async function createMultiWorker(
         }
       }
 
-      await exitPromise;
+      await exitPromiseState.promise;
       child = null;
     },
 
     isAlive(): boolean {
       return Boolean(child && child.exitCode === null);
     },
+
+    restartChild,
 
     getDiagnostics() {
       return {

--- a/plugin/src/temporal/worker-roll.test.ts
+++ b/plugin/src/temporal/worker-roll.test.ts
@@ -1,0 +1,284 @@
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { cleanupTempDir, createTempDir } from "../__tests__/setup";
+import { acquireWorkerLock, readLockContents } from "./worker-lock";
+import { writeWorkerBundleManifest } from "./worker-bundle-manifest";
+import {
+  createWorkerBundleRollMonitor,
+  initWorkerBundleRoll,
+} from "./worker-roll";
+
+const NOW = new Date("2026-07-15T00:00:00.000Z");
+
+describe("worker bundle roll monitor", () => {
+  let tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => cleanupTempDir(dir)));
+    tempDirs = [];
+  });
+
+  const tempDir = async (prefix: string) => {
+    const dir = await createTempDir(prefix);
+    tempDirs.push(dir);
+    return dir;
+  };
+
+  /**
+   * Fixture: a project state dir holding worker.lock and a bundle dir
+   * holding worker.js + workflows.js + the generation manifest.
+   */
+  const setup = async (options: {
+    lockGeneration?: string;
+    lockMatchesManifest?: boolean;
+    lockPid?: number;
+    withManifest?: boolean;
+  }) => {
+    const stateDir = await tempDir("worker-roll-state-");
+    const bundleDir = await tempDir("worker-roll-bundle-");
+
+    let manifestGeneration: string | null = null;
+    if (options.withManifest !== false) {
+      await writeFile(join(bundleDir, "worker.js"), "// worker v1\n");
+      await writeFile(join(bundleDir, "workflows.js"), "// workflows v1\n");
+      const manifest = await writeWorkerBundleManifest(bundleDir, {
+        now: () => NOW,
+      });
+      manifestGeneration = manifest.generation;
+    }
+
+    const lockGeneration = options.lockMatchesManifest
+      ? (manifestGeneration ?? undefined)
+      : (options.lockGeneration ?? "gen-stale");
+    const lock = await acquireWorkerLock(stateDir, {
+      pid: options.lockPid ?? process.pid,
+      schemaVersion: 2,
+      expectedQueue: "adv-test-queue",
+      bundleGeneration: lockGeneration,
+      now: () => NOW,
+    });
+
+    return { stateDir, bundleDir, manifestGeneration, lockPath: lock.lockPath };
+  };
+
+  test("drift between manifest and lock generation triggers exactly one restart and stamps the lock", async () => {
+    const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const restartChild = vi.fn(async () => {});
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result).toEqual({
+      rolled: true,
+      generation: manifestGeneration,
+      lockUpdated: true,
+    });
+    expect(restartChild).toHaveBeenCalledTimes(1);
+    await expect(readLockContents(lockPath)).resolves.toMatchObject({
+      bundle_generation: manifestGeneration,
+    });
+    expect(monitor.lastRolledGeneration()).toBe(manifestGeneration);
+  });
+
+  test("same generation is a no-op", async () => {
+    const { stateDir, bundleDir } = await setup({ lockMatchesManifest: true });
+    const restartChild = vi.fn(async () => {});
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result).toEqual({ rolled: false, reason: "same_generation" });
+    expect(restartChild).not.toHaveBeenCalled();
+  });
+
+  test("concurrent checks single-flight: one restart for two overlapping beats", async () => {
+    const { stateDir, bundleDir } = await setup({});
+    let releaseRoll!: () => void;
+    const restartChild = vi.fn(
+      () => new Promise<void>((resolve) => (releaseRoll = resolve)),
+    );
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+    });
+
+    const first = monitor.checkNow();
+    const second = monitor.checkNow();
+
+    // Let both calls run into the latch.
+    await new Promise((r) => setTimeout(r, 20));
+    releaseRoll();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(restartChild).toHaveBeenCalledTimes(1);
+    const rolledCount = [firstResult, secondResult].filter(
+      (r) => r.rolled,
+    ).length;
+    const latchedCount = [firstResult, secondResult].filter(
+      (r) => !r.rolled && r.reason === "roll_in_flight",
+    ).length;
+    expect(rolledCount).toBe(1);
+    expect(latchedCount).toBe(1);
+  });
+
+  test("lock generation is stamped only AFTER the replacement child is ready", async () => {
+    const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
+      lockGeneration: "gen-stale",
+    });
+
+    let generationDuringRoll: string | null = null;
+    const restartChild = vi.fn(async () => {
+      // Readiness gate: while the roll is executing, the lock must still
+      // show the OLD generation — the stamp happens after resolve.
+      const contents = await readLockContents(lockPath);
+      generationDuringRoll =
+        contents?.schema_version === 2
+          ? (contents.bundle_generation ?? null)
+          : null;
+    });
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+    });
+
+    await monitor.checkNow();
+
+    expect(generationDuringRoll).toBe("gen-stale");
+    await expect(readLockContents(lockPath)).resolves.toMatchObject({
+      bundle_generation: manifestGeneration,
+    });
+  });
+
+  test("a failed roll leaves the lock generation untouched and the next check retries", async () => {
+    const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const onRollError = vi.fn();
+    const restartChild = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("child never became ready"))
+      .mockResolvedValueOnce(undefined);
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+      onRollError,
+    });
+
+    const failed = await monitor.checkNow();
+
+    expect(failed).toMatchObject({ rolled: false, reason: "roll_failed" });
+    expect(onRollError).toHaveBeenCalledTimes(1);
+    // Lock NOT stamped — the child never became ready.
+    await expect(readLockContents(lockPath)).resolves.toMatchObject({
+      bundle_generation: "gen-stale",
+    });
+    expect(monitor.lastRolledGeneration()).toBeNull();
+
+    // Latch released: the next beat retries the roll.
+    const retried = await monitor.checkNow();
+    expect(restartChild).toHaveBeenCalledTimes(2);
+    expect(retried).toEqual({
+      rolled: true,
+      generation: manifestGeneration,
+      lockUpdated: true,
+    });
+  });
+
+  test("does not roll when the lock is held by a different pid (owner-driven only)", async () => {
+    const { stateDir, bundleDir } = await setup({ lockPid: 999_999 });
+    const restartChild = vi.fn(async () => {});
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result).toEqual({ rolled: false, reason: "not_lock_owner" });
+    expect(restartChild).not.toHaveBeenCalled();
+  });
+
+  test("does not roll when the manifest is missing", async () => {
+    const { stateDir, bundleDir } = await setup({ withManifest: false });
+    const restartChild = vi.fn(async () => {});
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result).toEqual({ rolled: false, reason: "manifest_unavailable" });
+    expect(restartChild).not.toHaveBeenCalled();
+  });
+
+  test("does not roll when the lock is missing or not v2", async () => {
+    const stateDir = await tempDir("worker-roll-nolock-");
+    const bundleDir = await tempDir("worker-roll-nolock-bundle-");
+    await writeFile(join(bundleDir, "worker.js"), "// worker\n");
+    await writeFile(join(bundleDir, "workflows.js"), "// workflows\n");
+    await writeWorkerBundleManifest(bundleDir);
+    const restartChild = vi.fn(async () => {});
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result).toEqual({ rolled: false, reason: "lock_unavailable" });
+    expect(restartChild).not.toHaveBeenCalled();
+  });
+
+  test("initWorkerBundleRoll stamps the current generation post-readiness and converges the monitor", async () => {
+    const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const restartChild = vi.fn(async () => {});
+
+    // The worker child was JUST spawned from the current bundle (ready
+    // handshake already resolved) — stamp the lock without rolling.
+    const monitor = await initWorkerBundleRoll({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+    });
+
+    expect(restartChild).not.toHaveBeenCalled();
+    await expect(readLockContents(lockPath)).resolves.toMatchObject({
+      bundle_generation: manifestGeneration,
+    });
+
+    // Converged: subsequent beats are same-generation no-ops.
+    const result = await monitor.checkNow();
+    expect(result).toEqual({ rolled: false, reason: "same_generation" });
+    expect(restartChild).not.toHaveBeenCalled();
+  });
+});

--- a/plugin/src/temporal/worker-roll.test.ts
+++ b/plugin/src/temporal/worker-roll.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { cleanupTempDir, createTempDir } from "../__tests__/setup";
 import { acquireWorkerLock, readLockContents } from "./worker-lock";
 import { writeWorkerBundleManifest } from "./worker-bundle-manifest";
+import { startWorkerLockHeartbeat } from "./worker-heartbeat";
 import {
   createWorkerBundleRollMonitor,
   initWorkerBundleRoll,
@@ -63,28 +64,30 @@ describe("worker bundle roll monitor", () => {
     return { stateDir, bundleDir, manifestGeneration, lockPath: lock.lockPath };
   };
 
-  test("drift between manifest and lock generation triggers exactly one restart and stamps the lock", async () => {
+  test("drift between manifest and lock generation triggers exactly one restart and hands the new generation to the heartbeat", async () => {
     const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
       lockGeneration: "gen-stale",
     });
     const restartChild = vi.fn(async () => {});
+    const setBundleGeneration = vi.fn();
 
     const monitor = createWorkerBundleRollMonitor({
       projectStateDir: stateDir,
       bundleDir,
       restartChild,
+      setBundleGeneration,
     });
 
     const result = await monitor.checkNow();
 
-    expect(result).toEqual({
-      rolled: true,
-      generation: manifestGeneration,
-      lockUpdated: true,
-    });
+    expect(result).toEqual({ rolled: true, generation: manifestGeneration });
     expect(restartChild).toHaveBeenCalledTimes(1);
+    expect(setBundleGeneration).toHaveBeenCalledTimes(1);
+    expect(setBundleGeneration).toHaveBeenCalledWith(manifestGeneration);
+    // The monitor NEVER writes the lock itself — the heartbeat (sole
+    // lock writer) stamps the handed-off generation on its next beat.
     await expect(readLockContents(lockPath)).resolves.toMatchObject({
-      bundle_generation: manifestGeneration,
+      bundle_generation: "gen-stale",
     });
     expect(monitor.lastRolledGeneration()).toBe(manifestGeneration);
   });
@@ -138,41 +141,38 @@ describe("worker bundle roll monitor", () => {
     expect(latchedCount).toBe(1);
   });
 
-  test("lock generation is stamped only AFTER the replacement child is ready", async () => {
-    const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
+  test("the generation is handed to the heartbeat only AFTER the replacement child is ready", async () => {
+    const { stateDir, bundleDir, manifestGeneration } = await setup({
       lockGeneration: "gen-stale",
     });
 
-    let generationDuringRoll: string | null = null;
+    const handed: string[] = [];
+    let handedDuringRoll: string[] = [];
     const restartChild = vi.fn(async () => {
-      // Readiness gate: while the roll is executing, the lock must still
-      // show the OLD generation — the stamp happens after resolve.
-      const contents = await readLockContents(lockPath);
-      generationDuringRoll =
-        contents?.schema_version === 2
-          ? (contents.bundle_generation ?? null)
-          : null;
+      // Readiness gate: while the roll is executing, no generation may
+      // have been handed off yet — the handoff happens after resolve.
+      handedDuringRoll = [...handed];
     });
 
     const monitor = createWorkerBundleRollMonitor({
       projectStateDir: stateDir,
       bundleDir,
       restartChild,
+      setBundleGeneration: (generation) => handed.push(generation),
     });
 
     await monitor.checkNow();
 
-    expect(generationDuringRoll).toBe("gen-stale");
-    await expect(readLockContents(lockPath)).resolves.toMatchObject({
-      bundle_generation: manifestGeneration,
-    });
+    expect(handedDuringRoll).toEqual([]);
+    expect(handed).toEqual([manifestGeneration]);
   });
 
-  test("a failed roll leaves the lock generation untouched and the next check retries", async () => {
+  test("a failed roll leaves the recorded generation untouched and the next check retries", async () => {
     const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
       lockGeneration: "gen-stale",
     });
     const onRollError = vi.fn();
+    const setBundleGeneration = vi.fn();
     const restartChild = vi
       .fn<() => Promise<void>>()
       .mockRejectedValueOnce(new Error("child never became ready"))
@@ -182,6 +182,7 @@ describe("worker bundle roll monitor", () => {
       projectStateDir: stateDir,
       bundleDir,
       restartChild,
+      setBundleGeneration,
       onRollError,
     });
 
@@ -189,7 +190,9 @@ describe("worker bundle roll monitor", () => {
 
     expect(failed).toMatchObject({ rolled: false, reason: "roll_failed" });
     expect(onRollError).toHaveBeenCalledTimes(1);
-    // Lock NOT stamped — the child never became ready.
+    // No handoff — the child never became ready, so neither the
+    // in-memory generation nor the lock may claim the new generation.
+    expect(setBundleGeneration).not.toHaveBeenCalled();
     await expect(readLockContents(lockPath)).resolves.toMatchObject({
       bundle_generation: "gen-stale",
     });
@@ -198,11 +201,8 @@ describe("worker bundle roll monitor", () => {
     // Latch released: the next beat retries the roll.
     const retried = await monitor.checkNow();
     expect(restartChild).toHaveBeenCalledTimes(2);
-    expect(retried).toEqual({
-      rolled: true,
-      generation: manifestGeneration,
-      lockUpdated: true,
-    });
+    expect(retried).toEqual({ rolled: true, generation: manifestGeneration });
+    expect(setBundleGeneration).toHaveBeenCalledWith(manifestGeneration);
   });
 
   test("does not roll when the lock is held by a different pid (owner-driven only)", async () => {
@@ -257,21 +257,72 @@ describe("worker bundle roll monitor", () => {
     expect(restartChild).not.toHaveBeenCalled();
   });
 
-  test("initWorkerBundleRoll stamps the current generation post-readiness and converges the monitor", async () => {
+  test("single-writer flow: a lagging lock stamp cannot trigger a re-roll", async () => {
     const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
       lockGeneration: "gen-stale",
     });
     const restartChild = vi.fn(async () => {});
+    const heartbeat = startWorkerLockHeartbeat(stateDir, { now: () => NOW });
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+      setBundleGeneration: (generation) =>
+        heartbeat.setBundleGeneration(generation),
+    });
+
+    const rolled = await monitor.checkNow();
+    expect(rolled).toEqual({ rolled: true, generation: manifestGeneration });
+
+    // The lock still shows the stale generation — the heartbeat has not
+    // beaten since the handoff. The in-memory generation is
+    // authoritative, so an immediate re-check is a no-op (AC5).
+    await expect(readLockContents(lockPath)).resolves.toMatchObject({
+      bundle_generation: "gen-stale",
+    });
+    await expect(monitor.checkNow()).resolves.toEqual({
+      rolled: false,
+      reason: "same_generation",
+    });
+    expect(restartChild).toHaveBeenCalledTimes(1);
+
+    // The heartbeat stamps the handed-off generation together with the
+    // next beat — one writer, no lost update.
+    await heartbeat.beatNow();
+    await expect(readLockContents(lockPath)).resolves.toMatchObject({
+      bundle_generation: manifestGeneration,
+      last_heartbeat: NOW.toISOString(),
+    });
+
+    await heartbeat.stop();
+  });
+
+  test("initWorkerBundleRoll hands the current generation to the heartbeat post-readiness and converges the monitor", async () => {
+    const { stateDir, bundleDir, manifestGeneration, lockPath } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const restartChild = vi.fn(async () => {});
+    const heartbeat = startWorkerLockHeartbeat(stateDir, { now: () => NOW });
 
     // The worker child was JUST spawned from the current bundle (ready
-    // handshake already resolved) — stamp the lock without rolling.
+    // handshake already resolved) — hand the generation to the heartbeat
+    // without rolling.
     const monitor = await initWorkerBundleRoll({
       projectStateDir: stateDir,
       bundleDir,
       restartChild,
+      setBundleGeneration: (generation) =>
+        heartbeat.setBundleGeneration(generation),
     });
 
     expect(restartChild).not.toHaveBeenCalled();
+    // The monitor never writes the lock directly...
+    await expect(readLockContents(lockPath)).resolves.toMatchObject({
+      bundle_generation: "gen-stale",
+    });
+    // ...the heartbeat stamps the handed-off generation on its next beat.
+    await heartbeat.beatNow();
     await expect(readLockContents(lockPath)).resolves.toMatchObject({
       bundle_generation: manifestGeneration,
     });
@@ -280,5 +331,7 @@ describe("worker bundle roll monitor", () => {
     const result = await monitor.checkNow();
     expect(result).toEqual({ rolled: false, reason: "same_generation" });
     expect(restartChild).not.toHaveBeenCalled();
+
+    await heartbeat.stop();
   });
 });

--- a/plugin/src/temporal/worker-roll.ts
+++ b/plugin/src/temporal/worker-roll.ts
@@ -10,11 +10,14 @@
  *   1. Each heartbeat beat (fire-and-forget — see worker-heartbeat.ts)
  *      calls `checkNow()`.
  *   2. The on-disk manifest generation (`bundle-manifest.json`) is
- *      compared against the `bundle_generation` stamped in worker.lock.
+ *      compared against the generation the current child is running,
+ *      tracked IN-MEMORY (seeded at spawn, updated on every roll) so a
+ *      lagging lock stamp can never trigger a redundant re-roll.
  *   3. On drift, the monitor drives a first-class `restartChild()` roll
  *      (NOT crash-respawn, NOT shutdown — see worker-multi.ts) and only
- *      AFTER the replacement child's ready handshake stamps the lock with
- *      the new generation via a readback-validated write.
+ *      AFTER the replacement child's ready handshake records the new
+ *      generation in-memory and hands it to the heartbeat controller,
+ *      which stamps worker.lock on its next beat.
  *
  * Hard rules (design constraints):
  *   - Owner-driven only: rolls happen exclusively when THIS process holds
@@ -22,17 +25,19 @@
  *     never reclaim an alive owner's lock.
  *   - Same generation is a no-op — including immediately after a roll.
  *   - Single-flight: overlapping beats share one in-flight roll. A failed
- *     roll leaves the lock generation untouched so the next beat retries.
+ *     roll leaves the recorded generation untouched so the next beat
+ *     retries.
+ *   - Single lock writer (AC5 no-lost-updates): the monitor NEVER writes
+ *     worker.lock directly. The heartbeat (`worker-heartbeat.ts`) is the
+ *     sole post-acquire lock writer; it persists the handed-off
+ *     generation together with `last_heartbeat` in one atomic rewrite,
+ *     so a concurrent beat can never clobber a completed roll's stamp.
  */
 
 import { join } from "path";
 
 import { readWorkerBundleGeneration } from "./worker-bundle-manifest";
-import {
-  readLockContents,
-  updateWorkerLockBundleGeneration,
-  WORKER_LOCK_FILENAME,
-} from "./worker-lock";
+import { readLockContents, WORKER_LOCK_FILENAME } from "./worker-lock";
 
 export interface WorkerBundleRollMonitorOptions {
   /** Project state directory holding worker.lock. */
@@ -44,6 +49,21 @@ export interface WorkerBundleRollMonitorOptions {
    * `() => outOfProcessWorker.restartChild()`.
    */
   restartChild: () => Promise<void>;
+  /**
+   * Sole-writer handoff: the worker.lock heartbeat controller's
+   * `setBundleGeneration`. Invoked with the generation the current child
+   * is running — at spawn (via `initWorkerBundleRoll`) and after every
+   * successful roll — so the heartbeat stamps it on its next beat. When
+   * omitted, the monitor still tracks the generation in-memory (drift
+   * detection is unaffected); the lock simply is never stamped.
+   */
+  setBundleGeneration?: (generation: string) => void;
+  /**
+   * Generation the current child is already running (seeded by
+   * `initWorkerBundleRoll` from the post-spawn manifest). When omitted,
+   * the first check falls back to the lock's `bundle_generation`.
+   */
+  initialGeneration?: string | null;
   lockFilename?: string;
   /** Owning pid for the lock-owner check. Defaults to process.pid. */
   pid?: number;
@@ -52,7 +72,7 @@ export interface WorkerBundleRollMonitorOptions {
 }
 
 export type WorkerRollCheckResult =
-  | { rolled: true; generation: string; lockUpdated: boolean }
+  | { rolled: true; generation: string }
   | {
       rolled: false;
       reason:
@@ -86,6 +106,10 @@ export function createWorkerBundleRollMonitor(
 
   let rollInFlight: Promise<WorkerRollCheckResult> | null = null;
   let lastRolled: string | null = null;
+  // Source of truth for the running child's bundle generation. Updated
+  // synchronously the moment a roll's readiness gate passes, so a lock
+  // stamp lagging up to one heartbeat interval cannot cause a re-roll.
+  let currentGeneration: string | null = options.initialGeneration ?? null;
 
   async function checkAndRoll(): Promise<WorkerRollCheckResult> {
     const manifestGeneration = await readWorkerBundleGeneration(
@@ -104,7 +128,11 @@ export function createWorkerBundleRollMonitor(
       // worker — never roll someone else's child.
       return { rolled: false, reason: "not_lock_owner" };
     }
-    if (lock.bundle_generation === manifestGeneration) {
+    // In-memory generation wins; the lock value is only a fallback for
+    // monitors created without spawn information.
+    const runningGeneration =
+      currentGeneration ?? lock.bundle_generation ?? null;
+    if (runningGeneration === manifestGeneration) {
       return { rolled: false, reason: "same_generation" };
     }
 
@@ -113,25 +141,16 @@ export function createWorkerBundleRollMonitor(
       // replacement. Resolves only after the new child sent ready.
       await options.restartChild();
 
-      // Readiness gate passed — stamp the lock with the generation the
-      // replacement child is actually running (readback-validated).
-      const stamp = await updateWorkerLockBundleGeneration(
-        options.projectStateDir,
-        {
-          bundleGeneration: manifestGeneration,
-          ...(options.lockFilename
-            ? { lockFilename: options.lockFilename }
-            : {}),
-        },
-      );
+      // Readiness gate passed — the replacement child is running
+      // `manifestGeneration` NOW. Record it in-memory immediately and
+      // hand it to the heartbeat (the sole worker.lock writer), which
+      // stamps it together with last_heartbeat on its next beat.
+      currentGeneration = manifestGeneration;
+      options.setBundleGeneration?.(manifestGeneration);
 
       lastRolled = manifestGeneration;
       options.onRolled?.(manifestGeneration);
-      return {
-        rolled: true,
-        generation: manifestGeneration,
-        lockUpdated: stamp.updated,
-      };
+      return { rolled: true, generation: manifestGeneration };
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       options.onRollError?.(error);
@@ -169,14 +188,15 @@ export function createWorkerBundleRollMonitor(
 /**
  * Post-spawn convergence: a freshly started worker child was created from
  * the CURRENT on-disk bundle and has already passed its ready handshake —
- * stamp the lock with the current manifest generation (no roll needed),
- * then return the drift monitor. This satisfies the "update the lock
+ * seed the monitor's in-memory generation and hand it to the heartbeat
+ * (the sole worker.lock writer) so the next beat stamps the lock, then
+ * return the drift monitor. This satisfies the "record the lock
  * generation only after child readiness" rule for initial spawn and keeps
  * the first post-start beat a same-generation no-op.
  *
- * Best-effort: a stamp failure (or a missing manifest) never prevents
- * monitor creation — the next beat simply sees drift and converges via a
- * roll.
+ * Best-effort: a missing manifest (or an unwired heartbeat handoff) never
+ * prevents monitor creation — the next beat simply sees drift and
+ * converges via a roll.
  */
 export async function initWorkerBundleRoll(
   options: WorkerBundleRollMonitorOptions,
@@ -185,10 +205,10 @@ export async function initWorkerBundleRoll(
     options.bundleDir,
   );
   if (manifestGeneration) {
-    await updateWorkerLockBundleGeneration(options.projectStateDir, {
-      bundleGeneration: manifestGeneration,
-      ...(options.lockFilename ? { lockFilename: options.lockFilename } : {}),
-    }).catch(() => undefined);
+    options.setBundleGeneration?.(manifestGeneration);
   }
-  return createWorkerBundleRollMonitor(options);
+  return createWorkerBundleRollMonitor({
+    ...options,
+    initialGeneration: manifestGeneration ?? null,
+  });
 }

--- a/plugin/src/temporal/worker-roll.ts
+++ b/plugin/src/temporal/worker-roll.ts
@@ -1,0 +1,194 @@
+/**
+ * Worker bundle roll monitor — owner-driven self-roll on bundle drift.
+ *
+ * The out-of-process Temporal worker child loads
+ * `dist/temporal/worker.js` + `dist/temporal/workflows.js`. When a deploy
+ * replaces those files, the RUNNING child keeps executing the old bundle
+ * until it is restarted. This monitor closes that gap for the lock-owning
+ * session:
+ *
+ *   1. Each heartbeat beat (fire-and-forget — see worker-heartbeat.ts)
+ *      calls `checkNow()`.
+ *   2. The on-disk manifest generation (`bundle-manifest.json`) is
+ *      compared against the `bundle_generation` stamped in worker.lock.
+ *   3. On drift, the monitor drives a first-class `restartChild()` roll
+ *      (NOT crash-respawn, NOT shutdown — see worker-multi.ts) and only
+ *      AFTER the replacement child's ready handshake stamps the lock with
+ *      the new generation via a readback-validated write.
+ *
+ * Hard rules (design constraints):
+ *   - Owner-driven only: rolls happen exclusively when THIS process holds
+ *     worker.lock (pid match). Never force-kill another session's worker,
+ *     never reclaim an alive owner's lock.
+ *   - Same generation is a no-op — including immediately after a roll.
+ *   - Single-flight: overlapping beats share one in-flight roll. A failed
+ *     roll leaves the lock generation untouched so the next beat retries.
+ */
+
+import { join } from "path";
+
+import { readWorkerBundleGeneration } from "./worker-bundle-manifest";
+import {
+  readLockContents,
+  updateWorkerLockBundleGeneration,
+  WORKER_LOCK_FILENAME,
+} from "./worker-lock";
+
+export interface WorkerBundleRollMonitorOptions {
+  /** Project state directory holding worker.lock. */
+  projectStateDir: string;
+  /** Directory holding worker.js/workflows.js/bundle-manifest.json. */
+  bundleDir: string;
+  /**
+   * First-class child roll (readiness-gated). Typically
+   * `() => outOfProcessWorker.restartChild()`.
+   */
+  restartChild: () => Promise<void>;
+  lockFilename?: string;
+  /** Owning pid for the lock-owner check. Defaults to process.pid. */
+  pid?: number;
+  onRolled?: (generation: string) => void;
+  onRollError?: (err: Error) => void;
+}
+
+export type WorkerRollCheckResult =
+  | { rolled: true; generation: string; lockUpdated: boolean }
+  | {
+      rolled: false;
+      reason:
+        | "roll_in_flight"
+        | "manifest_unavailable"
+        | "lock_unavailable"
+        | "not_lock_owner"
+        | "same_generation"
+        | "roll_failed";
+      error?: string;
+    };
+
+export interface WorkerBundleRollMonitor {
+  /**
+   * Single drift check + roll-if-needed. Safe to call fire-and-forget
+   * from every heartbeat beat — single-flights internally.
+   */
+  checkNow: () => Promise<WorkerRollCheckResult>;
+  /** Generation of the last successful roll, if any. */
+  lastRolledGeneration: () => string | null;
+}
+
+export function createWorkerBundleRollMonitor(
+  options: WorkerBundleRollMonitorOptions,
+): WorkerBundleRollMonitor {
+  const lockPath = join(
+    options.projectStateDir,
+    options.lockFilename ?? WORKER_LOCK_FILENAME,
+  );
+  const ownerPid = options.pid ?? process.pid;
+
+  let rollInFlight: Promise<WorkerRollCheckResult> | null = null;
+  let lastRolled: string | null = null;
+
+  async function checkAndRoll(): Promise<WorkerRollCheckResult> {
+    const manifestGeneration = await readWorkerBundleGeneration(
+      options.bundleDir,
+    );
+    if (!manifestGeneration) {
+      return { rolled: false, reason: "manifest_unavailable" };
+    }
+
+    const lock = await readLockContents(lockPath).catch(() => null);
+    if (!lock || lock.schema_version !== 2) {
+      return { rolled: false, reason: "lock_unavailable" };
+    }
+    if (lock.pid !== ownerPid) {
+      // Owner-driven self-roll only. Another (alive) session owns the
+      // worker — never roll someone else's child.
+      return { rolled: false, reason: "not_lock_owner" };
+    }
+    if (lock.bundle_generation === manifestGeneration) {
+      return { rolled: false, reason: "same_generation" };
+    }
+
+    try {
+      // First-class roll: graceful SIGTERM drain, readiness-gated
+      // replacement. Resolves only after the new child sent ready.
+      await options.restartChild();
+
+      // Readiness gate passed — stamp the lock with the generation the
+      // replacement child is actually running (readback-validated).
+      const stamp = await updateWorkerLockBundleGeneration(
+        options.projectStateDir,
+        {
+          bundleGeneration: manifestGeneration,
+          ...(options.lockFilename
+            ? { lockFilename: options.lockFilename }
+            : {}),
+        },
+      );
+
+      lastRolled = manifestGeneration;
+      options.onRolled?.(manifestGeneration);
+      return {
+        rolled: true,
+        generation: manifestGeneration,
+        lockUpdated: stamp.updated,
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      options.onRollError?.(error);
+      return {
+        rolled: false,
+        reason: "roll_failed",
+        error: error.message,
+      };
+    }
+  }
+
+  return {
+    checkNow(): Promise<WorkerRollCheckResult> {
+      // Single-flight latch: heartbeat beats are fire-and-forget, so a
+      // beat that arrives mid-roll (or mid-check) skips rather than
+      // stacking a second roll.
+      if (rollInFlight) {
+        return Promise.resolve({ rolled: false, reason: "roll_in_flight" });
+      }
+      const run = checkAndRoll();
+      rollInFlight = run;
+      const clearLatch = () => {
+        if (rollInFlight === run) rollInFlight = null;
+      };
+      run.then(clearLatch, clearLatch);
+      return run;
+    },
+
+    lastRolledGeneration(): string | null {
+      return lastRolled;
+    },
+  };
+}
+
+/**
+ * Post-spawn convergence: a freshly started worker child was created from
+ * the CURRENT on-disk bundle and has already passed its ready handshake —
+ * stamp the lock with the current manifest generation (no roll needed),
+ * then return the drift monitor. This satisfies the "update the lock
+ * generation only after child readiness" rule for initial spawn and keeps
+ * the first post-start beat a same-generation no-op.
+ *
+ * Best-effort: a stamp failure (or a missing manifest) never prevents
+ * monitor creation — the next beat simply sees drift and converges via a
+ * roll.
+ */
+export async function initWorkerBundleRoll(
+  options: WorkerBundleRollMonitorOptions,
+): Promise<WorkerBundleRollMonitor> {
+  const manifestGeneration = await readWorkerBundleGeneration(
+    options.bundleDir,
+  );
+  if (manifestGeneration) {
+    await updateWorkerLockBundleGeneration(options.projectStateDir, {
+      bundleGeneration: manifestGeneration,
+      ...(options.lockFilename ? { lockFilename: options.lockFilename } : {}),
+    }).catch(() => undefined);
+  }
+  return createWorkerBundleRollMonitor(options);
+}

--- a/plugin/src/temporal/worker.test.ts
+++ b/plugin/src/temporal/worker.test.ts
@@ -20,7 +20,9 @@ import {
   runMultiQueueTemporalWorker,
   createChildIPCHandler,
   startParentLivenessWatchdog,
+  TEMPORAL_WORKER_SHUTDOWN_GRACE_MS,
 } from "./worker";
+import { RESTART_HARD_KILL_DEADLINE_MS } from "./worker-multi";
 
 describe("temporal worker helpers", () => {
   beforeEach(() => {
@@ -265,6 +267,48 @@ describe("temporal worker helpers", () => {
         ADV_TEMPORAL_NAMESPACE: "default",
       } as NodeJS.ProcessEnv),
     ).rejects.toThrow(/ADV_TEMPORAL_TASK_QUEUES is empty/);
+  });
+
+  // Bundle-roll graceful drain: every Worker.create in the child must set
+  // an explicit Temporal shutdownGraceTime so SIGTERM (sent by the parent's
+  // restartChild roll) drains in-flight work instead of cancelling it at 0s
+  // (the SDK default). The parent's hard-kill deadline must strictly exceed
+  // the child grace so a draining child always gets its full grace period.
+  describe("shutdownGraceTime (bundle roll drain)", () => {
+    it("parent hard-kill deadline exceeds child Temporal shutdown grace", () => {
+      expect(RESTART_HARD_KILL_DEADLINE_MS).toBeGreaterThan(
+        TEMPORAL_WORKER_SHUTDOWN_GRACE_MS,
+      );
+    });
+
+    it("runTemporalWorker sets explicit shutdownGraceTime", async () => {
+      await runTemporalWorker({
+        taskQueue: "advance-grace",
+        address: "127.0.0.1:7233",
+        namespace: "default",
+        workflowsPath: "/tmp/workflows.js",
+      });
+
+      expect(workerMocks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          shutdownGraceTime: TEMPORAL_WORKER_SHUTDOWN_GRACE_MS,
+        }),
+      );
+    });
+
+    it("runMultiQueueTemporalWorker sets explicit shutdownGraceTime for every queue", async () => {
+      await runMultiQueueTemporalWorker(["advance-g1", "advance-g2"], {
+        ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
+        ADV_TEMPORAL_NAMESPACE: "default",
+      } as NodeJS.ProcessEnv);
+
+      expect(workerMocks.create).toHaveBeenCalledTimes(2);
+      for (const [opts] of workerMocks.create.mock.calls) {
+        expect((opts as { shutdownGraceTime?: number }).shutdownGraceTime).toBe(
+          TEMPORAL_WORKER_SHUTDOWN_GRACE_MS,
+        );
+      }
+    });
   });
 
   // P1.3.7 — Child IPC handler for dynamic queue register/unregister.

--- a/plugin/src/temporal/worker.ts
+++ b/plugin/src/temporal/worker.ts
@@ -10,6 +10,18 @@ function resolveWorkflowsPath(): string {
   return fileURLToPath(new URL("./workflows.ts", import.meta.url));
 }
 
+/**
+ * Explicit Temporal `shutdownGraceTime` for every Worker this child
+ * process creates. The SDK default is 0 — a SIGTERM (sent by the parent's
+ * first-class `restartChild` bundle roll, see worker-multi.ts) would
+ * cancel in-flight workflow/activity tasks immediately instead of draining
+ * them. 5s gives polls and in-flight tasks a real drain window while
+ * staying well under the parent's hard-kill deadline
+ * (`RESTART_HARD_KILL_DEADLINE_MS` in worker-multi.ts), which MUST always
+ * exceed this value.
+ */
+export const TEMPORAL_WORKER_SHUTDOWN_GRACE_MS = 5_000;
+
 export interface TemporalWorkerOptions {
   address?: string;
   namespace?: string;
@@ -31,6 +43,7 @@ export async function runTemporalWorker(
       taskQueue: options.taskQueue,
       workflowsPath: options.workflowsPath ?? resolveWorkflowsPath(),
       activities,
+      shutdownGraceTime: TEMPORAL_WORKER_SHUTDOWN_GRACE_MS,
     });
 
     await worker.run();
@@ -194,6 +207,7 @@ export async function runMultiQueueTemporalWorker(
           taskQueue,
           workflowsPath,
           activities,
+          shutdownGraceTime: TEMPORAL_WORKER_SHUTDOWN_GRACE_MS,
         }),
       ),
     );
@@ -223,6 +237,7 @@ export async function runMultiQueueTemporalWorker(
             taskQueue: queue,
             workflowsPath,
             activities,
+            shutdownGraceTime: TEMPORAL_WORKER_SHUTDOWN_GRACE_MS,
           });
           workerRegistry.set(queue, newWorker);
           // Fire-and-forget .run so the IPC handler returns promptly.

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -215,7 +215,7 @@ plugin_dist_stale_reason() {
 	fi
 
 	local output_rel output
-	for output_rel in dist/index.js dist/temporal/worker.js dist/temporal/workflows.js; do
+	for output_rel in dist/index.js dist/temporal/worker.js dist/temporal/workflows.js dist/temporal/bundle-manifest.json; do
 		output="$ADV_SOURCE_PLUGIN_PATH/$output_rel"
 		if [ ! -f "$output" ]; then
 			printf '%s\n' "plugin dist output is missing: $output_rel"


### PR DESCRIPTION
## Problem
On Bun hosts the ADV Temporal worker runs out-of-process as a Node child that loads dist/temporal/worker.js once at start. A rebuild/redeploy left running workers on stale code with no re-election — N sessions = N independently-stale workers.

## Fix
- Atomic bundle-generation manifest (SHA-256 over worker.js + workflows.js, written last by build:worker).
- Owner-driven self-roll: heartbeat owner detects generation drift and gracefully respawns its own Node child (first-class restartChild — distinct from crash-respawn, crash-counter untouched; explicit shutdownGraceTime, parent hard-kill > grace).
- Single-writer worker.lock: heartbeat is the sole writer; roll hands generation to it (closes an AC5 lost-update race found in review).

## Verification
53/53 worker suites green; pnpm run check green; build:worker manifest E2E. workflows.ts unchanged; no defineUpdate. Independent reviewer READY after single-writer remediation.

ADV change: autoRollStaleWorkerBundle