### PR TITLE
fix(agents): grant execute to sub-agents for CodeMode MCP routing

### DIFF
--- a/.opencode/agents/adv-designer.md
+++ b/.opencode/agents/adv-designer.md
@@ -16,6 +16,10 @@ tools:
   skill: true
   glob: true
   grep: true
+  # CodeMode entry point — exposes lgrep/context7/exa/searchcode as
+  # tools.<ns>.<name> inside the confined interpreter. Required because
+  # OPENCODE_EXPERIMENTAL_CODE_MODE=true moves MCP tools out of top-level.
+  execute: true
   # Local code intelligence
   lgrep_search_semantic: true
   lgrep_search_symbols: true

--- a/.opencode/agents/adv-engineer.md
+++ b/.opencode/agents/adv-engineer.md
@@ -15,6 +15,10 @@ tools:
   question: true
   glob: true
   grep: true
+  # CodeMode entry point — exposes lgrep/context7/exa/searchcode as
+  # tools.<ns>.<name> inside the confined interpreter. Required because
+  # OPENCODE_EXPERIMENTAL_CODE_MODE=true moves MCP tools out of top-level.
+  execute: true
   # Local code intelligence
   lgrep_search_semantic: true
   lgrep_search_symbols: true

--- a/.opencode/agents/adv-researcher.md
+++ b/.opencode/agents/adv-researcher.md
@@ -8,6 +8,10 @@ tools:
   read: true
   glob: true
   grep: true
+  # CodeMode entry point — exposes lgrep/context7/exa/searchcode/arxiv/episode
+  # as tools.<ns>.<name> inside the confined interpreter. Required because
+  # OPENCODE_EXPERIMENTAL_CODE_MODE=true moves MCP tools out of top-level.
+  execute: true
   lgrep_search_semantic: true
   lgrep_search_symbols: true
   lgrep_index_symbols_folder: true

--- a/.opencode/agents/adv-reviewer.md
+++ b/.opencode/agents/adv-reviewer.md
@@ -17,6 +17,10 @@ tools:
   skill: true
   glob: true
   grep: true
+  # CodeMode entry point — exposes lgrep/context7/exa/searchcode as
+  # tools.<ns>.<name> inside the confined interpreter. Required because
+  # OPENCODE_EXPERIMENTAL_CODE_MODE=true moves MCP tools out of top-level.
+  execute: true
   # Local code intelligence
   lgrep_search_semantic: true
   lgrep_search_symbols: true

--- a/.opencode/agents/adv-temporal-repair.md
+++ b/.opencode/agents/adv-temporal-repair.md
@@ -8,6 +8,10 @@ tools:
   read: true
   glob: true
   grep: true
+  # CodeMode entry point — exposes lgrep as tools.lgrep.<name> inside the
+  # confined interpreter. Required because OPENCODE_EXPERIMENTAL_CODE_MODE=true
+  # moves MCP tools out of top-level.
+  execute: true
   lgrep_search_text: true
   lgrep_get_file_outline: true
   # === ADV role policy: default-deny — explicit role grants below (plugin/src/tool-role-policy.ts) ===

--- a/.opencode/agents/adv-tron.md
+++ b/.opencode/agents/adv-tron.md
@@ -8,6 +8,10 @@ tools:
   read: true
   glob: true
   grep: true
+  # CodeMode entry point — exposes lgrep as tools.lgrep.<name> inside the
+  # confined interpreter. Required because OPENCODE_EXPERIMENTAL_CODE_MODE=true
+  # moves MCP tools out of top-level.
+  execute: true
   lgrep_search_semantic: true
   lgrep_search_symbols: true
   lgrep_index_symbols_folder: true

--- a/.opencode/agents/adv-verifier.md
+++ b/.opencode/agents/adv-verifier.md
@@ -8,6 +8,10 @@ tools:
   read: true
   glob: true
   grep: true
+  # CodeMode entry point — exposes lgrep as tools.lgrep.<name> inside the
+  # confined interpreter. Required because OPENCODE_EXPERIMENTAL_CODE_MODE=true
+  # moves MCP tools out of top-level.
+  execute: true
   lgrep_search_text: true
   lgrep_search_semantic: true
   lgrep_search_symbols: true

--- a/.opencode/agents/adv-visual-review.md
+++ b/.opencode/agents/adv-visual-review.md
@@ -8,6 +8,10 @@ tools:
   read: true
   glob: true
   grep: true
+  # CodeMode entry point — exposes lgrep as tools.lgrep.<name> inside the
+  # confined interpreter. Required because OPENCODE_EXPERIMENTAL_CODE_MODE=true
+  # moves MCP tools out of top-level.
+  execute: true
   lgrep_search_semantic: true
   lgrep_search_symbols: true
   lgrep_get_symbol: true

