### PR TITLE
fix(adv): reap leaked Temporal test servers + enforce teardown

### DIFF
--- a/bin/lib/oc-test-reaper.bash
+++ b/bin/lib/oc-test-reaper.bash
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Conservative stale-only reaper for leaked Temporal TypeScript test servers
+# (ADV change reapLeakedTestServers; contract AC3/AC4, constraint C1, DONT1).
+#
+# What it reaps: processes whose argv[0] basename matches the SDK time-skipping
+# test-server binary `temporal-test-server-sdk-typescript-*` (the single-file
+# binary the SDK extracts to $TMPDIR, e.g.
+# /tmp/temporal-test-server-sdk-typescript-1.17.2) AND that are provably stale.
+#
+# Conservative guarantees (design-validator mandated):
+#   * Same UID only — never touches other users' processes.
+#   * EXACT executable basename match on argv[0]; no substring/ps|grep sweeps.
+#   * Defense-in-depth exclusions retained: any argv token shaped like
+#     `start-dev` or port 7233 skips the candidate (the real dev server runs
+#     `temporal server start-dev --port 7233`; over-skipping is the safe
+#     direction).
+#   * Stale-only: candidate age must exceed OC_TEST_REAPER_MIN_AGE_SECONDS
+#     (default 7200s = 2h, far beyond the 20m full-tier timeout), so
+#     concurrent peer test runs are never disrupted (AC4).
+#   * Identity is re-established and revalidated immediately before every
+#     signal; a PID whose start-identity changed is skipped (PID reuse).
+#   * TERM -> bounded wait -> revalidate -> optional KILL. Never an unbounded
+#     wait, never a blind kill.
+#   * Linux reads /proc/<pid>/cmdline (NUL-separated) + start-time from
+#     /proc/<pid>/stat; macOS falls back to `ps -ww` (args/lstart/etime —
+#     all documented macOS ps(1) keywords; `etimes` is procps-only and is
+#     deliberately NOT used). If identity cannot be established the
+#     candidate is SKIPPED (no destructive action).
+#   * Never fails the caller: per-candidate problems are warnings on stderr.
+#
+# Known gap (accepted): `TestWorkflowEnvironment.createLocal()` spawns the
+# Temporal CLI dev server (`temporal server start-dev` from a $TMPDIR cache
+# dir), which is indistinguishable in argv shape from a user's real dev
+# server. The start-dev token exclusion therefore deliberately keeps
+# createLocal leaks out of this reaper's blast radius; helper-owned teardown
+# is the mitigation there. No plugin call site uses createLocal today.
+#
+# Usage:  oc-test-reaper.bash [pid ...]
+#   With no arguments, sweeps all visible processes. Positional PIDs restrict
+#   the candidate set (test seam; all safety checks still apply).
+#
+# Env knobs:
+#   OC_TEST_REAPER_MIN_AGE_SECONDS    default 7200
+#   OC_TEST_REAPER_TERM_GRACE_SECONDS default 5 (bounded TERM wait before KILL)
+#   OC_TEST_REAPER_DRY_RUN            default 0 (1 = report only, no signals)
+#   OC_TEST_REAPER_QUIET              default 0 (1 = suppress stderr log)
+#   OC_TEST_REAPER_PHASE              label for log lines (default "manual")
+
+set -uo pipefail
+
+MIN_AGE="${OC_TEST_REAPER_MIN_AGE_SECONDS:-7200}"
+TERM_GRACE="${OC_TEST_REAPER_TERM_GRACE_SECONDS:-5}"
+DRY_RUN="${OC_TEST_REAPER_DRY_RUN:-0}"
+QUIET="${OC_TEST_REAPER_QUIET:-0}"
+PHASE="${OC_TEST_REAPER_PHASE:-manual}"
+
+_is_uint() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+# Garbage knob values must never break arithmetic under `set -u`; fall back
+# to the conservative defaults instead.
+_is_uint "$MIN_AGE" || {
+  printf '[oc-test-reaper][%s] WARN invalid OC_TEST_REAPER_MIN_AGE_SECONDS %q; using 7200\n' "$PHASE" "$MIN_AGE" >&2
+  MIN_AGE=7200
+}
+_is_uint "$TERM_GRACE" || {
+  printf '[oc-test-reaper][%s] WARN invalid OC_TEST_REAPER_TERM_GRACE_SECONDS %q; using 5\n' "$PHASE" "$TERM_GRACE" >&2
+  TERM_GRACE=5
+}
+
+log() {
+  [[ "$QUIET" == "1" ]] && return 0
+  printf '[oc-test-reaper][%s] %s\n' "$PHASE" "$*" >&2
+}
+
+REAPER_ARGV=()
+
+# --- platform primitives -----------------------------------------------------
+# Each returns non-zero when the information cannot be established; callers
+# treat that as "skip this candidate" (never act on unknown identity).
+
+_load_argv_linux() {
+  local pid="$1" tok
+  [[ -r "/proc/$pid/cmdline" ]] || return 1
+  REAPER_ARGV=()
+  while IFS= read -r -d '' tok; do
+    REAPER_ARGV+=("$tok")
+  done <"/proc/$pid/cmdline"
+  ((${#REAPER_ARGV[@]} > 0))
+}
+
+_load_argv_macos() {
+  local pid="$1" args
+  args="$(ps -ww -o args= -p "$pid" 2>/dev/null)" || return 1
+  [[ -n "$args" ]] || return 1
+  # Lossy split on whitespace: acceptable for token scanning on the
+  # best-effort macOS path; argv[0] itself is space-free for this binary.
+  REAPER_ARGV=()
+  read -ra REAPER_ARGV <<<"$args"
+  ((${#REAPER_ARGV[@]} > 0))
+}
+
+_ident_token_linux() {
+  local pid="$1" stat rest
+  [[ -r "/proc/$pid/stat" ]] || return 1
+  stat="$(<"/proc/$pid/stat")"
+  rest="${stat##*) }"
+  # rest starts at field 3; starttime is field 22 -> index 19 (0-based).
+  local -a f
+  read -ra f <<<"$rest"
+  [[ -n "${f[19]:-}" ]] || return 1
+  printf '%s\n' "${f[19]}"
+}
+
+_ident_token_macos() {
+  local pid="$1" lstart
+  lstart="$(ps -ww -o lstart= -p "$pid" 2>/dev/null)" || return 1
+  [[ -n "$lstart" ]] || return 1
+  printf '%s\n' "$lstart"
+}
+
+_age_seconds_linux() {
+  local pid="$1" start btime now hz
+  start="$(_ident_token_linux "$pid")" || return 1
+  btime="$(awk '/^btime /{print $2; exit}' /proc/stat 2>/dev/null)"
+  [[ -n "$btime" ]] || return 1
+  hz="$(getconf CLK_TCK 2>/dev/null)"
+  [[ -n "$hz" && "$hz" -gt 0 ]] 2>/dev/null || hz=100
+  now="$(date +%s)"
+  # Sub-second precision: integer-second truncation made age a coin flip at
+  # the threshold boundary (observed flake: fresh peer reaped at age==MIN_AGE).
+  awk -v now="$now" -v btime="$btime" -v start="$start" -v hz="$hz" \
+    'BEGIN{ printf "%.3f", now - btime - (start / hz) }'
+}
+
+# Parse ps(1) `etime` output ([[dd-]hh:]mm:ss) to seconds. Pure function,
+# shared by the macOS path and unit tests. Returns non-zero on any shape it
+# cannot fully validate (callers skip the candidate — safe direction).
+_etime_to_seconds() {
+  local etime="$1" days=0 h=0 m=0 s rest
+  etime="${etime//[[:space:]]/}"
+  case "$etime" in
+    *-*) days="${etime%%-*}"; rest="${etime#*-}" ;;
+    *) rest="$etime" ;;
+  esac
+  case "$rest" in
+    *:*:*) IFS=: read -r h m s <<<"$rest" ;;
+    *:*) IFS=: read -r m s <<<"$rest" ;;
+    *) return 1 ;;
+  esac
+  _is_uint "$days" && _is_uint "$h" && _is_uint "$m" && _is_uint "$s" || return 1
+  # 10# guards against octal interpretation of zero-padded fields (e.g. 09).
+  printf '%s\n' $((10#$days * 86400 + 10#$h * 3600 + 10#$m * 60 + 10#$s))
+}
+
+_age_seconds_macos() {
+  local pid="$1" etime
+  # `etime` ([[dd-]hh:]mm:ss) is a documented macOS ps(1) keyword; the
+  # procps-only `etimes` does not exist there and must not be used.
+  etime="$(ps -ww -o etime= -p "$pid" 2>/dev/null)" || return 1
+  _etime_to_seconds "$etime"
+}
+
+_uid_of_linux() {
+  local pid="$1" uid
+  [[ -r "/proc/$pid/status" ]] || return 1
+  uid="$(awk '/^Uid:/{print $2; exit}' "/proc/$pid/status")"
+  [[ -n "$uid" ]] || return 1
+  printf '%s\n' "$uid"
+}
+
+_uid_of_macos() {
+  local pid="$1" uid
+  uid="$(ps -o uid= -p "$pid" 2>/dev/null | tr -d ' ')" || return 1
+  [[ "$uid" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$uid"
+}
+
+_gone_linux() {
+  local pid="$1" stat rest state
+  [[ ! -e "/proc/$pid/stat" ]] && return 0
+  stat="$(<"/proc/$pid/stat")"
+  rest="${stat##*) }"
+  state="${rest%% *}"
+  [[ "$state" == "Z" ]]
+}
+
+_gone_macos() {
+  local pid="$1" state
+  state="$(ps -o stat= -p "$pid" 2>/dev/null | tr -d ' ')" || return 0
+  [[ -z "$state" || "$state" == Z* ]]
+}
+
+IS_LINUX=0
+if [[ -d /proc && "$(uname -s)" == "Linux" ]]; then
+  IS_LINUX=1
+fi
+
+_load_argv() { if ((IS_LINUX)); then _load_argv_linux "$1"; else _load_argv_macos "$1"; fi; }
+_ident_token() { if ((IS_LINUX)); then _ident_token_linux "$1"; else _ident_token_macos "$1"; fi; }
+_age_seconds() { if ((IS_LINUX)); then _age_seconds_linux "$1"; else _age_seconds_macos "$1"; fi; }
+_uid_of() { if ((IS_LINUX)); then _uid_of_linux "$1"; else _uid_of_macos "$1"; fi; }
+_gone() { if ((IS_LINUX)); then _gone_linux "$1"; else _gone_macos "$1"; fi; }
+
+# --- candidate filters -------------------------------------------------------
+
+matches_identity() {
+  local base="${1##*/}"
+  [[ "$base" == temporal-test-server-sdk-typescript-* ]]
+}
+
+has_excluded_tokens() {
+  local tok
+  for tok in "$@"; do
+    case "$tok" in
+      *start-dev*) return 0 ;;
+      7233 | --port=7233 | *:7233) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+list_candidate_pids() {
+  if (($# > 0)); then
+    printf '%s\n' "$@"
+    return 0
+  fi
+  if ((IS_LINUX)); then
+    local d
+    for d in /proc/[0-9]*; do
+      [[ -d "$d" ]] && printf '%s\n' "${d#/proc/}"
+    done
+  else
+    ps -Ao pid= 2>/dev/null | tr -d ' ' | awk 'NF'
+  fi
+}
+
+# --- reaper core -------------------------------------------------------------
+
+reap_one() {
+  local pid="$1"
+  _load_argv "$pid" || return 0 # identity unreadable -> silent skip (kernel threads, zombies)
+
+  local argv0="${REAPER_ARGV[0]}"
+  matches_identity "$argv0" || return 0 # not our binary -> silent skip
+
+  local uid
+  uid="$(_uid_of "$pid")" || {
+    log "skip pid $pid ($argv0): uid unreadable"
+    return 0
+  }
+  [[ "$uid" == "$EUID" ]] || {
+    log "skip pid $pid ($argv0): uid $uid != $EUID"
+    return 0
+  }
+
+  if has_excluded_tokens "${REAPER_ARGV[@]}"; then
+    log "skip pid $pid ($argv0): excluded token (start-dev/7233 defense-in-depth)"
+    return 0
+  fi
+
+  local age
+  age="$(_age_seconds "$pid")" || {
+    log "skip pid $pid ($argv0): age unreadable"
+    return 0
+  }
+  if awk -v a="$age" -v m="$MIN_AGE" 'BEGIN{ exit !((a + 0) >= (m + 0)) }'; then
+    : # stale enough to consider
+  else
+    log "skip pid $pid ($argv0): age ${age}s < ${MIN_AGE}s minimum (fresh peer run)"
+    return 0
+  fi
+
+  local token
+  token="$(_ident_token "$pid")" || {
+    log "skip pid $pid ($argv0): start-identity unreadable"
+    return 0
+  }
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "DRY-RUN would reap pid $pid ($argv0, age ${age}s): TERM then KILL after ${TERM_GRACE}s"
+    return 0
+  fi
+
+  # Revalidate identity immediately before signaling (PID-reuse guard).
+  local now_token
+  now_token="$(_ident_token "$pid")" || return 0
+  [[ "$now_token" == "$token" ]] || {
+    log "skip pid $pid: identity changed before TERM"
+    return 0
+  }
+
+  log "TERM pid $pid ($argv0, age ${age}s)"
+  kill -TERM "$pid" 2>/dev/null || return 0
+
+  # Bounded wait for exit (0.2s steps; TERM_GRACE is a hard ceiling).
+  local steps=$((TERM_GRACE * 5)) i
+  for ((i = 0; i < steps; i++)); do
+    _gone "$pid" && {
+      log "pid $pid exited after TERM"
+      return 0
+    }
+    sleep 0.2
+  done
+  _gone "$pid" && {
+    log "pid $pid exited after TERM"
+    return 0
+  }
+
+  # Revalidate again before the kill shot.
+  now_token="$(_ident_token "$pid")" || return 0
+  [[ "$now_token" == "$token" ]] || {
+    log "skip KILL pid $pid: identity changed after TERM wait"
+    return 0
+  }
+
+  log "KILL pid $pid ($argv0): TERM ignored for ${TERM_GRACE}s"
+  kill -KILL "$pid" 2>/dev/null || return 0
+  for ((i = 0; i < 15; i++)); do
+    _gone "$pid" && break
+    sleep 0.2
+  done
+  if _gone "$pid"; then
+    log "pid $pid reaped via KILL"
+  else
+    log "WARN pid $pid survived KILL (investigate manually)"
+  fi
+  return 0
+}
+
+main() {
+  log "sweep start (min_age=${MIN_AGE}s term_grace=${TERM_GRACE}s dry_run=${DRY_RUN})"
+  local pid
+  while IFS= read -r pid; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    reap_one "$pid"
+  done < <(list_candidate_pids "$@")
+  log "sweep done"
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/bin/oc-test
+++ b/bin/oc-test
@@ -4,6 +4,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 plugin_dir="$repo_root/plugin"
+reaper_bin="$repo_root/bin/lib/oc-test-reaper.bash"
 
 usage() {
   cat >&2 <<'USAGE'
@@ -13,20 +14,48 @@ Tiers:
   targeted  Run Vitest with optional file/test filters.
   smoke     Run repo checks plus the ADV test-tool/subagent smoke slice.
   full      Run the plugin's full Vitest suite.
+
+Environment:
+  OC_TEST_REAPER_DISABLE=1   Skip the stale temporal-test-server sweep.
+  OC_TEST_REAPER_*           See bin/lib/oc-test-reaper.bash for reaper knobs.
 USAGE
   exit 64
+}
+
+# Conservative stale-only sweep for orphaned temporal-test-server processes
+# (reapLeakedTestServers, AC3). The reaper only acts on processes provably
+# older than OC_TEST_REAPER_MIN_AGE_SECONDS (default 2h), so pre- and
+# post-run sweeps are both safe for concurrent peer runs. A reaper failure
+# must never fail the test run.
+sweep_test_servers() {
+  local phase="$1"
+  [[ "${OC_TEST_REAPER_DISABLE:-0}" == "1" ]] && return 0
+  [[ -r "$reaper_bin" ]] || return 0
+  OC_TEST_REAPER_PHASE="$phase" bash "$reaper_bin" || true
 }
 
 run_with_optional_gate() {
   local tier="$1"
   shift
 
+  sweep_test_servers pre
+
+  local rc=0
   if command -v oc-test-gate >/dev/null 2>&1; then
-    exec oc-test-gate "$tier" -- "$@"
+    set +e
+    oc-test-gate "$tier" -- "$@"
+    rc=$?
+    set -e
+  else
+    printf 'bin/oc-test: oc-test-gate not found; running %s tier directly.\n' "$tier" >&2
+    set +e
+    "$@"
+    rc=$?
+    set -e
   fi
 
-  printf 'bin/oc-test: oc-test-gate not found; running %s tier directly.\n' "$tier" >&2
-  exec "$@"
+  sweep_test_servers post
+  exit "$rc"
 }
 
 tier="${1:-}"

--- a/bin/oc-test-reaper.test.ts
+++ b/bin/oc-test-reaper.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Integration tests for the conservative stale-only temporal test-server
+ * reaper (reapLeakedTestServers, AC3/AC4/AC5).
+ *
+ * Safety model under test:
+ *   - reaps ONLY processes whose argv[0] basename matches the
+ *     `temporal-test-server-sdk-typescript-*` test-server binary
+ *   - requires same UID, conservative minimum age, and PID/start-identity
+ *     revalidation before every signal (TERM → bounded wait → revalidate →
+ *     optional KILL)
+ *   - never touches `temporal server start-dev` / port 7233 shaped processes
+ *   - skips anything whose identity cannot be established
+ *
+ * Tests pass explicit PIDs to the reaper so concurrently running REAL test
+ * servers on this host are never candidates. Dummy servers are copies of the
+ * `sleep` binary renamed to match the test-server basename, or `exec -a`
+ * bash doubles for argv shapes `sleep` cannot express.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync, realpathSync } from "fs";
+import { join } from "path";
+
+const REAPER = join(import.meta.dir, "lib", "oc-test-reaper.bash");
+const OC_TEST = join(import.meta.dir, "oc-test");
+
+const spawnedPids: number[] = [];
+
+afterEach(() => {
+  for (const pid of spawnedPids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+  }
+  spawnedPids.length = 0;
+});
+
+/**
+ * Spawn a long-lived dummy whose argv[0] is a test-server-shaped path
+ * (basename `temporal-test-server-sdk-typescript-9.9.9-<tag>`) and whose
+ * remaining argv carries `tokens`. The fake path never exists on disk —
+ * `exec -a` only controls argv, so there is no file residue.
+ *
+ * Doubles are bash loops: this host's coreutils is a multicall binary that
+ * dispatches on argv[0], so renamed copies of `sleep` refuse to run, while
+ * bash ignores argv[0] and provides a faithful long-lived TERM-able process.
+ */
+function spawnDouble(tag: string, tokens: string[] = [], ignoreTerm = false): number {
+  const fakeArgv0 = `/tmp/temporal-test-server-sdk-typescript-9.9.9-${tag}`;
+  const body = ignoreTerm
+    ? "trap '' TERM; while :; do sleep 1; done"
+    : "while :; do sleep 5; done";
+  const script = `exec -a "$0" bash -c '${body}' -- "$@"`;
+  const proc = Bun.spawn(["bash", "-c", script, fakeArgv0, ...tokens], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  proc.unref();
+  spawnedPids.push(proc.pid);
+  return proc.pid;
+}
+
+interface ReaperRun {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function runReaper(pids: number[], env: Record<string, string> = {}): Promise<ReaperRun> {
+  const proc = Bun.spawn(["bash", REAPER, ...pids.map(String)], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { exitCode, stdout, stderr };
+}
+
+/** Process is gone from the reaper's perspective: no /proc entry or a zombie. */
+function isReaped(pid: number): boolean {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const rest = stat.slice(stat.lastIndexOf(")") + 2);
+    const state = rest.split(" ")[0];
+    return state === "Z";
+  } catch {
+    return true;
+  }
+}
+
+function isAlive(pid: number): boolean {
+  return !isReaped(pid);
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("oc-test temporal test-server reaper", () => {
+  test("reaps a stale orphaned test server (TERM path)", async () => {
+    const pid = spawnDouble("orphan-term");
+    await sleepMs(2000); // age the orphan past the threshold
+
+    const run = await runReaper([pid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "1",
+      OC_TEST_REAPER_TERM_GRACE_SECONDS: "3",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(isReaped(pid)).toBe(true);
+    expect(run.stderr).toContain(`${pid}`);
+  });
+
+  test("skips a fresh peer younger than the minimum age (AC4)", async () => {
+    const pid = spawnDouble("fresh-peer");
+
+    const run = await runReaper([pid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "3600",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(isAlive(pid)).toBe(true);
+  });
+
+  test("skips processes carrying the `server start-dev` token even with a matching basename", async () => {
+    const pid = spawnDouble("start-dev-shape", ["server", "start-dev", "--port", "7234"]);
+    await sleepMs(2000);
+
+    const run = await runReaper([pid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "1",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(isAlive(pid)).toBe(true);
+  });
+
+  test("skips processes bound to port 7233 (defense-in-depth for the real dev server)", async () => {
+    const pid = spawnDouble("port-7233-shape", ["--port", "7233"]);
+    await sleepMs(2000);
+
+    const run = await runReaper([pid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "1",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(isAlive(pid)).toBe(true);
+  });
+
+  test("escalates to KILL after a bounded wait when TERM is ignored", async () => {
+    const pid = spawnDouble("term-ignorer", [], true);
+    await sleepMs(2000);
+
+    const started = Date.now();
+    const run = await runReaper([pid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "1",
+      OC_TEST_REAPER_TERM_GRACE_SECONDS: "1",
+    });
+    const elapsed = Date.now() - started;
+
+    expect(run.exitCode).toBe(0);
+    expect(isReaped(pid)).toBe(true);
+    // Bounded: TERM grace (1s) + revalidation, not an unbounded hang.
+    expect(elapsed).toBeLessThan(15_000);
+  });
+
+  test("dry run reports but does not signal", async () => {
+    const pid = spawnDouble("dry-run");
+    await sleepMs(2000);
+
+    const run = await runReaper([pid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "1",
+      OC_TEST_REAPER_DRY_RUN: "1",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(isAlive(pid)).toBe(true);
+    expect(run.stderr.toLowerCase()).toContain("dry");
+  });
+
+  test("ignores processes that do not match the test-server identity", async () => {
+    // A plain `sleep` — argv[0] basename does not match the test-server pattern.
+    const proc = Bun.spawn([realpathSync(Bun.which("sleep") ?? "/bin/sleep"), "300"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    proc.unref();
+    spawnedPids.push(proc.pid);
+    await sleepMs(2000);
+
+    const run = await runReaper([proc.pid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "1",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(isAlive(proc.pid)).toBe(true);
+  });
+
+  test("skips a candidate whose identity cannot be established (nonexistent PID)", async () => {
+    const run = await runReaper([99999999], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "0",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(run.stderr).not.toContain("TERM pid 99999999");
+    expect(run.stderr).not.toContain("KILL pid 99999999");
+  });
+
+  test("falls back to the default minimum age when the knob is garbage", async () => {
+    // A ~2s-old double must survive: with the 7200s default restored it is a
+    // fresh peer; if the garbage value had been honored it would be reaped.
+    const pid = spawnDouble("garbage-knob");
+    await sleepMs(2000);
+
+    const run = await runReaper([pid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "banana",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(isAlive(pid)).toBe(true);
+    expect(run.stderr).toContain("invalid OC_TEST_REAPER_MIN_AGE_SECONDS");
+  });
+});
+
+describe("reaper etime parser (macOS age path)", () => {
+  async function parseEtime(etime: string): Promise<ReaperRun> {
+    const proc = Bun.spawn(
+      ["bash", "-c", `source "$1" && _etime_to_seconds "$2"`, "_", REAPER, etime],
+      { stdout: "pipe", stderr: "pipe", env: { ...process.env } },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { exitCode, stdout, stderr };
+  }
+
+  test("parses [[dd-]hh:]mm:ss shapes, base-10 safe", async () => {
+    expect((await parseEtime("04:09")).stdout.trim()).toBe(String(4 * 60 + 9));
+    expect((await parseEtime("1:02:03")).stdout.trim()).toBe(String(3600 + 120 + 3));
+    expect((await parseEtime("2-03:04:05")).stdout.trim()).toBe(
+      String(2 * 86400 + 3 * 3600 + 4 * 60 + 5),
+    );
+    expect((await parseEtime(" 00:30 ")).stdout.trim()).toBe("30");
+  });
+
+  test("rejects unparseable shapes", async () => {
+    for (const bad of ["", "abc", "1:2:3:4", "12-", "-", "10:xx"]) {
+      const run = await parseEtime(bad);
+      expect(run.exitCode).not.toBe(0);
+      expect(run.stdout.trim()).toBe("");
+    }
+  });
+});
+
+describe("residue-free proof (AC5)", () => {
+  test("induced orphan is reaped while a fresh peer and dev-server-shaped process stay untouched", async () => {
+    // Induce an orphan: a leaked test-server double nobody will tear down.
+    const orphanPid = spawnDouble("induced-orphan");
+    await sleepMs(3000); // orphan is now provably outside the active run window
+
+    // A fresh peer started by a "concurrent run" just before the sweep.
+    const freshPeerPid = spawnDouble("concurrent-fresh-peer");
+    // A dev-server-shaped process (start-dev token + 7233) that must never die.
+    const devServerPid = spawnDouble("dev-server-shape", [
+      "server",
+      "start-dev",
+      "--port",
+      "7233",
+    ]);
+
+    const run = await runReaper([orphanPid, freshPeerPid, devServerPid], {
+      OC_TEST_REAPER_MIN_AGE_SECONDS: "2",
+      OC_TEST_REAPER_TERM_GRACE_SECONDS: "3",
+    });
+
+    expect(run.exitCode).toBe(0);
+    expect(isReaped(orphanPid)).toBe(true); // stale orphan reaped
+    expect(isAlive(freshPeerPid)).toBe(true); // concurrent peer untouched
+    expect(isAlive(devServerPid)).toBe(true); // dev server untouched
+
+    // No residue: after the test's own cleanup kills the survivors, nothing
+    // matching this test's double tag may remain on the host.
+    for (const pid of [freshPeerPid, devServerPid]) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // already gone
+      }
+    }
+    await sleepMs(200);
+    for (const pid of [orphanPid, freshPeerPid, devServerPid]) {
+      expect(isReaped(pid)).toBe(true);
+    }
+  });
+});
+
+describe("bin/oc-test wiring", () => {
+  async function runOcTest(
+    args: string[],
+    env: Record<string, string> = {},
+  ): Promise<ReaperRun> {
+    const proc = Bun.spawn(["bash", OC_TEST, ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        // Never touch host processes during wiring tests: nothing is older
+        // than this threshold, so every sweep is a no-op scan.
+        OC_TEST_REAPER_MIN_AGE_SECONDS: "99999999",
+        ...env,
+      },
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { exitCode, stdout, stderr };
+  }
+
+  test("propagates a zero exit code and runs pre/post sweeps", async () => {
+    const run = await runOcTest(
+      ["targeted", "--", "--passWithNoTests", "oc-test-reaper-wiring-no-such-file"],
+      {},
+    );
+
+    expect(run.exitCode).toBe(0);
+    const sweepLines = run.stderr.split("\n").filter((l) => l.includes("oc-test-reaper"));
+    expect(sweepLines.length).toBeGreaterThanOrEqual(2); // pre + post
+  }, 120_000);
+
+  test("propagates a non-zero exit code from the tier", async () => {
+    const run = await runOcTest(
+      ["targeted", "--", "oc-test-reaper-wiring-no-such-file"],
+      {},
+    );
+
+    expect(run.exitCode).not.toBe(0);
+  }, 120_000);
+});

--- a/docs/temporal-recovery.md
+++ b/docs/temporal-recovery.md
@@ -797,15 +797,17 @@ Any code that enqueues more than a handful of workflows in a loop must satisfy *
 ### Positive pattern
 
 ```typescript
-import { TestWorkflowEnvironment } from "@temporalio/testing";
-import { withTestWorkflowEnvironment } from "./with-test-env";
+import {
+  createLocalTestWorkflowEnvironment,
+  withTestWorkflowEnvironment,
+} from "./with-test-env";
 
 async function dryRunBulkEnqueue(
   changes: Change[],
   projectId: string,
 ): Promise<void> {
   await withTestWorkflowEnvironment(
-    () => TestWorkflowEnvironment.createLocal(),
+    createLocalTestWorkflowEnvironment,
     async (env) => {
       const queue = `advance-${projectId}`;
       for (const change of changes) {

--- a/plugin/scripts/check-test-isolation.test.ts
+++ b/plugin/scripts/check-test-isolation.test.ts
@@ -2,7 +2,11 @@ import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import { mkdtemp, writeFile, rm, mkdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { runLint } from "./check-test-isolation";
+import {
+  isTemporalEnvAllowlisted,
+  runLint,
+  runTemporalEnvLint,
+} from "./check-test-isolation";
 
 describe("check-test-isolation lint script", () => {
   let tempDir: string;
@@ -112,5 +116,171 @@ test("checks banner", () => {
 
     const violations = await runLint(join(tempDir, "string-case"));
     expect(violations).toEqual([]);
+  });
+});
+
+describe("temporal test-env constructor guard (reapLeakedTestServers AC1/DONT1)", () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "adv-temporal-env-lint-"));
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("flags raw TestWorkflowEnvironment.createTimeSkipping in a .test.ts", async () => {
+    const srcDir = join(tempDir, "raw-skipping", "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      join(srcDir, "uses-raw.test.ts"),
+      `
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+
+test("uses raw constructor", async () => {
+  const env = await TestWorkflowEnvironment.createTimeSkipping();
+});
+`,
+    );
+
+    const violations = await runTemporalEnvLint(join(tempDir, "raw-skipping"));
+    expect(violations).toContain("uses-raw.test.ts");
+    expect(violations.length).toBe(1);
+  });
+
+  test("flags raw TestWorkflowEnvironment.createLocal in an .itest.ts", async () => {
+    const srcDir = join(tempDir, "raw-local", "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      join(srcDir, "uses-raw-local.itest.ts"),
+      `
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+
+test("uses raw local constructor", async () => {
+  const env = await TestWorkflowEnvironment.createLocal();
+});
+`,
+    );
+
+    const violations = await runTemporalEnvLint(join(tempDir, "raw-local"));
+    expect(violations).toContain("uses-raw-local.itest.ts");
+    expect(violations.length).toBe(1);
+  });
+
+  test("flags a bare constructor reference passed as a callback (no call parens)", async () => {
+    const srcDir = join(tempDir, "bare-ref", "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      join(srcDir, "bare-ref.test.ts"),
+      `
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+
+test("passes constructor by reference", async () => {
+  await withTestWorkflowEnvironment(TestWorkflowEnvironment.createTimeSkipping, fn);
+});
+`,
+    );
+
+    const violations = await runTemporalEnvLint(join(tempDir, "bare-ref"));
+    expect(violations).toContain("bare-ref.test.ts");
+  });
+
+  test("passes when construction routes through the helper wrappers", async () => {
+    const srcDir = join(tempDir, "helper-routed", "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      join(srcDir, "helper-routed.test.ts"),
+      `
+import {
+  createTimeSkippingTestWorkflowEnvironment,
+  withTimeSkippingTestWorkflowEnvironment,
+} from "./with-test-env";
+
+test("routes through helper", async () => {
+  await withTimeSkippingTestWorkflowEnvironment(async (env) => env);
+  const env = await createTimeSkippingTestWorkflowEnvironment();
+  await env.teardown();
+});
+`,
+    );
+
+    const violations = await runTemporalEnvLint(join(tempDir, "helper-routed"));
+    expect(violations).toEqual([]);
+  });
+
+  test("passes for the allow-listed helper module that owns the raw constructors", async () => {
+    const srcDir = join(
+      tempDir,
+      "helper-module",
+      "src",
+      "temporal",
+      "__tests__",
+    );
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      join(srcDir, "with-test-env.ts"),
+      `
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+
+export function createTimeSkippingTestWorkflowEnvironment() {
+  return createTestWorkflowEnvironment(() =>
+    TestWorkflowEnvironment.createTimeSkipping(),
+  );
+}
+`,
+    );
+
+    const violations = await runTemporalEnvLint(join(tempDir, "helper-module"));
+    expect(violations).toEqual([]);
+  });
+
+  test("ignores occurrences inside comments and string literals", async () => {
+    const srcDir = join(tempDir, "comment-only", "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      join(srcDir, "comment-only.test.ts"),
+      `
+// TestWorkflowEnvironment.createTimeSkipping() must stay in the helper.
+const doc = "use TestWorkflowEnvironment.createLocal via the wrapper";
+/* Also: TestWorkflowEnvironment.createTimeSkipping */
+
+test("documents the rule", () => {
+  expect(doc).toContain("wrapper");
+});
+`,
+    );
+
+    const violations = await runTemporalEnvLint(join(tempDir, "comment-only"));
+    expect(violations).toEqual([]);
+  });
+
+  test("allow-list matches the helper path with POSIX separators", () => {
+    expect(
+      isTemporalEnvAllowlisted("temporal/__tests__/with-test-env.ts"),
+    ).toBe(true);
+  });
+
+  test("allow-list matches the helper path with Windows separators", () => {
+    expect(
+      isTemporalEnvAllowlisted("temporal\\__tests__\\with-test-env.ts"),
+    ).toBe(true);
+  });
+
+  test("allow-list is exact: look-alike paths are not allow-listed", () => {
+    expect(
+      isTemporalEnvAllowlisted("temporal/__tests__/with-test-env.evil.ts"),
+    ).toBe(false);
+    expect(
+      isTemporalEnvAllowlisted("nested/temporal/__tests__/with-test-env.ts"),
+    ).toBe(false);
+    expect(isTemporalEnvAllowlisted("temporal/__tests__/other.ts")).toBe(false);
+    expect(isTemporalEnvAllowlisted("with-test-env.ts")).toBe(false);
+  });
+
+  test("fails clearly when the source directory does not exist", async () => {
+    await expect(
+      runTemporalEnvLint(join(tempDir, "missing-src-dir")),
+    ).rejects.toThrow(/Source directory not found/);
   });
 });

--- a/plugin/scripts/check-test-isolation.ts
+++ b/plugin/scripts/check-test-isolation.ts
@@ -7,9 +7,16 @@
 import { readdir, readFile } from "fs/promises";
 import { join, relative } from "path";
 
-export const ALLOWLIST = [
-  /-assets\.test\.ts$/,
-  /target-project\.test\.ts$/,
+export const ALLOWLIST = [/-assets\.test\.ts$/, /target-project\.test\.ts$/];
+
+/**
+ * Files permitted to call raw `TestWorkflowEnvironment.createLocal` /
+ * `createTimeSkipping`. Construction of Temporal test servers is owned by the
+ * shared harness (reapLeakedTestServers AC1); everywhere else must route
+ * through the named wrappers in `src/temporal/__tests__/with-test-env.ts`.
+ */
+export const TEMPORAL_ENV_ALLOWLIST = [
+  /^temporal\/__tests__\/with-test-env\.ts$/,
 ];
 
 export function isAllowlisted(filePath: string): boolean {
@@ -63,6 +70,18 @@ export async function* walkTestFiles(dir: string): AsyncGenerator<string> {
   }
 }
 
+export async function* walkSourceFiles(dir: string): AsyncGenerator<string> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkSourceFiles(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      yield fullPath;
+    }
+  }
+}
+
 export async function runLint(targetDir: string): Promise<string[]> {
   const srcDir = join(targetDir, "src");
   const violations: string[] = [];
@@ -81,9 +100,71 @@ export async function runLint(targetDir: string): Promise<string[]> {
         violations.push(relPath);
       }
     }
-  } catch (err: any) {
-    if (err.code === "ENOENT") {
-      throw new Error(`Source directory not found: ${srcDir}`);
+  } catch (err) {
+    if (isErrnoException(err, "ENOENT")) {
+      throw new Error(`Source directory not found: ${srcDir}`, {
+        cause: err,
+      });
+    }
+    throw err;
+  }
+
+  return violations;
+}
+
+/**
+ * Detect raw `TestWorkflowEnvironment.createLocal` / `createTimeSkipping`
+ * outside the allow-listed helper module. Server-spawning constructors must
+ * stay inside `src/temporal/__tests__/with-test-env.ts` so every
+ * `temporal-test-server-sdk-*` process has an auditable, finally-guaranteed
+ * teardown path (reapLeakedTestServers AC1, DONT1).
+ */
+export function hasRawTemporalEnvConstruction(source: string): boolean {
+  const cleaned = stripCommentsAndStrings(source);
+  return /\bTestWorkflowEnvironment\s*\.\s*create(?:Local|TimeSkipping)\b/.test(
+    cleaned,
+  );
+}
+
+export function isTemporalEnvAllowlisted(relPath: string): boolean {
+  // path.relative() yields platform separators ("\" on Windows); normalize so
+  // the exact allow-list pattern matches identically on every OS.
+  const normalized = relPath.replace(/\\/g, "/");
+  return TEMPORAL_ENV_ALLOWLIST.some((pattern) => pattern.test(normalized));
+}
+
+function isErrnoException(err: unknown, code: string): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === code
+  );
+}
+
+export async function runTemporalEnvLint(targetDir: string): Promise<string[]> {
+  const srcDir = join(targetDir, "src");
+  const violations: string[] = [];
+
+  try {
+    for await (const filePath of walkSourceFiles(srcDir)) {
+      const relPath = relative(srcDir, filePath);
+
+      if (isTemporalEnvAllowlisted(relPath)) {
+        continue;
+      }
+
+      const source = await readFile(filePath, "utf-8");
+
+      if (hasRawTemporalEnvConstruction(source)) {
+        violations.push(relPath);
+      }
+    }
+  } catch (err) {
+    if (isErrnoException(err, "ENOENT")) {
+      throw new Error(`Source directory not found: ${srcDir}`, {
+        cause: err,
+      });
     }
     throw err;
   }
@@ -94,10 +175,16 @@ export async function runLint(targetDir: string): Promise<string[]> {
 async function main() {
   const targetDir = process.argv[2] || process.cwd();
   const violations = await runLint(targetDir);
+  const temporalEnvViolations = await runTemporalEnvLint(targetDir);
 
-  if (violations.length > 0) {
+  if (violations.length > 0 || temporalEnvViolations.length > 0) {
     for (const v of violations) {
       console.log(v);
+    }
+    for (const v of temporalEnvViolations) {
+      console.log(
+        `${v}: raw TestWorkflowEnvironment.createLocal/createTimeSkipping is forbidden outside src/temporal/__tests__/with-test-env.ts; use the helper-owned wrappers`,
+      );
     }
     process.exit(1);
   }

--- a/plugin/src/__tests__/e2e-tool-calls.itest.ts
+++ b/plugin/src/__tests__/e2e-tool-calls.itest.ts
@@ -21,7 +21,6 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 
 import { createInProcessWorker } from "../temporal/in-process-worker";
 import { createTemporalStoreBackend } from "../storage/store-temporal";
@@ -29,107 +28,104 @@ import { createDiskStore as createLegacyStore } from "../storage/store-disk";
 import { changeTools } from "../tools/change";
 import { initStsl, closeStsl, resetStsl } from "../temporal/service";
 import { createTempDir, cleanupTempDir, parseToolOutput } from "./setup";
-import { withTestWorkflowEnvironment } from "../temporal/__tests__/with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "../temporal/__tests__/with-test-env";
 
 describe("P1.9 — E2E tool calls (real Temporal stack)", () => {
   it("adv_change_create → adv_change_show → adv_change_list end-to-end", async () => {
     const tempDir = await createTempDir("p1-9-e2e-");
     try {
-      await withTestWorkflowEnvironment(
-        () => TestWorkflowEnvironment.createTimeSkipping(),
-        async (env) => {
-          // Build a real Temporal client + worker using the env's
-          // shared connections. Worker uses workflowsPath; client uses
-          // the env's namespaceless default.
-          const namespace = "default";
-          const projectId = "e2e-proj";
-          const taskQueue = `advance-${projectId}`;
+      await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+        // Build a real Temporal client + worker using the env's
+        // shared connections. Worker uses workflowsPath; client uses
+        // the env's namespaceless default.
+        const namespace = "default";
+        const projectId = "e2e-proj";
+        const taskQueue = `advance-${projectId}`;
 
-          const worker = await createInProcessWorker({
-            address: env.address ?? "127.0.0.1:7233",
-            namespace,
-            queues: [taskQueue],
-            connection: env.nativeConnection,
+        const worker = await createInProcessWorker({
+          address: env.address ?? "127.0.0.1:7233",
+          namespace,
+          queues: [taskQueue],
+          connection: env.nativeConnection,
+        });
+
+        try {
+          // Initialize STSL against the test server. This registers
+          // ADV's custom search attributes (AdvAffectedProjects, etc.)
+          // which the workflow seed uses on start. Without this,
+          // workflow.start fails with "search attribute is not
+          // defined" on the test server (no shared state with prod).
+          resetStsl(); // clear any prior test's cached bundle
+          const bundle = await initStsl({
+            ADV_TEMPORAL_ADDRESS: env.address ?? "127.0.0.1:7233",
+            ADV_TEMPORAL_NAMESPACE: namespace,
+            ADV_TEMPORAL_ALLOW_REMOTE: "true",
           });
 
-          try {
-            // Initialize STSL against the test server. This registers
-            // ADV's custom search attributes (AdvAffectedProjects, etc.)
-            // which the workflow seed uses on start. Without this,
-            // workflow.start fails with "search attribute is not
-            // defined" on the test server (no shared state with prod).
-            resetStsl(); // clear any prior test's cached bundle
-            const bundle = await initStsl({
-              ADV_TEMPORAL_ADDRESS: env.address ?? "127.0.0.1:7233",
-              ADV_TEMPORAL_NAMESPACE: namespace,
-              ADV_TEMPORAL_ALLOW_REMOTE: "true",
-            });
+          // Build the Temporal-backed store directly (skips
+          // plugin-init's worker bootstrap, which we already exercise
+          // via createInProcessWorker above).
+          const legacy = await createLegacyStore(tempDir);
+          const store = createTemporalStoreBackend({
+            legacy,
+            // bundle.client is the real @temporalio/client Client, which
+            // satisfies TemporalHandleClient at runtime but the structural
+            // signatures don't unify (Client.workflow.start has stricter
+            // overloads). Cast through unknown — the e2e test exercises
+            // the real wire shape.
+            temporal: { client: bundle.client as unknown as never },
+            projectId,
+          });
+          await store.init();
 
-            // Build the Temporal-backed store directly (skips
-            // plugin-init's worker bootstrap, which we already exercise
-            // via createInProcessWorker above).
-            const legacy = await createLegacyStore(tempDir);
-            const store = createTemporalStoreBackend({
-              legacy,
-              // bundle.client is the real @temporalio/client Client, which
-              // satisfies TemporalHandleClient at runtime but the structural
-              // signatures don't unify (Client.workflow.start has stricter
-              // overloads). Cast through unknown — the e2e test exercises
-              // the real wire shape.
-              temporal: { client: bundle.client as unknown as never },
-              projectId,
-            });
-            await store.init();
+          // 1. adv_change_create — exercises legacy disk write +
+          //    ensureChangeWorkflowStarted + Temporal workflow start.
+          const createResult = await changeTools.adv_change_create.execute(
+            {
+              summary: "E2E test change",
+              proposal: "# E2E proposal",
+              problemStatement: "Test problem statement",
+            },
+            store,
+          );
+          const created = parseToolOutput<{
+            changeId: string;
+            proposalPath?: string;
+          }>(createResult);
+          expect(created.changeId).toBeTruthy();
+          expect(created.changeId).toMatch(/e2eTestChange|e2etestchange/i);
 
-            // 1. adv_change_create — exercises legacy disk write +
-            //    ensureChangeWorkflowStarted + Temporal workflow start.
-            const createResult = await changeTools.adv_change_create.execute(
-              {
-                summary: "E2E test change",
-                proposal: "# E2E proposal",
-                problemStatement: "Test problem statement",
-              },
-              store,
-            );
-            const created = parseToolOutput<{
-              changeId: string;
-              proposalPath?: string;
-            }>(createResult);
-            expect(created.changeId).toBeTruthy();
-            expect(created.changeId).toMatch(/e2eTestChange|e2etestchange/i);
+          // 2. adv_change_show — exercises Temporal query path.
+          const showResult = await changeTools.adv_change_show.execute(
+            { changeId: created.changeId },
+            store,
+          );
+          const shown = parseToolOutput<{
+            id: string;
+            title: string;
+            status: string;
+          }>(showResult);
+          expect(shown.id).toBe(created.changeId);
+          expect(shown.title).toBe("E2E test change");
+          expect(shown.status).toBe("draft");
 
-            // 2. adv_change_show — exercises Temporal query path.
-            const showResult = await changeTools.adv_change_show.execute(
-              { changeId: created.changeId },
-              store,
-            );
-            const shown = parseToolOutput<{
-              id: string;
-              title: string;
-              status: string;
-            }>(showResult);
-            expect(shown.id).toBe(created.changeId);
-            expect(shown.title).toBe("E2E test change");
-            expect(shown.status).toBe("draft");
-
-            // 3. adv_change_list — exercises Visibility API path.
-            const listResult = await changeTools.adv_change_list.execute(
-              {},
-              store,
-            );
-            const listed = parseToolOutput<{
-              changes: Array<{ id: string; title: string }>;
-            }>(listResult);
-            expect(listed.changes.length).toBeGreaterThanOrEqual(1);
-            expect(listed.changes.some((c) => c.id === created.changeId)).toBe(
-              true,
-            );
-          } finally {
-            await worker.shutdown();
-            await closeStsl();
-          }
-        },
-      );
+          // 3. adv_change_list — exercises Visibility API path.
+          const listResult = await changeTools.adv_change_list.execute(
+            {},
+            store,
+          );
+          const listed = parseToolOutput<{
+            changes: Array<{ id: string; title: string }>;
+          }>(listResult);
+          expect(listed.changes.length).toBeGreaterThanOrEqual(1);
+          expect(listed.changes.some((c) => c.id === created.changeId)).toBe(
+            true,
+          );
+        } finally {
+          await worker.shutdown();
+          await closeStsl();
+        }
+      });
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/plugin/src/storage/store-temporal/__tests__/signal-integration.test.ts
+++ b/plugin/src/storage/store-temporal/__tests__/signal-integration.test.ts
@@ -11,10 +11,9 @@
  */
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { WorkflowHandle } from "@temporalio/client";
-import { withTestWorkflowEnvironment } from "../../../temporal/__tests__/with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "../../../temporal/__tests__/with-test-env";
 import {
   taskAddedSignal,
   taskUpdatedSignal,
@@ -67,370 +66,340 @@ async function waitForProposalStatus(
 
 describe("changeWorkflow signal mutations (R1.0)", () => {
   it("gateCompletedSignal marks gate as done", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-gate-complete",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("gate-complete-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-gate-complete-${Date.now()}`,
           taskQueue: "sig-test-gate-complete",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("gate-complete-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-gate-complete-${Date.now()}`,
-            taskQueue: "sig-test-gate-complete",
-            args: [input],
-          });
-          await handle.signal(gateCompletedSignal, {
-            gateId: "proposal",
-            approvalEvidence: "test",
-            completedBy: "tester",
-            completedAt: new Date().toISOString(),
-            compatibilityReason:
-              "legacy signal integration fixture has no artifact store",
-          });
-          const state = await waitForProposalStatus(handle, "done");
-          expect(state.gates.proposal.status).toBe("done");
+        await handle.signal(gateCompletedSignal, {
+          gateId: "proposal",
+          approvalEvidence: "test",
+          completedBy: "tester",
+          completedAt: new Date().toISOString(),
+          compatibilityReason:
+            "legacy signal integration fixture has no artifact store",
         });
-      },
-    );
+        const state = await waitForProposalStatus(handle, "done");
+        expect(state.gates.proposal.status).toBe("done");
+      });
+    });
   }, 30_000);
 
   it("gateReenteredSignal reopens a gate", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-gate-reopen",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("gate-reopen-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-gate-reopen-${Date.now()}`,
           taskQueue: "sig-test-gate-reopen",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("gate-reopen-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-gate-reopen-${Date.now()}`,
-            taskQueue: "sig-test-gate-reopen",
-            args: [input],
-          });
-          // First complete the gate
-          await handle.signal(gateCompletedSignal, {
-            gateId: "proposal",
-            approvalEvidence: "test",
-            completedBy: "tester",
-            completedAt: new Date().toISOString(),
-            compatibilityReason:
-              "legacy signal integration fixture has no artifact store",
-          });
-          await waitForProposalStatus(handle, "done");
-          // Then reopen it
-          await handle.signal(gateReenteredSignal, {
-            fromGateId: "proposal",
-            reason: "reopen test",
-            reenteredBy: "tester",
-            reenteredAt: new Date().toISOString(),
-          });
-          const state = await waitForProposalStatus(handle, "pending");
-          expect(state.gates.proposal.status).toBe("pending");
+        // First complete the gate
+        await handle.signal(gateCompletedSignal, {
+          gateId: "proposal",
+          approvalEvidence: "test",
+          completedBy: "tester",
+          completedAt: new Date().toISOString(),
+          compatibilityReason:
+            "legacy signal integration fixture has no artifact store",
         });
-      },
-    );
+        await waitForProposalStatus(handle, "done");
+        // Then reopen it
+        await handle.signal(gateReenteredSignal, {
+          fromGateId: "proposal",
+          reason: "reopen test",
+          reenteredBy: "tester",
+          reenteredAt: new Date().toISOString(),
+        });
+        const state = await waitForProposalStatus(handle, "pending");
+        expect(state.gates.proposal.status).toBe("pending");
+      });
+    });
   }, 30_000);
 
   it("taskAddedSignal adds a task", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-task-add",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("task-add-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-task-add-${Date.now()}`,
           taskQueue: "sig-test-task-add",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("task-add-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-task-add-${Date.now()}`,
-            taskQueue: "sig-test-task-add",
-            args: [input],
-          });
-          const now = new Date().toISOString();
-          await handle.signal(taskAddedSignal, {
-            task: {
-              id: "tk-test-001",
-              title: "Test task",
-              type: "code",
-              status: "pending",
-              priority: 0,
-              created_at: now,
-              deps: [],
-            },
-            addedAt: now,
-          });
-          const state = await handle.query(changeStateQuery);
-          expect(state.tasks).toHaveLength(1);
-          expect(state.tasks[0].id).toBe("tk-test-001");
+        const now = new Date().toISOString();
+        await handle.signal(taskAddedSignal, {
+          task: {
+            id: "tk-test-001",
+            title: "Test task",
+            type: "code",
+            status: "pending",
+            priority: 0,
+            created_at: now,
+            deps: [],
+          },
+          addedAt: now,
         });
-      },
-    );
+        const state = await handle.query(changeStateQuery);
+        expect(state.tasks).toHaveLength(1);
+        expect(state.tasks[0].id).toBe("tk-test-001");
+      });
+    });
   }, 30_000);
 
   it("taskUpdatedSignal updates a task", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-task-update",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("task-update-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-task-update-${Date.now()}`,
           taskQueue: "sig-test-task-update",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("task-update-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-task-update-${Date.now()}`,
-            taskQueue: "sig-test-task-update",
-            args: [input],
-          });
-          const now = new Date().toISOString();
-          // Add task first
-          await handle.signal(taskAddedSignal, {
-            task: {
-              id: "tk-test-002",
-              title: "Test task",
-              type: "code",
-              status: "pending",
-              priority: 0,
-              created_at: now,
-              deps: [],
-            },
-            addedAt: now,
-          });
-          // Update it
-          await handle.signal(taskUpdatedSignal, {
-            taskId: "tk-test-002",
-            partial: { status: "done" },
-            updatedAt: now,
-          });
-          const state = await handle.query(changeStateQuery);
-          expect(state.tasks[0].status).toBe("done");
+        const now = new Date().toISOString();
+        // Add task first
+        await handle.signal(taskAddedSignal, {
+          task: {
+            id: "tk-test-002",
+            title: "Test task",
+            type: "code",
+            status: "pending",
+            priority: 0,
+            created_at: now,
+            deps: [],
+          },
+          addedAt: now,
         });
