### PR TITLE
fix(temporal): auto-link review_evidence_ref when task has no evidence_plan

### DIFF
--- a/plugin/src/temporal/change-state.test.ts
+++ b/plugin/src/temporal/change-state.test.ts
@@ -2134,6 +2134,29 @@ describe("reviewer-owned evidence reference", () => {
     });
   });
 
+  it("creates evidence_plan with review_evidence_ref when task has evidence_policy but no evidence_plan", () => {
+    // Regression: tasks created with only task-level evidence_policy (no
+    // evidence_plan object) must still get review_evidence_ref auto-linked
+    // when a reviewer report is persisted. Previously the truthy guard on
+    // task.evidence_plan silently skipped the write, permanently blocking
+    // task completion for review-policy tasks.
+    const state = stateWithReviewTask("review", undefined);
+
+    applySubagentReportSubmittedToState(state, {
+      taskId: "tk-review",
+      report: makeReviewerReport("reviewer-evidence-test", "tk-review"),
+      submittedAt: "2026-07-17T00:00:02.000Z",
+    });
+
+    const task = state.tasks[0];
+    expect(task.evidence_plan).toBeDefined();
+    expect(task.evidence_plan?.review_evidence_ref).toEqual({
+      report_key: "reviewer-evidence-test|tk-review|adv-reviewer|1",
+    });
+    expect(task.evidence_plan?.provenance).toBe("legacy");
+    expect(task.evidence_plan?.policy).toBe("review");
+  });
+
   it("does not write review_evidence_ref for test-route tasks", () => {
     const state = stateWithReviewTask("test", {
       policy: "test",

--- a/plugin/src/temporal/change-state.ts
+++ b/plugin/src/temporal/change-state.ts
@@ -1464,19 +1464,35 @@ export function applySubagentReportSubmittedToState(
   // for a behavior-critical task that uses a non-test route, write a typed
   // review_evidence_ref to the task's evidence plan. Callers cannot author this
   // ref — only the reviewer-report consumer does, and only on fresh (not
-  // duplicate) storage.
+  // duplicate) storage. Tasks created with only task-level evidence_policy
+  // (no evidence_plan object) get the plan created here so the ref is never
+  // silently dropped.
   if (
     task &&
     taskScoped &&
     payload.report.agent === "adv-reviewer" &&
-    task.evidence_plan &&
     isBehaviorCriticalEvidencePlanTask(task)
   ) {
-    task.evidence_plan = {
-      ...task.evidence_plan,
-      ...normalizeEvidencePlanCompatibility(task.evidence_plan),
-      review_evidence_ref: { report_key: reportId },
-    };
+    if (task.evidence_plan) {
+      task.evidence_plan = {
+        ...task.evidence_plan,
+        ...normalizeEvidencePlanCompatibility(task.evidence_plan),
+        review_evidence_ref: { report_key: reportId },
+      };
+    } else {
+      // Task has task-level evidence_policy but no evidence_plan object.
+      // isBehaviorCriticalEvidencePlanTask already guaranteed the policy
+      // exists and is a non-test route for behavior-critical work.
+      const policy = task.evidence_policy;
+      if (policy) {
+        task.evidence_plan = {
+          policy,
+          proof_target: "Reviewer-owned evidence",
+          provenance: "legacy",
+          review_evidence_ref: { report_key: reportId },
+        };
+      }
+    }
   }
 
   const blockers = blockerSummary(payload.report);


### PR DESCRIPTION
## Bug

`change-state.ts` `applySubagentReportSubmittedToState` checked `task.evidence_plan &&` as a truthy guard before writing `review_evidence_ref`. Tasks created with only task-level `evidence_policy` (no `evidence_plan` object) silently skipped the auto-linking, **permanently blocking task completion** for any review-policy task that received a reviewer report.

The reviewer report was persisted in `task.subagent_reports` but `evidence_plan.review_evidence_ref` was never written, so the task completion validator (`validateTaskEvidenceForStage`) rejected the checkpoint with:

```
Non-test route 'review' requires a linked review conclusion or reviewer evidence reference.
```

## Reproduction

1. Create a task with `evidence_policy: "review"` (no `evidence_plan` object)
2. Submit an adv-reviewer report for the task
3. Attempt `adv_task_checkpoint` → blocked by evidence validator
4. No tool exists to retroactively set `review_evidence_ref`

## Fix

When `task.evidence_plan` is absent, construct a minimal plan carrying `policy` (from `task.evidence_policy`), `proof_target`, `provenance: "legacy"`, and the `review_evidence_ref`. Existing plans are unchanged.

## Impact

Affects **all** ADV projects with review-policy tasks created without an explicit `evidence_plan`. The bug is in Temporal workflow state code (runs in the deployed worker).

## Verification

- `pnpm run check`: PASS (schemas, typecheck, lint, format)
- Targeted: 246/246 tests pass (change-state.test.ts, task-classifier.test.ts, prep-readiness.test.ts, gate-readiness.test.ts)
- Regression test: `creates evidence_plan with review_evidence_ref when task has evidence_policy but no evidence_plan`