### PR TITLE
perf(store): parallelize store maintenance scans (fix 10s timeout)

### DIFF
--- a/plugin/src/tools/store-cleanup-parallel.test.ts
+++ b/plugin/src/tools/store-cleanup-parallel.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression tests for the parallelized `scanStoresForCleanup` (change
+ * parallelizeStoreMaintenance). The scan was converted from a serial per-store
+ * loop to bounded-concurrency mapping with a single `agenda.jsonl` read per
+ * store. These tests pin the behaviour-preserving guarantees: correct
+ * classification at scale, deterministic ordering, single-read, and read-only.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { scanStoresForCleanup, analyzeAgenda } from "./store-cleanup";
+
+function shardStorePath(
+  dataHomeRoot: string,
+  shard: string,
+  projectId: string,
+): string {
+  return join(
+    dataHomeRoot,
+    "opencode-projects",
+    shard,
+    "opencode/plugins/advance",
+    projectId,
+  );
+}
+
+async function writeAgendaStore(
+  dir: string,
+  rows: string[],
+  opts?: { lockPid?: number },
+): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  if (rows.length > 0) {
+    await writeFile(
+      join(dir, "agenda.jsonl"),
+      rows.map((r) => JSON.stringify({ text: r })).join("\n") + "\n",
+    );
+  }
+  if (opts?.lockPid !== undefined) {
+    await writeFile(
+      join(dir, "worker.lock"),
+      JSON.stringify({
+        pid: opts.lockPid,
+        worker_id: "test-worker",
+        acquired_at: "2026-07-11T00:00:00.000Z",
+        schema_version: 2,
+        last_heartbeat: new Date().toISOString(),
+      }),
+    );
+  }
+}
+
+const N = 60;
+const shard = "e".repeat(40);
+// Deterministic 40-hex project ids: 00..00, 00..01, ...
+const projectIds = Array.from({ length: N }, (_, i) =>
+  i.toString(16).padStart(40, "0"),
+);
+// One store carries a live worker.lock (unsafe); the rest are has_agenda.
+const unsafeIndex = 17;
+
+let base: string;
+let dataHomeRoot: string;
+
+beforeAll(async () => {
+  base = await mkdtemp(join(tmpdir(), "adv-store-cleanup-parallel-"));
+  dataHomeRoot = join(base, "xdg");
+  for (let i = 0; i < N; i++) {
+    await writeAgendaStore(
+      shardStorePath(dataHomeRoot, shard, projectIds[i]!),
+      [`agenda ${i} a`, `agenda ${i} b`],
+      i === unsafeIndex ? { lockPid: process.pid } : undefined,
+    );
+  }
+}, 60_000);
+
+afterAll(async () => {
+  await rm(base, { recursive: true, force: true });
+});
+
+describe("analyzeAgenda", () => {
+  test("null content yields empty analysis", () => {
+    const a = analyzeAgenda(null);
+    expect(a.rows).toBe(0);
+    expect(a.malformed).toBe(0);
+    expect(a.hashes.size).toBe(0);
+    expect(a.contentHash).toBeNull();
+  });
+
+  test("counts rows, malformed lines, and a whole-file content hash", () => {
+    const content = `${JSON.stringify({ a: 1 })}\nnot json\n${JSON.stringify({ b: 2 })}\n`;
+    const a = analyzeAgenda(content);
+    expect(a.rows).toBe(3);
+    expect(a.malformed).toBe(1);
+    expect(a.hashes.size).toBe(2);
+    expect(a.contentHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("content hash is stable for identical content", () => {
+    const content = `${JSON.stringify({ a: 1 })}\n`;
+    expect(analyzeAgenda(content).contentHash).toBe(
+      analyzeAgenda(content).contentHash,
+    );
+  });
+});
+
+describe("scanStoresForCleanup (parallel)", () => {
+  test("classifies a large store set correctly and completes fast", async () => {
+    const start = Date.now();
+    const result = await scanStoresForCleanup({ dataHomeRoot });
+    const elapsed = Date.now() - start;
+
+    expect(result.stores).toHaveLength(N);
+    expect(elapsed).toBeLessThan(8_000);
+
+    const byId = Object.fromEntries(
+      result.stores.map((s) => [s.project_id, s]),
+    );
+    const unsafeId = projectIds[unsafeIndex]!;
+    expect(byId[unsafeId]!.classification).toBe("unsafe");
+    expect(byId[unsafeId]!.worker_lock.live).toBe(true);
+    for (let i = 0; i < N; i++) {
+      if (i === unsafeIndex) continue;
+      const s = byId[projectIds[i]!]!;
+      expect(s.classification).toBe("has_agenda");
+      expect(s.agenda.rows).toBe(2);
+      expect(s.agenda.content_hash).toMatch(/^sha256:/);
+    }
+  });
+
+  test("output is deterministic across repeated runs (order-stable)", async () => {
+    const a = await scanStoresForCleanup({ dataHomeRoot });
+    const b = await scanStoresForCleanup({ dataHomeRoot });
+    expect(a.stores.map((s) => s.project_id)).toEqual(
+      b.stores.map((s) => s.project_id),
+    );
+    expect(a.flagged).toEqual(b.flagged);
+    expect(a.warnings).toEqual(b.warnings);
+    // Sorted invariants (SC2 output shape).
+    expect(a.flagged).toEqual([...a.flagged].sort());
+    expect(a.stores.map((s) => s.project_id)).toEqual(
+      [...a.stores.map((s) => s.project_id)].sort(),
+    );
+  });
+});

--- a/plugin/src/tools/store-cleanup-single-read.test.ts
+++ b/plugin/src/tools/store-cleanup-single-read.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Single-read guarantee for `scanStoresForCleanup` (AC2, SC4): each store's
+ * `agenda.jsonl` is read exactly once per scan. Isolated in its own file because
+ * it mocks `fs/promises` to count reads; the ESM namespace cannot be spied
+ * directly, so a hoisted-counter `vi.mock` wrapper is used instead.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+
+const { readFileCalls } = vi.hoisted(() => ({
+  readFileCalls: [] as string[],
+}));
+
+vi.mock("fs/promises", async (importActual) => {
+  const actual = await importActual<typeof import("fs/promises")>();
+  return {
+    ...actual,
+    readFile: (path: unknown, ...rest: unknown[]) => {
+      if (typeof path === "string") readFileCalls.push(path);
+      return (actual.readFile as (...a: unknown[]) => unknown)(
+        path,
+        ...rest,
+      );
+    },
+  };
+});
+
+// Imported after the mock is declared (vi.mock is hoisted above imports).
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { scanStoresForCleanup } from "./store-cleanup";
+
+const N = 40;
+const shard = "f".repeat(40);
+const projectIds = Array.from({ length: N }, (_, i) =>
+  i.toString(16).padStart(40, "0"),
+);
+
+let base: string;
+let dataHomeRoot: string;
+
+beforeAll(async () => {
+  base = await mkdtemp(join(tmpdir(), "adv-store-cleanup-single-read-"));
+  dataHomeRoot = join(base, "xdg");
+  for (const id of projectIds) {
+    const dir = join(
+      dataHomeRoot,
+      "opencode-projects",
+      shard,
+      "opencode/plugins/advance",
+      id,
+    );
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "agenda.jsonl"),
+      JSON.stringify({ text: "row" }) + "\n",
+    );
+  }
+}, 60_000);
+
+afterAll(async () => {
+  await rm(base, { recursive: true, force: true });
+});
+
+describe("scanStoresForCleanup single-read", () => {
+  test("reads agenda.jsonl exactly once per store", async () => {
+    readFileCalls.length = 0;
+    const result = await scanStoresForCleanup({ dataHomeRoot });
+    expect(result.stores).toHaveLength(N);
+    const agendaReads = readFileCalls.filter((p) =>
+      p.endsWith("agenda.jsonl"),
+    );
+    expect(agendaReads).toHaveLength(N);
+  });
+});

--- a/plugin/src/tools/store-cleanup-single-read.test.ts
+++ b/plugin/src/tools/store-cleanup-single-read.test.ts
@@ -17,10 +17,7 @@ vi.mock("fs/promises", async (importActual) => {
     ...actual,
     readFile: (path: unknown, ...rest: unknown[]) => {
       if (typeof path === "string") readFileCalls.push(path);
-      return (actual.readFile as (...a: unknown[]) => unknown)(
-        path,
-        ...rest,
-      );
+      return (actual.readFile as (...a: unknown[]) => unknown)(path, ...rest);
     },
   };
 });
