### PR TITLE
docs(adv-designer): clarify designer is remediation-capable, not review-only

### DIFF
--- a/.opencode/agents/adv-designer.md
+++ b/.opencode/agents/adv-designer.md
@@ -76,7 +76,7 @@ tools:
   task: false
 ---
 
-You are the `adv-designer` agent: an ADV apply-phase frontend follow-up specialist. After a successful engineer or inline receipt, verify scoped UI/component corrections. Never initial route for `metadata.frontend == "true"`. The spawnable identifier is `adv-designer`; the `DESIGNER_REPORT.agent` field submitted to `adv_subagent_report_submit` must use that exact string.
+You are the `adv-designer` agent: an ADV apply-phase frontend follow-up specialist. After a successful engineer or inline receipt, **fix in-scope UI/component issues, then verify** the result. You are remediation-capable, not review-only. Never initial route for `metadata.frontend == "true"`. The spawnable identifier is `adv-designer`; the `DESIGNER_REPORT.agent` field submitted to `adv_subagent_report_submit` must use that exact string.
 
 You have full write capability (read, write, edit, bash, tests). The constraint is not what you *can* do — it's what you *choose* to touch. You work on ONE scoped frontend objective at a time, verify every iteration, and stop at the scope boundary.
 

--- a/.opencode/command/adv-apply.md
+++ b/.opencode/command/adv-apply.md
@@ -436,7 +436,7 @@ Hint semantics:
 
 **If delegated to `adv-engineer` (`delegate_allowed` or `delegate_preferred`):** Spawn `adv-engineer` sub-agent with the Apply Context Packet below.
 
-**For a classified frontend follow-up:** After a successful same-cycle `adv-engineer` report or classified inline implementation, spawn `adv-designer` with the Designer Apply Context Packet and its `IMPLEMENTATION_RECEIPT`. `adv-designer` validates UI/a11y/polish only; review/harden ownership remains with `adv-reviewer`.
+**For a classified frontend follow-up:** After a successful same-cycle `adv-engineer` report or classified inline implementation, spawn `adv-designer` with the Designer Apply Context Packet and its `IMPLEMENTATION_RECEIPT`. `adv-designer` **remediates in scope** (UI/a11y/polish fixes, then verifies); it is **not** review-only. Review/harden ownership remains with `adv-reviewer`.
 
 If sub-agent succeeds → run incremental verification → if passes → mark done. If sub-agent fails OR verification fails → immediate inline fallback, continue with Red/Green phases.
 

--- a/.opencode/command/adv-apply.md
+++ b/.opencode/command/adv-apply.md
@@ -436,7 +436,7 @@ Hint semantics:
 
 **If delegated to `adv-engineer` (`delegate_allowed` or `delegate_preferred`):** Spawn `adv-engineer` sub-agent with the Apply Context Packet below.
 
-**For a classified frontend follow-up:** After a successful same-cycle `adv-engineer` report or classified inline implementation, spawn `adv-designer` with the Designer Apply Context Packet and its `IMPLEMENTATION_RECEIPT`. `adv-designer` **remediates in scope** (UI/a11y/polish fixes, then verifies); it is **not** review-only. Review/harden ownership remains with `adv-reviewer`.
+**For a classified frontend follow-up:** After a successful same-cycle `adv-engineer` report or classified inline implementation, spawn `adv-designer` with the Designer Apply Context Packet and its `IMPLEMENTATION_RECEIPT`. `adv-designer` **remediates in scope** (UI/a11y/polish fixes, then verifies) — it is **not** review-only; review/harden ownership remains with `adv-reviewer`.
 
 If sub-agent succeeds → run incremental verification → if passes → mark done. If sub-agent fails OR verification fails → immediate inline fallback, continue with Red/Green phases.
 


### PR DESCRIPTION
## Problem

When the orchestrator spawned `adv-designer` to follow up on `adv-engineer` UI work, it constructed review/read-only spawn prompts — despite the designer agent file granting full write/edit/bash/test/Playwright access and explicitly mandating implementation.

## Root cause

Ambiguous verbs at two high-traffic dispatch-decision points:

- `.opencode/command/adv-apply.md:439` — "`adv-designer` **validates** UI/a11y/polish only"
- `.opencode/agents/adv-designer.md:79` — "**verify** scoped UI/component corrections"

"Validates" and "verify" read as evaluation-only, leading the orchestrator LLM to spawn the designer as a reviewer instead of a remediation worker.

The specs (`rq-delDefaults05/07/08/10`, `rq-designQualityEvidence01`) and the rest of the agent file already encode remediation-capable behavior. No contract change needed; prose clarity only.

## Fix

Replace the ambiguous verbs with explicit remediation language:

- `adv-apply.md:439` — "`adv-designer` **remediates in scope** (UI/a11y/polish fixes, then verifies); it is **not** review-only."
- `adv-designer.md:79` — "**fix in-scope UI/component issues, then verify** the result. You are remediation-capable, not review-only."

## Verification

- Two-line prose change only.
- No spec, contract, schema, or test changes.
- Post-commit hook redeployed ADV assets to local install.

## Triage evidence

Symptom reported: real `adv-designer` spawn was given review/read-only instructions. Tier-1 local evidence confirmed designer agent file already mandates implementation (line 2: "Implement scoped ADV frontend/component tasks"; line 81: "full write capability"; line 141: "Apply — Implement the UI/component change"). Tier-2 research validation: `caution` — contract supports remediation, prose ambiguity was the drift vector.