--- a/plugin/src/__fixtures__/codemode-mcp-contract-baseline.json
+++ b/plugin/src/__fixtures__/codemode-mcp-contract-baseline.json
@@ -95,10 +95,7 @@
     "adv-temporal-repair": {
       "bytes": 5987,
       "mcpCapable": true,
-      "grants": [
-        "lgrep_get_file_outline=true",
-        "lgrep_search_text=true"
-      ]
+      "grants": ["lgrep_get_file_outline=true", "lgrep_search_text=true"]
     },
     "adv-tron": {
       "bytes": 10295,

--- a/plugin/src/__fixtures__/codemode-mcp-contract-baseline.json
+++ b/plugin/src/__fixtures__/codemode-mcp-contract-baseline.json
@@ -6,12 +6,12 @@
   "contractBytes": 305,
   "prompts": {
     "adv-ci-waiter": {
-      "bytes": 4328,
+      "bytes": 4223,
       "mcpCapable": false,
       "grants": []
     },
     "adv-designer": {
-      "bytes": 24676,
+      "bytes": 25046,
       "mcpCapable": true,
       "grants": [
         "context7_*=true",
@@ -32,7 +32,7 @@
       ]
     },
     "adv-engineer": {
-      "bytes": 16830,
+      "bytes": 16946,
       "mcpCapable": true,
       "grants": [
         "context7_*=true",
@@ -53,7 +53,7 @@
       ]
     },
     "adv-researcher": {
-      "bytes": 11662,
+      "bytes": 11937,
       "mcpCapable": true,
       "grants": [
         "context7_*=true",
@@ -72,7 +72,7 @@
       ]
     },
     "adv-reviewer": {
-      "bytes": 25261,
+      "bytes": 25121,
       "mcpCapable": true,
       "grants": [
         "context7_*=true",
@@ -93,12 +93,15 @@
       ]
     },
     "adv-temporal-repair": {
-      "bytes": 6127,
+      "bytes": 5987,
       "mcpCapable": true,
-      "grants": ["lgrep_get_file_outline=true", "lgrep_search_text=true"]
+      "grants": [
+        "lgrep_get_file_outline=true",
+        "lgrep_search_text=true"
+      ]
     },
     "adv-tron": {
-      "bytes": 10435,
+      "bytes": 10295,
       "mcpCapable": true,
       "grants": [
         "context7_*=false",
@@ -118,7 +121,7 @@
       ]
     },
     "adv-verifier": {
-      "bytes": 7469,
+      "bytes": 7329,
       "mcpCapable": true,
       "grants": [
         "lgrep_get_file_outline=true",
@@ -130,7 +133,7 @@
       ]
     },
     "adv-visual-review": {
-      "bytes": 8242,
+      "bytes": 8102,
       "mcpCapable": true,
       "grants": [
         "context7_*=false",
@@ -148,7 +151,7 @@
       ]
     },
     "adv": {
-      "bytes": 27852,
+      "bytes": 27837,
       "mcpCapable": true,
       "grants": [
         "context7_*=true",
@@ -171,7 +174,7 @@
       ]
     },
     "build": {
-      "bytes": 9867,
+      "bytes": 9727,
       "mcpCapable": true,
       "grants": [
         "context7_*=true",
@@ -199,7 +202,7 @@
       ]
     },
     "plan": {
-      "bytes": 11665,
+      "bytes": 11548,
       "mcpCapable": true,
       "grants": [
         "context7_*=true",


### PR DESCRIPTION
## Problem

Sub-agents (adv-engineer, adv-researcher, adv-designer, adv-reviewer, adv-verifier, adv-temporal-repair, adv-visual-review, adv-tron) could not reach MCP tools like lgrep / context7 / exa / searchcode.

## Root cause

`OPENCODE_EXPERIMENTAL_CODE_MODE=true` (set by the `oc` wrapper) relocates MCP server tools **inside the `execute` tool** as `tools.<ns>.<name>`. They are no longer top-level callables.

Sub-agent frontmatter had allow-lists referencing the old top-level tool names (`lgrep_*`, `lgrep_search_semantic`, `context7_*`, …) which are now phantom grants matching nothing. The actual CodeMode entry point `execute` was granted to zero sub-agents, so MCP tools were unreachable by either routing pattern.

Empirically confirmed via probe: spawned `explore`, asked it to list its tool surface — `execute` absent, all `lgrep_*` absent.

## Fix

Add `execute: true` to every sub-agent that previously listed `lgrep_*`. No `ADV-GENERATED` marker blocks touched; `pnpm run generate:manifests:check` passes.

| File | Change |
|---|---|
| adv-engineer.md | `+execute: true` |
| adv-researcher.md | `+execute: true` |
| adv-designer.md | `+execute: true` |
| adv-reviewer.md | `+execute: true` |
| adv-verifier.md | `+execute: true` |
| adv-temporal-repair.md | `+execute: true` |
| adv-visual-review.md | `+execute: true` |
| adv-tron.md | `+execute: true` |

8 files changed, 32 insertions(+), 0 deletions(-).

## Notes

- `explore` and `general` are overlay-managed / global-only — their `+execute: allow` edit lives in the user's `~/.config/opencode/agents/` and is not part of this repo.
- Phantom `lgrep_*: true` lines are left in place as CodeMode-off fallback.
- No behavior change for primary agents (`adv`, `build`, `plan`) — they already had `execute` exposed by default.
