### PR TITLE
fix(store): active-only conflict authority to unblock archive validation

### DIFF
--- a/plugin/src/archive/archive.test.ts
+++ b/plugin/src/archive/archive.test.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "fs";
+import { createHash } from "crypto";
 import { execSync } from "child_process";
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
@@ -13,6 +14,11 @@ import {
   getArchiveContractProofErrors,
   reconcileInRepoArchive,
 } from "./archive";
+import {
+  TERMINAL_SUMMARY_FILE,
+  validateTerminalArchiveSummary,
+  verifyTerminalArchiveSummaryHash,
+} from "./terminal-summary";
 
 const createdAt = "2026-05-08T00:00:00.000Z";
 let tempDirs: string[] = [];
@@ -223,7 +229,7 @@ describe("contract archive traceability", () => {
         {
           repo_id: "web",
           path: web,
-          repo_project_id: "w".repeat(40),
+          repo_project_id: "a".repeat(40),
           required: true,
           merge_order: 2,
         },
@@ -552,9 +558,11 @@ describe("contract archive traceability", () => {
         contract: undefined,
         wisdom: [
           {
+            id: "ws-1",
             type: "convention",
             content: "Always write tests first",
             source_task: "tk-1",
+            recorded_at: createdAt,
           },
         ],
       });
@@ -666,9 +674,11 @@ describe("contract archive traceability", () => {
         id: "newline-external",
         wisdom: [
           {
+            id: "ws-newline",
             type: "convention",
             content: "newline matters",
             source_task: "tk-1",
+            recorded_at: createdAt,
           },
         ],
       });
@@ -728,15 +738,267 @@ describe("contract archive traceability", () => {
         id: "newline-inrepo",
         wisdom: [
           {
+            id: "ws-newline",
             type: "convention",
             content: "newline matters",
             source_task: "tk-1",
+            recorded_at: createdAt,
           },
         ],
       });
       const archivePath = await createInRepoArchive(change, archiveDir);
       await expectSingleTrailingNewline(join(archivePath, "change.json"));
       await expectSingleTrailingNewline(join(archivePath, "wisdom.json"));
+    });
+  });
+
+  describe("terminal-summary archive bundles (SC4/AC4/AC6)", () => {
+    test("archiveChange writes summary.v1.json to the external archive", async () => {
+      const root = await tempProject();
+      const change = changeWithContract({
+        id: "terminal-summary-external",
+        gates: {
+          proposal: { status: "done", completed_at: createdAt },
+          discovery: { status: "done", completed_at: createdAt },
+          design: { status: "done", completed_at: createdAt },
+          planning: { status: "done", completed_at: createdAt },
+          execution: { status: "done", completed_at: createdAt },
+          acceptance: { status: "done", completed_at: createdAt },
+          release: { status: "done", completed_at: createdAt },
+        },
+      });
+
+      const result = await archiveChange({
+        change,
+        specs: new Map(),
+        paths: {
+          specs: join(root, "specs"),
+          docs: join(root, "docs"),
+          archive: join(root, "archive"),
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const summaryPath = join(result.archivePath, TERMINAL_SUMMARY_FILE);
+      expect(existsSync(summaryPath)).toBe(true);
+      const raw = await readFile(summaryPath, "utf-8");
+      const summary = validateTerminalArchiveSummary(JSON.parse(raw));
+      expect(summary.version).toBe("1");
+      expect(summary.change_id).toBe("terminal-summary-external");
+      expect(summary.status).toBe("archived");
+      expect(summary.current_gate).toBe("done");
+      expect(summary.task_count).toBe(1);
+      expect(summary.completed_tasks).toBe(1);
+      expect(summary.change_hash).toMatch(/^[a-f0-9]{64}$/);
+      expect(summary.summary_hash).toMatch(/^[a-f0-9]{64}$/);
+      expect(verifyTerminalArchiveSummaryHash(summary)).toBe(true);
+    });
+
+    test("createInRepoArchive writes summary.v1.json to the in-repo archive", async () => {
+      const root = await tempProject();
+      const archiveDir = join(root, "archive");
+      const change = changeWithContract({
+        id: "terminal-summary-inrepo",
+        contract: undefined,
+      });
+
+      const archivePath = await createInRepoArchive(change, archiveDir);
+      const summaryPath = join(archivePath, TERMINAL_SUMMARY_FILE);
+      expect(existsSync(summaryPath)).toBe(true);
+      const raw = await readFile(summaryPath, "utf-8");
+      const summary = validateTerminalArchiveSummary(JSON.parse(raw));
+      expect(summary.version).toBe("1");
+      expect(summary.change_id).toBe("terminal-summary-inrepo");
+      expect(summary.status).toBe("archived");
+    });
+
+    test("external and in-repo terminal summaries are coherent for the same Change", async () => {
+      const root = await tempProject();
+      const change = changeWithContract({
+        id: "terminal-summary-coherent",
+        contract: undefined,
+      });
+      const inRepoArchiveDir = join(root, "repo", ".adv", "archive");
+
+      const result = await archiveChange({
+        change,
+        specs: new Map(),
+        paths: {
+          specs: join(root, "specs"),
+          docs: join(root, "docs"),
+          archive: join(root, "archive"),
+          inRepoArchive: inRepoArchiveDir,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const externalRaw = await readFile(
+        join(result.archivePath, TERMINAL_SUMMARY_FILE),
+        "utf-8",
+      );
+      const inRepoRaw = await readFile(
+        join(
+          inRepoArchiveDir,
+          `${new Date().toISOString().split("T")[0]}-terminal-summary-coherent`,
+          TERMINAL_SUMMARY_FILE,
+        ),
+        "utf-8",
+      );
+      const externalSummary = validateTerminalArchiveSummary(
+        JSON.parse(externalRaw),
+      );
+      const inRepoSummary = validateTerminalArchiveSummary(
+        JSON.parse(inRepoRaw),
+      );
+      expect(externalSummary.change_hash).toBe(inRepoSummary.change_hash);
+      expect(externalSummary.archived_at).toBe(inRepoSummary.archived_at);
+      expect(inRepoSummary).toEqual(externalSummary);
+    });
+
+    test("change_hash binds terminal summary to the sibling change.json bytes", async () => {
+      const root = await tempProject();
+      const change = changeWithContract({
+        id: "terminal-summary-hash-binding",
+        contract: undefined,
+      });
+      const archivePath = await createInRepoArchive(
+        change,
+        join(root, "archive"),
+      );
+      const changeJson = await readFile(
+        join(archivePath, "change.json"),
+        "utf-8",
+      );
+      const summary = validateTerminalArchiveSummary(
+        JSON.parse(
+          await readFile(join(archivePath, TERMINAL_SUMMARY_FILE), "utf-8"),
+        ),
+      );
+      const expectedHash = createHash("sha256")
+        .update(changeJson, "utf-8")
+        .digest("hex");
+      expect(summary.change_hash).toBe(expectedHash);
+    });
+
+    test("terminal summary is lightweight relative to full change.json", async () => {
+      const root = await tempProject();
+      const change = changeWithContract({
+        id: "terminal-summary-lightweight",
+        contract: undefined,
+        documents: {
+          proposal: "a".repeat(5000),
+          acceptance: "b".repeat(5000),
+        },
+      });
+      const archivePath = await createInRepoArchive(
+        change,
+        join(root, "archive"),
+      );
+      const changeJson = await readFile(
+        join(archivePath, "change.json"),
+        "utf-8",
+      );
+      const summaryJson = await readFile(
+        join(archivePath, TERMINAL_SUMMARY_FILE),
+        "utf-8",
+      );
+      expect(summaryJson.length).toBeLessThan(changeJson.length / 2);
+    });
+
+    test("summary.v1.json is newline-terminated", async () => {
+      const root = await tempProject();
+      const change = changeWithContract({
+        id: "terminal-summary-newline",
+        contract: undefined,
+      });
+      const result = await archiveChange({
+        change,
+        specs: new Map(),
+        paths: {
+          specs: join(root, "specs"),
+          docs: join(root, "docs"),
+          archive: join(root, "archive"),
+        },
+      });
+      const raw = await readFile(
+        join(result.archivePath, TERMINAL_SUMMARY_FILE),
+        "utf-8",
+      );
+      expect(raw.endsWith("\n")).toBe(true);
+      expect(raw.endsWith("\n\n")).toBe(false);
+    });
+
+    test("sibling files with generated names do not overwrite generated bundle files", async () => {
+      const root = await tempProject();
+      const archiveDir = join(root, "archive");
+      const sourceChangeDir = join(
+        root,
+        "changes",
+        "terminal-summary-preserve",
+      );
+      await mkdir(sourceChangeDir, { recursive: true });
+      const bogus = "this should not overwrite generated files";
+      await writeFile(
+        join(sourceChangeDir, "change.json"),
+        JSON.stringify({ bogus }),
+      );
+      await writeFile(
+        join(sourceChangeDir, TERMINAL_SUMMARY_FILE),
+        JSON.stringify({ bogus }),
+      );
+      await writeFile(join(sourceChangeDir, "ARCHIVE_SUMMARY.md"), bogus);
+      await writeFile(join(sourceChangeDir, "BRIEFING_DIGEST.md"), bogus);
+      await writeFile(join(sourceChangeDir, "CONTRACT_TRACEABILITY.md"), bogus);
+      await writeFile(
+        join(sourceChangeDir, "wisdom.json"),
+        JSON.stringify({ bogus }),
+      );
+      await writeFile(
+        join(sourceChangeDir, "multi-repo-archive.json"),
+        JSON.stringify({ bogus }),
+      );
+
+      const archivePath = await createInRepoArchive(
+        changeWithContract({
+          id: "terminal-summary-preserve",
+          contract: undefined,
+        }),
+        archiveDir,
+        sourceChangeDir,
+      );
+
+      const changeJson = JSON.parse(
+        await readFile(join(archivePath, "change.json"), "utf-8"),
+      );
+      expect(changeJson.status).toBe("archived");
+      expect(changeJson.bogus).toBeUndefined();
+
+      const summary = validateTerminalArchiveSummary(
+        JSON.parse(
+          await readFile(join(archivePath, TERMINAL_SUMMARY_FILE), "utf-8"),
+        ),
+      );
+      expect(summary.version).toBe("1");
+      expect(summary.change_id).toBe("terminal-summary-preserve");
+
+      const archiveSummary = await readFile(
+        join(archivePath, "ARCHIVE_SUMMARY.md"),
+        "utf-8",
+      );
+      expect(archiveSummary).toContain("Archive:");
+      expect(archiveSummary).not.toContain(bogus);
+
+      const digest = await readFile(
+        join(archivePath, "BRIEFING_DIGEST.md"),
+        "utf-8",
+      );
+      expect(digest).toContain("Archive Briefing Digest");
+      expect(digest).not.toContain(bogus);
+
+      expect(existsSync(join(archivePath, "wisdom.json"))).toBe(false);
+      expect(existsSync(join(archivePath, "multi-repo-archive.json"))).toBe(
+        false,
+      );
     });
   });
 });

--- a/plugin/src/archive/archive.ts
+++ b/plugin/src/archive/archive.ts
@@ -8,7 +8,13 @@
 import { join, dirname } from "path";
 import { readdir, readFile } from "fs/promises";
 import { atomicWriteFile } from "../utils/fs";
-import type { Spec, Change } from "../types";
+import { ChangeSchema, type Spec, type Change } from "../types";
+import {
+  buildTerminalArchiveSummary,
+  serializeTerminalArchiveSummary,
+  sha256HexString,
+  TERMINAL_SUMMARY_FILE,
+} from "./terminal-summary";
 import type {
   ArchiveContext,
   ArchiveOperationResult,
@@ -65,6 +71,77 @@ async function archiveBundlePathForWrite(
   );
 }
 
+/**
+ * Write the generated archive bundle artifacts for a change.
+ *
+ * This is the single source of truth for the files that are produced from
+ * workflow state (change.json, terminal summary, digest, traceability, etc.).
+ * Sibling copy loops elsewhere skip GENERATED_BUNDLE_FILES so that hand-written
+ * or legacy source files never clobber generated ones.
+ */
+async function writeArchiveBundleFiles(
+  change: Change,
+  archivePath: string,
+  multiRepo: MultiRepoArchiveMetadata | undefined,
+  archivedAt: string,
+): Promise<void> {
+  const archivedChange: Change = { ...change, status: "archived" };
+
+  // Sentinel: change.json is the durable archive authority and is written first.
+  const changeJson = bundleJsonStringify(archivedChange);
+  await atomicWriteFile(join(archivePath, "change.json"), changeJson);
+  const changeHash = sha256HexString(changeJson);
+
+  // Terminal summary is derived from the validated archived Change and bound to
+  // the exact change.json bytes via changeHash.
+  const validatedChange = ChangeSchema.parse(archivedChange);
+  const terminalSummary = buildTerminalArchiveSummary({
+    change: validatedChange,
+    archivedAt,
+    changeHash,
+  });
+  await atomicWriteFile(
+    join(archivePath, TERMINAL_SUMMARY_FILE),
+    serializeTerminalArchiveSummary(terminalSummary),
+  );
+
+  // Human-readable archive summary.
+  const summary = generateArchiveSummary(change);
+  await atomicWriteFile(join(archivePath, "ARCHIVE_SUMMARY.md"), summary);
+
+  // Archive-lane briefing digest (idempotent overwrite).
+  const digest = generateBriefingDigest(change);
+  await atomicWriteFile(join(archivePath, BRIEFING_DIGEST_FILE), digest);
+
+  // Contract traceability, when present.
+  const traceability = generateContractTraceability(change);
+  if (traceability) {
+    await atomicWriteFile(
+      join(archivePath, "CONTRACT_TRACEABILITY.md"),
+      traceability,
+    );
+  }
+
+  // Wisdom sidecar, when present.
+  if (change.wisdom && change.wisdom.length > 0) {
+    await atomicWriteFile(
+      join(archivePath, "wisdom.json"),
+      bundleJsonStringify({
+        entries: change.wisdom,
+        count: change.wisdom.length,
+      }),
+    );
+  }
+
+  // Multi-repo archive metadata, when present.
+  if (multiRepo) {
+    await atomicWriteFile(
+      join(archivePath, "multi-repo-archive.json"),
+      bundleJsonStringify(multiRepo),
+    );
+  }
+}
+
 function sortedScopeRepos(change: Change): NonNullable<Change["scope_repos"]> {
   return [...(change.scope_repos ?? [])].sort((a, b) => {
     const aOrder = a.merge_order ?? Number.MAX_SAFE_INTEGER;
@@ -75,6 +152,16 @@ function sortedScopeRepos(change: Change): NonNullable<Change["scope_repos"]> {
 }
 
 const BRIEFING_DIGEST_FILE = "BRIEFING_DIGEST.md";
+
+const GENERATED_BUNDLE_FILES = new Set([
+  "change.json",
+  TERMINAL_SUMMARY_FILE,
+  "ARCHIVE_SUMMARY.md",
+  "BRIEFING_DIGEST.md",
+  "CONTRACT_TRACEABILITY.md",
+  "wisdom.json",
+  "multi-repo-archive.json",
+]);
 
 function buildTerminalGateSummary(change: Change): Record<string, string> {
   const gates = change.gates ?? createDefaultGates();
@@ -762,6 +849,7 @@ export async function archiveChange(
   const sourceChangeDir = paths.changes
     ? join(paths.changes, change.id)
     : undefined;
+  const archivedAt = new Date().toISOString();
   const archivePath = await createArchive(
     change,
     paths.archive,
@@ -769,6 +857,7 @@ export async function archiveChange(
     sourceChangeDir,
     errors,
     multiRepo.metadata,
+    archivedAt,
   );
 
   // In-repo archive: write identical bundle to in-repo path (warning-only on failure)
@@ -779,6 +868,7 @@ export async function archiveChange(
         paths.inRepoArchive,
         sourceChangeDir,
         multiRepo.metadata,
+        archivedAt,
       );
     } catch {
       // In-repo failure is warning-only — do NOT add to errors array
@@ -794,7 +884,7 @@ export async function archiveChange(
     docsGenerated,
     archivePath,
     errors,
-    archivedAt: new Date().toISOString(),
+    archivedAt,
     ...(multiRepo.metadata ? { multiRepo: multiRepo.metadata } : {}),
     ...(wisdomPromoted > 0 && { wisdomPromoted }),
   };
@@ -820,63 +910,23 @@ async function createArchive(
   sourceChangeDir?: string,
   errors?: string[],
   multiRepo?: MultiRepoArchiveMetadata,
+  archivedAt: string = new Date().toISOString(),
 ): Promise<string> {
   const archivePath = dryRun
     ? archiveBundlePath(archiveDir, change.id)
     : await archiveBundlePathForWrite(archiveDir, change.id);
 
   if (!dryRun) {
-    // Write the change as archived
-    const archivedChange: Change = {
-      ...change,
-      status: "archived",
-    };
-    await atomicWriteFile(
-      join(archivePath, "change.json"),
-      bundleJsonStringify(archivedChange),
-    );
-
-    // Write archive summary
-    const summary = generateArchiveSummary(change);
-    await atomicWriteFile(join(archivePath, "ARCHIVE_SUMMARY.md"), summary);
-
-    // Write archive-lane briefing digest (idempotent overwrite)
-    const digest = generateBriefingDigest(change);
-    await atomicWriteFile(join(archivePath, BRIEFING_DIGEST_FILE), digest);
-
-    const traceability = generateContractTraceability(change);
-    if (traceability) {
-      await atomicWriteFile(
-        join(archivePath, "CONTRACT_TRACEABILITY.md"),
-        traceability,
-      );
-    }
-
-    // Copy wisdom entries to archive if present
-    if (change.wisdom && change.wisdom.length > 0) {
-      await atomicWriteFile(
-        join(archivePath, "wisdom.json"),
-        bundleJsonStringify({
-          entries: change.wisdom,
-          count: change.wisdom.length,
-        }),
-      );
-    }
-
-    if (multiRepo) {
-      await atomicWriteFile(
-        join(archivePath, "multi-repo-archive.json"),
-        bundleJsonStringify(multiRepo),
-      );
-    }
+    await writeArchiveBundleFiles(change, archivePath, multiRepo, archivedAt);
 
     // Copy sibling files from source change directory (proposal.md, problem-statement.md, etc.)
     if (sourceChangeDir) {
       try {
         const entries = await readdir(sourceChangeDir, { withFileTypes: true });
         for (const entry of entries) {
-          // Skip change.json (already written above with stripped evidence)
-          if (entry.name === "change.json" || !entry.isFile()) continue;
+          // Skip generated bundle files (already written from validated state)
+          if (GENERATED_BUNDLE_FILES.has(entry.name) || !entry.isFile())
+            continue;
           try {
             const content = await readFile(
               join(sourceChangeDir, entry.name),
@@ -960,61 +1010,21 @@ export async function createInRepoArchive(
   inRepoArchiveDir: string,
   sourceChangeDir?: string,
   multiRepo?: MultiRepoArchiveMetadata,
+  archivedAt: string = new Date().toISOString(),
 ): Promise<string> {
   const archivePath = await archiveBundlePathForWrite(
     inRepoArchiveDir,
     change.id,
   );
 
-  const archivedChange: Change = {
-    ...change,
-    status: "archived",
-  };
-  await atomicWriteFile(
-    join(archivePath, "change.json"),
-    bundleJsonStringify(archivedChange),
-  );
-
-  // Write archive summary
-  const summary = generateArchiveSummary(change);
-  await atomicWriteFile(join(archivePath, "ARCHIVE_SUMMARY.md"), summary);
-
-  // Write archive-lane briefing digest (idempotent overwrite)
-  const digest = generateBriefingDigest(change);
-  await atomicWriteFile(join(archivePath, BRIEFING_DIGEST_FILE), digest);
-
-  const traceability = generateContractTraceability(change);
-  if (traceability) {
-    await atomicWriteFile(
-      join(archivePath, "CONTRACT_TRACEABILITY.md"),
-      traceability,
-    );
-  }
-
-  // Copy wisdom entries to archive if present
-  if (change.wisdom && change.wisdom.length > 0) {
-    await atomicWriteFile(
-      join(archivePath, "wisdom.json"),
-      bundleJsonStringify({
-        entries: change.wisdom,
-        count: change.wisdom.length,
-      }),
-    );
-  }
-
-  if (multiRepo) {
-    await atomicWriteFile(
-      join(archivePath, "multi-repo-archive.json"),
-      bundleJsonStringify(multiRepo),
-    );
-  }
+  await writeArchiveBundleFiles(change, archivePath, multiRepo, archivedAt);
 
   // Copy sibling files from source change directory
   if (sourceChangeDir) {
     try {
       const entries = await readdir(sourceChangeDir, { withFileTypes: true });
       for (const entry of entries) {
-        if (entry.name === "change.json" || !entry.isFile()) continue;
+        if (GENERATED_BUNDLE_FILES.has(entry.name) || !entry.isFile()) continue;
         try {
           const content = await readFile(
             join(sourceChangeDir, entry.name),

--- a/plugin/src/archive/terminal-summary.test.ts
+++ b/plugin/src/archive/terminal-summary.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildTerminalArchiveSummary,
+  serializeTerminalArchiveSummary,
+  sha256HexString,
+  TerminalArchiveSummarySchema,
+  validateTerminalArchiveSummary,
+  verifyTerminalArchiveSummaryHash,
+} from "./terminal-summary";
+import type { Change } from "../types";
+
+function makeChange(overrides: Partial<Change> = {}): Change {
+  return {
+    id: "terminal-summary-change",
+    title: "Terminal summary change",
+    status: "archived",
+    created_at: "2026-05-08T00:00:00.000Z",
+    tasks: [
+      {
+        id: "tk-1",
+        title: "Task one",
+        type: "code",
+        status: "done",
+        priority: 0,
+        created_at: "2026-05-08T00:00:00.000Z",
+      },
+      {
+        id: "tk-2",
+        title: "Task two",
+        type: "code",
+        status: "pending",
+        priority: 1,
+        created_at: "2026-05-08T00:00:00.000Z",
+      },
+    ],
+    deltas: {
+      capabilityA: [
+        {
+          id: "delta-1",
+          operation: "add",
+          requirement: { id: "REQ-1", title: "Req", capability: "capabilityA" },
+        },
+      ],
+      capabilityB: [
+        {
+          id: "delta-2",
+          operation: "modify",
+          requirement: { id: "REQ-2", title: "Req", capability: "capabilityB" },
+          target: { id: "REQ-2", title: "Req", capability: "capabilityB" },
+        },
+      ],
+    },
+    gates: {
+      proposal: { status: "done", completed_at: "2026-05-08T01:00:00.000Z" },
+      discovery: { status: "done", completed_at: "2026-05-08T02:00:00.000Z" },
+      design: { status: "done", completed_at: "2026-05-08T03:00:00.000Z" },
+      planning: { status: "done", completed_at: "2026-05-08T04:00:00.000Z" },
+      execution: { status: "done", completed_at: "2026-05-08T05:00:00.000Z" },
+      acceptance: { status: "done", completed_at: "2026-05-08T06:00:00.000Z" },
+      release: { status: "done", completed_at: "2026-05-08T07:00:00.000Z" },
+    },
+    ...overrides,
+  } as Change;
+}
+
+describe("buildTerminalArchiveSummary", () => {
+  test("produces a lightweight, versioned summary from a validated Change", () => {
+    const change = makeChange();
+    const summary = buildTerminalArchiveSummary({
+      change,
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+
+    expect(summary.version).toBe("1");
+    expect(summary.change_id).toBe("terminal-summary-change");
+    expect(summary.title).toBe("Terminal summary change");
+    expect(summary.status).toBe("archived");
+    expect(summary.created_at).toBe("2026-05-08T00:00:00.000Z");
+    expect(summary.archived_at).toBe("2026-07-18T12:00:00.000Z");
+    expect(summary.current_gate).toBe("done");
+    expect(summary.task_count).toBe(2);
+    expect(summary.completed_tasks).toBe(1);
+    expect(summary.capabilities).toEqual(["capabilityA", "capabilityB"]);
+    expect(summary.change_hash).toBe("abc123");
+    expect(summary.summary_hash).toBe("");
+    expect(summary.last_activity_at).toBe("2026-05-08T07:00:00.000Z");
+  });
+
+  test("derives the first open gate when not all gates are done", () => {
+    const change = makeChange({
+      gates: {
+        proposal: { status: "done", completed_at: "2026-05-08T01:00:00.000Z" },
+        discovery: { status: "pending" },
+        design: { status: "pending" },
+        planning: { status: "pending" },
+        execution: { status: "pending" },
+        acceptance: { status: "pending" },
+        release: { status: "pending" },
+      },
+    });
+    const summary = buildTerminalArchiveSummary({
+      change,
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    expect(summary.current_gate).toBe("discovery");
+  });
+
+  test("passes through optional relational fields", () => {
+    const change = makeChange({
+      fast_follow_of: {
+        parent_change_id: "parent-1",
+        followup_ref: "fu-1",
+      },
+      epic_membership: {
+        epic_id: "epic-1",
+        entry_id: "entry-1",
+        order: 0,
+        title: "Epic title",
+        linked_at: "2026-05-08T00:00:00.000Z",
+      },
+    });
+    const summary = buildTerminalArchiveSummary({
+      change,
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    expect(summary.fast_follow_of).toEqual({
+      parent_change_id: "parent-1",
+      followup_ref: "fu-1",
+    });
+    expect(summary.epic_membership).toMatchObject({ epic_id: "epic-1" });
+  });
+});
+
+describe("serializeTerminalArchiveSummary", () => {
+  test("emits versioned JSON with a trailing newline and populated hash", () => {
+    const summary = buildTerminalArchiveSummary({
+      change: makeChange(),
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    const serialized = serializeTerminalArchiveSummary(summary);
+
+    expect(serialized.endsWith("\n")).toBe(true);
+    expect(serialized.endsWith("\n\n")).toBe(false);
+    const parsed = JSON.parse(serialized);
+    expect(parsed.version).toBe("1");
+    expect(parsed.change_id).toBe("terminal-summary-change");
+    expect(parsed.summary_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(parsed.change_hash).toBe("abc123");
+  });
+
+  test("produces deterministic output for identical inputs", () => {
+    const summary = buildTerminalArchiveSummary({
+      change: makeChange(),
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    const first = serializeTerminalArchiveSummary(summary);
+    const second = serializeTerminalArchiveSummary(
+      JSON.parse(first) as ReturnType<typeof buildTerminalArchiveSummary>,
+    );
+    expect(second).toBe(first);
+  });
+
+  test("sorts keys lexicographically", () => {
+    const summary = buildTerminalArchiveSummary({
+      change: makeChange(),
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    const serialized = serializeTerminalArchiveSummary(summary);
+    const firstLine = serialized.split("\n")[1];
+    expect(firstLine).toBe('  "archived_at": "2026-07-18T12:00:00.000Z",');
+  });
+});
+
+describe("TerminalArchiveSummarySchema", () => {
+  test("accepts a valid summary", () => {
+    const summary = buildTerminalArchiveSummary({
+      change: makeChange(),
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    expect(() => TerminalArchiveSummarySchema.parse(summary)).not.toThrow();
+  });
+
+  test("rejects an unsupported version", () => {
+    const summary = buildTerminalArchiveSummary({
+      change: makeChange(),
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    expect(() =>
+      TerminalArchiveSummarySchema.parse({ ...summary, version: "2" }),
+    ).toThrow();
+  });
+
+  test("rejects a non-terminal status", () => {
+    const summary = buildTerminalArchiveSummary({
+      change: makeChange(),
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    expect(() =>
+      TerminalArchiveSummarySchema.parse({ ...summary, status: "draft" }),
+    ).toThrow();
+  });
+});
+
+describe("verifyTerminalArchiveSummaryHash", () => {
+  test("returns true for a freshly serialized summary", () => {
+    const summary = buildTerminalArchiveSummary({
+      change: makeChange(),
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    const serialized = serializeTerminalArchiveSummary(summary);
+    const parsed = validateTerminalArchiveSummary(JSON.parse(serialized));
+    expect(verifyTerminalArchiveSummaryHash(parsed)).toBe(true);
+  });
+
+  test("returns false when the summary has been tampered with", () => {
+    const summary = buildTerminalArchiveSummary({
+      change: makeChange(),
+      archivedAt: "2026-07-18T12:00:00.000Z",
+      changeHash: "abc123",
+    });
+    const serialized = serializeTerminalArchiveSummary(summary);
+    const parsed = validateTerminalArchiveSummary(JSON.parse(serialized));
+    parsed.title = "Tampered";
+    expect(verifyTerminalArchiveSummaryHash(parsed)).toBe(false);
+  });
+});
+
+describe("sha256HexString", () => {
+  test("produces a 64-character hex digest", () => {
+    const hash = sha256HexString("hello");
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/plugin/src/archive/terminal-summary.ts
+++ b/plugin/src/archive/terminal-summary.ts
@@ -1,0 +1,183 @@
+/**
+ * Archive Terminal Summary
+ *
+ * Versioned, schema-validated lightweight terminal summary sidecar for ADV
+ * archive bundles.  The sidecar is small enough to enumerate large terminal
+ * histories without parsing the full change.json, while still carrying enough
+ * structural fields to reconstruct a ChangeListResponse row or ChangeSummary.
+ *
+ * The sidecar is bound to its sibling change.json by SHA-256 of the exact
+ * change.json bytes, and its own integrity is protected by a summaryHash that
+ * is computed over the canonical UTF-8 JSON with lexicographic key order and
+ * the summaryHash field omitted.
+ */
+
+import { createHash } from "crypto";
+import { z } from "zod";
+import {
+  ChangeLifecycleStateSchema,
+  FastFollowOfSchema,
+  OpsFollowupLinkSchema,
+  OpsFollowupProfileSchema,
+  type Change,
+} from "../types";
+import { EpicMembershipSchema } from "../types/epics";
+import { GateIdSchema } from "../types/gates";
+import { computeLastActivity, firstOpenGate } from "../storage/store-types";
+
+export const TERMINAL_SUMMARY_FILE = "summary.v1.json";
+
+export const TerminalArchiveSummarySchema = z.object({
+  version: z.literal("1"),
+  change_id: z.string(),
+  title: z.string(),
+  status: z.enum(["archived", "closed"]),
+  lifecycle_state: ChangeLifecycleStateSchema.optional(),
+  created_at: z.string(),
+  last_activity_at: z.string(),
+  current_gate: z.union([GateIdSchema, z.literal("done")]),
+  task_count: z.number().int().nonnegative(),
+  completed_tasks: z.number().int().nonnegative(),
+  capabilities: z.array(z.string()),
+  archived_at: z.string(),
+  change_hash: z.string(),
+  summary_hash: z.string(),
+  fast_follow_of: FastFollowOfSchema.optional(),
+  ops_followup: OpsFollowupProfileSchema.optional(),
+  ops_followup_links: z.array(OpsFollowupLinkSchema).optional(),
+  epic_membership: EpicMembershipSchema.optional(),
+});
+
+export type TerminalArchiveSummary = z.infer<
+  typeof TerminalArchiveSummarySchema
+>;
+
+export interface BuildTerminalArchiveSummaryInput {
+  change: Change;
+  archivedAt: string;
+  changeHash: string;
+}
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf-8").digest("hex");
+}
+
+function sortJsonKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonKeys);
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => [key, sortJsonKeys(nested)]);
+    return Object.fromEntries(entries);
+  }
+
+  return value;
+}
+
+/**
+ * Build a lightweight terminal summary from a validated archived Change.
+ *
+ * The caller is responsible for passing a Change that has already been
+ * schema-validated and carries a terminal status (archived/closed).
+ */
+export function buildTerminalArchiveSummary(
+  input: BuildTerminalArchiveSummaryInput,
+): TerminalArchiveSummary {
+  const { change, archivedAt, changeHash } = input;
+  if (change.status !== "archived" && change.status !== "closed") {
+    throw new Error(
+      `Terminal summary requires a terminal Change status, got "${change.status}"`,
+    );
+  }
+  const doneTasks = change.tasks.filter((task) => task.status === "done");
+
+  return {
+    version: "1",
+    change_id: change.id,
+    title: change.title,
+    status: change.status,
+    lifecycle_state: change.lifecycleState,
+    created_at: change.created_at,
+    last_activity_at: computeLastActivity(change),
+    current_gate: firstOpenGate(change.gates),
+    task_count: change.tasks.length,
+    completed_tasks: doneTasks.length,
+    capabilities: Object.keys(change.deltas).sort((a, b) => a.localeCompare(b)),
+    archived_at: archivedAt,
+    change_hash: changeHash,
+    summary_hash: "", // populated by serializeTerminalArchiveSummary
+    fast_follow_of: change.fast_follow_of,
+    ops_followup: change.ops_followup,
+    ops_followup_links: change.ops_followup_links,
+    epic_membership: change.epic_membership,
+  };
+}
+
+/**
+ * Serialize a terminal summary to canonical UTF-8 JSON with a trailing newline.
+ *
+ * The summaryHash is computed over the JSON with lexicographic key order and
+ * the summaryHash field omitted, then appended to the output.  This lets a
+ * reader verify both the summary integrity and the binding to the sibling
+ * change.json (via change_hash) without re-parsing the full change record.
+ */
+export function serializeTerminalArchiveSummary(
+  summary: TerminalArchiveSummary,
+): string {
+  TerminalArchiveSummarySchema.parse(summary);
+
+  const { summary_hash: _omitted, ...canonical } = summary;
+  const canonicalBytes = `${JSON.stringify(
+    sortJsonKeys(canonical),
+    null,
+    2,
+  )}\n`;
+  const summaryHash = sha256Hex(canonicalBytes);
+
+  const withHash: TerminalArchiveSummary = {
+    ...summary,
+    summary_hash: summaryHash,
+  };
+
+  return `${JSON.stringify(sortJsonKeys(withHash), null, 2)}\n`;
+}
+
+/**
+ * Parse and validate a raw terminal summary sidecar.
+ */
+export function validateTerminalArchiveSummary(
+  value: unknown,
+): TerminalArchiveSummary {
+  return TerminalArchiveSummarySchema.parse(value);
+}
+
+/**
+ * Verify that a terminal summary's summaryHash matches the canonical bytes
+ * (summaryHash omitted).  Returns true when the sidecar is internally
+ * consistent; callers should also verify change_hash against the sibling
+ * change.json when authoritative binding is required.
+ */
+export function verifyTerminalArchiveSummaryHash(
+  summary: TerminalArchiveSummary,
+): boolean {
+  const { summary_hash, ...canonical } = summary;
+  const canonicalBytes = `${JSON.stringify(
+    sortJsonKeys(canonical),
+    null,
+    2,
+  )}\n`;
+  return sha256Hex(canonicalBytes) === summary_hash;
+}
+
+/**
+ * Compute the SHA-256 hex digest of a UTF-8 string.
+ *
+ * Exposed so archive.ts can compute the binding change_hash from the exact
+ * change.json bytes that are written to disk.
+ */
+export function sha256HexString(input: string): string {
+  return sha256Hex(input);
+}

--- a/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
+++ b/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
@@ -92,14 +92,6 @@ function archivedChange(id: string): Change {
   };
 }
 
-function closedChange(id: string): Change {
-  return {
-    ...activeChange(id, []),
-    title: `Closed ${id}`,
-    status: "closed",
-  };
-}
-
 function workflowStateFor(change: Change) {
   return {
     id: change.id,

--- a/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
+++ b/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
@@ -176,6 +176,49 @@ function mockTemporalClient(opts: MockTemporalOptions = {}) {
   };
 }
 
+/**
+ * Settle a pending authority read that interleaves real disk I/O with
+ * fake-timer-delayed workflow-fallback queries.
+ *
+ * A single fixed `advanceTimersByTimeAsync` is flaky under slower CI: the
+ * fallback query/cap timers are registered only after a real `loadChange`
+ * macrotask resolves, so a one-shot advance can miss them entirely (hang) —
+ * while `runAllTimersAsync` overshoots and fires the 1,000ms cap even when the
+ * 650ms query should win. Instead advance the fake clock in small steps,
+ * flushing real I/O before each step so any newly-needed timer is registered
+ * first, and stop as soon as the read settles. Because the fallback query
+ * (regTime+650ms) always precedes the cap (regTime+1,000ms), the success case
+ * settles before the cap; the poison case (regTime+1,200ms query) settles when
+ * the cap fires. Bounded by `maxTotalMs` so a real hang still fails fast (DC10).
+ */
+async function settlePending<T>(
+  pending: Promise<T>,
+  {
+    stepMs = 50,
+    maxTotalMs = 5_000,
+  }: { stepMs?: number; maxTotalMs?: number } = {},
+): Promise<T> {
+  let settled = false;
+  void pending.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  let total = 0;
+  while (!settled && total < maxTotalMs) {
+    // Flush real macro/microtasks (e.g. the missing-file loadChange) so the
+    // fallback timers exist before we advance the fake clock onto them.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(stepMs);
+    total += stepMs;
+  }
+  return pending;
+}
+
 describe("active conflict authority", () => {
   let tempDir: string | undefined;
 
@@ -323,12 +366,9 @@ describe("active conflict authority", () => {
     const pending = store.changes.listConflictAuthority!({
       deadline: createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS),
     });
-    // Yield to real I/O so the missing-file load resolves, then advance fake
-    // timers past the 650ms fallback delay.
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(800);
-    const result = await pending;
+    // Interleave real missing-file I/O with the 650ms fake-timer fallback
+    // delay deterministically (see settlePending rationale).
+    const result = await settlePending(pending);
 
     expect(result.completeness).toBe("complete");
     expect(result.canConcludeClean).toBe(true);
@@ -355,11 +395,10 @@ describe("active conflict authority", () => {
     const pending = store.changes.listConflictAuthority!({
       deadline: createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS),
     });
-    // Yield to real I/O, then advance past the 1,000ms fallback cap.
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(1_100);
-    const result = await pending;
+    // Both candidates fall back to a 1,200ms query; the 1,000ms cap must fire
+    // first. settlePending drains the real missing-file I/O and the fake
+    // fallback/cap timers deterministically.
+    const result = await settlePending(pending);
 
     expect(result.completeness).toBe("incomplete");
     expect(result.canConcludeClean).toBe(false);

--- a/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
+++ b/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
@@ -177,45 +177,27 @@ function mockTemporalClient(opts: MockTemporalOptions = {}) {
 }
 
 /**
- * Settle a pending authority read that interleaves real disk I/O with
- * fake-timer-delayed workflow-fallback queries.
+ * Settle a pending authority read whose workflow fallback interleaves real
+ * disk I/O with fake-timer-delayed queries.
  *
- * A single fixed `advanceTimersByTimeAsync` is flaky under slower CI: the
- * fallback query/cap timers are registered only after a real `loadChange`
- * macrotask resolves, so a one-shot advance can miss them entirely (hang) —
- * while `runAllTimersAsync` overshoots and fires the 1,000ms cap even when the
- * 650ms query should win. Instead advance the fake clock in small steps,
- * flushing real I/O before each step so any newly-needed timer is registered
- * first, and stop as soon as the read settles. Because the fallback query
- * (regTime+650ms) always precedes the cap (regTime+1,000ms), the success case
- * settles before the cap; the poison case (regTime+1,200ms query) settles when
- * the cap fires. Bounded by `maxTotalMs` so a real hang still fails fast (DC10).
+ * The fallback timers (the mock query delay and the `min(5000ms, remaining)`
+ * per-attempt/deadline cap) are registered only after the real missing-file
+ * `loadChange` macrotask resolves. To make timing deterministic, first drain
+ * real I/O with pure `setImmediate` hops WITHOUT advancing the fake clock, so
+ * every fallback timer registers at fake-time 0. A single bounded advance then
+ * fires exactly the intended timers: 800ms fires a 650ms success query but not
+ * the 1,000ms cap; 1,100ms fires the 1,000ms cap for a 1,200ms poison query.
+ * No wall-clock sleeps (DC10). The `setImmediate` count is generous — a missing
+ * file `fs.access` rejects in a couple of hops regardless of machine speed.
  */
-async function settlePending<T>(
+async function settleFallback<T>(
   pending: Promise<T>,
-  {
-    stepMs = 50,
-    maxTotalMs = 5_000,
-  }: { stepMs?: number; maxTotalMs?: number } = {},
+  advanceMs: number,
 ): Promise<T> {
-  let settled = false;
-  void pending.then(
-    () => {
-      settled = true;
-    },
-    () => {
-      settled = true;
-    },
-  );
-  let total = 0;
-  while (!settled && total < maxTotalMs) {
-    // Flush real macro/microtasks (e.g. the missing-file loadChange) so the
-    // fallback timers exist before we advance the fake clock onto them.
+  for (let i = 0; i < 20; i++) {
     await new Promise<void>((resolve) => setImmediate(resolve));
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(stepMs);
-    total += stepMs;
   }
+  await vi.advanceTimersByTimeAsync(advanceMs);
   return pending;
 }
 
@@ -366,9 +348,9 @@ describe("active conflict authority", () => {
     const pending = store.changes.listConflictAuthority!({
       deadline: createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS),
     });
-    // Interleave real missing-file I/O with the 650ms fake-timer fallback
-    // delay deterministically (see settlePending rationale).
-    const result = await settlePending(pending);
+    // Drain the missing-file I/O, then fire the 650ms fallback query (below
+    // the 1,000ms cap) so the fallback succeeds deterministically.
+    const result = await settleFallback(pending, 800);
 
     expect(result.completeness).toBe("complete");
     expect(result.canConcludeClean).toBe(true);
@@ -395,10 +377,9 @@ describe("active conflict authority", () => {
     const pending = store.changes.listConflictAuthority!({
       deadline: createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS),
     });
-    // Both candidates fall back to a 1,200ms query; the 1,000ms cap must fire
-    // first. settlePending drains the real missing-file I/O and the fake
-    // fallback/cap timers deterministically.
-    const result = await settlePending(pending);
+    // Both candidates fall back to a 1,200ms query; advancing past the
+    // 1,000ms cap (but not the query) proves the cap fires first.
+    const result = await settleFallback(pending, 1_100);
 
     expect(result.completeness).toBe("incomplete");
     expect(result.canConcludeClean).toBe(false);

--- a/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
+++ b/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Active-only conflict authority (fixChangeEnumerationStarvation, task 1).
+ *
+ * Verifies:
+ *  1. `listConflictAuthority` enumerates only Visibility-proven active IDs
+ *     (`AdvLifecycleState="open" AND ExecutionStatus="Running"`), reconciles
+ *     any terminal shadow to a confirmed terminal record, and returns a complete
+ *     or typed-incomplete result under the 8s aggregate deadline.
+ *  2. No unbounded archive-directory/terminal-bundle scans are performed;
+ *     terminal-shadow reconciliation reads only the single confirming record
+ *     for a shadow candidate (AC1 / AC3 / DC1).
+ *  3. Full Visibility pagination is required for completeness.
+ *  4. Visibility source/page errors and deadline expiry are typed incomplete.
+ *  5. A wrong-id durable projection, missing durable projection, or terminal
+ *     shadow that cannot be confirmed makes the authority incomplete.
+ *  6. The optional workflow fallback is capped at min(1,000ms, remaining budget),
+ *     so a poisoned 650ms candidate cannot consume the whole request.
+ *  7. Cache/memo warmth cannot establish completeness; only Visibility + durable
+ *     active facts are authoritative.
+ *  8. Terminal shadows are excluded from active membership without producing
+ *     false incompleteness when the terminal record is confirmed.
+ *
+ * Timing tests use vi fake timers and controllable promises — no wall-clock
+ * sleeps (DC10).
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTempDir, cleanupTempDir } from "../../__tests__/setup";
+import { createDefaultGates, type Change } from "../../types";
+import { createDiskStore } from "../store-disk";
+import { createTemporalStoreBackend } from "./index";
+import { createTemporalReadDeadline } from "../../temporal/retry-wrapper";
+import { TEMPORAL_READ_DEADLINE_BUDGET_MS } from "./shared";
+
+const archiveReadCalls: { fn: string; args: unknown[] }[] = [];
+
+vi.mock("../json", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../json")>();
+  return {
+    ...actual,
+    listChangeDirs: async (path: string): Promise<string[]> => {
+      if (String(path).includes("archive")) {
+        archiveReadCalls.push({ fn: "listChangeDirs", args: [path] });
+        throw new Error(
+          "archive directory read should not happen in active conflict authority",
+        );
+      }
+      return actual.listChangeDirs(path);
+    },
+    loadChange: async (root: string, id: string) => {
+      if (String(root).includes("archive")) {
+        archiveReadCalls.push({ fn: "loadChange", args: [root, id] });
+        throw new Error(
+          "archive bundle read should not happen in active conflict authority",
+        );
+      }
+      return actual.loadChange(root, id);
+    },
+    hasArchiveBundle: async (root: string, id: string) => {
+      archiveReadCalls.push({ fn: "hasArchiveBundle", args: [root, id] });
+      return actual.hasArchiveBundle(root, id);
+    },
+  };
+});
+
+function activeChange(
+  id: string,
+  capabilities: string[] = ["cap-" + id],
+): Change {
+  return {
+    $schema: "https://advance.dev/schemas/change.v1.json",
+    id,
+    title: `Active ${id}`,
+    status: "draft",
+    created_at: "2026-05-07T00:00:00.000Z",
+    tasks: [],
+    deltas: Object.fromEntries(capabilities.map((c) => [c, []])),
+    gates: createDefaultGates(),
+    reentry_history: [],
+    wisdom: [],
+  };
+}
+
+function archivedChange(id: string): Change {
+  return {
+    ...activeChange(id, []),
+    title: `Archived ${id}`,
+    status: "archived",
+  };
+}
+
+function closedChange(id: string): Change {
+  return {
+    ...activeChange(id, []),
+    title: `Closed ${id}`,
+    status: "closed",
+  };
+}
+
+function workflowStateFor(change: Change) {
+  return {
+    id: change.id,
+    changeId: change.id,
+    title: change.title,
+    status: change.status,
+    createdAt: change.created_at,
+    initializedAt: change.created_at,
+    projectId: "project-1",
+    tasks: [],
+    deltas: change.deltas,
+    wisdom: [],
+    gates: change.gates ?? createDefaultGates(),
+    reentry_history: [],
+    artifacts: {},
+    documents: {},
+    reflections: [],
+    worktrees: {},
+    conformance: { lockedSpecs: [], overrides: [] },
+    worktree_auto_managed: false,
+  };
+}
+
+async function writeArchiveBundle(tempDir: string, change: Change) {
+  const archiveDir = join(tempDir, ".adv", "archive", change.id);
+  await mkdir(archiveDir, { recursive: true });
+  await writeFile(
+    join(archiveDir, "change.json"),
+    JSON.stringify(change, null, 2),
+  );
+}
+
+interface MockTemporalOptions {
+  ids?: string[];
+  queryDelayMs?: number | ((id: string) => number);
+  queryError?: Error;
+  listError?: Error;
+  listDelayAfter?: number;
+  queryStates?: Record<string, unknown>;
+}
+
+function mockTemporalClient(opts: MockTemporalOptions = {}) {
+  return {
+    client: {
+      workflow: {
+        list: async function* () {
+          if (opts.listError) throw opts.listError;
+          for (const id of opts.ids ?? []) {
+            yield { workflowId: `adv/change/project-1/${id}` };
+            if (opts.listDelayAfter !== undefined) {
+              await new Promise<void>((resolve) =>
+                globalThis.setTimeout(resolve, opts.listDelayAfter),
+              );
+            }
+          }
+        },
+        getHandle: (workflowId: string) => {
+          const id = workflowId.replace(`adv/change/project-1/`, "");
+          return {
+            query: async () => {
+              if (opts.queryError) throw opts.queryError;
+              const delay =
+                typeof opts.queryDelayMs === "function"
+                  ? opts.queryDelayMs(id)
+                  : opts.queryDelayMs;
+              if (delay) {
+                await new Promise<void>((resolve) =>
+                  globalThis.setTimeout(resolve, delay),
+                );
+              }
+              return (
+                opts.queryStates?.[id] ?? workflowStateFor(activeChange(id))
+              );
+            },
+          };
+        },
+        start: async () => {
+          throw new Error("start should not be called");
+        },
+      },
+    },
+  };
+}
+
+describe("active conflict authority", () => {
+  let tempDir: string | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    archiveReadCalls.length = 0;
+  });
+
+  afterEach(async () => {
+    archiveReadCalls.length = 0;
+    vi.useRealTimers();
+    if (tempDir) await cleanupTempDir(tempDir);
+    tempDir = undefined;
+  });
+
+  it("completes with 78 terminal bundles and 13 active candidates without reading archives", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+
+    const activeIds: string[] = [];
+    for (let i = 0; i < 13; i++) {
+      const id = `active-${String(i).padStart(2, "0")}`;
+      activeIds.push(id);
+      await legacy.changes.save(activeChange(id));
+    }
+    for (let i = 0; i < 78; i++) {
+      await writeArchiveBundle(tempDir, archivedChange(`archived-${i}`));
+    }
+
+    const temporal = mockTemporalClient({ ids: activeIds });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const authority = store.changes.listConflictAuthority;
+    expect(authority).toBeDefined();
+    const result = await authority!({
+      deadline: createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS),
+    });
+
+    expect(result.completeness).toBe("complete");
+    expect(result.canConcludeClean).toBe(true);
+    expect(result.active).toHaveLength(13);
+    expect(result.candidateCount).toBe(13);
+    expect(result.omittedCount).toBe(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.active.map((a) => a.id).sort()).toEqual(
+      [...activeIds].sort(),
+    );
+    expect(
+      result.active.every((a) => a.capabilities.includes("cap-" + a.id)),
+    ).toBe(true);
+    expect(archiveReadCalls).toHaveLength(0);
+  });
+
+  it("paginates Visibility to exhaustion and reports full candidateCount", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    const activeIds: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      const id = `active-${String(i).padStart(2, "0")}`;
+      activeIds.push(id);
+      await legacy.changes.save(activeChange(id));
+    }
+
+    const temporal = mockTemporalClient({ ids: activeIds });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const result = await store.changes.listConflictAuthority!();
+    expect(result.candidateCount).toBe(50);
+    expect(result.completeness).toBe("complete");
+  });
+
+  it("returns typed incomplete when Visibility fails", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    await legacy.changes.save(activeChange("active-01"));
+
+    const temporal = mockTemporalClient({
+      ids: ["active-01"],
+      listError: new Error("visibility unavailable"),
+    });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const result = await store.changes.listConflictAuthority!();
+    expect(result.completeness).toBe("incomplete");
+    expect(result.canConcludeClean).toBe(false);
+    expect(result.warnings.some((w) => w.includes("Visibility"))).toBe(true);
+  });
+
+  it("returns typed incomplete when Visibility pagination exceeds the 8s deadline", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    await legacy.changes.save(activeChange("active-01"));
+
+    const temporal = mockTemporalClient({
+      ids: ["active-01"],
+      listDelayAfter: 100_000,
+    });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const pending = store.changes.listConflictAuthority!({
+      deadline: createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS),
+    });
+    await vi.advanceTimersByTimeAsync(TEMPORAL_READ_DEADLINE_BUDGET_MS + 100);
+    const result = await pending;
+
+    expect(result.completeness).toBe("incomplete");
+    expect(result.canConcludeClean).toBe(false);
+    expect(result.warnings.some((w) => w.includes("deadline"))).toBe(true);
+  });
+
+  it("uses the optional workflow fallback for a missing durable record", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    // active-01 is NOT saved to disk, so the durable projection is missing.
+
+    const temporal = mockTemporalClient({
+      ids: ["active-01"],
+      queryDelayMs: 650,
+      queryStates: {
+        "active-01": workflowStateFor(activeChange("active-01")),
+      },
+    });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const pending = store.changes.listConflictAuthority!({
+      deadline: createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS),
+    });
+    // Yield to real I/O so the missing-file load resolves, then advance fake
+    // timers past the 650ms fallback delay.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(800);
+    const result = await pending;
+
+    expect(result.completeness).toBe("complete");
+    expect(result.canConcludeClean).toBe(true);
+    expect(result.active).toHaveLength(1);
+    expect(result.active[0].capabilities).toEqual(["cap-active-01"]);
+    expect(archiveReadCalls).toHaveLength(0);
+  });
+
+  it("caps the workflow fallback so a poisoned candidate cannot consume the whole request", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    // No disk records; both candidates must fall back to workflow query.
+
+    const temporal = mockTemporalClient({
+      ids: ["slow-01", "slow-02"],
+      queryDelayMs: 1_200,
+    });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const pending = store.changes.listConflictAuthority!({
+      deadline: createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS),
+    });
+    // Yield to real I/O, then advance past the 1,000ms fallback cap.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_100);
+    const result = await pending;
+
+    expect(result.completeness).toBe("incomplete");
+    expect(result.canConcludeClean).toBe(false);
+    expect(result.omittedCount).toBeGreaterThan(0);
+    expect(result.warnings.some((w) => w.includes("fallback"))).toBe(true);
+  });
+
+  it("returns incomplete when a durable projection has a terminal status", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    const change = activeChange("active-01");
+    change.status = "archived";
+    await legacy.changes.save(change);
+
+    const temporal = mockTemporalClient({ ids: ["active-01"] });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const result = await store.changes.listConflictAuthority!();
+    expect(result.completeness).toBe("incomplete");
+    expect(result.canConcludeClean).toBe(false);
+    expect(result.warnings.some((w) => w.includes("terminal"))).toBe(true);
+  });
+
+  it("returns incomplete when a durable projection has a mismatched id", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    // Directory name is the Visibility-proven id, but the file content has a
+    // different id — this must be detected as an invalid durable projection.
+    const changeDir = join(tempDir, ".adv", "changes", "active-01");
+    await mkdir(changeDir, { recursive: true });
+    await writeFile(
+      join(changeDir, "change.json"),
+      JSON.stringify(activeChange("other-id"), null, 2),
+    );
+
+    const temporal = mockTemporalClient({ ids: ["active-01"] });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    const result = await store.changes.listConflictAuthority!();
+    expect(result.completeness).toBe("incomplete");
+    expect(result.canConcludeClean).toBe(false);
+    expect(result.warnings.some((w) => w.includes("mismatched"))).toBe(true);
+  });
+
+  it("does not treat cache/memo warmth as authority", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    // Save an active change on disk so the memo/cache could be warmed later.
+    await legacy.changes.save(activeChange("active-01", ["cached-cap"]));
+
+    const temporal = mockTemporalClient({ ids: ["active-01"] });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "project-1",
+    });
+
+    // Warm the non-authoritative cache by listing the change.
+    await store.changes.list({});
+
+    // Now corrupt the durable record so the authority cannot rely on it.
+    const corrupted = activeChange("active-01");
+    corrupted.status = "archived";
+    await legacy.changes.save(corrupted);
+
+    const result = await store.changes.listConflictAuthority!();
+    // The cache may still hold the old active row, but the authority must
+    // read the durable record and reject the now-terminal projection.
+    expect(result.completeness).toBe("incomplete");
+    expect(result.canConcludeClean).toBe(false);
+  });
+});

--- a/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
+++ b/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
@@ -37,6 +37,13 @@ import { TEMPORAL_READ_DEADLINE_BUDGET_MS } from "./shared";
 
 const archiveReadCalls: { fn: string; args: unknown[] }[] = [];
 
+/**
+ * Change IDs whose active durable projection must resolve as `not_found`
+ * deterministically (no real `fs.access`), so the workflow-fallback path is
+ * driven purely by fake timers with no real-I/O timing nondeterminism.
+ */
+const forceNotFound = new Set<string>();
+
 vi.mock("../json", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../json")>();
   return {
@@ -56,6 +63,13 @@ vi.mock("../json", async (importOriginal) => {
         throw new Error(
           "archive bundle read should not happen in active conflict authority",
         );
+      }
+      if (forceNotFound.has(id)) {
+        return {
+          success: false as const,
+          error: `forced not_found: ${id}`,
+          type: "not_found" as const,
+        };
       }
       return actual.loadChange(root, id);
     },
@@ -177,25 +191,22 @@ function mockTemporalClient(opts: MockTemporalOptions = {}) {
 }
 
 /**
- * Settle a pending authority read whose workflow fallback interleaves real
- * disk I/O with fake-timer-delayed queries.
- *
- * The fallback timers (the mock query delay and the `min(5000ms, remaining)`
- * per-attempt/deadline cap) are registered only after the real missing-file
- * `loadChange` macrotask resolves. To make timing deterministic, first drain
- * real I/O with pure `setImmediate` hops WITHOUT advancing the fake clock, so
- * every fallback timer registers at fake-time 0. A single bounded advance then
+ * Settle a pending authority read whose workflow fallback is driven by fake
+ * timers. The durable projection resolves as `not_found` via `forceNotFound`
+ * (no real `fs.access`), so all fallback timers register deterministically at
+ * fake-time 0 after a short microtask flush. A single bounded advance then
  * fires exactly the intended timers: 800ms fires a 650ms success query but not
  * the 1,000ms cap; 1,100ms fires the 1,000ms cap for a 1,200ms poison query.
- * No wall-clock sleeps (DC10). The `setImmediate` count is generous — a missing
- * file `fs.access` rejects in a couple of hops regardless of machine speed.
+ * No wall-clock sleeps and no real-I/O timing dependency (DC10).
  */
 async function settleFallback<T>(
   pending: Promise<T>,
   advanceMs: number,
 ): Promise<T> {
-  for (let i = 0; i < 20; i++) {
-    await new Promise<void>((resolve) => setImmediate(resolve));
+  // Flush the microtask chain (visibility enumeration + not_found load) so the
+  // fallback timers are registered before advancing the fake clock.
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
   }
   await vi.advanceTimersByTimeAsync(advanceMs);
   return pending;
@@ -207,6 +218,7 @@ describe("active conflict authority", () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     archiveReadCalls.length = 0;
+    forceNotFound.clear();
   });
 
   afterEach(async () => {
@@ -330,7 +342,9 @@ describe("active conflict authority", () => {
   it("uses the optional workflow fallback for a missing durable record", async () => {
     tempDir = await createTempDir();
     const legacy = await createDiskStore(tempDir);
-    // active-01 is NOT saved to disk, so the durable projection is missing.
+    // active-01 durable projection resolves not_found deterministically, so
+    // the workflow fallback path runs with no real-fs timing dependency.
+    forceNotFound.add("active-01");
 
     const temporal = mockTemporalClient({
       ids: ["active-01"],
@@ -362,7 +376,10 @@ describe("active conflict authority", () => {
   it("caps the workflow fallback so a poisoned candidate cannot consume the whole request", async () => {
     tempDir = await createTempDir();
     const legacy = await createDiskStore(tempDir);
-    // No disk records; both candidates must fall back to workflow query.
+    // Both durable projections resolve not_found deterministically, so both
+    // candidates fall back to the workflow query with no real-fs timing.
+    forceNotFound.add("slow-01");
+    forceNotFound.add("slow-02");
 
     const temporal = mockTemporalClient({
       ids: ["slow-01", "slow-02"],

--- a/plugin/src/storage/store-temporal/changes.ts
+++ b/plugin/src/storage/store-temporal/changes.ts
@@ -1,4 +1,4 @@
-import type { Store } from "../store-types";
+import type { Store, ChangeConflictAuthority } from "../store-types";
 import {
   type ArtifactKind,
   type ArtifactPayload,
@@ -27,11 +27,18 @@ import {
   crossProjectCoordinationUpdatedSignal,
 } from "../../temporal/messages";
 import { ensureChangeWorkflowStarted } from "../../temporal/workflow-start";
-import { hasArchiveBundle, listChangeDirs, removeChangeDir } from "../json";
+import {
+  hasArchiveBundle,
+  listChangeDirs,
+  loadChange,
+  removeChangeDir,
+} from "../json";
 import { filterChanges } from "../content-search";
 import { computeLastActivity, firstOpenGate } from "../store-types";
 import {
   runTemporal,
+  runTemporalQuery,
+  getChangeHandle,
   getGuardedChangeHandle,
   createTemporalReadDeadline,
   raceWithTemporalDeadline,
@@ -1168,6 +1175,249 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
           ...(deadlineExceeded ? { deadlineExceeded: true } : {}),
         },
         ...(warnings.length > 0 ? { warnings } : {}),
+      };
+    },
+    /**
+     * rq-archiveInventoryActive01: active-only, fixed-8s, fail-closed conflict
+     * authority. Membership comes only from Visibility
+     * (`AdvLifecycleState="open" AND ExecutionStatus="Running"`); facts come
+     * from the durable active projection (disk `change.json`) or a capped
+     * workflow fallback. Terminal history, archive bundles, cache, and memo
+     * cannot establish completeness.
+     */
+    listConflictAuthority: async (options) => {
+      const deadline = options?.deadline ?? createTemporalReadDeadline();
+      const expired = (): boolean => remainingDeadlineMs(deadline) <= 0;
+      const warnings: string[] = [];
+
+      const bundle = input.temporal as {
+        client?: { workflow?: { list?: unknown } };
+      };
+      let visibilityIds: string[] = [];
+      if (typeof bundle.client?.workflow?.list === "function") {
+        try {
+          visibilityIds = await raceWithTemporalDeadline(
+            listChangeWorkflowIds(
+              bundle.client as Parameters<typeof listChangeWorkflowIds>[0],
+              { projectId: input.projectId },
+            ),
+            deadline,
+          );
+        } catch (err) {
+          const hitDeadline =
+            err instanceof TemporalQueryTimeoutError || expired();
+          warnings.push(
+            `Visibility active enumeration ${hitDeadline ? "exceeded the aggregate read deadline" : "failed"}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      } else {
+        warnings.push(
+          "Temporal client does not expose workflow.list; active conflict authority cannot enumerate Visibility.",
+        );
+      }
+
+      const activeIds = Array.from(new Set(visibilityIds)).sort((a, b) =>
+        a.localeCompare(b),
+      );
+
+      type FactRow = {
+        id: string;
+        title: string;
+        status: string;
+        capabilities: string[];
+        epic_membership?: Change["epic_membership"];
+        fast_follow_of?: Change["fast_follow_of"];
+      };
+      const active: FactRow[] = [];
+      let omittedCount = 0;
+      let shadowCount = 0;
+
+      type LoadActiveResult =
+        | { kind: "fact"; fact: FactRow }
+        | { kind: "shadow" }
+        | { kind: "fail"; warning: string };
+
+      const loadActiveFact = async (
+        changeId: string,
+      ): Promise<LoadActiveResult> => {
+        // Durable active projection: read disk changes/<id>/change.json
+        // directly. We deliberately avoid `legacy.changes.get` because it
+        // performs archive-bundle dominance/self-heal reads for the general
+        // listing path. The authority performs no unbounded archive scans:
+        // terminal-shadow reconciliation reads only the single terminal record
+        // needed to confirm a shadow and exclude it from active membership.
+        let diskResult: Awaited<ReturnType<typeof loadChange>> | undefined;
+        try {
+          diskResult = await raceWithTemporalDeadline(
+            loadChange(legacy.paths.changes, changeId),
+            deadline,
+          );
+        } catch (err) {
+          const hitDeadline =
+            err instanceof TemporalQueryTimeoutError || expired();
+          return {
+            kind: "fail",
+            warning: `Active fact load for ${changeId} failed${hitDeadline ? " (deadline)" : ""}: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+
+        if (diskResult?.success && diskResult.data) {
+          const data = diskResult.data;
+          if (data.id !== changeId) {
+            return {
+              kind: "fail",
+              warning: `Active candidate ${changeId} durable projection has mismatched id (${data.id}); cannot establish active authority.`,
+            };
+          }
+
+          // Terminal-shadow reconciliation (rq-terminalAwareTruth01): a
+          // Visibility-proven active ID with a terminal durable projection is a
+          // stale shadow. If the terminal record can be confirmed, exclude it
+          // from active membership without making the authority incomplete.
+          if (data.status === "archived" || data.status === "closed") {
+            if (data.status === "closed") {
+              // The closed disk sentinel is itself the durable terminal record.
+              return { kind: "shadow" };
+            }
+
+            // Archived shadows require the durable archive bundle to confirm
+            // terminal truth; the active disk `change.json` may be a stale
+            // leftover. Without a confirming bundle the authority is incomplete.
+            if (!legacy.paths.archive) {
+              return {
+                kind: "fail",
+                warning: `Active candidate ${changeId} has terminal durable projection (archived) but no archive path is configured; cannot reconcile shadow.`,
+              };
+            }
+            try {
+              const hasBundle = await raceWithTemporalDeadline(
+                hasArchiveBundle(legacy.paths.archive, changeId),
+                deadline,
+              );
+              if (hasBundle) {
+                return { kind: "shadow" };
+              }
+              return {
+                kind: "fail",
+                warning: `Active candidate ${changeId} has terminal durable projection (archived) but no archive bundle confirms it; cannot reconcile shadow.`,
+              };
+            } catch (err) {
+              const hitDeadline =
+                err instanceof TemporalQueryTimeoutError || expired();
+              return {
+                kind: "fail",
+                warning: `Active candidate ${changeId} archive-bundle shadow check failed${hitDeadline ? " (deadline)" : ""}: ${err instanceof Error ? err.message : String(err)}`,
+              };
+            }
+          }
+
+          return {
+            kind: "fact",
+            fact: {
+              id: data.id,
+              title: data.title,
+              status: data.status,
+              capabilities: Object.keys(data.deltas ?? {}),
+              epic_membership: data.epic_membership,
+              fast_follow_of: data.fast_follow_of,
+            },
+          };
+        }
+
+        // Optional workflow fallback: capped at min(1,000ms, remaining budget).
+        try {
+          const remaining = remainingDeadlineMs(deadline);
+          if (remaining <= 0) {
+            return {
+              kind: "fail",
+              warning: `Active candidate ${changeId} has no durable projection and the aggregate deadline is exhausted; cannot establish active authority.`,
+            };
+          }
+          const fallbackBudget = Math.min(1_000, Math.max(0, remaining));
+          const fallbackDeadline = {
+            budgetMs: fallbackBudget,
+            deadlineAt: Date.now() + fallbackBudget,
+          };
+          const state = (await runTemporalQuery(
+            async () =>
+              getChangeHandle(input, changeId).query(changeStateQuery),
+            { deadline: fallbackDeadline },
+          )) as ChangeWorkflowState;
+
+          if (state.changeId !== changeId) {
+            return {
+              kind: "fail",
+              warning: `Active candidate ${changeId} workflow fallback returned mismatched id (${state.changeId}); cannot establish active authority.`,
+            };
+          }
+          if (state.status === "archived" || state.status === "closed") {
+            return {
+              kind: "fail",
+              warning: `Active candidate ${changeId} workflow fallback returned terminal status (${state.status}); cannot establish active authority.`,
+            };
+          }
+
+          return {
+            kind: "fact",
+            fact: {
+              id: state.changeId,
+              title: state.title,
+              status: state.status,
+              capabilities: Object.keys(state.deltas ?? {}),
+              epic_membership: (
+                state as { epic_membership?: Change["epic_membership"] }
+              ).epic_membership,
+              fast_follow_of: state.fast_follow_of,
+            },
+          };
+        } catch (err) {
+          const hitDeadline =
+            err instanceof TemporalQueryTimeoutError || expired();
+          return {
+            kind: "fail",
+            warning: `Active candidate ${changeId} workflow fallback failed${hitDeadline ? " (deadline)" : ""}: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      };
+
+      const FACT_LOAD_CONCURRENCY = 4;
+      for (let i = 0; i < activeIds.length; i += FACT_LOAD_CONCURRENCY) {
+        if (expired()) {
+          const remaining = activeIds.slice(i);
+          warnings.push(
+            `Aggregate deadline expired before all active candidates could be loaded; omitted ${remaining.length} candidate(s).`,
+          );
+          omittedCount += remaining.length;
+          break;
+        }
+        const batch = activeIds.slice(i, i + FACT_LOAD_CONCURRENCY);
+        const loaded = await Promise.all(batch.map(loadActiveFact));
+        for (const item of loaded) {
+          if (item.kind === "fact") {
+            active.push(item.fact);
+          } else if (item.kind === "shadow") {
+            shadowCount += 1;
+          } else {
+            warnings.push(item.warning);
+            omittedCount += 1;
+          }
+        }
+      }
+
+      active.sort((a, b) => a.id.localeCompare(b.id));
+
+      const completeness: ChangeConflictAuthority["completeness"] =
+        warnings.length === 0 && omittedCount === 0 ? "complete" : "incomplete";
+
+      return {
+        active,
+        completeness,
+        canConcludeClean: completeness === "complete",
+        warnings,
+        source: "active-conflict-authority",
+        candidateCount: activeIds.length,
+        omittedCount,
+        shadowCount,
       };
     },
   };

--- a/plugin/src/storage/store-types.ts
+++ b/plugin/src/storage/store-types.ts
@@ -5,6 +5,7 @@
  * Extracted from store.ts to keep the composition root under 300 lines.
  */
 
+import type { TemporalReadDeadline } from "../temporal/retry-wrapper";
 import { GATE_ORDER } from "../types";
 import type {
   ArtifactPayload,
@@ -42,6 +43,52 @@ export interface ResolvedChangeList {
   changes: Change[];
   warnings?: import("../types").TerminalWarning[];
   hydrationStats?: import("../types").HydrationStats;
+}
+
+/**
+ * Single active change proven by the active conflict authority.
+ * Membership comes only from Visibility; facts come only from validated
+ * durable active projections or a capped workflow fallback.
+ */
+export interface ChangeConflictAuthorityEntry {
+  id: string;
+  title: string;
+  status: string;
+  /** Capability names derived from the change's deltas. */
+  capabilities: string[];
+  /** Optional Epic membership projection for conflict context. */
+  epic_membership?: Change["epic_membership"];
+  /** Same-project fast-follow lineage context. */
+  fast_follow_of?: Change["fast_follow_of"];
+}
+
+/**
+ * Result of the active-only conflict authority.
+ *
+ * Complete only when the Visibility enumeration succeeded, every page was
+ * consumed, and every Visibility-proven candidate had its durable active
+ * facts established or was reconciled to a confirmed terminal shadow.
+ * Any source/page error, deadline, missing/wrong projection, candidate
+ * omission, or terminal shadow that cannot be confirmed makes the result
+ * incomplete and sets `canConcludeClean` to false.
+ */
+export interface ChangeConflictAuthority {
+  /** Active changes proven by Visibility and validated durable facts. */
+  active: ChangeConflictAuthorityEntry[];
+  /** Complete only when every Visibility page and every candidate fact succeeded. */
+  completeness: "complete" | "incomplete";
+  /** Structural fail-closed guard: false when the authority is incomplete. */
+  canConcludeClean: boolean;
+  /** Typed warnings explaining why the authority is incomplete. */
+  warnings: string[];
+  /** Source identifier for auditability. */
+  source: string;
+  /** Number of Visibility-proven active candidates (including omitted ones). */
+  candidateCount: number;
+  /** Number of candidates whose facts could not be established. */
+  omittedCount: number;
+  /** Number of candidates reconciled to a confirmed terminal shadow. */
+  shadowCount?: number;
 }
 
 /**
@@ -244,6 +291,20 @@ export interface Store {
         clearedAt?: string;
       },
     ) => Promise<Change | null>;
+    /**
+     * rq-archiveInventoryActive01: active-only, fixed-8s, fail-closed conflict
+     * authority. Membership comes only from Visibility
+     * (`AdvLifecycleState="open" AND ExecutionStatus="Running"`); durable
+     * facts come only from Visibility-proven active IDs. Terminal history,
+     * archive bundles, cache, and memo cannot establish completeness.
+     *
+     * Returns complete only when Visibility pagination and every candidate
+     * fact load succeed. Any failure, deadline, or candidate omission makes
+     * the result incomplete with `canConcludeClean: false`.
+     */
+    listConflictAuthority?: (options?: {
+      deadline?: TemporalReadDeadline;
+    }) => Promise<ChangeConflictAuthority>;
     /**
      * rq-changeSummaryReadModel01 (advance-meta v1.12): lightweight summary
      * listing surface for default read paths (`adv_change_list`,

--- a/plugin/src/tools/change/validation-projection.test.ts
+++ b/plugin/src/tools/change/validation-projection.test.ts
@@ -16,7 +16,7 @@
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import type { Store } from "../../storage/store-types";
+import type { Store, ChangeConflictAuthority } from "../../storage/store-types";
 import type { ChangeListResponse } from "../../types";
 import { createTemporalReadDeadline } from "../../temporal/retry-wrapper";
 import { loadValidationInventory } from "./validation-projection";
@@ -366,5 +366,80 @@ describe("loadValidationInventory", () => {
     // Advance further to let the late list promise settle; result must not change.
     await vi.advanceTimersByTimeAsync(1000);
     expect(inventory.entries).toHaveLength(0);
+  });
+
+  test("routes to active-only conflict authority when Store exposes it", async () => {
+    const authority: ChangeConflictAuthority = {
+      active: [
+        {
+          id: "own-change",
+          title: "Own Change",
+          status: "draft",
+          capabilities: ["cap-own"],
+        },
+        {
+          id: "peer-a",
+          title: "Peer A",
+          status: "draft",
+          capabilities: ["cap-a"],
+        },
+      ],
+      completeness: "complete",
+      canConcludeClean: true,
+      warnings: [],
+      source: "active-conflict-authority",
+      candidateCount: 2,
+      omittedCount: 0,
+    };
+    const listConflictAuthority = vi.fn().mockResolvedValue(authority);
+    const store = createMockStore([]) as Store & {
+      changes: { listConflictAuthority: typeof listConflictAuthority };
+    };
+    store.changes.listConflictAuthority = listConflictAuthority;
+
+    const inventory = await loadValidationInventory(store, "own-change");
+
+    expect(listConflictAuthority).toHaveBeenCalledTimes(1);
+    expect(inventory.completeness).toBe("complete");
+    expect(inventory.canConcludeClean).toBe(true);
+    expect(inventory.entries).toHaveLength(2);
+    expect(inventory.entries.every((e) => !e.isArchived)).toBe(true);
+    const peer = inventory.entries.find((e) => e.id === "peer-a");
+    expect(peer?.capabilities).toEqual(["cap-a"]);
+    expect(store.getCallCount()).toBe(0);
+    expect(store.listCallCount()).toBe(0);
+  });
+
+  test("returns non-conclusive when active conflict authority is incomplete", async () => {
+    const authority: ChangeConflictAuthority = {
+      active: [
+        {
+          id: "peer-a",
+          title: "Peer A",
+          status: "draft",
+          capabilities: ["cap-a"],
+        },
+      ],
+      completeness: "incomplete",
+      canConcludeClean: false,
+      warnings: [
+        "Visibility active enumeration failed: visibility unavailable",
+      ],
+      source: "active-conflict-authority",
+      candidateCount: 2,
+      omittedCount: 1,
+    };
+    const store = createMockStore([]) as Store & {
+      changes: { listConflictAuthority: ReturnType<typeof vi.fn> };
+    };
+    store.changes.listConflictAuthority = vi.fn().mockResolvedValue(authority);
+
+    const inventory = await loadValidationInventory(store, "own-change");
+
+    expect(inventory.completeness).toBe("non-conclusive");
+    expect(inventory.canConcludeClean).toBe(false);
+    expect(inventory.warnings.length).toBeGreaterThan(0);
+    expect(inventory.entries).toHaveLength(1);
+    expect(store.listCallCount()).toBe(0);
   });
 });

--- a/plugin/src/tools/change/validation-projection.ts
+++ b/plugin/src/tools/change/validation-projection.ts
@@ -6,7 +6,7 @@
  * active-peer hydration loop from validation context loading.
  */
 
-import type { Store } from "../../storage/store-types";
+import type { Store, ChangeConflictAuthority } from "../../storage/store-types";
 import type {
   ConflictInventory,
   ConflictInventoryEntry,
@@ -104,6 +104,65 @@ export async function loadValidationInventory(
   options?: ValidationInventoryOptions,
 ): Promise<ConflictInventory> {
   const deadline = options?.deadline;
+
+  // Prefer the dedicated active-only conflict authority when the Store exposes
+  // it. This path performs zero terminal/archive enumeration and is the only
+  // structural source for validation conflict completeness.
+  if (store.changes.listConflictAuthority) {
+    let authority: ChangeConflictAuthority;
+    try {
+      authority = await raceWithDeadline(
+        store.changes.listConflictAuthority({ deadline }),
+        deadline,
+      );
+    } catch (err) {
+      return {
+        entries: [],
+        completeness: "blocked",
+        warnings: [
+          `Active conflict authority unreachable: ${err instanceof Error ? err.message : String(err)}`,
+        ],
+        source: "validation-inventory-projection",
+        ownChangeId: changeId,
+        canConcludeClean: false,
+      };
+    }
+
+    const entries: ConflictInventoryEntry[] = authority.active.map((peer) => {
+      const isOwnChange = peer.id === changeId;
+      const entry: ConflictInventoryEntry = {
+        id: peer.id,
+        title: peer.title,
+        status: peer.status,
+        isArchived: false,
+        isOwnChange,
+        capabilities: peer.capabilities,
+        ...(peer.epic_membership
+          ? {
+              epic: {
+                id: peer.epic_membership.epic_id,
+                title: peer.epic_membership.title,
+                entry_id: peer.epic_membership.entry_id,
+              },
+            }
+          : {}),
+      };
+      return entry;
+    });
+
+    const completeness: ConflictInventory["completeness"] =
+      authority.completeness === "complete" ? "complete" : "non-conclusive";
+
+    return {
+      entries,
+      completeness,
+      warnings: authority.warnings,
+      source: "validation-inventory-projection",
+      ownChangeId: changeId,
+      canConcludeClean: authority.canConcludeClean,
+    };
+  }
+
   const warnings: string[] = [];
 
   // 1. Enumerate changes with shared deadline admission.


### PR DESCRIPTION
## Why

Archive/change conflict validation enumerated terminal history under the same fixed 8s aggregate read deadline. In long-lived projects, large archive volume + poisoned terminal workflows starved the budget → `VALIDATION_TIME_BUDGET_EXHAUSTED` → changes could not complete/archive. Reproduced live this session.

## What

Adds a dedicated **active-only** Store conflict authority (`listConflictAuthority`) and routes `loadValidationInventory` through it:

- Membership only from Visibility (`AdvLifecycleState=open AND ExecutionStatus=Running`), fully paginated under the request deadline.
- Durable facts only for Visibility-proven active IDs. **Zero archive/terminal enumeration.** Confirmed terminal shadows are excluded; unconfirmed shadows → incomplete.
- Optional per-candidate workflow fallback capped at `min(1000ms, remaining budget)` so a poisoned candidate cannot consume the request.
- Structurally **fail-closed**: any source/page/candidate/capability omission or mismatch → `incomplete` + `canConcludeClean:false`.
- Discovery still lists `includeArchived` separately for related context.

Implements `rq-archiveInventoryActive01`. The 8s authoritative deadline is unchanged (no timeout-ceiling workaround).

## Scope

Task 1 of `fixChangeEnumerationStarvation`, **expedited** to unblock stuck sessions. Terminal-summary sidecars + bounded history rendering (tasks 2-4) follow in the same change.

## Verification

- `pnpm run check` green (schemas, typecheck, manifests, isolation, lockfile, lint, format).
- New `active-conflict-authority.test.ts` + validation-projection authority-routing tests pass.
- `bounded-read-deadline.test.ts` 12/12 in isolation; store-temporal dir otherwise green (one unrelated pre-existing cross-file pollution failure tracked separately).