-      },
-    );
+        // Update it
+        await handle.signal(taskUpdatedSignal, {
+          taskId: "tk-test-002",
+          partial: { status: "done" },
+          updatedAt: now,
+        });
+        const state = await handle.query(changeStateQuery);
+        expect(state.tasks[0].status).toBe("done");
+      });
+    });
   }, 30_000);
 
   it("taskCancelledSignal cancels a task", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-task-cancel",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("task-cancel-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-task-cancel-${Date.now()}`,
           taskQueue: "sig-test-task-cancel",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("task-cancel-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-task-cancel-${Date.now()}`,
-            taskQueue: "sig-test-task-cancel",
-            args: [input],
-          });
-          const now = new Date().toISOString();
-          await handle.signal(taskAddedSignal, {
-            task: {
-              id: "tk-test-003",
-              title: "Test task",
-              type: "code",
-              status: "pending",
-              priority: 0,
-              created_at: now,
-              deps: [],
-            },
-            addedAt: now,
-          });
-          await handle.signal(taskCancelledSignal, {
-            taskId: "tk-test-003",
-            approvalEvidence: "test-cancel",
-            reason: "no longer needed",
-            cancelledAt: now,
-          });
-          const state = await handle.query(changeStateQuery);
-          expect(state.tasks[0].status).toBe("cancelled");
+        const now = new Date().toISOString();
+        await handle.signal(taskAddedSignal, {
+          task: {
+            id: "tk-test-003",
+            title: "Test task",
+            type: "code",
+            status: "pending",
+            priority: 0,
+            created_at: now,
+            deps: [],
+          },
+          addedAt: now,
         });
