### PR TITLE
test(cross-project): use valid scope repo fixture IDs

### DIFF
--- a/plugin/src/tools/cross-project-coordination.test.ts
+++ b/plugin/src/tools/cross-project-coordination.test.ts
@@ -220,13 +220,13 @@ describe("cross-project coordination metadata", () => {
     sourceStore.productContext = {
       currentRoot: sourceDir,
       currentRepoId: "web",
-      repoProjectId: "w".repeat(40),
+      repoProjectId: "a".repeat(40),
       productId: "example-product",
       productProjectId: "b".repeat(40),
       primaryRoot: targetDir,
       primaryRepoId: "backend",
       repos: {
-        web: { id: "web", root: sourceDir, repoProjectId: "w".repeat(40) },
+        web: { id: "web", root: sourceDir, repoProjectId: "a".repeat(40) },
         backend: {
           id: "backend",
           root: targetDir,
@@ -249,7 +249,7 @@ describe("cross-project coordination metadata", () => {
     expect(parsed.scope_repos).toEqual([
       expect.objectContaining({
         repo_id: "web",
-        repo_project_id: "w".repeat(40),
+        repo_project_id: "a".repeat(40),
       }),
     ]);
   });
@@ -258,13 +258,13 @@ describe("cross-project coordination metadata", () => {
     sourceStore.productContext = {
       currentRoot: sourceDir,
       currentRepoId: "web",
-      repoProjectId: "w".repeat(40),
+      repoProjectId: "a".repeat(40),
       productId: "example-product",
       productProjectId: "b".repeat(40),
       primaryRoot: targetDir,
       primaryRepoId: "backend",
       repos: {
-        web: { id: "web", root: sourceDir, repoProjectId: "w".repeat(40) },
+        web: { id: "web", root: sourceDir, repoProjectId: "a".repeat(40) },
       },
       mode: "secondary",
       missingPrimaryPolicy: "block",
@@ -286,13 +286,13 @@ describe("cross-project coordination metadata", () => {
     sourceStore.productContext = {
       currentRoot: sourceDir,
       currentRepoId: "web",
-      repoProjectId: "w".repeat(40),
+      repoProjectId: "a".repeat(40),
       productId: "example-product",
       productProjectId: "b".repeat(40),
       primaryRoot: targetDir,
       primaryRepoId: "backend",
       repos: {
-        web: { id: "web", root: sourceDir, repoProjectId: "w".repeat(40) },
+        web: { id: "web", root: sourceDir, repoProjectId: "a".repeat(40) },
         backend: {
           id: "backend",
           root: targetDir,


### PR DESCRIPTION
## Problem

`cross-project-coordination.test.ts` used `"w".repeat(40)` for `repoProjectId`, but ADV project IDs must match lowercase 40-hex. The invalid fixture propagated into schema-validated `scope_repos`, producing intermittent `scope_repos: undefined` failures in CI.

## Fix

Replace invalid non-hex project ID fixtures with consistent valid 40-hex values. Production code and assertions remain unchanged.

## Verification

- Deterministic RED: invalid fixture detector failed before correction
- GREEN: invalid fixture detector passes
- `cross-project-coordination.test.ts`: 10 consecutive targeted runs passed (8/8 each)
- `pnpm --dir plugin run typecheck`: passed
- Prettier check for affected file: passed

## ADV

Change: `fixScopeRepoFixture`
Task: `tk-fc4b64c47349`
No spec-law update required: fixture correction only.