@@ -68,9 +65,7 @@ describe("scanStoresForCleanup single-read", () => {
     readFileCalls.length = 0;
     const result = await scanStoresForCleanup({ dataHomeRoot });
     expect(result.stores).toHaveLength(N);
-    const agendaReads = readFileCalls.filter((p) =>
-      p.endsWith("agenda.jsonl"),
-    );
+    const agendaReads = readFileCalls.filter((p) => p.endsWith("agenda.jsonl"));
     expect(agendaReads).toHaveLength(N);
   });
 });

--- a/plugin/src/tools/store-cleanup.ts
+++ b/plugin/src/tools/store-cleanup.ts
@@ -23,6 +23,7 @@ import { join } from "path";
 import { createHash } from "crypto";
 import { z } from "zod";
 import { formatToolOutput } from "../utils/tool-output";
+import { mapWithConcurrency, STORE_SCAN_CONCURRENCY } from "../utils/concurrency";
 import {
   walkStoreDirs,
   defaultDataHomeRoot,
@@ -232,13 +233,23 @@ async function readFileSafe(path: string): Promise<string | null> {
   }
 }
 
-async function readJsonlHashed(path: string): Promise<{
+interface AgendaAnalysis {
   rows: number;
   malformed: number;
   hashes: Set<string>;
-}> {
-  const content = await readFileSafe(path);
-  if (content === null) return { rows: 0, malformed: 0, hashes: new Set() };
+  /** SHA-256 of the whole raw agenda.jsonl content, or null when absent. */
+  contentHash: string | null;
+}
+
+/**
+ * Pure analysis of a single `agenda.jsonl` payload. Callers read the file once
+ * (via {@link readFileSafe}) and pass the content here, so a store is never
+ * read twice during a scan (AC2, SC4).
+ */
+export function analyzeAgenda(content: string | null): AgendaAnalysis {
+  if (content === null) {
+    return { rows: 0, malformed: 0, hashes: new Set(), contentHash: null };
+  }
   const lines = content.split("\n").filter((l) => l.trim().length > 0);
   const hashes = new Set<string>();
   let malformed = 0;
@@ -251,7 +262,7 @@ async function readJsonlHashed(path: string): Promise<{
       malformed += 1;
     }
   }
-  return { rows: lines.length, malformed, hashes };
+  return { rows: lines.length, malformed, hashes, contentHash: sha256(content) };
 }
 
 async function probeWorkerLock(storePath: string): Promise<{
@@ -339,55 +350,66 @@ export async function scanStoresForCleanup(
   options: ScanStoresForCleanupOptions,
 ): Promise<StoreCleanupScanResult> {
   const { stores } = await walkStoreDirs(options.dataHomeRoot);
-  const warnings: string[] = [];
-  const entries: StoreCleanupStore[] = [];
 
-  for (const ref of stores) {
-    const agendaPath = join(ref.path, "agenda.jsonl");
-    const agenda = await readJsonlHashed(agendaPath);
-    const agendaExists = agenda.rows > 0 || agenda.malformed > 0;
-    const agendaContent = await readFileSafe(agendaPath);
-    const agendaHash = agendaContent !== null ? sha256(agendaContent) : null;
+  // Probe each store with bounded concurrency (DONT1: never unbounded). Within
+  // a store the four independent files are read in parallel, and agenda.jsonl
+  // is read exactly once (AC2, SC4). Ordering is deterministic because results
+  // are collected in input order and then sorted by project_id below.
+  const perStore = await mapWithConcurrency(
+    stores,
+    STORE_SCAN_CONCURRENCY,
+    async (ref) => {
+      const agendaPath = join(ref.path, "agenda.jsonl");
+      const [agendaContent, lock, ledger, manifest] = await Promise.all([
+        readFileSafe(agendaPath),
+        probeWorkerLock(ref.path),
+        probeConsolidationLedger(ref.path),
+        probeCleanupManifest(ref.path),
+      ]);
+      const agenda = analyzeAgenda(agendaContent);
+      const agendaExists = agenda.rows > 0 || agenda.malformed > 0;
 
-    const lock = await probeWorkerLock(ref.path);
-    const ledger = await probeConsolidationLedger(ref.path);
-    const manifest = await probeCleanupManifest(ref.path);
+      const warnings: string[] = [];
+      let classification: StoreCleanupStore["classification"];
+      if (!agendaExists) {
+        classification = manifest.manifest_exists
+          ? "already_cleaned"
+          : "no_agenda";
+      } else if (lock.present && lock.live) {
+        classification = "unsafe";
+        warnings.push(
+          `store ${ref.projectId} holds a live worker.lock (pid ${lock.pid}); cleanup refuses until stale sessions are closed`,
+        );
+      } else if (ledger.exists && ledger.agenda_rows > 0) {
+        classification = "unsafe";
+        warnings.push(
+          `store ${ref.projectId} has a consolidation ledger with ${ledger.agenda_rows} agenda_row entries; cleanup refuses to preserve consolidation evidence`,
+        );
+      } else {
+        classification = "has_agenda";
+      }
 
-    let classification: StoreCleanupStore["classification"];
-    if (!agendaExists) {
-      classification = manifest.manifest_exists
-        ? "already_cleaned"
-        : "no_agenda";
-    } else if (lock.present && lock.live) {
-      classification = "unsafe";
-      warnings.push(
-        `store ${ref.projectId} holds a live worker.lock (pid ${lock.pid}); cleanup refuses until stale sessions are closed`,
-      );
-    } else if (ledger.exists && ledger.agenda_rows > 0) {
-      classification = "unsafe";
-      warnings.push(
-        `store ${ref.projectId} has a consolidation ledger with ${ledger.agenda_rows} agenda_row entries; cleanup refuses to preserve consolidation evidence`,
-      );
-    } else {
-      classification = "has_agenda";
-    }
+      const entry: StoreCleanupStore = {
+        project_id: ref.projectId,
+        path: ref.path,
+        layout: ref.layout,
+        agenda: {
+          exists: agendaExists,
+          rows: agenda.rows,
+          content_hash: agenda.contentHash,
+          malformed: agenda.malformed,
+        },
+        worker_lock: lock,
+        consolidation_ledger: ledger,
+        cleanup: manifest,
+        classification,
+      };
+      return { entry, warnings };
+    },
+  );
 
-    entries.push({
-      project_id: ref.projectId,
-      path: ref.path,
-      layout: ref.layout,
-      agenda: {
-        exists: agendaExists,
-        rows: agenda.rows,
-        content_hash: agendaHash,
-        malformed: agenda.malformed,
-      },
-      worker_lock: lock,
-      consolidation_ledger: ledger,
-      cleanup: manifest,
-      classification,
-    });
-  }
+  const entries: StoreCleanupStore[] = perStore.map((p) => p.entry);
+  const warnings: string[] = perStore.flatMap((p) => p.warnings);
 
   return {
     action: "scan",

--- a/plugin/src/tools/store-cleanup.ts
+++ b/plugin/src/tools/store-cleanup.ts
@@ -23,7 +23,10 @@ import { join } from "path";
 import { createHash } from "crypto";
 import { z } from "zod";
 import { formatToolOutput } from "../utils/tool-output";
-import { mapWithConcurrency, STORE_SCAN_CONCURRENCY } from "../utils/concurrency";
+import {
+  mapWithConcurrency,
+  STORE_SCAN_CONCURRENCY,
+} from "../utils/concurrency";
 import {
   walkStoreDirs,
   defaultDataHomeRoot,
@@ -262,7 +265,12 @@ export function analyzeAgenda(content: string | null): AgendaAnalysis {
       malformed += 1;
     }
   }
-  return { rows: lines.length, malformed, hashes, contentHash: sha256(content) };
+  return {
+    rows: lines.length,
+    malformed,
+    hashes,
+    contentHash: sha256(content),
+  };
 }
 
 async function probeWorkerLock(storePath: string): Promise<{

--- a/plugin/src/tools/store-consolidate-parallel.test.ts
+++ b/plugin/src/tools/store-consolidate-parallel.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression tests for the parallelized `scanStoresForRepo` (change
+ * parallelizeStoreMaintenance). The per-store loop — which spawns git identity
+ * probes and reads several directories per store — was converted from serial to
+ * bounded-concurrency mapping. These tests pin behaviour-preserving guarantees:
+ * correct classification at scale, deterministic ordering, order-preserved
+ * warnings, and fast completion.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+import { scanStoresForRepo } from "./store-consolidate";
+
+const run = promisify(execFile);
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await run("git", args, { cwd });
+  return stdout.trim();
+}
+
+function shardStorePath(
+  dataHomeRoot: string,
+  shard: string,
+  projectId: string,
+): string {
+  return join(
+    dataHomeRoot,
+    "opencode-projects",
+    shard,
+    "opencode/plugins/advance",
+    projectId,
+  );
+}
+
+async function writeStore(
+  dir: string,
+  opts?: { lockPid?: number },
+): Promise<void> {
+  await mkdir(join(dir, "changes"), { recursive: true });
+  if (opts?.lockPid !== undefined) {
+    await writeFile(
+      join(dir, "worker.lock"),
+      JSON.stringify({
+        pid: opts.lockPid,
+        worker_id: "test-worker",
+        acquired_at: "2026-07-11T00:00:00.000Z",
+        schema_version: 2,
+        last_heartbeat: new Date().toISOString(),
+      }),
+    );
+  }
+}
+
+const shard = "a".repeat(40);
+const UNRELATED_COUNT = 50;
+
+let base: string;
+let repoDir: string;
+let dataHomeRoot: string;
+let rootSha: string;
+let childSha: string;
+const unrelatedIds = Array.from({ length: UNRELATED_COUNT }, (_, i) =>
+  (i + 1).toString(16).padStart(40, "0"),
+);
+const lockedIndex = 21;
+
+beforeAll(async () => {
+  base = await mkdtemp(join(tmpdir(), "adv-store-consolidate-parallel-"));
+  repoDir = join(base, "repo");
+  await run("git", ["init", "-b", "main", repoDir]);
+  await git(repoDir, "config", "user.email", "t@t");
+  await git(repoDir, "config", "user.name", "t");
+  await writeFile(join(repoDir, "f.txt"), "x\n");
+  await git(repoDir, "add", ".");
+  await git(repoDir, "commit", "-m", "c1");
+  rootSha = (await git(repoDir, "rev-list", "--max-parents=0", "HEAD"))
+    .split("\n")[0]!
+    .trim();
+  await writeFile(join(repoDir, "f.txt"), "y\n");
+  await git(repoDir, "add", ".");
+  await git(repoDir, "commit", "-m", "c2");
+  childSha = await git(repoDir, "rev-parse", "HEAD");
+
+  dataHomeRoot = join(base, "xdg");
+  // True store (id == identity root commit).
+  await writeStore(shardStorePath(dataHomeRoot, shard, rootSha));
+  // Orphan candidate (a commit of this repo but not the root).
+  await writeStore(shardStorePath(dataHomeRoot, shard, childSha));
+  // Many unrelated stores (valid 40-hex ids that are not commits here).
+  for (let i = 0; i < UNRELATED_COUNT; i++) {
+    await writeStore(
+      shardStorePath(dataHomeRoot, shard, unrelatedIds[i]!),
+      i === lockedIndex ? { lockPid: process.pid } : undefined,
+    );
+  }
+}, 60_000);
+
+afterAll(async () => {
+  await rm(base, { recursive: true, force: true });
+});
+
+describe("scanStoresForRepo (parallel)", () => {
+  test("classifies a large store set and completes fast", async () => {
+    const start = Date.now();
+    const result = await scanStoresForRepo({ directory: repoDir, dataHomeRoot });
+    const elapsed = Date.now() - start;
+
+    expect(result.identity.kind).toBe("ok");
+    expect(result.stores).toHaveLength(UNRELATED_COUNT + 2);
+    expect(elapsed).toBeLessThan(8_000);
+
+    const byId = Object.fromEntries(
+      result.stores.map((s) => [s.project_id, s]),
+    );
+    expect(byId[rootSha]!.relation).toBe("true_store");
+    expect(byId[childSha]!.relation).toBe("orphan_candidate");
+    expect(byId[childSha]!.unstable_identity_suspect).toBe(true);
+    // Orphan candidate is flagged.
+    expect(result.flagged).toContain(childSha);
+    // Unrelated ids classified as unrelated.
+    for (const id of unrelatedIds) {
+      expect(byId[id]!.relation).toBe("unrelated");
+    }
+    // Live worker.lock surfaces exactly one warning.
+    expect(result.warnings.filter((w) => w.includes("holds a live"))).toHaveLength(
+      1,
+    );
+  });
+
+  test("output is deterministic across repeated runs", async () => {
+    const a = await scanStoresForRepo({ directory: repoDir, dataHomeRoot });
+    const b = await scanStoresForRepo({ directory: repoDir, dataHomeRoot });
+    expect(a.stores.map((s) => s.project_id)).toEqual(
+      b.stores.map((s) => s.project_id),
+    );
+    expect(a.flagged).toEqual(b.flagged);
+    expect(a.warnings).toEqual(b.warnings);
+    // Entries are project_id-sorted (SC2 output shape).
+    expect(a.stores.map((s) => s.project_id)).toEqual(
+      [...a.stores.map((s) => s.project_id)].sort(),
+    );
+  });
+});

--- a/plugin/src/tools/store-consolidate-parallel.test.ts
+++ b/plugin/src/tools/store-consolidate-parallel.test.ts
@@ -106,7 +106,10 @@ afterAll(async () => {
 describe("scanStoresForRepo (parallel)", () => {
   test("classifies a large store set and completes fast", async () => {
     const start = Date.now();
-    const result = await scanStoresForRepo({ directory: repoDir, dataHomeRoot });
+    const result = await scanStoresForRepo({
+      directory: repoDir,
+      dataHomeRoot,
+    });
     const elapsed = Date.now() - start;
 
     expect(result.identity.kind).toBe("ok");
@@ -126,9 +129,9 @@ describe("scanStoresForRepo (parallel)", () => {
       expect(byId[id]!.relation).toBe("unrelated");
     }
     // Live worker.lock surfaces exactly one warning.
-    expect(result.warnings.filter((w) => w.includes("holds a live"))).toHaveLength(
-      1,
-    );
+    expect(
+      result.warnings.filter((w) => w.includes("holds a live")),
+    ).toHaveLength(1);
   });
 
   test("output is deterministic across repeated runs", async () => {

--- a/plugin/src/tools/store-consolidate.ts
+++ b/plugin/src/tools/store-consolidate.ts
@@ -41,7 +41,10 @@ import { basename, dirname, join } from "path";
 import { createHash } from "crypto";
 import { z } from "zod";
 import { formatToolOutput } from "../utils/tool-output";
-import { mapWithConcurrency, STORE_SCAN_CONCURRENCY } from "../utils/concurrency";
+import {
+  mapWithConcurrency,
+  STORE_SCAN_CONCURRENCY,
+} from "../utils/concurrency";
 import { getDataHome, resolveProjectIdentity } from "../utils/project-id";
 import { execFileGitAsync } from "../utils/git-binary";
 import { isProcessAlive } from "../utils/process-liveness";
@@ -695,15 +698,21 @@ export async function scanStoresForRepo(
         }
       }
 
-      const [lock, changes, archiveBundles, retiredEpics, wisdomRows, reflRows] =
-        await Promise.all([
-          probeWorkerLock(ref.path),
-          readdirSafe(join(ref.path, "changes")).then((d) => d.length),
-          readdirSafe(join(ref.path, "archive")).then((d) => d.length),
-          readdirSafe(join(ref.path, "retired-epics")).then((d) => d.length),
-          countJsonlRows(join(ref.path, "wisdom.jsonl")),
-          countJsonlRows(join(ref.path, "reflections.jsonl")),
-        ]);
+      const [
+        lock,
+        changes,
+        archiveBundles,
+        retiredEpics,
+        wisdomRows,
+        reflRows,
+      ] = await Promise.all([
+        probeWorkerLock(ref.path),
+        readdirSafe(join(ref.path, "changes")).then((d) => d.length),
+        readdirSafe(join(ref.path, "archive")).then((d) => d.length),
+        readdirSafe(join(ref.path, "retired-epics")).then((d) => d.length),
+        countJsonlRows(join(ref.path, "wisdom.jsonl")),
+        countJsonlRows(join(ref.path, "reflections.jsonl")),
+      ]);
 
       const warnings: string[] = [];
       if (lock.present && lock.live) {

--- a/plugin/src/tools/store-consolidate.ts
+++ b/plugin/src/tools/store-consolidate.ts
@@ -41,6 +41,7 @@ import { basename, dirname, join } from "path";
 import { createHash } from "crypto";
 import { z } from "zod";
 import { formatToolOutput } from "../utils/tool-output";
+import { mapWithConcurrency, STORE_SCAN_CONCURRENCY } from "../utils/concurrency";
 import { getDataHome, resolveProjectIdentity } from "../utils/project-id";
 import { execFileGitAsync } from "../utils/git-binary";
 import { isProcessAlive } from "../utils/process-liveness";
@@ -648,76 +649,94 @@ export async function scanStoresForRepo(
           };
 
   const { stores, layouts } = await walkStoreDirs(options.dataHomeRoot);
-  const warnings: string[] = [];
-  const entries: ConsolidationScanStore[] = [];
 
-  for (const ref of stores) {
-    const isSha = SHA40.test(ref.projectId);
-    let relation: ConsolidationScanStore["relation"] = "malformed";
-    let isCommit: boolean | null = null;
-    let isRoot: boolean | null = null;
-    let suspect = false;
-    let note: string | null = null;
+  // Classify each store with bounded concurrency (DONT1: never unbounded). The
+  // per-store git identity probes (gitIsCommit/gitIsRootCommit) spawn a git
+  // process each; a serial loop over hundreds of orphan stores blows the tool
+  // budget. Results are collected in input order (mapWithConcurrency preserves
+  // it), so warnings retain their original order and entries sort deterministically.
+  const perStore = await mapWithConcurrency(
+    stores,
+    STORE_SCAN_CONCURRENCY,
+    async (ref) => {
+      const isSha = SHA40.test(ref.projectId);
+      let relation: ConsolidationScanStore["relation"] = "malformed";
+      let isCommit: boolean | null = null;
+      let isRoot: boolean | null = null;
+      let suspect = false;
+      let note: string | null = null;
 
-    if (!isSha) {
-      note = "directory name is not a 40-hex project id";
-    } else if (identity.kind !== "ok") {
-      relation = "identity_unresolved";
-      note =
-        "repo identity could not be resolved; structural comparison skipped";
-    } else {
-      isCommit = await gitIsCommit(options.directory, ref.projectId);
-      if (!isCommit) {
-        relation = "unrelated";
-        note = "not a commit of this repository (belongs to another repo)";
+      if (!isSha) {
+        note = "directory name is not a 40-hex project id";
+      } else if (identity.kind !== "ok") {
+        relation = "identity_unresolved";
+        note =
+          "repo identity could not be resolved; structural comparison skipped";
       } else {
-        isRoot = await gitIsRootCommit(options.directory, ref.projectId);
-        if (ref.projectId === identity.project_id) {
-          relation = "true_store";
+        isCommit = await gitIsCommit(options.directory, ref.projectId);
+        if (!isCommit) {
+          relation = "unrelated";
+          note = "not a commit of this repository (belongs to another repo)";
         } else {
-          relation = "orphan_candidate";
-          if (!isRoot) {
-            suspect = true;
-            note =
-              "store id is a non-root commit of this repo — the shallow-boundary / graft unstable-identity class; consolidation candidate";
+          isRoot = await gitIsRootCommit(options.directory, ref.projectId);
+          if (ref.projectId === identity.project_id) {
+            relation = "true_store";
           } else {
-            note =
-              "store id is a root commit but not the canonical identity root (multi-root repo); review before consolidating";
+            relation = "orphan_candidate";
+            if (!isRoot) {
+              suspect = true;
+              note =
+                "store id is a non-root commit of this repo — the shallow-boundary / graft unstable-identity class; consolidation candidate";
+            } else {
+              note =
+                "store id is a root commit but not the canonical identity root (multi-root repo); review before consolidating";
+            }
           }
         }
       }
-    }
 
-    const lock = await probeWorkerLock(ref.path);
-    if (lock.present && lock.live) {
-      warnings.push(
-        `store ${ref.projectId} holds a live ${WORKER_LOCK_FILENAME} (pid ${lock.pid}) — stale sessions may still write; execute refuses while present`,
-      );
-    }
+      const [lock, changes, archiveBundles, retiredEpics, wisdomRows, reflRows] =
+        await Promise.all([
+          probeWorkerLock(ref.path),
+          readdirSafe(join(ref.path, "changes")).then((d) => d.length),
+          readdirSafe(join(ref.path, "archive")).then((d) => d.length),
+          readdirSafe(join(ref.path, "retired-epics")).then((d) => d.length),
+          countJsonlRows(join(ref.path, "wisdom.jsonl")),
+          countJsonlRows(join(ref.path, "reflections.jsonl")),
+        ]);
 
-    entries.push({
-      project_id: ref.projectId,
-      path: ref.path,
-      layout: ref.layout,
-      shard: ref.shard,
-      relation,
-      is_commit_in_repo: isCommit,
-      is_root_commit: isRoot,
-      unstable_identity_suspect: suspect,
-      note,
-      worker_lock: lock,
-      summary: {
-        changes: (await readdirSafe(join(ref.path, "changes"))).length,
-        archive_bundles: (await readdirSafe(join(ref.path, "archive"))).length,
-        retired_epics: (await readdirSafe(join(ref.path, "retired-epics")))
-          .length,
-        wisdom_rows: await countJsonlRows(join(ref.path, "wisdom.jsonl")),
-        reflections_rows: await countJsonlRows(
-          join(ref.path, "reflections.jsonl"),
-        ),
-      },
-    });
-  }
+      const warnings: string[] = [];
+      if (lock.present && lock.live) {
+        warnings.push(
+          `store ${ref.projectId} holds a live ${WORKER_LOCK_FILENAME} (pid ${lock.pid}) — stale sessions may still write; execute refuses while present`,
+        );
+      }
+
+      const entry: ConsolidationScanStore = {
+        project_id: ref.projectId,
+        path: ref.path,
+        layout: ref.layout,
+        shard: ref.shard,
+        relation,
+        is_commit_in_repo: isCommit,
+        is_root_commit: isRoot,
+        unstable_identity_suspect: suspect,
+        note,
+        worker_lock: lock,
+        summary: {
+          changes,
+          archive_bundles: archiveBundles,
+          retired_epics: retiredEpics,
+          wisdom_rows: wisdomRows,
+          reflections_rows: reflRows,
+        },
+      };
+      return { entry, warnings };
+    },
+  );
+
+  const entries: ConsolidationScanStore[] = perStore.map((p) => p.entry);
+  const warnings: string[] = perStore.flatMap((p) => p.warnings);
 
   return {
     action: "scan",

--- a/plugin/src/utils/concurrency.test.ts
+++ b/plugin/src/utils/concurrency.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { mapWithConcurrency, STORE_SCAN_CONCURRENCY } from "./concurrency";
+
+function deferredDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("mapWithConcurrency", () => {
+  it("preserves input order regardless of completion order", async () => {
+    const input = [40, 5, 30, 10, 0, 25];
+    const result = await mapWithConcurrency(input, 3, async (n) => {
+      await deferredDelay(n);
+      return n * 2;
+    });
+    expect(result).toEqual([80, 10, 60, 20, 0, 50]);
+  });
+
+  it("passes the index to the mapper", async () => {
+    const input = ["a", "b", "c"];
+    const result = await mapWithConcurrency(input, 2, async (v, i) => `${v}${i}`);
+    expect(result).toEqual(["a0", "b1", "c2"]);
+  });
+
+  it("never exceeds the concurrency limit of in-flight tasks", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 50 }, (_, i) => i);
+    await mapWithConcurrency(items, 4, async (n) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await deferredDelay(n % 5);
+      inFlight -= 1;
+      return n;
+    });
+    expect(maxInFlight).toBeLessThanOrEqual(4);
+    expect(maxInFlight).toBeGreaterThan(1);
+  });
+
+  it("clamps concurrency above item count without error", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = [1, 2, 3];
+    const result = await mapWithConcurrency(items, 100, async (n) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await deferredDelay(1);
+      inFlight -= 1;
+      return n;
+    });
+    expect(result).toEqual([1, 2, 3]);
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it("treats concurrency < 1 as a single worker", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = [1, 2, 3, 4];
+    const result = await mapWithConcurrency(items, 0, async (n) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await deferredDelay(1);
+      inFlight -= 1;
+      return n;
+    });
+    expect(result).toEqual([1, 2, 3, 4]);
+    expect(maxInFlight).toBe(1);
+  });
+
+  it("returns an empty array for empty input without invoking the mapper", async () => {
+    let called = false;
+    const result = await mapWithConcurrency([], 8, async (n) => {
+      called = true;
+      return n;
+    });
+    expect(result).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it("propagates a mapper rejection", async () => {
+    const items = [1, 2, 3];
+    await expect(
+      mapWithConcurrency(items, 2, async (n) => {
+        if (n === 2) throw new Error("boom");
+        return n;
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("exposes a sane default store-scan concurrency", () => {
+    expect(STORE_SCAN_CONCURRENCY).toBeGreaterThanOrEqual(8);
+    expect(STORE_SCAN_CONCURRENCY).toBeLessThanOrEqual(64);
+  });
+});

--- a/plugin/src/utils/concurrency.test.ts
+++ b/plugin/src/utils/concurrency.test.ts
@@ -18,7 +18,11 @@ describe("mapWithConcurrency", () => {
 
   it("passes the index to the mapper", async () => {
     const input = ["a", "b", "c"];
-    const result = await mapWithConcurrency(input, 2, async (v, i) => `${v}${i}`);
+    const result = await mapWithConcurrency(
+      input,
+      2,
+      async (v, i) => `${v}${i}`,
+    );
     expect(result).toEqual(["a0", "b1", "c2"]);
   });
 

--- a/plugin/src/utils/concurrency.ts
+++ b/plugin/src/utils/concurrency.ts
@@ -1,0 +1,56 @@
+/**
+ * Bounded-concurrency async mapping.
+ *
+ * Used by filesystem-heavy maintenance scans (store-cleanup, store-consolidate)
+ * that must probe hundreds of store directories within the fixed tool timeout.
+ * A serial `for…of await` loop over N stores performs N × per-store I/O ops
+ * sequentially and blows the budget; an unbounded `Promise.all` over N stores
+ * opens N descriptors at once and risks EMFILE. This helper bounds the number
+ * of in-flight tasks while preserving input order in the results array.
+ */
+
+/**
+ * Default in-flight concurrency for per-store maintenance-scan probing.
+ * Chosen to saturate filesystem I/O while staying well below typical OS
+ * file-descriptor limits (DONT1: never unbounded).
+ */
+export const STORE_SCAN_CONCURRENCY = 16;
+
+/**
+ * Map `items` through async `fn` with at most `concurrency` invocations in
+ * flight at any time. Results are returned in the same order as `items`
+ * (position `i` holds the result of `fn(items[i], i)`), independent of
+ * completion order.
+ *
+ * - `concurrency` is clamped to `[1, items.length]`; non-finite or `< 1`
+ *   values fall back to a single worker.
+ * - Empty input resolves to `[]` without invoking `fn`.
+ * - A rejection from any `fn` invocation rejects the returned promise with the
+ *   first such error (other already-started tasks are not cancelled).
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const n = items.length;
+  const results = new Array<R>(n);
+  if (n === 0) return results;
+
+  const limit = Number.isFinite(concurrency)
+    ? Math.max(1, Math.min(Math.floor(concurrency), n))
+    : 1;
+
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= n) return;
+      results[index] = await fn(items[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: limit }, () => worker()));
+  return results;
+}


### PR DESCRIPTION
## Problem

`adv_store_cleanup action:scan` and `adv_store_consolidate action:scan` time out at the hard 10s tool ceiling (`safeExecute` DEFAULT_TOOL_TIMEOUT_MS, matched by the SDK host) on data-homes with many local ADV stores (observed: ~379 orphan-shard + ~32 drain-* + others = 400+). Both scans used a fully **serial** per-store `for…of await` loop:

- `scanStoresForCleanup` (store-cleanup.ts): ~6 fs ops/store incl. a **redundant double read** of `agenda.jsonl`.
- `scanStoresForRepo` (store-consolidate.ts): a **git subprocess per store** (`gitIsCommit`/`gitIsRootCommit`) + 5 fs ops — ~758 serial git spawns for 379 stores.

The 10s ceiling can't be raised (SDK cap; `rq-boundedAuthoritativeRead01`), so the fix is structural.

## Change

- New `plugin/src/utils/concurrency.ts` — `mapWithConcurrency(items, concurrency, fn)`: order-preserving, bounded worker-pool (no unbounded `Promise.all` → no EMFILE). `STORE_SCAN_CONCURRENCY=16`.
- `store-cleanup.ts`: parallelize the scan loop; single-read via pure `analyzeAgenda(content)` (removes the double read).
- `store-consolidate.ts`: parallelize the `scanStoresForRepo` per-store loop; per-store fs summary reads batched via `Promise.all`.
- Behavior preserved: classification, warnings order, deterministic `project_id`-sorted output all identical to the serial version.

## Verification

- `mapWithConcurrency` unit tests: order, bounded in-flight, rejection, clamp, empty.
- store-cleanup: large-N classification parity, determinism, single-read (agenda reads == store count).
- store-consolidate: 50 unrelated + true_store + orphan-suspect + live-lock warning parity, determinism.
- `pnpm run check` green; 84/84 targeted store/concurrency tests green.

Scope: store-scan enumeration only. The archived/terminal change-enumeration timeout family (hygiene, archived_branches) is owned by `fixChangeEnumerationStarvation` + a fast-follow.

ADV change: `parallelizeStoreMaintenance`