-      },
-    );
+        await handle.signal(taskCancelledSignal, {
+          taskId: "tk-test-003",
+          approvalEvidence: "test-cancel",
+          reason: "no longer needed",
+          cancelledAt: now,
+        });
+        const state = await handle.query(changeStateQuery);
+        expect(state.tasks[0].status).toBe("cancelled");
+      });
+    });
   }, 30_000);
 
   it("taskUpdatedSignal carries reclassify (reclassifyTdd proxy)", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-task-reclassify",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("task-reclassify-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-task-reclassify-${Date.now()}`,
           taskQueue: "sig-test-task-reclassify",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("task-reclassify-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-task-reclassify-${Date.now()}`,
-            taskQueue: "sig-test-task-reclassify",
-            args: [input],
-          });
-          const now = new Date().toISOString();
-          await handle.signal(taskAddedSignal, {
-            task: {
-              id: "tk-test-004",
-              title: "Test task",
-              type: "code",
-              status: "pending",
-              priority: 0,
-              created_at: now,
-              deps: [],
-            },
-            addedAt: now,
-          });
-          await handle.signal(taskUpdatedSignal, {
-            taskId: "tk-test-004",
-            partial: {
-              metadata: { tdd_intent: "separate_verification" },
-            },
-            updatedAt: now,
-          });
-          const state = await handle.query(changeStateQuery);
-          expect(state.tasks[0].metadata?.tdd_intent).toBe(
-            "separate_verification",
-          );
+        const now = new Date().toISOString();
+        await handle.signal(taskAddedSignal, {
+          task: {
+            id: "tk-test-004",
+            title: "Test task",
+            type: "code",
+            status: "pending",
+            priority: 0,
+            created_at: now,
+            deps: [],
+          },
+          addedAt: now,
         });
-      },
-    );
+        await handle.signal(taskUpdatedSignal, {
+          taskId: "tk-test-004",
+          partial: {
+            metadata: { tdd_intent: "separate_verification" },
+          },
+          updatedAt: now,
+        });
+        const state = await handle.query(changeStateQuery);
+        expect(state.tasks[0].metadata?.tdd_intent).toBe(
+          "separate_verification",
+        );
+      });
+    });
   }, 30_000);
 
   it("wisdomAddedSignal adds wisdom", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-wisdom-add",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("wisdom-add-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-wisdom-add-${Date.now()}`,
           taskQueue: "sig-test-wisdom-add",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("wisdom-add-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-wisdom-add-${Date.now()}`,
-            taskQueue: "sig-test-wisdom-add",
-            args: [input],
-          });
-          const now = new Date().toISOString();
-          await handle.signal(wisdomAddedSignal, {
-            entry: {
-              id: "ws-test-001",
-              type: "pattern",
-              content: "Test wisdom",
-              source_task: "tk-test-001",
-              recorded_at: now,
-            },
-            addedAt: now,
-          });
-          const state = await handle.query(changeStateQuery);
-          expect(state.wisdom).toHaveLength(1);
-          expect(state.wisdom[0].content).toBe("Test wisdom");
+        const now = new Date().toISOString();
+        await handle.signal(wisdomAddedSignal, {
+          entry: {
+            id: "ws-test-001",
+            type: "pattern",
+            content: "Test wisdom",
+            source_task: "tk-test-001",
+            recorded_at: now,
+          },
+          addedAt: now,
         });
-      },
-    );
+        const state = await handle.query(changeStateQuery);
+        expect(state.wisdom).toHaveLength(1);
+        expect(state.wisdom[0].content).toBe("Test wisdom");
+      });
+    });
   }, 30_000);
 
   // Tests 8-10 require NEW signals that do not exist on trunk.
   // They are expected to fail until R1.1.3 adds the handlers.
 
   it("archiveChangeSignal archives the change (NEW signal)", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-archive",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("archive-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-archive-${Date.now()}`,
           taskQueue: "sig-test-archive",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("archive-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-archive-${Date.now()}`,
-            taskQueue: "sig-test-archive",
-            args: [input],
-          });
-          // NEW signal — does not exist on trunk
-          const { archiveChangeSignal } =
-            await import("../../../temporal/messages");
-          await handle.signal(archiveChangeSignal);
-          const state = await handle.query(changeStateQuery);
-          expect(state.status).toBe("archived");
-        });
-      },
-    );
+        // NEW signal — does not exist on trunk
+        const { archiveChangeSignal } =
+          await import("../../../temporal/messages");
+        await handle.signal(archiveChangeSignal);
+        const state = await handle.query(changeStateQuery);
+        expect(state.status).toBe("archived");
+      });
+    });
   }, 30_000);
 
   it("closeChangeSignal closes the change (NEW signal)", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-close",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("close-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-close-${Date.now()}`,
           taskQueue: "sig-test-close",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("close-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-close-${Date.now()}`,
-            taskQueue: "sig-test-close",
-            args: [input],
-          });
-          // NEW signal — does not exist on trunk
-          const { closeChangeSignal } =
-            await import("../../../temporal/messages");
-          await handle.signal(closeChangeSignal, {
-            reason: "cancelled",
-            approved_by_user: true,
-            approval_evidence: "test",
-            approved_at: new Date().toISOString(),
-          });
-          const state = await handle.query(changeStateQuery);
-          expect(state.status).toBe("closed");
+        // NEW signal — does not exist on trunk
+        const { closeChangeSignal } =
+          await import("../../../temporal/messages");
+        await handle.signal(closeChangeSignal, {
+          reason: "cancelled",
+          approved_by_user: true,
+          approval_evidence: "test",
+          approved_at: new Date().toISOString(),
         });
-      },
-    );
+        const state = await handle.query(changeStateQuery);
+        expect(state.status).toBe("closed");
+      });
+    });
   }, 30_000);
 
   it("updateArtifactMetadataSignal updates artifact metadata (NEW signal)", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "sig-test-artifact",
+      });
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("artifact-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `sig-artifact-${Date.now()}`,
           taskQueue: "sig-test-artifact",
+          args: [input],
         });
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("artifact-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `sig-artifact-${Date.now()}`,
-            taskQueue: "sig-test-artifact",
-            args: [input],
-          });
-          // NEW signal — does not exist on trunk
-          const { updateArtifactMetadataSignal } =
-            await import("../../../temporal/messages");
-          await handle.signal(updateArtifactMetadataSignal, {
-            kind: "proposal",
-            metadata: {
-              path: "/tmp/proposal.md",
-              updatedAt: new Date().toISOString(),
-            },
-          });
-          const state = await handle.query(changeStateQuery);
-          expect(state.artifacts.proposal?.path).toBe("/tmp/proposal.md");
+        // NEW signal — does not exist on trunk
+        const { updateArtifactMetadataSignal } =
+          await import("../../../temporal/messages");
+        await handle.signal(updateArtifactMetadataSignal, {
+          kind: "proposal",
+          metadata: {
+            path: "/tmp/proposal.md",
+            updatedAt: new Date().toISOString(),
+          },
         });
-      },
-    );
+        const state = await handle.query(changeStateQuery);
+        expect(state.artifacts.proposal?.path).toBe("/tmp/proposal.md");
+      });
+    });
   }, 30_000);
 });

