### PR TITLE
feat(deploy): add explore overlay for MCP routing contract

### DIFF
--- a/.opencode/overlays/explore.overlay.md
+++ b/.opencode/overlays/explore.overlay.md
@@ -1,0 +1,9 @@
+<!-- ADV_SYNC:START explore -->
+## ADV Overlay
+
+- NEVER invoke `/adv-*` from inside this agent; use ADV tools directly or execute the needed workflow inline instead of slash-command dispatch
+- Spawned workers must complete inline and must not spawn additional sub-agents
+- Nested sub-agent depth is hard-limited to `1`
+- Canonical TDD path here is documentation, not enforcement: use editing tools for test-file changes and `adv_run_test` for red/green; enforcement lives in plugin/runtime + spec.
+- For external MCP capabilities, use only the active tool surface. If `execute` is exposed, follow its generated catalog and exact returned paths. Otherwise use direct MCP callables exactly as exposed. Never infer availability from prose or normalize identifiers; report an absent capability as unavailable.
+<!-- ADV_SYNC:END explore -->

--- a/plugin/src/tool-name-assets.test.ts
+++ b/plugin/src/tool-name-assets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { readdirSync, readFileSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { join, resolve } from "path";
 import { ADV_TOOL_NAMES } from "./tool-registry";
 import {
@@ -313,6 +313,36 @@ describe("mode-neutral MCP prompt contract", () => {
         synced,
         `${name}.md inline ADV_SYNC block drifted from overlay`,
       ).toBe(agent);
+    }
+  });
+
+  test("overlay-only sources each carry the canonical contract exactly once", () => {
+    // Overlay-only managed agents are those WITHOUT a matching advance-source
+    // agent file at `.opencode/agents/{name}.md`. For these agents the overlay
+    // is the only advance-authored surface, so the mode-neutral contract must
+    // ride there verbatim. Source-backed shared agents (adv, build, plan) may
+    // carry the contract in the source body or the overlay; this test does not
+    // constrain them (the effective-prompt test above does).
+    //
+    // rq: fixSubAgentMcpRouting — closes the gap that allowed explore.md to
+    // silently miss the contract under CodeMode-on sessions.
+    const overlayDir = join(REPO_ROOT, ".opencode/overlays");
+    const agentsDir = join(REPO_ROOT, ".opencode/agents");
+    const overlayOnly = readdirSync(overlayDir)
+      .filter((name) => name.endsWith(".overlay.md"))
+      .filter((name) => {
+        const agentName = name.replace(/\.overlay\.md$/, ".md");
+        return !existsSync(join(agentsDir, agentName));
+      })
+      .sort();
+    // Today: explore.overlay.md (new) and general.overlay.md.
+    expect(overlayOnly).toEqual(["explore.overlay.md", "general.overlay.md"]);
+    for (const name of overlayOnly) {
+      const content = readFileSync(join(overlayDir, name), "utf8");
+      expect(
+        countContractOccurrences(content),
+        `${name} must carry the canonical contract exactly once`,
+      ).toBe(1);
     }
   });
 });

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1605,8 +1605,9 @@ sync_adv_runtime_agent
 # `adv` is intentionally NOT in this list — see SHARED_OVERLAY_ONLY note above.
 if [ -d "$REPO_OVERLAYS" ]; then
 	echo "    syncing shared-agent overlays"
-	apply_overlay_block "general" "$GLOBAL_AGENTS/general.md"
 	apply_overlay_block "build" "$GLOBAL_AGENTS/build.md" "$REPO_AGENTS/build.md"
+	apply_overlay_block "explore" "$GLOBAL_AGENTS/explore.md"
+	apply_overlay_block "general" "$GLOBAL_AGENTS/general.md"
 	apply_overlay_block "plan" "$GLOBAL_AGENTS/plan.md" "$REPO_AGENTS/plan.md"
 fi
 


### PR DESCRIPTION
## Problem

Spawned `explore` sub-agent silently fell back to `glob`/`grep` instead of using lgrep under CodeMode-on sessions. Root cause: `explore.md` was the only user-owned top-level agent without an ADV_SYNC overlay carrying the canonical `MCP_ACTIVE_SURFACE_CONTRACT`. ADV-owned agents (`adv-researcher`, etc.) and the other 3 shared agents (`general`, `build`, `plan`) already had the contract delivered (via overlay or source body).

Prior art: archived change `updateCodemodeMcpContracts` (2026-07-15) established the routing contract for ADV-owned agents; this change closes the gap for the remaining shared agent.

## Changes

- **NEW** `.opencode/overlays/explore.overlay.md` — byte-identical to `general.overlay.md` (9 lines, includes ADV_SYNC markers + ADV Overlay heading + 5 bullets with the canonical `MCP_ACTIVE_SURFACE_CONTRACT` line).
- **EDIT** `scripts/deploy-local.sh` lines 1606-1611 — register `explore` in the `apply_overlay_block` sequence (alphabetical: build, explore, general, plan). Uses 2-arg form (no bootstrap_source) since `~/.config/opencode/agents/explore.md` already exists on every OpenCode install.
- **EDIT** `plugin/src/tool-name-assets.test.ts` — new test inside the existing `mode-neutral MCP prompt contract` describe block. Iterates `.opencode/overlays/*.overlay.md` filtered to overlay-only managed agents (no matching advance-source agent file) and asserts each carries the canonical contract exactly once. Catches future drift in overlay content.

## Verification

- RED: new test failed as expected (explore.overlay.md absent).
- GREEN: 14/14 `tool-name-assets.test.ts` pass after creating `explore.overlay.md` and adding deploy line.
- VERIFY: 11/11 `mcp-runtime-matrix.test.ts` pass. `pnpm run check` all green (schemas, typecheck, isolation, lockfile, lint, format).

## Post-merge follow-ups (tracked in ADV change)

This PR is **Stage 1** of ADV change `fixSubAgentMcpRouting`. After merge:

1. **Stage 2 (deploy)** — run `bash scripts/deploy-local.sh --fix` from trunk; verify `overlay synced: explore` log line; verify `~/.config/opencode/agents/explore.md` contains the injected ADV_SYNC block.
2. **Stage 3 (user file cleanup)** — rewrite stale direct-callable prose in `~/.config/opencode/agents/{explore,general,build,plan}.md` to reference the ADV_SYNC contract instead of enumerating direct callables. These files are user-owned (not in advance repo); ship via OpenCode restart. **Build/plan existing contract location (source body line 172/173) must be preserved** per design AD8.
3. **Restart OpenCode** to load new prompt content.

The follow-ups are tracked as tasks tk-b0bc8a964818 (deploy), tk-3aca03a1e520 (user file rewrite), tk-346e103e1012 (verification matrix) in the ADV change.

## Constraints respected

- No MCP tool identifier normalization (DONT1)
- No env-var conditional logic in user files (DONT3)
- Existing permission grants in agent frontmatter untouched (DONT2)
- ADV-owned agent files untouched (DONT4)
- Build/plan existing contract location preserved (DONT5/DONT13)
- Drift-detection test extends existing file, not new file (DONT6)
- explore.md stays user-owned via overlay-only management (DONT7)
- `effectiveAgentPrompts()` not modified (DONT8)
- No spec deltas required (no ADV capability spec covers user-owned agent prompt content)

🤓 Generated with ADV. Change ID: `fixSubAgentMcpRouting`.