### PR TITLE
fix(store): serve archived disk projection without querying poisoned terminal workflows

### DIFF
--- a/plugin/src/storage/store-temporal/index.test.ts
+++ b/plugin/src/storage/store-temporal/index.test.ts
@@ -546,7 +546,12 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     expect(startInputs()).toEqual([
       expect.objectContaining({ changeId: "activeDiskOnlyList" }),
     ]);
-    expect(queryCount("archivedDiskOnlyList")).toBe(1);
+    // Poison read-resilience: both terminal statuses are now served from the
+    // disk terminal projection WITHOUT a live workflow query. Archived
+    // previously incurred one query (then reseed-to-disk); it is now consistent
+    // with closed at zero queries, so a poisoned/terminated terminal workflow is
+    // never touched during enumeration.
+    expect(queryCount("archivedDiskOnlyList")).toBe(0);
     expect(queryCount("closedDiskOnlyList")).toBe(0);
   });
 
@@ -1422,6 +1427,54 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
     const result = await store.changes.get("archiveDominatesGet");
     expect(result.success).toBe(true);
     expect(result.data?.status).toBe("archived");
+    expect(queryCount).toBe(0);
+  });
+
+  it("serves an archived disk projection without querying a poisoned workflow when no archive bundle exists (poison read-resilience)", async () => {
+    // Regression guard: an archived change.json with NO archive bundle must be
+    // served from the disk terminal projection WITHOUT a live workflow query.
+    // Previously loadDiskTerminalProjection only short-circuited `closed`, so an
+    // archived-without-bundle change fell through to the live query and hit the
+    // poisoned/terminated workflow (TMPRL1100) before the catch→reseed path
+    // finally returned the same disk data — the per-candidate cost that
+    // accumulated into the enumeration wedge.
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    await legacy.changes.save(archivedChange("archivedNoBundlePoisoned"));
+
+    let queryCount = 0;
+    const temporal = {
+      client: {
+        workflow: {
+          getHandle: () => ({
+            query: async () => {
+              queryCount += 1;
+              throw poisonedHistoryError();
+            },
+          }),
+          list: async function* () {
+            yield {
+              workflowId: "adv/change/project-1/archivedNoBundlePoisoned",
+            };
+          },
+          start: async () => {
+            throw new Error("start should not be called");
+          },
+        },
+      },
+    };
+
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const result = await store.changes.get("archivedNoBundlePoisoned");
+    expect(result.success).toBe(true);
+    expect(result.data?.status).toBe("archived");
+    // The disk-terminal short-circuit must serve archived without any live
+    // query — never touching the poisoned workflow history.
     expect(queryCount).toBe(0);
   });
 

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -741,8 +741,27 @@ export function createTemporalStoreBackend(
   ): Promise<Change | null> => {
     try {
       const result = await legacy.changes.get(changeId);
-      if (result.success && result.data && result.data.status === "closed") {
-        return result.data;
+      // rq-terminalProjectionTruth01 / poison read-resilience: a terminal
+      // change.json (archived OR closed) is disk-authoritative and MUST be
+      // served without a live workflow round-trip. Archived previously relied
+      // solely on loadArchiveBundleDominantProjection (bundle-present); when the
+      // archive bundle is missing/raced, an archived change fell through to the
+      // live query and could hit a poisoned/terminated workflow (TMPRL1100),
+      // paying a wasteful query + describe() probe per candidate before the
+      // catch→reseedChangeFromDisk path finally returned the same disk data.
+      // Short-circuiting both terminal statuses here mirrors reseedChangeFromDisk
+      // and keeps enumeration/status reads fast even against poisoned terminal
+      // workflows.
+      if (
+        result.success &&
+        result.data &&
+        (result.data.status === "closed" || result.data.status === "archived")
+      ) {
+        // Mark the disk source so callers report source "disk" (matching the
+        // prior catch→reseedChangeFromDisk path). This is terminal-projection
+        // dominance, NOT a temporal_query_fallback recovery, so it does not
+        // carry the _recovery reconciliation marker.
+        return { ...result.data, _source: "disk" } as Change;
       }
     } catch {
       // Disk projection is only a terminal-state dominance check. Missing or

--- a/plugin/src/tools/trunk-write-firewall.ts
+++ b/plugin/src/tools/trunk-write-firewall.ts
@@ -149,6 +149,13 @@ function getWorktreeTopology(
   return cached;
 }
 
+// rq-crossProjectTrunkFirewall01: Target-Relative Cross-Project Trunk Write
+// Firewall. The firewall is evaluated relative to each write target's OWN git
+// root/branch topology (not just the current session's project), so a FOREIGN
+// repo's main checkout on its default branch is protected exactly like the
+// session project's trunk, while an eligible foreign linked worktree is allowed
+// (rq-crossProjectTrunkFirewall01.1 / .2). Target-root artifact and uncertainty
+// boundaries stay narrow (.3) and missing-parent/prunable topology is safe (.4).
 async function resolveTrunkContext(
   targetPath: string,
   deps: TrunkWriteFirewallDeps,


### PR DESCRIPTION
## Problem

Poisoned/terminated terminal workflows (TMPRL1100 nondeterminism) were being **queried** during `adv_change_list` / `adv_status` / archive conflict-inventory enumeration, causing the 8s aggregate-read wedge that slowed/blocked agents across projects.

Root cause: `loadDiskTerminalProjection` only short-circuited `status==='closed'`. An **archived** change.json whose archive bundle was missing/raced fell through `loadArchiveBundleDominantProjection` (bundle-present only) to the **live workflow query**, paying a wasteful query + `describe()` probe per candidate before the catch→`reseedChangeFromDisk` path finally returned the same disk data. That per-candidate cost accumulated into the enumeration wedge.

## Fix

Extend the pre-flight disk-terminal short-circuit to cover `archived` (terminal = disk-authoritative, mirroring `reseedChangeFromDisk`), marking `_source:'disk'` (dominance, not a `temporal_query_fallback` recovery). Terminal changes are now **never queried** during enumeration → a poisoned terminal workflow can no longer slow or wedge reads. Open/in-progress changes still query the live workflow (status preserved).

**Host/storage-layer only** — no workflow-bundle or replay-determinism change (worker bundle generation unchanged). This is the safe half of the poison-resilience work; "retire workflow at archive" already exists (workflows.ts:1734).

## Tests
- New regression guard: archived-without-bundle + poisoned query → served from disk, `queryCount===0`.
- Updated terminal-list test: archived now 0 queries (consistent with closed).
- Full store-temporal suite (145) + change/gate/bounded-read/status-repair (212) + `pnpm run check` green.

## Context
Follows operator-approved termination of 92 poisoned shipped workflows across pokeedge/pokeedge-web/advance. Also fixes ZLauncher `adv status`/`adv epic list` 3s-probe degradation under poison.