--- a/plugin/src/temporal/__tests__/archive-phase9-splitbrain.itest.ts
+++ b/plugin/src/temporal/__tests__/archive-phase9-splitbrain.itest.ts
@@ -29,7 +29,6 @@ import { execFileSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import type { WorkflowHandle } from "@temporalio/client";
 
 import { createDefaultGates } from "../../types";
@@ -48,7 +47,7 @@ import {
   cleanupTempDir,
   parseToolOutput,
 } from "../../__tests__/setup";
-import { withTestWorkflowEnvironment } from "./with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./with-test-env";
 
 const CHANGE_ID = "splitbrainPhase9Recovery";
 
@@ -195,84 +194,81 @@ describe("AC3 — phase9 split-brain recovery via archive re-run (live Temporal)
       await mkdir(bundleDir, { recursive: true });
       await writeFile(join(bundleDir, "change.json"), "{}\n");
 
-      await withTestWorkflowEnvironment(
-        () => TestWorkflowEnvironment.createTimeSkipping(),
-        async (env) => {
-          const namespace = "default";
-          const taskQueue = buildProjectTaskQueue(projectId!);
+      await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+        const namespace = "default";
+        const taskQueue = buildProjectTaskQueue(projectId!);
 
-          const worker = await createInProcessWorker({
-            address: env.address ?? "127.0.0.1:7233",
-            namespace,
-            queues: [taskQueue],
-            connection: env.nativeConnection,
+        const worker = await createInProcessWorker({
+          address: env.address ?? "127.0.0.1:7233",
+          namespace,
+          queues: [taskQueue],
+          connection: env.nativeConnection,
+        });
+
+        try {
+          // Real STSL so getService() inside recordPhase9Status resolves and
+          // the phase9 signal routes through a live Temporal client.
+          resetStsl();
+          const bundle = await initStsl({
+            ADV_TEMPORAL_ADDRESS: env.address ?? "127.0.0.1:7233",
+            ADV_TEMPORAL_NAMESPACE: namespace,
+            ADV_TEMPORAL_ALLOW_REMOTE: "true",
           });
 
-          try {
-            // Real STSL so getService() inside recordPhase9Status resolves and
-            // the phase9 signal routes through a live Temporal client.
-            resetStsl();
-            const bundle = await initStsl({
-              ADV_TEMPORAL_ADDRESS: env.address ?? "127.0.0.1:7233",
-              ADV_TEMPORAL_NAMESPACE: namespace,
-              ADV_TEMPORAL_ALLOW_REMOTE: "true",
-            });
+          const store = createTemporalStoreBackend({
+            legacy,
+            temporal: { client: bundle.client as unknown as never },
+            projectId: projectId!,
+          });
+          await store.init();
 
-            const store = createTemporalStoreBackend({
-              legacy,
-              temporal: { client: bundle.client as unknown as never },
-              projectId: projectId!,
-            });
-            await store.init();
+          // Live change workflow the re-run will signal.
+          const handle = (await env.client.workflow.start("changeWorkflow", {
+            workflowId: buildChangeWorkflowId(projectId!, CHANGE_ID),
+            taskQueue,
+            args: [makeChangeInput(projectId!, CHANGE_ID)],
+          })) as ChangeWorkflowHandle;
 
-            // Live change workflow the re-run will signal.
-            const handle = (await env.client.workflow.start("changeWorkflow", {
-              workflowId: buildChangeWorkflowId(projectId!, CHANGE_ID),
-              taskQueue,
-              args: [makeChangeInput(projectId!, CHANGE_ID)],
-            })) as ChangeWorkflowHandle;
+          const change = makeSplitBrainChange(CHANGE_ID);
+          const output = await reconcileArchivedBundleRetry({
+            store,
+            change,
+            changeId: CHANGE_ID,
+            archiveMode: "direct",
+            phase9: "run",
+            existingBundlePath: bundleDir,
+            openOpsObligationsPayload: {},
+            validationWarnings: [],
+          });
 
-            const change = makeSplitBrainChange(CHANGE_ID);
-            const output = await reconcileArchivedBundleRetry({
-              store,
-              change,
-              changeId: CHANGE_ID,
-              archiveMode: "direct",
-              phase9: "run",
-              existingBundlePath: bundleDir,
-              openOpsObligationsPayload: {},
-              validationWarnings: [],
-            });
+          const parsed = parseToolOutput<{
+            success?: boolean;
+            noOp?: boolean;
+            error?: string;
+            releaseGate?: { status?: string };
+          }>(output);
+          // The re-run itself must succeed (reached the phase9 recording step).
+          expect(
+            parsed.error,
+            `re-run errored: ${parsed.error}`,
+          ).toBeUndefined();
+          expect(parsed.success).toBe(true);
 
-            const parsed = parseToolOutput<{
-              success?: boolean;
-              noOp?: boolean;
-              error?: string;
-              releaseGate?: { status?: string };
-            }>(output);
-            // The re-run itself must succeed (reached the phase9 recording step).
-            expect(
-              parsed.error,
-              `re-run errored: ${parsed.error}`,
-            ).toBeUndefined();
-            expect(parsed.success).toBe(true);
+          // The release gate reconciled to done through live Temporal.
+          const stateAfter: ChangeWorkflowState =
+            await handle.query(getChangeStateQuery);
+          expect(stateAfter.gates.release?.status).toBe("done");
 
-            // The release gate reconciled to done through live Temporal.
-            const stateAfter: ChangeWorkflowState =
-              await handle.query(getChangeStateQuery);
-            expect(stateAfter.gates.release?.status).toBe("done");
-
-            // AC3 core: phase9_status is durably recorded as done via the live
-            // Temporal phase9StatusUpdatedSignal. RED against the unfixed guard
-            // (unset phase9_status is skipped), GREEN once recorded.
-            expect(stateAfter.phase9_status?.status).toBe("done");
-            expect(stateAfter.phase9_status?.completedAt).toBeTruthy();
-          } finally {
-            await worker.shutdown();
-            await closeStsl();
-          }
-        },
-      );
+          // AC3 core: phase9_status is durably recorded as done via the live
+          // Temporal phase9StatusUpdatedSignal. RED against the unfixed guard
+          // (unset phase9_status is skipped), GREEN once recorded.
+          expect(stateAfter.phase9_status?.status).toBe("done");
+          expect(stateAfter.phase9_status?.completedAt).toBeTruthy();
+        } finally {
+          await worker.shutdown();
+          await closeStsl();
+        }
+      });
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/plugin/src/temporal/__tests__/concurrent-signaling.itest.ts
+++ b/plugin/src/temporal/__tests__/concurrent-signaling.itest.ts
@@ -1,6 +1,5 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { WorkflowHandle } from "@temporalio/client";
 
@@ -22,7 +21,7 @@ import {
   taskUpdatedSignal,
   wisdomAddedSignal,
 } from "../messages";
-import { withTestWorkflowEnvironment } from "./with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./with-test-env";
 
 const workflowsPath = fileURLToPath(
   new URL("../workflows.ts", import.meta.url),
@@ -269,146 +268,139 @@ function buildAgentRemainingSignals(
 
 describe("concurrent signaling integration", () => {
   it("handles 3 agents × 50 signals to the same change workflow without rejection (SC1, SC9)", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `concurrent-signaling-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `concurrent-signaling-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const workflowId = `concurrent-signaling-${Date.now()}`;
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId,
           taskQueue,
+          args: [makeChangeInput("concurrent-test")],
         });
 
-        await worker.runUntil(async () => {
-          const workflowId = `concurrent-signaling-${Date.now()}`;
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId,
-            taskQueue,
-            args: [makeChangeInput("concurrent-test")],
-          });
+        // Phase 1 — seed tasks so subsequent updates never race against adds.
+        const addSignals: Promise<void>[] = [];
+        for (let agentIdx = 0; agentIdx < 3; agentIdx++) {
+          addSignals.push(...buildAgentTaskAdds(handle, agentIdx));
+        }
+        const addResults = await Promise.allSettled(addSignals);
+        expect(addResults.filter((r) => r.status === "rejected")).toHaveLength(
+          0,
+        );
 
-          // Phase 1 — seed tasks so subsequent updates never race against adds.
-          const addSignals: Promise<void>[] = [];
+        // Barrier: confirm all 30 tasks exist before the concurrent burst.
+        await pollForState(handle, (s) => s.tasks.length >= 30, 30000);
+
+        // Phase 2 — complete dependent gates in order. The workflow's gate
+        // model is intentionally order-sensitive; this stress test exercises
+        // concurrency without making proposal/discovery/design race each other.
+        const orderedGateSignals: Promise<void>[] = [];
+        const orderedGates = ["proposal", "discovery", "design"] as const;
+        for (let gateIdx = 0; gateIdx < orderedGates.length; gateIdx++) {
+          const gateId = orderedGates[gateIdx];
+          const gateSignals: Promise<void>[] = [];
           for (let agentIdx = 0; agentIdx < 3; agentIdx++) {
-            addSignals.push(...buildAgentTaskAdds(handle, agentIdx));
-          }
-          const addResults = await Promise.allSettled(addSignals);
-          expect(
-            addResults.filter((r) => r.status === "rejected"),
-          ).toHaveLength(0);
-
-          // Barrier: confirm all 30 tasks exist before the concurrent burst.
-          await pollForState(handle, (s) => s.tasks.length >= 30, 30000);
-
-          // Phase 2 — complete dependent gates in order. The workflow's gate
-          // model is intentionally order-sensitive; this stress test exercises
-          // concurrency without making proposal/discovery/design race each other.
-          const orderedGateSignals: Promise<void>[] = [];
-          const orderedGates = ["proposal", "discovery", "design"] as const;
-          for (let gateIdx = 0; gateIdx < orderedGates.length; gateIdx++) {
-            const gateId = orderedGates[gateIdx];
-            const gateSignals: Promise<void>[] = [];
-            for (let agentIdx = 0; agentIdx < 3; agentIdx++) {
-              const signal = buildAgentGateCompletion(
-                handle,
-                agentIdx,
-                gateId,
-                gateIdx,
-              );
-              gateSignals.push(signal);
-              orderedGateSignals.push(signal);
-            }
-
-            const gateResults = await Promise.allSettled(gateSignals);
-            expect(
-              gateResults.filter((r) => r.status === "rejected"),
-            ).toHaveLength(0);
-            await pollForState(
+            const signal = buildAgentGateCompletion(
               handle,
-              (s) => s.gates[gateId]?.status === "done",
-              30000,
+              agentIdx,
+              gateId,
+              gateIdx,
             );
+            gateSignals.push(signal);
+            orderedGateSignals.push(signal);
           }
 
-          // Phase 3 — fire the remaining 111 independent signals concurrently.
-          const burstSignals: Promise<void>[] = [];
-          for (let agentIdx = 0; agentIdx < 3; agentIdx++) {
-            burstSignals.push(...buildAgentRemainingSignals(handle, agentIdx));
-          }
-          expect(burstSignals).toHaveLength(111);
-
-          // SC9: total signal count sanity check (30 adds + 9 ordered gates +
-          // 111 burst = 150)
-          expect(orderedGateSignals).toHaveLength(9);
-          const totalSignals =
-            addSignals.length + orderedGateSignals.length + burstSignals.length;
-          expect(totalSignals).toBe(150);
-          expect(totalSignals).toBeLessThanOrEqual(300);
-
-          // SC1: concurrent burst; none should reject
-          const burstResults = await Promise.allSettled(burstSignals);
-          const rejections = burstResults.filter(
-            (r) => r.status === "rejected",
-          );
-          expect(rejections).toHaveLength(0);
-
-          // Query/describe barrier — wait until all mutations are reflected
-          const state = await pollForState(
+          const gateResults = await Promise.allSettled(gateSignals);
+          expect(
+            gateResults.filter((r) => r.status === "rejected"),
+          ).toHaveLength(0);
+          await pollForState(
             handle,
-            (s) =>
-              s.wisdom.length >= 30 &&
-              s.gates.proposal?.status === "done" &&
-              s.gates.discovery?.status === "done" &&
-              s.gates.design?.status === "done" &&
-              s.gates.planning?.status === "in_progress" &&
-              s.gates.execution?.status === "in_progress" &&
-              s.gates.acceptance?.status === "awaiting_approval" &&
-              s.gates.release?.status === "stuck",
+            (s) => s.gates[gateId]?.status === "done",
             30000,
           );
+        }
 
-          // Verify applied counts
-          expect(state.tasks).toHaveLength(30);
-          expect(state.wisdom).toHaveLength(30);
+        // Phase 3 — fire the remaining 111 independent signals concurrently.
+        const burstSignals: Promise<void>[] = [];
+        for (let agentIdx = 0; agentIdx < 3; agentIdx++) {
+          burstSignals.push(...buildAgentRemainingSignals(handle, agentIdx));
+        }
+        expect(burstSignals).toHaveLength(111);
 
-          // All tasks were updated (priority > 0 proves update ran)
-          const updatedTasks = state.tasks.filter(
-            (t) => t.priority && t.priority > 0,
-          );
-          expect(updatedTasks.length).toBe(30);
+        // SC9: total signal count sanity check (30 adds + 9 ordered gates +
+        // 111 burst = 150)
+        expect(orderedGateSignals).toHaveLength(9);
+        const totalSignals =
+          addSignals.length + orderedGateSignals.length + burstSignals.length;
+        expect(totalSignals).toBe(150);
+        expect(totalSignals).toBeLessThanOrEqual(300);
 
-          // Blocked tasks: 5 per agent
-          const blockedTasks = state.tasks.filter(
-            (t) => t.status === "blocked",
-          );
-          expect(blockedTasks.length).toBe(15);
+        // SC1: concurrent burst; none should reject
+        const burstResults = await Promise.allSettled(burstSignals);
+        const rejections = burstResults.filter((r) => r.status === "rejected");
+        expect(rejections).toHaveLength(0);
 
-          // Assigned tasks: 5 per agent (status flipped to in_progress)
-          const assignedTasks = state.tasks.filter(
-            (t) => t.status === "in_progress" && t.assignedTo,
-          );
-          expect(assignedTasks.length).toBe(15);
+        // Query/describe barrier — wait until all mutations are reflected
+        const state = await pollForState(
+          handle,
+          (s) =>
+            s.wisdom.length >= 30 &&
+            s.gates.proposal?.status === "done" &&
+            s.gates.discovery?.status === "done" &&
+            s.gates.design?.status === "done" &&
+            s.gates.planning?.status === "in_progress" &&
+            s.gates.execution?.status === "in_progress" &&
+            s.gates.acceptance?.status === "awaiting_approval" &&
+            s.gates.release?.status === "stuck",
+          30000,
+        );
 
-          // Gate edge case: duplicate proposal completion from 3 agents
-          // Queue serializes; last write wins; state must be sane
-          expect(state.gates.proposal?.status).toBe("done");
-          expect(state.gates.discovery?.status).toBe("done");
-          expect(state.gates.design?.status).toBe("done");
-          expect(state.gates.planning?.status).toBe("in_progress");
-          expect(state.gates.execution?.status).toBe("in_progress");
-          expect(state.gates.acceptance?.status).toBe("awaiting_approval");
-          expect(state.gates.release?.status).toBe("stuck");
+        // Verify applied counts
+        expect(state.tasks).toHaveLength(30);
+        expect(state.wisdom).toHaveLength(30);
 
-          // Documents
-          expect(state.documents?.proposal).toBeDefined();
-          expect(state.documents?.agreement).toBeDefined();
-          expect(state.documents?.design).toBeDefined();
+        // All tasks were updated (priority > 0 proves update ran)
+        const updatedTasks = state.tasks.filter(
+          (t) => t.priority && t.priority > 0,
+        );
+        expect(updatedTasks.length).toBe(30);
 
-          // Workflow healthy — not failed or terminated
-          const description = await handle.describe();
-          expect(description.status.name).toBe("RUNNING");
-        });
-      },
-    );
+        // Blocked tasks: 5 per agent
+        const blockedTasks = state.tasks.filter((t) => t.status === "blocked");
+        expect(blockedTasks.length).toBe(15);
+
+        // Assigned tasks: 5 per agent (status flipped to in_progress)
+        const assignedTasks = state.tasks.filter(
+          (t) => t.status === "in_progress" && t.assignedTo,
+        );
+        expect(assignedTasks.length).toBe(15);
+
+        // Gate edge case: duplicate proposal completion from 3 agents
+        // Queue serializes; last write wins; state must be sane
+        expect(state.gates.proposal?.status).toBe("done");
+        expect(state.gates.discovery?.status).toBe("done");
+        expect(state.gates.design?.status).toBe("done");
+        expect(state.gates.planning?.status).toBe("in_progress");
+        expect(state.gates.execution?.status).toBe("in_progress");
+        expect(state.gates.acceptance?.status).toBe("awaiting_approval");
+        expect(state.gates.release?.status).toBe("stuck");
+
+        // Documents
+        expect(state.documents?.proposal).toBeDefined();
+        expect(state.documents?.agreement).toBeDefined();
+        expect(state.documents?.design).toBeDefined();
+
+        // Workflow healthy — not failed or terminated
+        const description = await handle.describe();
+        expect(description.status.name).toBe("RUNNING");
+      });
+    });
   }, 60_000);
 });

