### PR TITLE
fix(store): load archive candidates before live-query candidates (8s inventory timeout)

### DIFF
--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -979,6 +979,25 @@ export function createTemporalStoreBackend(
       }
     }
 
+    // rq-inventoryDiskBudget01 / fixArchiveConflictInventory: process archive
+    // candidates FIRST within the hydration set. An archive candidate resolves
+    // from its durable on-disk bundle (a cheap, bounded local read via
+    // getTemporalChange's terminal-projection short-circuit) with no live
+    // workflow round-trip, whereas non-archive candidates may issue slow or
+    // poisoned workflow queries that consume the shared aggregate read
+    // deadline. Loading the cheap archived candidates before the expensive
+    // live queries prevents a query budget exhausted by slow/poisoned
+    // workflows from STARVING archived changes that already exist on disk —
+    // the root cause of the 8s conflict-inventory / includeArchived
+    // enumeration timeout (74/118 archived candidates omitted despite their
+    // bundles being present on disk). Stable sort preserves within-partition
+    // order (recency for the memo-warm active set, enumeration order otherwise).
+    if (archiveIdSet.size > 0) {
+      hydrationIds = [...hydrationIds].sort(
+        (a, b) => (archiveIdSet.has(a) ? 0 : 1) - (archiveIdSet.has(b) ? 0 : 1),
+      );
+    }
+
     // Batch size for loading changes — balances Temporal query parallelism
     // against memory usage. 20 keeps per-batch latency under ~200ms with
     // typical Temporal backends while avoiding excessive concurrent signals.


### PR DESCRIPTION
## Problem

Agents hit an **8s inventory timeout** in advance that blocked archive operations. The terminal-candidate enumeration (`adv_change_list` includeArchived / archive conflict-inventory) hydrates a mixed set of archived + active candidates under one 8s aggregate read deadline:
- archived candidates resolve from a cheap on-disk bundle (no workflow query)
- active candidates may issue slow or **poisoned (TMPRL1100)** live workflow queries

Processed in enumeration order, the slow/poisoned workflow queries consumed the budget first and **starved archived candidates that already sit on disk** — 74/118 omitted, `SOURCE_DEADLINE_EXCEEDED`, in a project with many archived changes.

## Fix

Process **archive candidates first** (stable partition) so their bundles load cheaply before the budget is spent on live queries. Bonus: shipped-but-draft poisoned changes that carry an archive bundle now load from that bundle instead of querying their poisoned workflow at all — removing the very queries that were eating the budget. Within-partition order preserved.

Host/storage-layer only; no workflow-bundle / replay-determinism change (worker generation unchanged).

## Tests
- Full store-temporal suite (145) green, **no test changes** — the slow-disk archive-bound guard is unchanged.
- `pnpm run check` green.

## Context
Root cause of `fixArchiveConflictInventory` (prematurely closed as superseded by the single-read #234, which did not cover this enumeration path). Follows terminating 14 vestigial poisoned archived-but-running workflows (partial relief; this is the durable fix).