--- a/plugin/src/temporal/__tests__/continue-as-new.itest.ts
+++ b/plugin/src/temporal/__tests__/continue-as-new.itest.ts
@@ -1,6 +1,5 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type {
   WorkflowHandle,
@@ -14,7 +13,7 @@ import {
   shouldContinueAsNewFromInfo,
 } from "../contracts";
 import { getChangeStateQuery, taskAddedSignal } from "../messages";
-import { withTestWorkflowEnvironment } from "./with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./with-test-env";
 
 const workflowsPath = fileURLToPath(
   new URL("../workflows.ts", import.meta.url),
@@ -92,128 +91,122 @@ describe("changeWorkflow continue-as-new", () => {
   });
 
   it("continues as new after 5,000+ history events while preserving in-flight signal state", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `continue-as-new-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
-          taskQueue,
-        });
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `continue-as-new-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
 
-        await worker.runUntil(async () => {
-          const workflowId = `continue-as-new-${Date.now()}`;
-          const handle: StartedChangeWorkflowHandle =
-            await env.client.workflow.start("changeWorkflow", {
-              workflowId,
-              taskQueue,
-              args: [makeChangeInput("can-test")],
-            });
-          const firstRunId = handle.firstExecutionRunId;
-          expect(DEFAULT_CHANGE_HISTORY_THRESHOLD).toBe(5000);
+      await worker.runUntil(async () => {
+        const workflowId = `continue-as-new-${Date.now()}`;
+        const handle: StartedChangeWorkflowHandle =
+          await env.client.workflow.start("changeWorkflow", {
+            workflowId,
+            taskQueue,
+            args: [makeChangeInput("can-test")],
+          });
+        const firstRunId = handle.firstExecutionRunId;
+        expect(DEFAULT_CHANGE_HISTORY_THRESHOLD).toBe(5000);
 
-          const signalCount = 5_200;
-          const signalResults = await Promise.allSettled(
-            Array.from({ length: signalCount }, (_, i) =>
-              handle.signal(taskAddedSignal, {
-                task: makeTask(`can-tk-${i}`),
-                addedAt: `2026-05-05T00:${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}.000Z`,
-              }),
-            ),
+        const signalCount = 5_200;
+        const signalResults = await Promise.allSettled(
+          Array.from({ length: signalCount }, (_, i) =>
+            handle.signal(taskAddedSignal, {
+              task: makeTask(`can-tk-${i}`),
+              addedAt: `2026-05-05T00:${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}.000Z`,
+            }),
+          ),
+        );
+
+        expect(
+          signalResults.filter((r) => r.status === "rejected"),
+        ).toHaveLength(0);
+
+        const latestHandle =
+          env.client.workflow.getHandle<
+            typeof import("../workflows").changeWorkflow
+          >(workflowId);
+        const state = await pollForState(
+          latestHandle,
+          (s) => s.tasks.length === signalCount,
+          60000,
+        );
+        const description = await latestHandle.describe();
+
+        expect(state.tasks).toHaveLength(signalCount);
+        expect(new Set(state.tasks.map((t) => t.id)).size).toBe(signalCount);
+        expect(description.status.name).toBe("RUNNING");
+        if (description.runId === firstRunId) {
+          throw new Error(
+            `continue-as-new did not rotate; historyLength=${description.historyLength}`,
           );
-
-          expect(
-            signalResults.filter((r) => r.status === "rejected"),
-          ).toHaveLength(0);
-
-          const latestHandle =
-            env.client.workflow.getHandle<
-              typeof import("../workflows").changeWorkflow
-            >(workflowId);
-          const state = await pollForState(
-            latestHandle,
-            (s) => s.tasks.length === signalCount,
-            60000,
-          );
-          const description = await latestHandle.describe();
-
-          expect(state.tasks).toHaveLength(signalCount);
-          expect(new Set(state.tasks.map((t) => t.id)).size).toBe(signalCount);
-          expect(description.status.name).toBe("RUNNING");
-          if (description.runId === firstRunId) {
-            throw new Error(
-              `continue-as-new did not rotate; historyLength=${description.historyLength}`,
-            );
-          }
-          expect(description.runId).not.toBe(firstRunId);
-          expect(description.historyLength).toBeLessThan(
-            DEFAULT_CHANGE_HISTORY_THRESHOLD,
-          );
-        });
-      },
-    );
+        }
+        expect(description.runId).not.toBe(firstRunId);
+        expect(description.historyLength).toBeLessThan(
+          DEFAULT_CHANGE_HISTORY_THRESHOLD,
+        );
+      });
+    });
   }, 120000);
 
   it("preserves seenReportIds and seenReportIdsTotal across continue-as-new", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `continue-as-new-seen-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
-          taskQueue,
-        });
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `continue-as-new-seen-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
 
-        await worker.runUntil(async () => {
-          const workflowId = `continue-as-new-seen-${Date.now()}`;
-          const handle: StartedChangeWorkflowHandle =
-            await env.client.workflow.start("changeWorkflow", {
-              workflowId,
-              taskQueue,
-              args: [
-                {
-                  ...makeChangeInput("can-seen-test"),
-                  seedState: {
-                    ...makeChangeInput("can-seen-test").seedState,
-                    seenReportIds: ["can-seen-test|tk-1|adv-engineer|1"],
-                    seenReportIdsTotal: 1,
-                  },
+      await worker.runUntil(async () => {
+        const workflowId = `continue-as-new-seen-${Date.now()}`;
+        const handle: StartedChangeWorkflowHandle =
+          await env.client.workflow.start("changeWorkflow", {
+            workflowId,
+            taskQueue,
+            args: [
+              {
+                ...makeChangeInput("can-seen-test"),
+                seedState: {
+                  ...makeChangeInput("can-seen-test").seedState,
+                  seenReportIds: ["can-seen-test|tk-1|adv-engineer|1"],
+                  seenReportIdsTotal: 1,
                 },
-              ],
-            });
-          const firstRunId = handle.firstExecutionRunId;
+              },
+            ],
+          });
+        const firstRunId = handle.firstExecutionRunId;
 
-          // Trigger continue-as-new with enough signals to cross threshold
-          const signalCount = 5_200;
-          await Promise.allSettled(
-            Array.from({ length: signalCount }, (_, i) =>
-              handle.signal(taskAddedSignal, {
-                task: makeTask(`can-seen-tk-${i}`),
-                addedAt: `2026-05-05T00:${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}.000Z`,
-              }),
-            ),
-          );
+        // Trigger continue-as-new with enough signals to cross threshold
+        const signalCount = 5_200;
+        await Promise.allSettled(
+          Array.from({ length: signalCount }, (_, i) =>
+            handle.signal(taskAddedSignal, {
+              task: makeTask(`can-seen-tk-${i}`),
+              addedAt: `2026-05-05T00:${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}.000Z`,
+            }),
+          ),
+        );
 
-          const latestHandle =
-            env.client.workflow.getHandle<
-              typeof import("../workflows").changeWorkflow
-            >(workflowId);
-          const state = await pollForState(
-            latestHandle,
-            (s) => s.tasks.length === signalCount,
-            60000,
-          );
-          const description = await latestHandle.describe();
+        const latestHandle =
+          env.client.workflow.getHandle<
+            typeof import("../workflows").changeWorkflow
+          >(workflowId);
+        const state = await pollForState(
+          latestHandle,
+          (s) => s.tasks.length === signalCount,
+          60000,
+        );
+        const description = await latestHandle.describe();
 
-          expect(description.runId).not.toBe(firstRunId);
-          expect(state.seenReportIds).toEqual([
-            "can-seen-test|tk-1|adv-engineer|1",
-          ]);
-          expect(state.seenReportIdsTotal).toBe(1);
-        });
-      },
-    );
+        expect(description.runId).not.toBe(firstRunId);
+        expect(state.seenReportIds).toEqual([
+          "can-seen-test|tk-1|adv-engineer|1",
+        ]);
+        expect(state.seenReportIdsTotal).toBe(1);
+      });
+    });
   }, 120000);
 });

--- a/plugin/src/temporal/__tests__/with-test-env-residue.itest.ts
+++ b/plugin/src/temporal/__tests__/with-test-env-residue.itest.ts
@@ -1,0 +1,303 @@
+/**
+ * Real Temporal test-server residue proof (reapLeakedTestServers AC5, AC2;
+ * safety constraint C1).
+ *
+ * The acceptance gap: earlier residue coverage (bin/oc-test-reaper.test.ts)
+ * used fake argv process doubles (`exec -a` bash loops), which cannot prove
+ * that a REAL `TestWorkflowEnvironment` lifecycle failure leaves no
+ * test-server residue. This suite uses an actual time-skipping test server
+ * constructed through the named helper wrappers (the raw-constructor guard
+ * keeps `TestWorkflowEnvironment.create*` inside `with-test-env.ts`):
+ *
+ *   1. Induced mid-test failure (fn throws): the helper's finally-guaranteed
+ *      teardown kills the REAL server — no residue (AC2 + AC5).
+ *   2. Crashed runner (a child process SIGKILLs itself with the env live, so
+ *      no finally can run): the genuinely leaked REAL server goes stale and
+ *      is eliminated by the next conservative pre-run sweep, while a fresh
+ *      REAL peer (concurrent-run analogue) and a start-dev/7233-shaped
+ *      process are left untouched (AC5 + C1).
+ *
+ * Process identity evidence comes from the actual server: argv[0] read from
+ * /proc must be the real `temporal-test-server-sdk-typescript-*` binary that
+ * exists on disk, parented to the creating process.
+ *
+ * Linux-only: identity is /proc-based (the reaper's macOS fallback path is
+ * covered by the doubles in bin/oc-test-reaper.test.ts).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  createTimeSkippingTestWorkflowEnvironment,
+  withTimeSkippingTestWorkflowEnvironment,
+} from "./with-test-env";
+
+const REAPER = fileURLToPath(
+  new URL("../../../../bin/lib/oc-test-reaper.bash", import.meta.url),
+);
+const CRASH_FIXTURE = fileURLToPath(
+  new URL(
+    "../../../test/fixtures/temporal/crash-leaks-test-server.mts",
+    import.meta.url,
+  ),
+);
+
+const isLinux = process.platform === "linux" && existsSync("/proc");
+
+/** PIDs this suite spawned; SIGKILLed in afterEach so a failed assertion can
+ * never leak a process. The helper/reaper own the happy path; this is the
+ * last-resort backstop. */
+const trackedPids = new Set<number>();
+
+afterEach(() => {
+  for (const pid of trackedPids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+  }
+  trackedPids.clear();
+});
+
+interface TestServerProc {
+  pid: number;
+  ppid: number;
+  argv0: string;
+}
+
+/** All live processes whose argv[0] basename is the SDK test-server binary. */
+function listTestServers(): TestServerProc[] {
+  const out: TestServerProc[] = [];
+  for (const entry of readdirSync("/proc")) {
+    if (!/^\d+$/.test(entry)) continue;
+    let cmdline: string;
+    try {
+      cmdline = readFileSync(`/proc/${entry}/cmdline`, "utf8");
+    } catch {
+      continue; // kernel thread or raced exit
+    }
+    const argv0 = cmdline.split("\0")[0] ?? "";
+    const base = argv0.slice(argv0.lastIndexOf("/") + 1);
+    if (!base.startsWith("temporal-test-server-sdk-typescript-")) continue;
+    let stat: string;
+    try {
+      stat = readFileSync(`/proc/${entry}/stat`, "utf8");
+    } catch {
+      continue;
+    }
+    const rest = stat.slice(stat.lastIndexOf(")") + 2);
+    const ppid = Number(rest.split(" ")[1]);
+    out.push({ pid: Number(entry), ppid, argv0 });
+  }
+  return out;
+}
+
+/** Identity evidence: the candidate is the real extracted SDK binary on
+ * disk, not an `exec -a` argv double. */
+function assertRealServerIdentity(proc: TestServerProc): void {
+  const base = proc.argv0.slice(proc.argv0.lastIndexOf("/") + 1);
+  expect(base.startsWith("temporal-test-server-sdk-typescript-")).toBe(true);
+  expect(existsSync(proc.argv0)).toBe(true);
+}
+
+/** Gone from the reaper's perspective: no /proc entry or a zombie. */
+function isGone(pid: number): boolean {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const rest = stat.slice(stat.lastIndexOf(")") + 2);
+    return rest.split(" ")[0] === "Z";
+  } catch {
+    return true;
+  }
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForGone(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (isGone(pid)) return;
+    await sleepMs(100);
+  }
+  expect(
+    isGone(pid),
+    `pid ${pid} still present ${timeoutMs}ms after teardown`,
+  ).toBe(true);
+}
+
+/**
+ * Run the crash fixture: a child node process that creates a REAL env via the
+ * named helper constructor, reports the server pid, then SIGKILLs itself.
+ * Returns the genuinely leaked real test-server pid.
+ */
+async function spawnCrashFixture(): Promise<number> {
+  const child = spawn(process.execPath, [CRASH_FIXTURE], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (child.pid !== undefined) trackedPids.add(child.pid);
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  await new Promise<void>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", () => resolve());
+  });
+  expect(
+    child.signalCode,
+    `crash fixture must die by SIGKILL; stderr: ${stderr}`,
+  ).toBe("SIGKILL");
+  const match = stdout.match(/"serverPid"\s*:\s*(\d+)/);
+  if (!match) {
+    throw new Error(
+      `crash fixture did not report a server pid; stderr: ${stderr}`,
+    );
+  }
+  return Number(match[1]);
+}
+
+/** Long-lived double wearing the real dev server's argv shape
+ * (`server start-dev --port 7233`) under a test-server basename. */
+function spawnDevShapedDouble(): number {
+  const fakeArgv0 = "/tmp/temporal-test-server-sdk-typescript-9.9.9-dev-shape";
+  // bash ignores argv[0]; this host's coreutils multicall binary refuses a
+  // renamed argv[0] (see change wisdom ws-qAkWA_).
+  const script = `exec -a "$0" bash -c 'while :; do sleep 5; done' -- "$@"`;
+  const child = spawn(
+    "bash",
+    ["-c", script, fakeArgv0, "server", "start-dev", "--port", "7233"],
+    { stdio: "ignore" },
+  );
+  child.unref();
+  if (child.pid === undefined) {
+    throw new Error("failed to spawn dev-shaped double");
+  }
+  trackedPids.add(child.pid);
+  return child.pid;
+}
+
+interface ReaperRun {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+async function runReaper(
+  pids: number[],
+  env: Record<string, string>,
+): Promise<ReaperRun> {
+  const child = spawn("bash", [REAPER, ...pids.map(String)], {
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code));
+  });
+  return { exitCode, stdout, stderr };
+}
+
+describe.skipIf(!isLinux)(
+  "real Temporal test-server residue proof (reapLeakedTestServers AC5)",
+  () => {
+    it("induced mid-test failure tears down the REAL test server (AC2/AC5)", async () => {
+      let server: TestServerProc | undefined;
+      await expect(
+        withTimeSkippingTestWorkflowEnvironment(async () => {
+          const ours = listTestServers().filter((s) => s.ppid === process.pid);
+          expect(ours).toHaveLength(1);
+          server = ours[0];
+          trackedPids.add(server.pid);
+          assertRealServerIdentity(server);
+          throw new Error("induced mid-test failure (AC5)");
+        }),
+      ).rejects.toThrow("induced mid-test failure (AC5)");
+
+      if (!server) {
+        throw new Error("server identity was not captured inside fn");
+      }
+      // The helper's finally ran teardown: the REAL server process is gone.
+      await waitForGone(server.pid, 10_000);
+    }, 90_000);
+
+    it("crashed runner's REAL leaked server is reaped by the next conservative sweep; fresh peer + start-dev/7233 survive (AC5/C1)", async () => {
+      // Genuine crash: the fixture SIGKILLs itself with the env live, so no
+      // finally/teardown can run. What remains is a REAL leaked test server.
+      const leakedPid = await spawnCrashFixture();
+      trackedPids.add(leakedPid);
+      const leaked = listTestServers().find((s) => s.pid === leakedPid);
+      if (!leaked) {
+        throw new Error(
+          `leaked server pid ${leakedPid} vanished before the sweep`,
+        );
+      }
+      assertRealServerIdentity(leaked);
+      expect(isGone(leakedPid)).toBe(false); // the leak is real
+
+      // Age the orphan past this run's conservative threshold: provably
+      // outside the active run window (AC4 shape, scaled down for test).
+      await sleepMs(2500);
+
+      // A fresh REAL peer: the concurrent-run neighbour that must never be
+      // reaped. Constructed through the named helper, torn down in finally.
+      const peerEnv = await createTimeSkippingTestWorkflowEnvironment();
+      let peerPid: number | undefined;
+      let devShapePid: number | undefined;
+      try {
+        const peers = listTestServers().filter((s) => s.ppid === process.pid);
+        expect(peers).toHaveLength(1);
+        peerPid = peers[0].pid;
+        trackedPids.add(peerPid);
+        assertRealServerIdentity(peers[0]);
+
+        devShapePid = spawnDevShapedDouble();
+
+        const run = await runReaper([leakedPid, peerPid, devShapePid], {
+          OC_TEST_REAPER_MIN_AGE_SECONDS: "2",
+          OC_TEST_REAPER_TERM_GRACE_SECONDS: "3",
+        });
+
+        expect(run.exitCode).toBe(0);
+        // Stale REAL leak reaped; identity visible in the reaper log.
+        expect(isGone(leakedPid)).toBe(true);
+        expect(run.stderr).toContain(`TERM pid ${leakedPid}`);
+        // Fresh REAL peer untouched (below the conservative minimum age).
+        expect(isGone(peerPid)).toBe(false);
+        expect(run.stderr).toContain(`skip pid ${peerPid}`);
+        // start-dev/7233-shaped process untouched (token exclusion).
+        expect(isGone(devShapePid)).toBe(false);
+        expect(run.stderr).toContain(`skip pid ${devShapePid}`);
+      } finally {
+        await peerEnv.teardown();
+        if (devShapePid !== undefined) {
+          try {
+            process.kill(devShapePid, "SIGKILL");
+          } catch {
+            // already gone
+          }
+        }
+      }
+
+      // No residue from anything this test spawned.
+      if (peerPid !== undefined) await waitForGone(peerPid, 10_000);
+      if (devShapePid !== undefined) await waitForGone(devShapePid, 10_000);
+      await waitForGone(leakedPid, 10_000);
+    }, 120_000);
+  },
+);

--- a/plugin/src/temporal/__tests__/with-test-env-residue.itest.ts
+++ b/plugin/src/temporal/__tests__/with-test-env-residue.itest.ts
@@ -117,7 +117,11 @@ function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function waitForGone(pid: number, timeoutMs: number): Promise<void> {
+async function waitForGone(
+  pid: number,
+  timeoutMs: number,
+  context?: string,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (isGone(pid)) return;
@@ -125,7 +129,7 @@ async function waitForGone(pid: number, timeoutMs: number): Promise<void> {
   }
   expect(
     isGone(pid),
-    `pid ${pid} still present ${timeoutMs}ms after teardown`,
+    `pid ${pid} still present ${timeoutMs}ms after teardown${context ? `; ${context}` : ""}`,
   ).toBe(true);
 }
 
@@ -190,12 +194,28 @@ interface ReaperRun {
   stderr: string;
 }
 
+const REAPER_ENV_PREFIX = "OC_TEST_REAPER_";
+
+/** Hermetic reaper config: an inherited OC_TEST_REAPER_* knob (a stray
+ * DRY_RUN=1 or QUIET=1 in the runner environment) must never silently change
+ * what the proof asks the reaper to do — the acceptance flake was exactly
+ * this signature (sweep exits 0, leak left alive, assertion blind). */
+function hermeticReaperEnv(
+  overrides: Record<string, string>,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!key.startsWith(REAPER_ENV_PREFIX)) env[key] = value;
+  }
+  return { ...env, ...overrides };
+}
+
 async function runReaper(
   pids: number[],
   env: Record<string, string>,
 ): Promise<ReaperRun> {
   const child = spawn("bash", [REAPER, ...pids.map(String)], {
-    env: { ...process.env, ...env },
+    env: hermeticReaperEnv(env),
     stdio: ["ignore", "pipe", "pipe"],
   });
   let stdout = "";
@@ -273,10 +293,22 @@ describe.skipIf(!isLinux)(
           OC_TEST_REAPER_TERM_GRACE_SECONDS: "3",
         });
 
-        expect(run.exitCode).toBe(0);
-        // Stale REAL leak reaped; identity visible in the reaper log.
-        expect(isGone(leakedPid)).toBe(true);
-        expect(run.stderr).toContain(`TERM pid ${leakedPid}`);
+        expect(
+          run.exitCode,
+          `reaper sweep exited non-zero; log:\n${run.stderr}`,
+        ).toBe(0);
+        // The reaper must have ACTED on the stale leak: a skip or DRY-RUN
+        // line here means the sweep proved nothing — fail with the log
+        // attached instead of a blind boolean.
+        expect(
+          run.stderr,
+          `reaper did not TERM the stale real leak; log:\n${run.stderr}`,
+        ).toContain(`TERM pid ${leakedPid}`);
+        // Death can still be in flight when the sweep returns (KILL
+        // latency, slow zombie reaping under load): the AC5 obligation is
+        // that the residue is gone, so wait bounded rather than asserting
+        // a single instant.
+        await waitForGone(leakedPid, 10_000, `reaper log:\n${run.stderr}`);
         // Fresh REAL peer untouched (below the conservative minimum age).
         expect(isGone(peerPid)).toBe(false);
         expect(run.stderr).toContain(`skip pid ${peerPid}`);

--- a/plugin/src/temporal/__tests__/with-test-env.test.ts
+++ b/plugin/src/temporal/__tests__/with-test-env.test.ts
@@ -1,8 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createLocalTestWorkflowEnvironment,
   createTestWorkflowEnvironment,
+  createTimeSkippingTestWorkflowEnvironment,
   withTestWorkflowEnvironment,
+  withTimeSkippingTestWorkflowEnvironment,
 } from "./with-test-env";
+
+const { createTimeSkippingMock, createLocalMock } = vi.hoisted(() => ({
+  createTimeSkippingMock: vi.fn(),
+  createLocalMock: vi.fn(),
+}));
+
+vi.mock("@temporalio/testing", () => ({
+  TestWorkflowEnvironment: {
+    createTimeSkipping: createTimeSkippingMock,
+    createLocal: createLocalMock,
+  },
+}));
 
 interface FakeEnv {
   teardown: () => Promise<void>;
@@ -81,5 +96,75 @@ describe("withTestWorkflowEnvironment", () => {
     await expect(withTestWorkflowEnvironment(createEnv, fn)).rejects.toThrow(
       /fn-err|teardown-err/,
     );
+  });
+});
+
+describe("named constructor wrappers", () => {
+  beforeEach(() => {
+    createTimeSkippingMock.mockReset();
+    createLocalMock.mockReset();
+  });
+
+  it("createTimeSkippingTestWorkflowEnvironment constructs via the SDK from the stable cwd and restores cwd", async () => {
+    const originalCwd = process.cwd();
+    let observedCwd = "";
+    const fakeEnv = { teardown: vi.fn(async () => {}) };
+    createTimeSkippingMock.mockImplementation(async () => {
+      observedCwd = process.cwd();
+      return fakeEnv;
+    });
+
+    const env = await createTimeSkippingTestWorkflowEnvironment();
+
+    expect(createTimeSkippingMock).toHaveBeenCalledTimes(1);
+    expect(env).toBe(fakeEnv);
+    expect(observedCwd).toContain("advance-temporal-test-cwd");
+    expect(process.cwd()).toBe(originalCwd);
+  });
+
+  it("createLocalTestWorkflowEnvironment constructs via createLocal from the stable cwd and restores cwd", async () => {
+    const originalCwd = process.cwd();
+    let observedCwd = "";
+    const fakeEnv = { teardown: vi.fn(async () => {}) };
+    createLocalMock.mockImplementation(async () => {
+      observedCwd = process.cwd();
+      return fakeEnv;
+    });
+
+    const env = await createLocalTestWorkflowEnvironment();
+
+    expect(createLocalMock).toHaveBeenCalledTimes(1);
+    expect(env).toBe(fakeEnv);
+    expect(observedCwd).toContain("advance-temporal-test-cwd");
+    expect(process.cwd()).toBe(originalCwd);
+  });
+
+  it("withTimeSkippingTestWorkflowEnvironment runs fn with the created env and tears down on success", async () => {
+    const teardown = vi.fn(async () => {});
+    const fakeEnv = { teardown };
+    createTimeSkippingMock.mockResolvedValue(fakeEnv);
+
+    const result = await withTimeSkippingTestWorkflowEnvironment(
+      async (env) => {
+        expect(env).toBe(fakeEnv);
+        return "ok";
+      },
+    );
+
+    expect(result).toBe("ok");
+    expect(createTimeSkippingMock).toHaveBeenCalledTimes(1);
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+
+  it("withTimeSkippingTestWorkflowEnvironment tears down when fn throws and propagates fn's error", async () => {
+    const teardown = vi.fn(async () => {});
+    createTimeSkippingMock.mockResolvedValue({ teardown });
+
+    await expect(
+      withTimeSkippingTestWorkflowEnvironment(async () => {
+        throw new Error("boom from fn");
+      }),
+    ).rejects.toThrow("boom from fn");
+    expect(teardown).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugin/src/temporal/__tests__/with-test-env.test.ts
+++ b/plugin/src/temporal/__tests__/with-test-env.test.ts
@@ -168,3 +168,64 @@ describe("named constructor wrappers", () => {
     expect(teardown).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("signal-aware teardown regression (reapLeakedTestServers AC2)", () => {
+  it("runs teardown when fn rejects via an external AbortSignal", async () => {
+    // Deterministic interrupt: proves the finally-guarantee holds when fn is
+    // cancelled mid-flight, which is exactly how a signal-aware fn behaves
+    // when Vitest aborts the test signal on timeout.
+    const controller = new AbortController();
+    const teardown = vi.fn(async () => {});
+
+    const promise = withTestWorkflowEnvironment(
+      async () => ({ teardown }),
+      () =>
+        new Promise<never>((_, reject) => {
+          controller.signal.addEventListener("abort", () => {
+            reject(new Error("AbortError: test interrupted"));
+          });
+        }),
+    );
+    setTimeout(() => controller.abort(), 10);
+
+    await expect(promise).rejects.toThrow("AbortError: test interrupted");
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+
+  describe("Vitest timeout path", () => {
+    const teardownLog: string[] = [];
+
+    // it.fails: this test is DESIGNED to time out. Vitest 4 aborts the
+    // TestContext signal on timeout (verified empirically against vitest
+    // 4.1.8: the timed-out test reports as expected-fail and the follow-up
+    // assertion below observes the teardown side effects).
+    it.fails(
+      "interrupts fn via the Vitest test signal on timeout",
+      async ({ signal }) => {
+        await withTestWorkflowEnvironment(
+          async () => ({
+            teardown: async () => {
+              teardownLog.push("teardown");
+            },
+          }),
+          () =>
+            new Promise<never>((_, reject) => {
+              signal.addEventListener("abort", () => {
+                teardownLog.push("fn-aborted");
+                reject(new Error("AbortError: vitest timeout"));
+              });
+            }),
+        );
+      },
+      150, // deliberately tiny: the timeout IS the scenario under test
+    );
+
+    it("ran teardown for the timed-out test (finally survived the abort)", () => {
+      // If the helper's finally-guarantee breaks (teardown removed, or fn
+      // never settles so finally never runs), this assertion fails even
+      // though the it.fails test above still counts as an expected fail.
+      expect(teardownLog).toContain("fn-aborted");
+      expect(teardownLog).toContain("teardown");
+    });
+  });
+});

--- a/plugin/src/temporal/__tests__/with-test-env.ts
+++ b/plugin/src/temporal/__tests__/with-test-env.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
 
 /**
  * Shared harness for Temporal test environments.
@@ -13,8 +14,17 @@ import { tmpdir } from "node:os";
  *
  * This helper wraps the env lifecycle in a `try/finally` block so every
  * call site drains the server regardless of whether the test body throws.
- * Teardown errors propagate (they must not be silently swallowed) so operators
- * notice a broken teardown path instead of silently leaking procs again.
+ *
+ * Error-propagation caveat: this module propagates any error thrown across
+ * the `teardown()` call boundary, but the SDK's own
+ * `TestWorkflowEnvironment.teardown()` catches, logs (`console.error`), and
+ * swallows its internal connection-close / server-shutdown failures (verified
+ * in @temporalio/testing v1.17.x `lib/testing-workflow-environment.js`). A
+ * broken SDK-internal shutdown therefore surfaces only as SDK log output, not
+ * a test failure — the `try/finally` here is the only teardown guarantee we
+ * control. Known upstream caveats: temporalio/sdk-typescript#1443 (startup
+ * failure skips shutdown), #1394 (ephemeral-server kill hangs), #2068
+ * (native-resource teardown races).
  */
 export interface TestEnvironmentLike {
   teardown: () => Promise<void>;
@@ -52,6 +62,11 @@ export async function createTestWorkflowEnvironment<TEnv>(
  *   the runtime sees first via finally semantics). Either is an actionable
  *   signal; silent success is NOT acceptable and is the whole reason this
  *   helper exists.
+ *
+ * Note: the SDK's own `TestWorkflowEnvironment.teardown()` logs and swallows
+ * its internal close/shutdown failures (see module docstring). The
+ * propagation semantics above apply to errors that cross the `teardown()`
+ * call boundary itself — custom envs and wrapper-level failures.
  */
 export async function withTestWorkflowEnvironment<
   TEnv extends TestEnvironmentLike,
@@ -66,4 +81,43 @@ export async function withTestWorkflowEnvironment<
   } finally {
     await env.teardown();
   }
+}
+
+/**
+ * Named constructor: create a time-skipping test environment from the stable
+ * non-worktree cwd.
+ *
+ * Raw `TestWorkflowEnvironment.create*` calls must stay inside this module so
+ * every construction path is auditable in one place. Call sites use these
+ * wrappers (or `withTimeSkippingTestWorkflowEnvironment` for full lifecycle).
+ */
+export function createTimeSkippingTestWorkflowEnvironment(): Promise<TestWorkflowEnvironment> {
+  return createTestWorkflowEnvironment(() =>
+    TestWorkflowEnvironment.createTimeSkipping(),
+  );
+}
+
+/**
+ * Named constructor: create a full local (non-time-skipping) test environment
+ * from the stable non-worktree cwd.
+ */
+export function createLocalTestWorkflowEnvironment(): Promise<TestWorkflowEnvironment> {
+  return createTestWorkflowEnvironment(() =>
+    TestWorkflowEnvironment.createLocal(),
+  );
+}
+
+/**
+ * Create a time-skipping test environment, run `fn` with it, and always tear
+ * down. Equivalent to
+ * `withTestWorkflowEnvironment(() => TestWorkflowEnvironment.createTimeSkipping(), fn)`
+ * with construction owned by this module.
+ */
+export function withTimeSkippingTestWorkflowEnvironment<TResult>(
+  fn: (env: TestWorkflowEnvironment) => Promise<TResult>,
+): Promise<TResult> {
+  return withTestWorkflowEnvironment(
+    createTimeSkippingTestWorkflowEnvironment,
+    fn,
+  );
 }

--- a/plugin/src/temporal/__tests__/workflow-termination.test.ts
+++ b/plugin/src/temporal/__tests__/workflow-termination.test.ts
@@ -13,9 +13,9 @@
  */
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
+import type { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
-import { withTestWorkflowEnvironment } from "./with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./with-test-env";
 import { archiveRequestedSignal, changeCancelledSignal } from "../messages";
 import { createDefaultGates } from "../../types";
 import type { ChangeWorkflowInput } from "../contracts";
@@ -84,81 +84,75 @@ function makeChangeInput(changeId: string): ChangeWorkflowInput {
 
 describe("changeWorkflow terminal-state exit (terminatechangeworkflowonarchi)", () => {
   it("Completes after archiveChangeUpdate resolves", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        await registerAdvSearchAttributes(env);
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      await registerAdvSearchAttributes(env);
 
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "termination-test-archive",
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("archive-test-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `term-archive-${Date.now()}`,
           taskQueue: "termination-test-archive",
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("archive-test-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `term-archive-${Date.now()}`,
-            taskQueue: "termination-test-archive",
-            args: [input],
-          });
-
-          // Trigger archive — sets state.status = "archived"
-          await handle.signal(archiveRequestedSignal, {
-            approvalEvidence: "Test archive approval",
-            requestedBy: "tester",
-            requestedAt: new Date().toISOString(),
-          });
-
-          // After fix: workflow exits cleanly via terminal-state branch.
-          // Before fix: workflow stays Running until history rotation.
-          const outcome = await waitForCompleted(handle, 5_000);
-          expect(outcome).toBe("completed");
-
-          // Confirm via describe() — defense in depth
-          const description = await handle.describe();
-          expect(description.status.name).toBe("COMPLETED");
+        // Trigger archive — sets state.status = "archived"
+        await handle.signal(archiveRequestedSignal, {
+          approvalEvidence: "Test archive approval",
+          requestedBy: "tester",
+          requestedAt: new Date().toISOString(),
         });
-      },
-    );
+
+        // After fix: workflow exits cleanly via terminal-state branch.
+        // Before fix: workflow stays Running until history rotation.
+        const outcome = await waitForCompleted(handle, 5_000);
+        expect(outcome).toBe("completed");
+
+        // Confirm via describe() — defense in depth
+        const description = await handle.describe();
+        expect(description.status.name).toBe("COMPLETED");
+      });
+    });
   }, 30_000);
 
   it("Completes after closeChangeUpdate resolves", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        await registerAdvSearchAttributes(env);
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      await registerAdvSearchAttributes(env);
 
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue: "termination-test-close",
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeChangeInput("close-test-001");
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `term-close-${Date.now()}`,
           taskQueue: "termination-test-close",
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeChangeInput("close-test-001");
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `term-close-${Date.now()}`,
-            taskQueue: "termination-test-close",
-            args: [input],
-          });
-
-          // Trigger close with a cancellation payload — sets state.status = "closed"
-          await handle.signal(changeCancelledSignal, {
-            approvalEvidence: "Test cancellation",
-            reason: "cancelled",
-            cancelledBy: "tester",
-            cancelledAt: new Date().toISOString(),
-          });
-
-          const outcome = await waitForCompleted(handle, 5_000);
-          expect(outcome).toBe("completed");
-
-          const description = await handle.describe();
-          expect(description.status.name).toBe("COMPLETED");
+        // Trigger close with a cancellation payload — sets state.status = "closed"
+        await handle.signal(changeCancelledSignal, {
+          approvalEvidence: "Test cancellation",
+          reason: "cancelled",
+          cancelledBy: "tester",
+          cancelledAt: new Date().toISOString(),
         });
-      },
-    );
+
+        const outcome = await waitForCompleted(handle, 5_000);
+        expect(outcome).toBe("completed");
+
+        const description = await handle.describe();
+        expect(description.status.name).toBe("COMPLETED");
+      });
+    });
   }, 30_000);
 
   // Note: a "stays Running on non-terminal status" negative test was

--- a/plugin/src/temporal/out-of-process-worker.itest.ts
+++ b/plugin/src/temporal/out-of-process-worker.itest.ts
@@ -25,10 +25,9 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import {
-  createTestWorkflowEnvironment,
-  withTestWorkflowEnvironment,
+  createTimeSkippingTestWorkflowEnvironment,
+  withTimeSkippingTestWorkflowEnvironment,
 } from "./__tests__/with-test-env";
 import { createOutOfProcessWorker } from "./out-of-process-worker";
 import { resolveNodeExecutable } from "./runtime-manager";
@@ -55,48 +54,44 @@ describe.skipIf(!canRun)("createOutOfProcessWorker integration", () => {
     const script = workerScriptAvailable();
     expect(script).not.toBeNull();
 
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const address = String(env.address ?? "127.0.0.1:7233");
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const address = String(env.address ?? "127.0.0.1:7233");
 
-        // Retry worker creation — child process may exit before ready IPC
-        // due to Temporal server startup timing or port races (CI flake).
-        const worker = await retry(
-          async () => {
-            const w = await createOutOfProcessWorker({
-              address,
-              namespace: "default",
-              queues: ["advance-oop-itest"],
-              workerScript: script!.path,
-              projectId: "oop-itest",
-            });
-            await waitForWorkerAlive(w, 5_000, 100);
-            return w;
-          },
-          3,
-          1_000,
-        );
+      // Retry worker creation — child process may exit before ready IPC
+      // due to Temporal server startup timing or port races (CI flake).
+      const worker = await retry(
+        async () => {
+          const w = await createOutOfProcessWorker({
+            address,
+            namespace: "default",
+            queues: ["advance-oop-itest"],
+            workerScript: script!.path,
+            projectId: "oop-itest",
+          });
+          await waitForWorkerAlive(w, 5_000, 100);
+          return w;
+        },
+        3,
+        1_000,
+      );
 
-        try {
-          expect(worker.queues).toEqual(["advance-oop-itest"]);
-          expect((worker as { isAlive?: () => boolean }).isAlive?.()).toBe(
-            true,
-          );
-        } finally {
-          await worker.shutdown();
-          expect((worker as { isAlive?: () => boolean }).isAlive?.()).toBe(
-            false,
-          );
-        }
-      },
-    );
+      try {
+        expect(worker.queues).toEqual(["advance-oop-itest"]);
+        expect((worker as { isAlive?: () => boolean }).isAlive?.()).toBe(true);
+      } finally {
+        await worker.shutdown();
+        expect((worker as { isAlive?: () => boolean }).isAlive?.()).toBe(false);
+      }
+    });
   }, 120_000);
 
   it("reaps the specific temporal-test-server process opened for its port", async () => {
-    const env = await createTestWorkflowEnvironment(() =>
-      TestWorkflowEnvironment.createTimeSkipping(),
-    );
+    // DELIBERATE EXCEPTION: this test asserts the test-server PID actually
+    // exits after teardown(), so it must control teardown timing explicitly
+    // and cannot route through withTimeSkippingTestWorkflowEnvironment
+    // (whose teardown runs only in finally). Construction still goes through
+    // the helper-owned named constructor.
+    const env = await createTimeSkippingTestWorkflowEnvironment();
     const port = extractPort(String(env.address ?? ""));
     expect(port).not.toBeNull();
 
@@ -219,5 +214,5 @@ if (!canRun) {
 }
 
 // beforeAll/afterAll are intentionally not imported here; the in-process
-// itest pattern uses them, but withTestWorkflowEnvironment owns lifecycle
+// itest pattern uses them, but the with-test-env helpers own lifecycle
 // in this file.

--- a/plugin/src/temporal/workflows.epic.test.ts
+++ b/plugin/src/temporal/workflows.epic.test.ts
@@ -1,6 +1,5 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { WorkflowHandle } from "@temporalio/client";
 
@@ -16,7 +15,7 @@ import {
   shellAddedSignal,
   shellPromotedSignal,
 } from "./messages";
-import { withTestWorkflowEnvironment } from "./__tests__/with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./__tests__/with-test-env";
 import { DEFAULT_CHANGE_HISTORY_THRESHOLD } from "./contracts";
 
 const workflowsPath = fileURLToPath(new URL("./workflows.ts", import.meta.url));
@@ -40,430 +39,410 @@ async function queryState(
 
 describe("epicWorkflow", () => {
   it("persists Epic state across signals and queries", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `epic-wf-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `epic-wf-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput();
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId: `epic-${input.epicId}`,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput();
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId: `epic-${input.epicId}`,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-
-          await handle.signal(shellAddedSignal, {
-            entryId: "shell-1",
-            title: "Shell One",
-            successHint: "Do the thing",
-            idempotencyKey: "add-shell-1",
-            addedAt: "2026-06-24T00:01:00.000Z",
-          });
-
-          await handle.signal(shellPromotedSignal, {
-            entryId: "shell-1",
-            changeId: "change-1",
-            promotedBy: "agent",
-            promotedAt: "2026-06-24T00:02:00.000Z",
-            idempotencyKey: "promote-shell-1",
-          });
-
-          await handle.signal(changeLinkedSignal, {
-            entryId: "entry-2",
-            changeId: "change-2",
-            title: "Linked Change",
-            order: 5,
-            idempotencyKey: "link-change-2",
-            linkedAt: "2026-06-24T00:03:00.000Z",
-          });
-
-          const state = await queryState(handle);
-          expect(state.epic.entries).toHaveLength(2);
-          expect(state.epic.entries[0].kind).toBe("change");
-          expect(state.epic.entries[1].kind).toBe("change");
-
-          const epic = await handle.query(getEpicQuery);
-          expect(epic.id).toBe(input.epicId);
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+
+        await handle.signal(shellAddedSignal, {
+          entryId: "shell-1",
+          title: "Shell One",
+          successHint: "Do the thing",
+          idempotencyKey: "add-shell-1",
+          addedAt: "2026-06-24T00:01:00.000Z",
+        });
+
+        await handle.signal(shellPromotedSignal, {
+          entryId: "shell-1",
+          changeId: "change-1",
+          promotedBy: "agent",
+          promotedAt: "2026-06-24T00:02:00.000Z",
+          idempotencyKey: "promote-shell-1",
+        });
+
+        await handle.signal(changeLinkedSignal, {
+          entryId: "entry-2",
+          changeId: "change-2",
+          title: "Linked Change",
+          order: 5,
+          idempotencyKey: "link-change-2",
+          linkedAt: "2026-06-24T00:03:00.000Z",
+        });
+
+        const state = await queryState(handle);
+        expect(state.epic.entries).toHaveLength(2);
+        expect(state.epic.entries[0].kind).toBe("change");
+        expect(state.epic.entries[1].kind).toBe("change");
+
+        const epic = await handle.query(getEpicQuery);
+        expect(epic.id).toBe(input.epicId);
+      });
+    });
   }, 60000);
 
   it("records rejection for stale-version update instead of failing workflow", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `epic-wf-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `epic-wf-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput();
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId: `epic-${input.epicId}`,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput();
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId: `epic-${input.epicId}`,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-
-          await handle.signal(epicUpdatedSignal, {
-            title: "Updated Title",
-            expectedVersion: 5,
-            idempotencyKey: "update-stale",
-            updatedAt: "2026-06-24T00:01:00.000Z",
-          });
-
-          const state = await queryState(handle);
-          expect(state.rejections).toHaveLength(1);
-          expect(state.rejections![0].signalName).toBe("epicUpdated");
-          expect(state.epic.title).toBe(input.title);
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+
+        await handle.signal(epicUpdatedSignal, {
+          title: "Updated Title",
+          expectedVersion: 5,
+          idempotencyKey: "update-stale",
+          updatedAt: "2026-06-24T00:01:00.000Z",
+        });
+
+        const state = await queryState(handle);
+        expect(state.rejections).toHaveLength(1);
+        expect(state.rejections![0].signalName).toBe("epicUpdated");
+        expect(state.epic.title).toBe(input.title);
+      });
+    });
   }, 60000);
 
   it("preserves idempotency ledger and Epic state across continue-as-new", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `epic-can-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `epic-can-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput();
+        const workflowId = `epic-can-${input.epicId}`;
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput();
-          const workflowId = `epic-can-${input.epicId}`;
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-
-          const signalCount = DEFAULT_CHANGE_HISTORY_THRESHOLD + 200;
-          const results = await Promise.allSettled(
-            Array.from({ length: signalCount }, (_, i) =>
-              handle.signal(shellAddedSignal, {
-                entryId: `shell-${i}`,
-                title: `Shell ${i}`,
-                successHint: "hint",
-                idempotencyKey: `add-shell-${i}`,
-                addedAt: `2026-06-24T00:${String(Math.floor((i + 1) / 60)).padStart(2, "0")}:${String((i + 1) % 60).padStart(2, "0")}.000Z`,
-              }),
-            ),
-          );
-          expect(results.filter((r) => r.status === "rejected")).toHaveLength(
-            0,
-          );
-
-          const latestHandle = env.client.workflow.getHandle(workflowId);
-          let state = await queryState(latestHandle);
-          for (
-            let i = 0;
-            i < 30 && state.epic.entries.length < signalCount;
-            i++
-          ) {
-            await new Promise((r) => setTimeout(r, 50));
-            state = await queryState(latestHandle);
-          }
-
-          expect(state.epic.entries).toHaveLength(signalCount);
-          expect(new Set(state.epic.entries.map((e) => e.entry_id)).size).toBe(
-            signalCount,
-          );
-
-          const description = await latestHandle.describe();
-          expect(description.status.name).toBe("RUNNING");
-          expect(description.historyLength).toBeLessThan(
-            DEFAULT_CHANGE_HISTORY_THRESHOLD,
-          );
-
-          // Idempotency ledger survived continue-as-new.
-          expect(state.idempotencyLedger["add-shell-0"]).toBeDefined();
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+
+        const signalCount = DEFAULT_CHANGE_HISTORY_THRESHOLD + 200;
+        const results = await Promise.allSettled(
+          Array.from({ length: signalCount }, (_, i) =>
+            handle.signal(shellAddedSignal, {
+              entryId: `shell-${i}`,
+              title: `Shell ${i}`,
+              successHint: "hint",
+              idempotencyKey: `add-shell-${i}`,
+              addedAt: `2026-06-24T00:${String(Math.floor((i + 1) / 60)).padStart(2, "0")}:${String((i + 1) % 60).padStart(2, "0")}.000Z`,
+            }),
+          ),
+        );
+        expect(results.filter((r) => r.status === "rejected")).toHaveLength(0);
+
+        const latestHandle = env.client.workflow.getHandle(workflowId);
+        let state = await queryState(latestHandle);
+        for (
+          let i = 0;
+          i < 30 && state.epic.entries.length < signalCount;
+          i++
+        ) {
+          await new Promise((r) => setTimeout(r, 50));
+          state = await queryState(latestHandle);
+        }
+
+        expect(state.epic.entries).toHaveLength(signalCount);
+        expect(new Set(state.epic.entries.map((e) => e.entry_id)).size).toBe(
+          signalCount,
+        );
+
+        const description = await latestHandle.describe();
+        expect(description.status.name).toBe("RUNNING");
+        expect(description.historyLength).toBeLessThan(
+          DEFAULT_CHANGE_HISTORY_THRESHOLD,
+        );
+
+        // Idempotency ledger survived continue-as-new.
+        expect(state.idempotencyLedger["add-shell-0"]).toBeDefined();
+      });
+    });
   }, 120000);
 
   it("records entry terminal summary and recomputes Epic progress", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `epic-wf-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `epic-wf-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput();
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId: `epic-${input.epicId}`,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput();
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId: `epic-${input.epicId}`,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-
-          await handle.signal(changeLinkedSignal, {
-            entryId: "entry-1",
-            changeId: "change-1",
-            title: "Linked Change",
-            order: 0,
-            idempotencyKey: "link-change-1",
-            linkedAt: "2026-06-24T00:01:00.000Z",
-          });
-
-          await handle.signal(entryTerminalSummarySignal, {
-            entryId: "entry-1",
-            status: "archived",
-            completedAt: "2026-06-24T00:02:00.000Z",
-            idempotencyKey: "terminal-1",
-          });
-
-          const state = await queryState(handle);
-          expect(state.epic.entries).toHaveLength(1);
-          const entry = state.epic.entries[0];
-          expect(entry.kind).toBe("change");
-          if (entry.kind !== "change") throw new Error("Expected change entry");
-          expect(entry.terminal_summary).toEqual({
-            status: "archived",
-            completed_at: "2026-06-24T00:02:00.000Z",
-          });
-          expect(state.epic.progress.completed_entries).toBe(1);
-          expect(state.epic.progress.active_entries).toBe(0);
-          expect(state.epic.progress.status).toBe("completed");
-          expect(state.epic.progress.next_entry_id).toBeNull();
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+
+        await handle.signal(changeLinkedSignal, {
+          entryId: "entry-1",
+          changeId: "change-1",
+          title: "Linked Change",
+          order: 0,
+          idempotencyKey: "link-change-1",
+          linkedAt: "2026-06-24T00:01:00.000Z",
+        });
+
+        await handle.signal(entryTerminalSummarySignal, {
+          entryId: "entry-1",
+          status: "archived",
+          completedAt: "2026-06-24T00:02:00.000Z",
+          idempotencyKey: "terminal-1",
+        });
+
+        const state = await queryState(handle);
+        expect(state.epic.entries).toHaveLength(1);
+        const entry = state.epic.entries[0];
+        expect(entry.kind).toBe("change");
+        if (entry.kind !== "change") throw new Error("Expected change entry");
+        expect(entry.terminal_summary).toEqual({
+          status: "archived",
+          completed_at: "2026-06-24T00:02:00.000Z",
+        });
+        expect(state.epic.progress.completed_entries).toBe(1);
+        expect(state.epic.progress.active_entries).toBe(0);
+        expect(state.epic.progress.status).toBe("completed");
+        expect(state.epic.progress.next_entry_id).toBeNull();
+      });
+    });
   }, 60000);
 
   it("archives the completed Epic and completes the workflow", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `epic-wf-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `epic-wf-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput();
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId: `epic-${input.epicId}`,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput();
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId: `epic-${input.epicId}`,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-
-          await handle.signal(changeLinkedSignal, {
-            entryId: "entry-1",
-            changeId: "change-1",
-            title: "Linked Change",
-            order: 0,
-            idempotencyKey: "link-change-1",
-            linkedAt: "2026-06-24T00:01:00.000Z",
-          });
-
-          await handle.signal(entryTerminalSummarySignal, {
-            entryId: "entry-1",
-            status: "archived",
-            completedAt: "2026-06-24T00:02:00.000Z",
-            idempotencyKey: "terminal-1",
-          });
-
-          const state = await queryState(handle);
-          expect(state.epic.progress.status).toBe("completed");
-
-          await handle.signal(epicArchivedSignal, {
-            archivedAt: "2026-06-24T00:03:00.000Z",
-            archivedBy: "agent",
-            expectedVersion: state.epic.version,
-            idempotencyKey: "archive-1",
-          });
-
-          let description = await handle.describe();
-          for (
-            let i = 0;
-            i < 30 && description.status.name !== "COMPLETED";
-            i++
-          ) {
-            await new Promise((r) => setTimeout(r, 50));
-            description = await handle.describe();
-          }
-          expect(description.status.name).toBe("COMPLETED");
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+
+        await handle.signal(changeLinkedSignal, {
+          entryId: "entry-1",
+          changeId: "change-1",
+          title: "Linked Change",
+          order: 0,
+          idempotencyKey: "link-change-1",
+          linkedAt: "2026-06-24T00:01:00.000Z",
+        });
+
+        await handle.signal(entryTerminalSummarySignal, {
+          entryId: "entry-1",
+          status: "archived",
+          completedAt: "2026-06-24T00:02:00.000Z",
+          idempotencyKey: "terminal-1",
+        });
+
+        const state = await queryState(handle);
+        expect(state.epic.progress.status).toBe("completed");
+
+        await handle.signal(epicArchivedSignal, {
+          archivedAt: "2026-06-24T00:03:00.000Z",
+          archivedBy: "agent",
+          expectedVersion: state.epic.version,
+          idempotencyKey: "archive-1",
+        });
+
+        let description = await handle.describe();
+        for (
+          let i = 0;
+          i < 30 && description.status.name !== "COMPLETED";
+          i++
+        ) {
+          await new Promise((r) => setTimeout(r, 50));
+          description = await handle.describe();
+        }
+        expect(description.status.name).toBe("COMPLETED");
+      });
+    });
   }, 60000);
 
   it("records rejection when archive signal targets an incomplete Epic", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = `epic-wf-${Date.now()}`;
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = `epic-wf-${Date.now()}`;
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput();
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId: `epic-${input.epicId}`,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput();
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId: `epic-${input.epicId}`,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-
-          await handle.signal(changeLinkedSignal, {
-            entryId: "entry-1",
-            changeId: "change-1",
-            title: "Active Change",
-            order: 0,
-            idempotencyKey: "link-change-1",
-            linkedAt: "2026-06-24T00:01:00.000Z",
-          });
-
-          await handle.signal(epicArchivedSignal, {
-            archivedAt: "2026-06-24T00:02:00.000Z",
-            archivedBy: "agent",
-            expectedVersion: 1,
-            idempotencyKey: "archive-1",
-          });
-
-          const state = await queryState(handle);
-          expect(state.rejections).toHaveLength(1);
-          expect(state.rejections![0].signalName).toBe("epicArchived");
-          expect(state.rejections![0].errorMessage).toContain(
-            "incomplete entries",
-          );
-          expect(state.rejections![0].errorMessage).toContain("entry-1");
-          expect(state.status).toBe("active");
-
-          const description = await handle.describe();
-          expect(description.status.name).toBe("RUNNING");
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+
+        await handle.signal(changeLinkedSignal, {
+          entryId: "entry-1",
+          changeId: "change-1",
+          title: "Active Change",
+          order: 0,
+          idempotencyKey: "link-change-1",
+          linkedAt: "2026-06-24T00:01:00.000Z",
+        });
+
+        await handle.signal(epicArchivedSignal, {
+          archivedAt: "2026-06-24T00:02:00.000Z",
+          archivedBy: "agent",
+          expectedVersion: 1,
+          idempotencyKey: "archive-1",
+        });
+
+        const state = await queryState(handle);
+        expect(state.rejections).toHaveLength(1);
+        expect(state.rejections![0].signalName).toBe("epicArchived");
+        expect(state.rejections![0].errorMessage).toContain(
+          "incomplete entries",
+        );
+        expect(state.rejections![0].errorMessage).toContain("entry-1");
+        expect(state.status).toBe("active");
+
+        const description = await handle.describe();
+        expect(description.status.name).toBe("RUNNING");
+      });
+    });
   }, 60000);
 });

--- a/plugin/src/temporal/workflows.ops-follow-up.test.ts
+++ b/plugin/src/temporal/workflows.ops-follow-up.test.ts
@@ -3,7 +3,6 @@
  */
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { WorkflowHandle } from "@temporalio/client";
 
@@ -17,7 +16,7 @@ import {
   opsRunEvidenceAppendedSignal,
   opsRunUpsertedSignal,
 } from "./messages";
-import { withTestWorkflowEnvironment } from "./__tests__/with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./__tests__/with-test-env";
 
 const workflowsPath = fileURLToPath(new URL("./workflows.ts", import.meta.url));
 
@@ -50,26 +49,23 @@ async function withOpsSignalWorker(
     handle: WorkflowHandle<typeof import("./workflows").changeWorkflow>,
   ) => Promise<void>,
 ): Promise<void> {
-  await withTestWorkflowEnvironment(
-    () => TestWorkflowEnvironment.createTimeSkipping(),
-    async (env) => {
-      const taskQueue = `ops-signal-${name}`;
-      const worker = await Worker.create({
-        connection: env.nativeConnection,
-        workflowsPath,
-        taskQueue,
-      });
+  await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+    const taskQueue = `ops-signal-${name}`;
+    const worker = await Worker.create({
+      connection: env.nativeConnection,
+      workflowsPath,
+      taskQueue,
+    });
 
-      await worker.runUntil(async () => {
-        const handle = await env.client.workflow.start("changeWorkflow", {
-          workflowId: `ops-${name}-${Date.now()}`,
-          taskQueue,
-          args: [makeChangeInput(name)],
-        });
-        await fn(handle);
+    await worker.runUntil(async () => {
+      const handle = await env.client.workflow.start("changeWorkflow", {
+        workflowId: `ops-${name}-${Date.now()}`,
+        taskQueue,
+        args: [makeChangeInput(name)],
       });
-    },
-  );
+      await fn(handle);
+    });
+  });
 }
 
 describe("changeWorkflow ops follow-up signal handlers", () => {

--- a/plugin/src/temporal/workflows.projection.test.ts
+++ b/plugin/src/temporal/workflows.projection.test.ts
@@ -2,7 +2,6 @@ import { fileURLToPath } from "node:url";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 
 import { createDefaultGates } from "../types";
@@ -10,7 +9,7 @@ import { cleanupTempDir, createTempDir } from "../__tests__/setup";
 import type { ChangeWorkflowInput } from "./contracts";
 import { writeChangeProjection } from "./activities";
 import { archiveRequestedSignal, gateCompletedSignal } from "./messages";
-import { withTestWorkflowEnvironment } from "./__tests__/with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./__tests__/with-test-env";
 
 const workflowsPath = fileURLToPath(new URL("./workflows.ts", import.meta.url));
 
@@ -48,63 +47,58 @@ describe("changeWorkflow disk projection", () => {
   it("projects gate signals best-effort and terminal archive before completion", async () => {
     const dir = await createTempDir();
     try {
-      await withTestWorkflowEnvironment(
-        () => TestWorkflowEnvironment.createTimeSkipping(),
-        async (env) => {
-          const taskQueue = `projection-workflow-${Date.now()}`;
-          const worker = await Worker.create({
-            connection: env.nativeConnection,
-            workflowsPath,
-            activities: { writeChangeProjection },
+      await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+        const taskQueue = `projection-workflow-${Date.now()}`;
+        const worker = await Worker.create({
+          connection: env.nativeConnection,
+          workflowsPath,
+          activities: { writeChangeProjection },
+          taskQueue,
+        });
+        const projectionChangesDir = join(dir, "changes");
+
+        await worker.runUntil(async () => {
+          const handle = await env.client.workflow.start("changeWorkflow", {
+            workflowId: `projection-workflow-${Date.now()}`,
             taskQueue,
+            args: [makeChangeInput("projection-change", projectionChangesDir)],
           });
-          const projectionChangesDir = join(dir, "changes");
 
-          await worker.runUntil(async () => {
-            const handle = await env.client.workflow.start("changeWorkflow", {
-              workflowId: `projection-workflow-${Date.now()}`,
-              taskQueue,
-              args: [
-                makeChangeInput("projection-change", projectionChangesDir),
-              ],
-            });
+          await handle.signal(gateCompletedSignal, {
+            gateId: "proposal",
+            completedBy: "tester",
+            completedAt: "2026-05-05T00:00:01.000Z",
+            compatibilityReason:
+              "projection fixture validates projection, not artifact inspection",
+          });
 
-            await handle.signal(gateCompletedSignal, {
-              gateId: "proposal",
-              completedBy: "tester",
-              completedAt: "2026-05-05T00:00:01.000Z",
-              compatibilityReason:
-                "projection fixture validates projection, not artifact inspection",
-            });
-
-            await expect
-              .poll(() =>
-                readProjection(projectionChangesDir, "projection-change"),
-              )
-              .toMatchObject({
-                schemaVersion: 2,
-                state: {
-                  changeId: "projection-change",
-                  gates: { proposal: { status: "done" } },
-                },
-              });
-
-            await handle.signal(archiveRequestedSignal, {
-              approvalEvidence: "ship it",
-              requestedBy: "tester",
-              requestedAt: "2026-05-05T00:00:02.000Z",
-            });
-
-            await expect(handle.result()).resolves.toBeUndefined();
-            await expect(
+          await expect
+            .poll(() =>
               readProjection(projectionChangesDir, "projection-change"),
-            ).resolves.toMatchObject({
+            )
+            .toMatchObject({
               schemaVersion: 2,
-              state: { status: "archived" },
+              state: {
+                changeId: "projection-change",
+                gates: { proposal: { status: "done" } },
+              },
             });
+
+          await handle.signal(archiveRequestedSignal, {
+            approvalEvidence: "ship it",
+            requestedBy: "tester",
+            requestedAt: "2026-05-05T00:00:02.000Z",
           });
-        },
-      );
+
+          await expect(handle.result()).resolves.toBeUndefined();
+          await expect(
+            readProjection(projectionChangesDir, "projection-change"),
+          ).resolves.toMatchObject({
+            schemaVersion: 2,
+            state: { status: "archived" },
+          });
+        });
+      });
     } finally {
       await cleanupTempDir(dir);
     }

--- a/plugin/src/temporal/workflows.queries.test.ts
+++ b/plugin/src/temporal/workflows.queries.test.ts
@@ -1,6 +1,5 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 
 import type { Task } from "../types";
@@ -20,7 +19,7 @@ import {
   taskBlockedSignal,
   taskCompletedSignal,
 } from "./messages";
-import { withTestWorkflowEnvironment } from "./__tests__/with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./__tests__/with-test-env";
 
 const workflowsPath = fileURLToPath(new URL("./workflows.ts", import.meta.url));
 
@@ -71,125 +70,118 @@ function makeChangeInput(): ChangeWorkflowInput {
 
 describe("changeWorkflow query handlers", () => {
   it("returns derived state, bucket, ready tasks, investment, review, and task summaries", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        const taskQueue = "workflow-query-handlers";
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      const taskQueue = "workflow-query-handlers";
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `query-handlers-${Date.now()}`,
           taskQueue,
+          args: [makeChangeInput()],
         });
 
-        await worker.runUntil(async () => {
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId: `query-handlers-${Date.now()}`,
-            taskQueue,
-            args: [makeChangeInput()],
-          });
-
-          await handle.signal(taskAddedSignal, {
-            task: makeTask("tk-new"),
-            addedAt: "2026-05-05T00:00:01.000Z",
-          });
-          await handle.signal(taskCompletedSignal, {
-            taskId: "tk-new",
-            verification: "query tests pass",
-            summary: "completed via signal",
-            filesTouched: ["plugin/src/temporal/workflows.ts"],
-            completedAt: "2026-05-05T00:00:02.000Z",
-          });
-          await handle.signal(taskBlockedSignal, {
-            taskId: "tk-blocker",
-            reason: "needs user input",
-            attempts: [
-              {
-                attempt_number: 1,
-                error: "missing input",
-                diagnosis: "human decision needed",
-                fix_tried: "surface question",
-                strategy_label: "ask-user",
-                outcome: "failed",
-                attempted_at: "2026-05-05T00:00:03.000Z",
-              },
-            ],
-            blockedAt: "2026-05-05T00:00:03.000Z",
-          });
-          await handle.signal(gateAwaitingApprovalSignal, {
-            gateId: "acceptance",
-            evidence: "review done",
-            triggeredAt: "2026-05-05T00:00:04.000Z",
-          });
-          await handle.signal(acceptanceCriteriaSetSignal, {
-            criteria: ["SC1", "SC2", "SC3"],
-            setAt: "2026-05-05T00:00:05.000Z",
-          });
-
-          await expect(
-            handle.query(getChangeStateQuery),
-          ).resolves.toMatchObject({
-            changeId: "query-test-change",
-            acceptanceCriteria: ["SC1", "SC2", "SC3"],
-          });
-          await expect(handle.query(getCurrentBucketQuery)).resolves.toBe(
-            "awaiting_approval",
-          );
-          await expect(handle.query(getDirectiveQuery)).resolves.toMatchObject({
-            changeId: "query-test-change",
-            canArchive: false,
-            action: expect.objectContaining({
-              kind: expect.any(String),
-            }),
-            gateStatus: expect.objectContaining({
-              proposal: "done",
-              execution: "done",
-            }),
-          });
-          await expect(handle.query(getReadyTasksQuery)).resolves.toMatchObject(
+        await handle.signal(taskAddedSignal, {
+          task: makeTask("tk-new"),
+          addedAt: "2026-05-05T00:00:01.000Z",
+        });
+        await handle.signal(taskCompletedSignal, {
+          taskId: "tk-new",
+          verification: "query tests pass",
+          summary: "completed via signal",
+          filesTouched: ["plugin/src/temporal/workflows.ts"],
+          completedAt: "2026-05-05T00:00:02.000Z",
+        });
+        await handle.signal(taskBlockedSignal, {
+          taskId: "tk-blocker",
+          reason: "needs user input",
+          attempts: [
             {
-              ready: [expect.objectContaining({ id: "tk-ready" })],
-              blocked: [
-                expect.objectContaining({
-                  task: expect.objectContaining({ id: "tk-blocked" }),
-                  blockedBy: ["tk-blocker"],
-                }),
-              ],
+              attempt_number: 1,
+              error: "missing input",
+              diagnosis: "human decision needed",
+              fix_tried: "surface question",
+              strategy_label: "ask-user",
+              outcome: "failed",
+              attempted_at: "2026-05-05T00:00:03.000Z",
             },
-          );
-          await expect(
-            handle.query(getInvestmentReportQuery),
-          ).resolves.toMatchObject({
-            taskCounts: {
-              total: 5,
-              done: 2,
-              pending: 2,
-              blocked: 1,
-            },
-            retryCount: 1,
-          });
-          await expect(
-            handle.query(getReviewVerificationQuery),
-          ).resolves.toMatchObject({
-            acceptanceCriteriaCount: 3,
-            incompleteTaskCount: 3,
-            readyForAcceptance: false,
-          });
-          await expect(handle.query(getTaskRunSummaryQuery)).resolves.toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({
-                taskId: "tk-new",
-                status: "done",
-                verification: "query tests pass",
-              }),
-              expect.objectContaining({
-                taskId: "tk-blocker",
-                status: "blocked",
-                attempts: 1,
-              }),
-            ]),
-          );
+          ],
+          blockedAt: "2026-05-05T00:00:03.000Z",
         });
-      },
-    );
+        await handle.signal(gateAwaitingApprovalSignal, {
+          gateId: "acceptance",
+          evidence: "review done",
+          triggeredAt: "2026-05-05T00:00:04.000Z",
+        });
+        await handle.signal(acceptanceCriteriaSetSignal, {
+          criteria: ["SC1", "SC2", "SC3"],
+          setAt: "2026-05-05T00:00:05.000Z",
+        });
+
+        await expect(handle.query(getChangeStateQuery)).resolves.toMatchObject({
+          changeId: "query-test-change",
+          acceptanceCriteria: ["SC1", "SC2", "SC3"],
+        });
+        await expect(handle.query(getCurrentBucketQuery)).resolves.toBe(
+          "awaiting_approval",
+        );
+        await expect(handle.query(getDirectiveQuery)).resolves.toMatchObject({
+          changeId: "query-test-change",
+          canArchive: false,
+          action: expect.objectContaining({
+            kind: expect.any(String),
+          }),
+          gateStatus: expect.objectContaining({
+            proposal: "done",
+            execution: "done",
+          }),
+        });
+        await expect(handle.query(getReadyTasksQuery)).resolves.toMatchObject({
+          ready: [expect.objectContaining({ id: "tk-ready" })],
+          blocked: [
+            expect.objectContaining({
+              task: expect.objectContaining({ id: "tk-blocked" }),
+              blockedBy: ["tk-blocker"],
+            }),
+          ],
+        });
+        await expect(
+          handle.query(getInvestmentReportQuery),
+        ).resolves.toMatchObject({
+          taskCounts: {
+            total: 5,
+            done: 2,
+            pending: 2,
+            blocked: 1,
+          },
+          retryCount: 1,
+        });
+        await expect(
+          handle.query(getReviewVerificationQuery),
+        ).resolves.toMatchObject({
+          acceptanceCriteriaCount: 3,
+          incompleteTaskCount: 3,
+          readyForAcceptance: false,
+        });
+        await expect(handle.query(getTaskRunSummaryQuery)).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              taskId: "tk-new",
+              status: "done",
+              verification: "query tests pass",
+            }),
+            expect.objectContaining({
+              taskId: "tk-blocker",
+              status: "blocked",
+              attempts: 1,
+            }),
+          ]),
+        );
+      });
+    });
   }, 30_000);
 });

--- a/plugin/src/temporal/workflows.search-attrs.test.ts
+++ b/plugin/src/temporal/workflows.search-attrs.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
+import type { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 
 import { createDefaultGates } from "../types";
@@ -15,7 +15,7 @@ import {
   searchAttributesRefreshedSignal,
 } from "./messages";
 import { requiredAdvSearchAttributes } from "./search-attributes";
-import { withTestWorkflowEnvironment } from "./__tests__/with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./__tests__/with-test-env";
 
 const workflowsPath = fileURLToPath(new URL("./workflows.ts", import.meta.url));
 
@@ -72,226 +72,214 @@ function makeEpicInput(
 
 describe("changeWorkflow search attribute upserts", () => {
   it("upserts signal-driven search attributes from a state-changing signal", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        await registerSearchAttributes(env);
-        const taskQueue = "workflow-search-attrs";
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      await registerSearchAttributes(env);
+      const taskQueue = "workflow-search-attrs";
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const workflowId = `search-attrs-${Date.now()}`;
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId,
           taskQueue,
+          args: [makeInput()],
         });
 
-        await worker.runUntil(async () => {
-          const workflowId = `search-attrs-${Date.now()}`;
-          const handle = await env.client.workflow.start("changeWorkflow", {
-            workflowId,
-            taskQueue,
-            args: [makeInput()],
-          });
-
-          await handle.signal(proposalUpdatedSignal, {
-            text: "proposal",
-            updatedAt: "2026-05-05T00:00:01.000Z",
-          });
-          await handle.query(getChangeStateQuery);
-
-          const description = await handle.describe();
-          const serialized = JSON.stringify(description);
-
-          expect(serialized).toContain("AdvChangeId");
-          expect(serialized).toContain("search-attrs-change");
-          expect(serialized).toContain("AdvCurrentBucket");
-          expect(serialized).toContain("in_flight");
+        await handle.signal(proposalUpdatedSignal, {
+          text: "proposal",
+          updatedAt: "2026-05-05T00:00:01.000Z",
         });
-      },
-    );
+        await handle.query(getChangeStateQuery);
+
+        const description = await handle.describe();
+        const serialized = JSON.stringify(description);
+
+        expect(serialized).toContain("AdvChangeId");
+        expect(serialized).toContain("search-attrs-change");
+        expect(serialized).toContain("AdvCurrentBucket");
+        expect(serialized).toContain("in_flight");
+      });
+    });
   }, 30_000);
 });
 
 describe("epicWorkflow search attribute upserts", () => {
   it("upserts AdvEpicStatus as active and then completed for CLI active-list filtering", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        await registerSearchAttributes(env);
-        const taskQueue = "epic-workflow-search-attrs";
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      await registerSearchAttributes(env);
+      const taskQueue = "epic-workflow-search-attrs";
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput();
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId: `epic-search-attrs-${input.epicId}`,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput();
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId: `epic-search-attrs-${input.epicId}`,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-          await handle.signal(changeLinkedSignal, {
-            entryId: "entry-1",
-            changeId: "change-1",
-            title: "Linked Change",
-            order: 0,
-            idempotencyKey: "link-change-1",
-            linkedAt: "2026-05-05T00:01:00.000Z",
-          });
-          await handle.signal(entryTerminalSummarySignal, {
-            entryId: "entry-1",
-            status: "archived",
-            completedAt: "2026-05-05T00:02:00.000Z",
-            idempotencyKey: "terminal-1",
-          });
-          await handle.query(getEpicStateQuery);
-
-          const description = await handle.describe();
-          const serialized = JSON.stringify(description);
-
-          expect(serialized).toContain("AdvEpicStatus");
-          expect(serialized).toContain("completed");
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+        await handle.signal(changeLinkedSignal, {
+          entryId: "entry-1",
+          changeId: "change-1",
+          title: "Linked Change",
+          order: 0,
+          idempotencyKey: "link-change-1",
+          linkedAt: "2026-05-05T00:01:00.000Z",
+        });
+        await handle.signal(entryTerminalSummarySignal, {
+          entryId: "entry-1",
+          status: "archived",
+          completedAt: "2026-05-05T00:02:00.000Z",
+          idempotencyKey: "terminal-1",
+        });
+        await handle.query(getEpicStateQuery);
+
+        const description = await handle.describe();
+        const serialized = JSON.stringify(description);
+
+        expect(serialized).toContain("AdvEpicStatus");
+        expect(serialized).toContain("completed");
+      });
+    });
   }, 30_000);
 
   it("searchAttributesRefreshed signal upserts status without bumping version or mutating progress", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        await registerSearchAttributes(env);
-        const taskQueue = "epic-search-attrs-refresh";
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      await registerSearchAttributes(env);
+      const taskQueue = "epic-search-attrs-refresh";
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput();
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId: `epic-search-attrs-refresh-${input.epicId}`,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput();
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId: `epic-search-attrs-refresh-${input.epicId}`,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-
-          const before = await handle.query(getEpicStateQuery);
-          expect(before.epic.version).toBe(0);
-          expect(before.epic.progress.status).toBe("active");
-
-          await handle.signal(searchAttributesRefreshedSignal, {
-            evidence: "Legacy index repair",
-            refreshedAt: "2026-05-05T00:01:00.000Z",
-            idempotencyKey: "repair-1",
-          });
-
-          const after = await handle.query(getEpicStateQuery);
-          expect(after.epic.version).toBe(0);
-          expect(after.epic.progress.status).toBe("active");
-          expect(after.idempotencyLedger).toHaveProperty("repair-1");
-          expect(after.lastSignalAt).toBe("2026-05-05T00:01:00.000Z");
-
-          const description = await handle.describe();
-          const serialized = JSON.stringify(description);
-          expect(serialized).toContain("AdvEpicStatus");
-          expect(serialized).toContain("active");
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+
+        const before = await handle.query(getEpicStateQuery);
+        expect(before.epic.version).toBe(0);
+        expect(before.epic.progress.status).toBe("active");
+
+        await handle.signal(searchAttributesRefreshedSignal, {
+          evidence: "Legacy index repair",
+          refreshedAt: "2026-05-05T00:01:00.000Z",
+          idempotencyKey: "repair-1",
+        });
+
+        const after = await handle.query(getEpicStateQuery);
+        expect(after.epic.version).toBe(0);
+        expect(after.epic.progress.status).toBe("active");
+        expect(after.idempotencyLedger).toHaveProperty("repair-1");
+        expect(after.lastSignalAt).toBe("2026-05-05T00:01:00.000Z");
+
+        const description = await handle.describe();
+        const serialized = JSON.stringify(description);
+        expect(serialized).toContain("AdvEpicStatus");
+        expect(serialized).toContain("active");
+      });
+    });
   }, 30_000);
 
   it("searchAttributesRefreshed signal backfills legacy epics started with search attributes disabled", async () => {
-    await withTestWorkflowEnvironment(
-      () => TestWorkflowEnvironment.createTimeSkipping(),
-      async (env) => {
-        await registerSearchAttributes(env);
-        const taskQueue = "epic-search-attrs-refresh-legacy";
-        const worker = await Worker.create({
-          connection: env.nativeConnection,
-          workflowsPath,
+    await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+      await registerSearchAttributes(env);
+      const taskQueue = "epic-search-attrs-refresh-legacy";
+      const worker = await Worker.create({
+        connection: env.nativeConnection,
+        workflowsPath,
+        taskQueue,
+      });
+
+      await worker.runUntil(async () => {
+        const input = makeEpicInput({ searchAttributesEnabled: false });
+        const handle = await env.client.workflow.start("epicWorkflow", {
+          workflowId: `epic-search-attrs-refresh-legacy-${input.epicId}`,
           taskQueue,
+          args: [input],
         });
 
-        await worker.runUntil(async () => {
-          const input = makeEpicInput({ searchAttributesEnabled: false });
-          const handle = await env.client.workflow.start("epicWorkflow", {
-            workflowId: `epic-search-attrs-refresh-legacy-${input.epicId}`,
-            taskQueue,
-            args: [input],
-          });
-
-          await handle.signal(epicCreatedSignal, {
-            id: input.epicId,
-            title: input.title,
-            narrative: input.narrative,
-            entries: [],
-            progress: {
-              status: "active" as const,
-              total_entries: 0,
-              completed_entries: 0,
-              active_entries: 0,
-              next_entry_id: null,
-              updated_at: input.initializedAt,
-            },
-            created_at: input.initializedAt,
+        await handle.signal(epicCreatedSignal, {
+          id: input.epicId,
+          title: input.title,
+          narrative: input.narrative,
+          entries: [],
+          progress: {
+            status: "active" as const,
+            total_entries: 0,
+            completed_entries: 0,
+            active_entries: 0,
+            next_entry_id: null,
             updated_at: input.initializedAt,
-            version: 0,
-          });
-
-          await handle.signal(searchAttributesRefreshedSignal, {
-            evidence: "Legacy index repair",
-            refreshedAt: "2026-05-05T00:01:00.000Z",
-            idempotencyKey: "legacy-repair-1",
-          });
-
-          const after = await handle.query(getEpicStateQuery);
-          expect(after.epic.version).toBe(0);
-          expect(after.epic.progress.status).toBe("active");
-          expect(after.idempotencyLedger).toHaveProperty("legacy-repair-1");
-
-          const description = await handle.describe();
-          const serialized = JSON.stringify(description);
-          expect(serialized).toContain("AdvEpicStatus");
-          expect(serialized).toContain("active");
+          },
+          created_at: input.initializedAt,
+          updated_at: input.initializedAt,
+          version: 0,
         });
-      },
-    );
+
+        await handle.signal(searchAttributesRefreshedSignal, {
+          evidence: "Legacy index repair",
+          refreshedAt: "2026-05-05T00:01:00.000Z",
+          idempotencyKey: "legacy-repair-1",
+        });
+
+        const after = await handle.query(getEpicStateQuery);
+        expect(after.epic.version).toBe(0);
+        expect(after.epic.progress.status).toBe("active");
+        expect(after.idempotencyLedger).toHaveProperty("legacy-repair-1");
+
+        const description = await handle.describe();
+        const serialized = JSON.stringify(description);
+        expect(serialized).toContain("AdvEpicStatus");
+        expect(serialized).toContain("active");
+      });
+    });
   }, 30_000);
 });

--- a/plugin/src/temporal/workflows.signal-handlers.test.ts
+++ b/plugin/src/temporal/workflows.signal-handlers.test.ts
@@ -5,7 +5,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { WorkflowHandle } from "@temporalio/client";
 
@@ -52,7 +51,7 @@ import {
   worktreeDeletedSignal,
   worktreeSetupFailedSignal,
 } from "./messages";
-import { withTestWorkflowEnvironment } from "./__tests__/with-test-env";
+import { withTimeSkippingTestWorkflowEnvironment } from "./__tests__/with-test-env";
 import { inspectArtifactActivity, writeArtifactActivity } from "./activities";
 import { cleanupTempDir, createTempDir } from "../__tests__/setup";
 
@@ -150,26 +149,23 @@ async function withSignalWorker(
     handle: WorkflowHandle<typeof import("./workflows").changeWorkflow>,
   ) => Promise<void>,
 ): Promise<void> {
-  await withTestWorkflowEnvironment(
-    () => TestWorkflowEnvironment.createTimeSkipping(),
-    async (env) => {
-      const taskQueue = `signal-handlers-${name}`;
-      const worker = await Worker.create({
-        connection: env.nativeConnection,
-        workflowsPath,
-        taskQueue,
-      });
+  await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+    const taskQueue = `signal-handlers-${name}`;
+    const worker = await Worker.create({
+      connection: env.nativeConnection,
+      workflowsPath,
+      taskQueue,
+    });
 
-      await worker.runUntil(async () => {
-        const handle = await env.client.workflow.start("changeWorkflow", {
-          workflowId: `signal-${name}-${Date.now()}`,
-          taskQueue,
-          args: [makeChangeInput(name)],
-        });
-        await fn(handle);
+    await worker.runUntil(async () => {
+      const handle = await env.client.workflow.start("changeWorkflow", {
+        workflowId: `signal-${name}-${Date.now()}`,
+        taskQueue,
+        args: [makeChangeInput(name)],
       });
-    },
-  );
+      await fn(handle);
+    });
+  });
 }
 
 async function withArtifactSignalWorker(
@@ -179,27 +175,24 @@ async function withArtifactSignalWorker(
     handle: WorkflowHandle<typeof import("./workflows").changeWorkflow>,
   ) => Promise<void>,
 ): Promise<void> {
-  await withTestWorkflowEnvironment(
-    () => TestWorkflowEnvironment.createTimeSkipping(),
-    async (env) => {
-      const taskQueue = `signal-handlers-${name}`;
-      const worker = await Worker.create({
-        connection: env.nativeConnection,
-        workflowsPath,
-        taskQueue,
-        activities: { inspectArtifactActivity, writeArtifactActivity },
-      });
+  await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+    const taskQueue = `signal-handlers-${name}`;
+    const worker = await Worker.create({
+      connection: env.nativeConnection,
+      workflowsPath,
+      taskQueue,
+      activities: { inspectArtifactActivity, writeArtifactActivity },
+    });
 
-      await worker.runUntil(async () => {
-        const handle = await env.client.workflow.start("changeWorkflow", {
-          workflowId: `signal-${name}-${Date.now()}`,
-          taskQueue,
-          args: [input],
-        });
-        await fn(handle);
+    await worker.runUntil(async () => {
+      const handle = await env.client.workflow.start("changeWorkflow", {
+        workflowId: `signal-${name}-${Date.now()}`,
+        taskQueue,
+        args: [input],
       });
-    },
-  );
+      await fn(handle);
+    });
+  });
 }
 
 async function queryState(

--- a/plugin/test/fixtures/temporal/crash-leaks-test-server.mts
+++ b/plugin/test/fixtures/temporal/crash-leaks-test-server.mts
@@ -1,0 +1,51 @@
+/**
+ * Crash fixture for the real-server residue proof (reapLeakedTestServers AC5).
+ *
+ * Spawned as a child process by `with-test-env-residue.itest.ts`. It creates
+ * a REAL time-skipping test environment through the named helper constructor
+ * (raw `TestWorkflowEnvironment.create*` stays inside the helper module per
+ * the constructor guard), prints the real test-server PID on stdout, then
+ * SIGKILLs itself. No `finally` / teardown can run on a SIGKILL, so the
+ * `/tmp/temporal-test-server-sdk-typescript-*` child is genuinely leaked —
+ * the exact crashed-runner scenario the conservative pre-run sweep exists for.
+ *
+ * Runs under plain Node (>=23.6) type stripping; invoked as
+ * `node crash-leaks-test-server.mts`. Stdout carries exactly one JSON line:
+ *   {"serverPid": <pid>}
+ */
+import { readdirSync, readFileSync, writeSync } from "node:fs";
+import { createTimeSkippingTestWorkflowEnvironment } from "../../../src/temporal/__tests__/with-test-env.ts";
+
+function findOwnTestServerPid(): number {
+  const self = process.pid;
+  for (const entry of readdirSync("/proc")) {
+    if (!/^\d+$/.test(entry)) continue;
+    let cmdline: string;
+    try {
+      cmdline = readFileSync(`/proc/${entry}/cmdline`, "utf8");
+    } catch {
+      continue; // kernel thread or raced exit
+    }
+    const argv0 = cmdline.split("\0")[0] ?? "";
+    const base = argv0.slice(argv0.lastIndexOf("/") + 1);
+    if (!base.startsWith("temporal-test-server-sdk-typescript-")) continue;
+    let stat: string;
+    try {
+      stat = readFileSync(`/proc/${entry}/stat`, "utf8");
+    } catch {
+      continue;
+    }
+    const rest = stat.slice(stat.lastIndexOf(")") + 2);
+    const ppid = Number(rest.split(" ")[1]);
+    if (ppid === self) return Number(entry);
+  }
+  throw new Error("crash fixture: no temporal test-server child found");
+}
+
+const env = await createTimeSkippingTestWorkflowEnvironment();
+// Deliberately never torn down: this process crashes right after reporting.
+void env;
+const serverPid = findOwnTestServerPid();
+// Synchronous flush: SIGKILL does not drain stdio buffers.
+writeSync(1, JSON.stringify({ serverPid }) + "\n");
+process.kill(process.pid, "SIGKILL");


### PR DESCRIPTION
## Problem
OOP Temporal integration tests spawn /tmp/temporal-test-server-sdk-* children; crashes/timeouts and helper-bypassing call sites leaked orphans that ran for days.

## Fix
- Helper-owned test-env constructors (33 raw call sites migrated); check-test-isolation guard forbids raw TestWorkflowEnvironment.create* outside the helper. Docstring corrected (SDK teardown swallows internal errors).
- Signal-aware teardown regression (throw + Vitest AbortSignal timeout).
- Conservative stale-only reaper (bin/lib/oc-test-reaper.bash): same-UID, exact basename, min-age >> suite duration (7200s), /proc (Linux) / ps -ww (macOS), start-dev/port-7233 exclusion, pre-signal revalidation, TERM->KILL, skip-on-unknown-identity, never fails caller.
- Real-server residue proof: induced orphan reaped; fresh peer + real dev server untouched.

## Verification
Reaper 14/14 bun tests; guard 15/15; with-test-env 11+1-expected-fail; residue proof 2/2; pnpm run check green. Independent reviewer READY.

ADV change: reapLeakedTestServers