### PR TITLE
Add ADV MCP read surface (Tier-4 reads via tools.adv.*)

### DIFF
--- a/docs/adr/0008-adv-mcp-stdio-via-vision.md
+++ b/docs/adr/0008-adv-mcp-stdio-via-vision.md
@@ -1,0 +1,223 @@
+# ADR 0008: ADV MCP read surface via stdio subprocess under Vision HTTP termination
+
+- **Status:** Proposed (pending archive of `addAdvMcpReadSurface`)
+- **Date:** 2026-07-21
+- **Associated change:** `addAdvMcpReadSurface` (Epic: `systemizeAdvOrchestration`)
+- **Supersedes:** none
+- **Related:** ADR 0001 (adv prefix), scout SCOUT-1..4
+
+## Context
+
+The ADV plugin registers 83 unique `adv_*` tools that load as top-level plugin tools in every OpenCode Code Mode prompt. Tool-schema weight is the #1 cause of ADV workflow feeling "heavier and slower." OpenCode 1.18.4 CodeMode only defers **MCP server tools**; plugin tools are exempt.
+
+To move ~13 Tier-4 read-only tools out of every prompt and into on-demand `tools.adv.*` discovery, we need a managed MCP server that:
+
+1. Speaks the Model Context Protocol
+2. Shares ADV internals (storage reads, project-id resolver, tool handlers)
+3. Stays strictly read-only (no mutation/approval/operator paths)
+4. Isolates failure (MCP crash never disables plugin)
+5. Survives across OpenCode session restarts
+6. Resolves project identity structurally (no per-call override)
+
+Three transport topology options were considered:
+
+- **(a) HTTP child** — ADV subprocess speaks HTTP/SSE directly
+- **(b) Per-session OpenCode local stdio** — OpenCode spawns stdio child per session
+- **(c) Stdio subprocess under Vision HTTP termination** — Vision spawns stdio child, terminates HTTP, supervises lifecycle
+
+## Decision
+
+**Option (c): stdio subprocess under Vision HTTP termination.**
+
+The ADV MCP server is a Node stdio process (`plugin/dist/mcp-server.js`) using `@modelcontextprotocol/sdk` v1.x (`McpServer` + `StdioServerTransport`). Vision spawns one subprocess per ADV-enabled repo, terminates HTTP on a localhost port (6298+ range), bridges HTTP↔stdio, and provides lifecycle supervision (`restart_policy: on-failure`, `max_restarts: 5`, `health_check_interval: 30s`). OpenCode connects via `mcp.adv: { type: "remote", url: "http://localhost:<port>/mcp" }`.
+
+Each ADV-enabled repo gets its own Vision entry + dedicated port + project-pinned cwd. The Vision entry's `cwd:` field is the **single source of truth** for project identity; no `ADV_MCP_PROJECT_ROOT` env var.
+
+### Tier-4 catalog (13 tools, AC2')
+
+| # | Tool name | Source tool | Classification |
+|---|---|---|---|
+| 1 | `status` | `adv_status` | needs-temporal + needs-host-probe |
+| 2 | `spec` | `adv_spec` | needs-context |
+| 3 | `wisdom_list` | `adv_wisdom_list` | needs-context |
+| 4 | `reflection_list` | `adv_reflection_list` | needs-context |
+| 5 | `project_context` | `adv_project_context` | pure |
+| 6 | `backlog_list` | `adv_backlog_list` | needs-context |
+| 7 | `backlog_show` | `adv_backlog_show` | needs-context |
+| 8 | `epic_list` | `adv_epic_list` | needs-temporal |
+| 9 | `epic_show` | `adv_epic_show` | needs-temporal |
+| 10 | `wip_state` | `adv_wip_state` | needs-temporal |
+| 11 | `worktree_triage` | `adv_worktree_triage` | needs-host-git |
+| 12 | `tool_catalog` | `adv_tool_catalog` | pure |
+| 13 | `tool_describe` | `adv_tool_describe` | pure |
+
+Five tools were removed from the original 18-tool proposal:
+- `adv_reflect` (pure write, violates DONT1)
+- `adv_project_metadata` (`action: read|write|list`, mutates)
+- `adv_conformance` (`action: status|init|lock|unlock|override|run`, mutates)
+- `adv_session_list` (host PID ACL tied to OpenCode's own process)
+- `adv_session_show` (same)
+
+## Rationale
+
+### Pattern fit (5 of 9 production MCP servers use this exact topology)
+
+Vision-managed stdio subprocess is the established long-term pattern for Node-based MCP servers in this user's stack: lgrep, context7, exa, svelte, notion (verified by reading `~/.config/vision/servers.yaml:11-62,108-123`). Only playwright uses `transport: managed-http` because the Playwright subprocess itself speaks HTTP. Episode is a Rust MCP server (`rmcp = "2.2.0"` with `transport-io`) — also stdio under Vision, same topology different language.
+
+### Resolves prior validator blockers
+
+- **Shared `process.cwd()` cannot vary by workspace** → resolved by per-project Vision entries pinning cwd at spawn
+- **DNS rebinding on loopback** → moot; subprocess has no network listener
+
+### SDK choice
+
+`@modelcontextprotocol/sdk` v1.x (production-supported). v2 beta explicitly avoided per researcher guidance (KD5).
+
+The MCP server uses **`McpServer` (high-level)** rather than the low-level `Server` class. `registerTool` is the API for schema-validated tool registration. The skeleton smoke test (`plugin/src/mcp-server/sdk-exports.test.ts`) verifies actual v1.29.0 exports.
+
+### SDK-free catalog module (KD2, AMEND-3)
+
+Original KD2 plan: extract `PUBLIC_TOOL_ENTRIES` + `ADV_TOOL_METADATA` into an SDK-free canonical module (`plugin/src/tool-catalog-entries.ts`).
+
+**Discovery during execution:** `PUBLIC_TOOL_ENTRIES` is derived from `PUBLIC_TOOL_GROUPS` which imports 30+ SDK-coupled tool-group modules (`tools/spec.ts`, `tools/change.ts`, etc.). Full extraction would require refactoring all tool-group modules to be data-only — too invasive.
+
+**Resolution (AMEND-3):** Extract only types + pure functions + derivation tables to `plugin/src/tool-catalog-entries.ts` (shipped in task `tk-9ad1a04909a2`). Runtime data access via dynamic import (`await import("../tool-registry.js")`); matches the existing `adv_contract_mint` pattern at `tool-registry.ts:1330-1332`. KD2 intent preserved: MCP descriptors depend on SDK-free module only; MCP rebuilds stay decoupled from SDK changes.
+
+### Capability/version handshake (KD7, AMEND-4)
+
+`serverInfo` carries only MCP-standard `name` + `version` (per MCP spec). ADV-specific compatibility metadata (`tier4_tools`, `adv_contract_version`) is exposed via the `adv_handshake` meta-tool — `serverInfo.capabilities` is reserved for protocol-level declarations (sampling/roots/etc.), not arbitrary metadata bags.
+
+`ADV_CONTRACT_VERSION = 1` tracks the **handshake schema shape** (not plugin version, not SDK version). Bump on breaking changes to `HandshakeResult` (tool removed from `tier4_tools`, field renamed, semantic redefined).
+
+## Consequences
+
+### Positive
+
+- **83% prompt-weight reduction** (combined with sibling `slimMutationToolSurface`): 83 → 14 top-level tools
+- **Read-only isolation** (DONT1): no mutation path opens through MCP
+- **Failure isolation** (SC4): MCP crash never disables plugin or mutates ADV state
+- **Per-project isolation** (KD8): one Vision entry per repo = one cwd = one project id
+- **Reversibility**: falling back to per-session OpenCode stdio spawn is one OpenCode config change (no ADV code change)
+- **Cross-MCP compatibility verified**: episode (Rust), lgrep (TS), context7/exa/svelte/time/notion (TS remote) all structurally isolated — distinct namespaces, ports, storage, code
+
+### Negative
+
+- **Operator deploy burden**: each ADV-enabled repo requires a Vision entry + OpenCode config snippet (documented below)
+- **No CI coverage of live deploy**: post-deploy smoke (task `tk-6705bb3ceaf0`) was cancelled; requires operator verification per the runbook below
+- **Dynamic import overhead**: MCP server pays one-time dynamic-import cost for `tool-registry.js` (~50ms measured) on first tool call
+
+### Neutral
+
+- **Port allocation**: 6298+ sequential per ADV project (episode=6297, lgrep=6278 — no collision)
+
+## Alternatives considered
+
+### (a) HTTP child — rejected
+
+ADV subprocess would speak HTTP/SSE directly. Rejected because:
+- Duplicates HTTP/session code already in Vision
+- Exposes DNS rebinding surface on loopback (validator blocker PB2)
+- No lifecycle supervision without separate wrapper
+- Counter to user's established pattern (no production HTTP-child MCP server in stack)
+
+### (b) Per-session OpenCode local stdio — rejected
+
+OpenCode spawns a stdio child per session via `mcp.adv: { type: "local", command: "node", args: ["dist/mcp-server.js"] }`. Rejected because:
+- OpenCode does not auto-restart crashed children (verified at `opencode/src/mcp/index.ts#L212-L236`)
+- Per-session spawn wastes resources (one subprocess per session vs one per project)
+- No cross-session state sharing
+- No health checks
+
+## Operator deployment runbook
+
+### Per-project setup
+
+For each ADV-enabled repo:
+
+#### 1. Add Vision entry (`~/.config/vision/servers.yaml`)
+
+```yaml
+adv-<project-slug>:
+  port: <next-free, 6298+>  # avoid episode=6297, lgrep=6278
+  command: /home/jon/.local/share/fnm/fnm
+  args:
+    - exec
+    - --using=24.15.0
+    - --
+    - node
+    - /home/jon/.local/share/Advance/plugin/dist/mcp-server.js
+  cwd: "<project-path>"  # single source of truth for project identity; NO env var
+  autostart: true
+  restart_policy: on-failure
+  max_restarts: 5
+  health_check_interval: 30s
+  session_timeout: 30m
+  max_sessions: 20
+```
+
+#### 2. Add OpenCode config (`~/.config/opencode/opencode.jsonc`, per-project section)
+
+```jsonc
+{
+  "mcp": {
+    "adv": {
+      "type": "remote",
+      "url": "http://localhost:<project-port>/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+#### 3. Restart services
+
+```bash
+vision daemon reload          # picks up new servers.yaml entry
+# Restart OpenCode to pick up new mcp.adv config (NO live reload for plugin config)
+```
+
+### Post-deploy verification (deferred from task `tk-6705bb3ceaf0`)
+
+```bash
+# 1. Confirm Vision entry is running
+vision daemon status | grep adv-<project-slug>
+
+# 2. Confirm MCP server responds (health probe)
+curl -s http://localhost:<port>/mcp | head
+
+# 3. From a fresh OpenCode session, call the handshake tool
+# In OpenCode agent:
+#   const r = await tools.adv.adv_handshake({});
+#   console.log(r);  // expect {tier4_tools:[...13 names...], adv_contract_version:1}
+
+# 4. Verify tool catalog
+#   const cat = await tools.adv.tool_catalog({});
+#   expect 13 Tier-4 entries + adv_handshake
+
+# 5. Verify degradation tagging (when Temporal is down)
+#   const s = await tools.adv.status({});
+#   expect s to contain degraded:true, source:"disk_projection" or "host_probe_unavailable_in_mcp"
+```
+
+### Fresh-session caveat
+
+Source edits and `dist/` builds do NOT update the current OpenCode tool registry. Adding `mcp.adv` to `opencode.jsonc` requires an OpenCode restart before agents can call `tools.adv.*`. Plugin-side code changes (e.g., to `tool-catalog-entries.ts`) require: rebuild → redeploy → restart Vision subprocess → restart OpenCode (if config changed).
+
+### Release gate (constraint C1)
+
+This change MUST NOT release before sibling `slimMutationToolSurface` ships. Verify:
+
+```bash
+./scripts/check-release-gate.sh slimMutationToolSurface addAdvMcpReadSurface
+# Expect: exit 0 (OK) only after slimMutationToolSurface is archived
+```
+
+## References
+
+- Proposal: `addAdvMcpReadSurface` proposal.md (scope-refreshed 2026-07-20)
+- Design: `addAdvMcpReadSurface` design.md (10 KDs, 7 DDCs, 12 risks, AMEND-1..4)
+- Sibling: `slimMutationToolSurface` (Tier-3 mutation tools → `adv_tool_invoke` routing)
+- Scout: SCOUT-1 (Vision stdio topology), SCOUT-2 (pure descriptors), SCOUT-3 (parity harness), SCOUT-4 (bundle manifest)
+- Validator: Round-1 FAIL (HTTP-child draft), Round-2 CONFLICT (resolved by UD-V1/V2/V3 user decisions)
+- MCP SDK: `@modelcontextprotocol/sdk@1.29.0` — `McpServer`, `StdioServerTransport`, `registerTool`
+- Existing pattern: `adv_contract_mint` dynamic-import pattern at `tool-registry.ts:1330-1332`

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -16,6 +16,7 @@
   "author": "Anomaly",
   "scripts": {
     "build": "tsx scripts/build-plugin.ts && pnpm run build:worker && pnpm run build:identity",
+    "build:mcp-server": "tsup src/mcp-server/index.ts --format esm --out-dir dist --no-splitting",
     "build:worker": "tsup src/temporal/worker.ts src/temporal/workflows.ts --format esm --out-dir dist/temporal && tsx scripts/write-worker-bundle-manifest.ts",
     "build:identity": "tsx scripts/write-build-identity.ts",
     "dev": "tsup src/index.ts --format esm --watch",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -36,6 +36,7 @@
     "bench:latency": "bun --smol scripts/bench-adv-latency.ts"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/plugin": "^1.15.7",
     "@temporalio/client": "^1.16.0",
     "@temporalio/worker": "^1.16.0",

--- a/plugin/pnpm-lock.yaml
+++ b/plugin/pnpm-lock.yaml
@@ -1201,8 +1201,8 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/types@0.1.26':
-    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
+  '@swc/types@0.1.27':
+    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
   '@temporalio/activity@1.17.2':
     resolution: {integrity: sha512-NPaR+R4q3cBr6VH6cvsQ6jgBX6PwymOmM4ZFPH9FLHypzelPY9STI/SG+0fxgGLCYmZSuUhdEdT7yDNpUWpDwA==}
@@ -1433,6 +1433,11 @@ packages:
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2235,8 +2240,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3654,7 +3659,7 @@ snapshots:
   '@swc/core@1.15.40':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.26
+      '@swc/types': 0.1.27
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.15.40
       '@swc/core-darwin-x64': 1.15.40
@@ -3671,7 +3676,7 @@ snapshots:
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/types@0.1.26':
+  '@swc/types@0.1.27':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -4059,6 +4064,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  acorn@8.17.0: {}
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -4844,7 +4851,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   nanoid@5.1.11: {}
 
@@ -4976,7 +4983,7 @@ snapshots:
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5243,7 +5250,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 

--- a/plugin/pnpm-lock.yaml
+++ b/plugin/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@opencode-ai/plugin':
         specifier: ^1.15.7
         version: 1.16.2
@@ -399,6 +402,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -557,6 +566,16 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: 4.4.3
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -1397,6 +1416,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -1415,6 +1438,14 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -1459,6 +1490,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
@@ -1480,9 +1515,21 @@ packages:
     peerDependencies:
       esbuild: '>=0.28.1'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001797:
     resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
@@ -1524,8 +1571,32 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1543,9 +1614,20 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   effect@4.0.0-beta.74:
     resolution: {integrity: sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==}
@@ -1556,12 +1638,28 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   enhanced-resolve@5.23.0:
     resolution: {integrity: sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==}
     engines: {node: '>=10.13.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -1571,6 +1669,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1635,6 +1736,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -1643,9 +1748,27 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-check@4.8.0:
     resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
@@ -1679,6 +1802,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
@@ -1701,6 +1828,14 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
 
@@ -1709,9 +1844,20 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -1729,6 +1875,10 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1736,12 +1886,28 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   heap-js@2.7.1:
     resolution: {integrity: sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==}
     engines: {node: '>=10.0.0'}
 
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
@@ -1749,6 +1915,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -1763,9 +1933,20 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ini@7.0.0:
     resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1778,6 +1959,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1801,6 +1985,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1855,6 +2042,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1990,10 +2180,22 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs@4.57.6:
     resolution: {integrity: sha512-WQK+DGjKCnPdpSyJUXphz+COF2uEhhsxQ3VIWBSbzpbbXuch3h4FePMqXrXGdLjsTgo4JFzBFsP6AWd9pVazGw==}
     peerDependencies:
       tslib: '2'
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2001,6 +2203,10 @@ packages:
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2042,6 +2248,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -2061,9 +2271,20 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.2:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2084,6 +2305,10 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2091,6 +2316,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2105,6 +2333,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -2148,12 +2380,28 @@ packages:
     resolution: {integrity: sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2184,6 +2432,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -2199,6 +2451,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2206,6 +2469,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2237,6 +2516,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -2355,6 +2638,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   toml@4.1.1:
     resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
     engines: {node: '>=20'}
@@ -2409,6 +2696,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript-eslint@8.60.1:
     resolution: {integrity: sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2434,6 +2725,10 @@ packages:
   unionfs@4.6.0:
     resolution: {integrity: sha512-fJAy3gTHjFi5S3TP5EGdjs/OUMFFvI/ady3T8qVuZfkv8Qi8prV/Q8BuFEgODJslhZTT2z2qdD2lGdee9qjEnA==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2446,6 +2741,10 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -2571,6 +2870,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2591,6 +2893,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: 4.4.3
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -2812,6 +3119,10 @@ snapshots:
       protobufjs: 8.6.1
       yargs: 17.7.2
 
+  '@hono/node-server@1.19.14(hono@4.12.31)':
+    dependencies:
+      hono: 4.12.31
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2975,6 +3286,28 @@ snapshots:
       '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.31)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.6.0(express@5.2.1)
+      hono: 4.12.31
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -3712,6 +4045,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3723,6 +4061,10 @@ snapshots:
   acorn@8.16.0: {}
 
   ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
 
@@ -3765,6 +4107,20 @@ snapshots:
 
   baseline-browser-mapping@2.10.34: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
@@ -3788,7 +4144,19 @@ snapshots:
       esbuild: 0.28.1
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001797: {}
 
@@ -3820,7 +4188,22 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3834,7 +4217,17 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
 
   effect@4.0.0-beta.74:
     dependencies:
@@ -3853,12 +4246,22 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  encodeurl@2.0.0: {}
+
   enhanced-resolve@5.23.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -3890,6 +4293,8 @@ snapshots:
       '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3974,11 +4379,60 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.6.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-check@4.8.0:
     dependencies:
@@ -4004,6 +4458,17 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way-ts@0.1.6: {}
 
   find-up@5.0.0:
@@ -4028,12 +4493,36 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-monkey@1.1.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -4049,17 +4538,39 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   heap-js@2.7.1: {}
 
+  hono@4.12.31: {}
+
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   hyperdyperid@1.2.0: {}
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -4069,7 +4580,13 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
   ini@7.0.0: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -4078,6 +4595,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -4101,6 +4620,8 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.7.0: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 
@@ -4138,6 +4659,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4251,6 +4774,10 @@ snapshots:
     dependencies:
       semver: 7.8.2
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
   memfs@4.57.6(tslib@2.8.1):
     dependencies:
       '@jsonjoy.com/fs-core': 4.57.6(tslib@2.8.1)
@@ -4268,9 +4795,15 @@ snapshots:
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   minimatch@10.2.5:
     dependencies:
@@ -4317,6 +4850,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   nexus-rpc@0.0.2: {}
@@ -4330,7 +4865,17 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -4396,9 +4941,13 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -4407,6 +4956,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -4441,9 +4992,28 @@ snapshots:
     dependencies:
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
   pure-rand@8.4.0: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   readdirp@4.1.2: {}
 
@@ -4507,6 +5077,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -4522,11 +5102,66 @@ snapshots:
 
   semver@7.8.2: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -4550,6 +5185,8 @@ snapshots:
   source-map@0.7.6: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -4635,6 +5272,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   toml@4.1.1: {}
 
   tree-dump@1.1.0(tslib@2.8.1):
@@ -4690,6 +5329,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
@@ -4713,6 +5358,8 @@ snapshots:
     dependencies:
       fs-monkey: 1.1.0
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -4724,6 +5371,8 @@ snapshots:
       punycode: 2.3.1
 
   uuid@14.0.0: {}
+
+  vary@1.1.2: {}
 
   vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -4834,6 +5483,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrappy@1.0.2: {}
+
   y18n@5.0.8: {}
 
   yaml@2.9.0: {}
@@ -4851,5 +5502,9 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/plugin/src/mcp-server/conformance.test.ts
+++ b/plugin/src/mcp-server/conformance.test.ts
@@ -44,7 +44,9 @@ async function closeClient(
   await serverTransport.close();
 }
 
-function extractText(result: { content?: Array<{ type: string; text?: string }> }): string {
+function extractText(result: {
+  content?: Array<{ type: string; text?: string }>;
+}): string {
   if (!result.content || result.content.length === 0) {
     throw new Error("MCP result has no content");
   }
@@ -107,7 +109,9 @@ describe("DDC5 — conformance corpus (parity vs plugin)", () => {
   it.todo("worktree_triage: MCP deep-equals plugin (needs git fixture)");
   it.todo("tool_catalog: MCP deep-equals plugin (pure)");
   it.todo("tool_describe: MCP deep-equals plugin (pure)");
-  it.todo("status: parity may be partial (host-probe fields non-deterministic)");
+  it.todo(
+    "status: parity may be partial (host-probe fields non-deterministic)",
+  );
 
   it("conformance coverage accounting: 1 of 13 tools currently deep-equal tested; 12 deferred to follow-up burst", () => {
     // DDC5 target: ≥ 11 of 13 (≥ 80%). Current: 1 of 13 (~7.7%).

--- a/plugin/src/mcp-server/conformance.test.ts
+++ b/plugin/src/mcp-server/conformance.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Conformance corpus (DDC5 ≥ 80% — 11 of 13 Tier-4 tools).
+ *
+ * Gate for task tk-c9f8b70c21d8. Each Tier-4 tool should produce a deep-equal
+ * response via MCP vs direct plugin invocation for the same bounded inputs.
+ *
+ * Current coverage:
+ *   - project_context: deep-equal parity verified (also in server.test.ts)
+ *
+ * Deferred to follow-up (Kimi sub-agent quota exhausted during execution;
+ * main-agent context pressure):
+ *   - The remaining 12 tools require either:
+ *     (a) Disk-fixture seeding (spec, wisdom_list, reflection_list, backlog_*)
+ *     (b) Temporal mocking (epic_list/show, wip_state, status)
+ *     (c) Git-fixture repos (worktree_triage)
+ *     (d) Pure-tool direct comparison (tool_catalog, tool_describe)
+ *   - Target: ≥ 11 of 13 tools by acceptance gate. project_context here + 10
+ *     more in a follow-up burst.
+ *
+ * This file establishes the conformance harness pattern so the follow-up
+ * burst can add cases without re-architecting the test infrastructure.
+ */
+import { describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { startServer } from "./index.js";
+
+async function connectToServer() {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await startServer({ transport: serverTransport });
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return { client, clientTransport, serverTransport };
+}
+
+async function closeClient(
+  client: Client,
+  clientTransport: InMemoryTransport,
+  serverTransport: InMemoryTransport,
+) {
+  await client.close();
+  await clientTransport.close();
+  await serverTransport.close();
+}
+
+function extractText(result: { content?: Array<{ type: string; text?: string }> }): string {
+  if (!result.content || result.content.length === 0) {
+    throw new Error("MCP result has no content");
+  }
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error("MCP result content[0].text is not a string");
+  }
+  return text;
+}
+
+describe("DDC5 — conformance corpus (parity vs plugin)", () => {
+  it("project_context: MCP response deep-equals plugin response for same cwd", async () => {
+    // This is the canonical parity test (also asserted in server.test.ts).
+    // Re-stated here under the conformance banner for DDC5 accounting.
+    //
+    // The plugin's adv_project_context.execute(args, store) reads project.md
+    // from the cwd. The MCP handler does the same via dynamic import. Both
+    // resolve to the same project.md file at process.cwd(); therefore
+    // responses must be deep-equal.
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const mcpResult = await client.callTool({
+      name: "project_context",
+      arguments: {},
+    });
+    const mcpText = extractText(mcpResult);
+
+    // Direct plugin call via dynamic import (matches production code path
+    // in plugin/src/mcp-server/tools/project_context.ts).
+    const { createToolMap } = await import("../tool-registry.js");
+    const { createDiskStore } = await import("../storage/store-disk.js");
+    const cwd = process.cwd();
+    const store = await createDiskStore(cwd);
+    let pluginText: string;
+    try {
+      const tools = createToolMap(store, cwd);
+      const result = await tools.adv_project_context.execute({});
+      pluginText =
+        typeof result === "string"
+          ? result
+          : ((result as { output?: string }).output ?? JSON.stringify(result));
+    } finally {
+      store.close();
+    }
+
+    expect(mcpText).toEqual(pluginText);
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it.todo("spec: MCP deep-equals plugin for bounded fixture (needs disk seed)");
+  it.todo("wisdom_list: MCP deep-equals plugin (needs disk seed)");
+  it.todo("reflection_list: MCP deep-equals plugin (needs disk seed)");
+  it.todo("backlog_list: MCP deep-equals plugin (needs disk seed)");
+  it.todo("backlog_show: MCP deep-equals plugin (needs disk seed)");
+  it.todo("epic_list: MCP deep-equals plugin (needs Temporal mock)");
+  it.todo("epic_show: MCP deep-equals plugin (needs Temporal mock)");
+  it.todo("wip_state: MCP deep-equals plugin (needs Temporal mock)");
+  it.todo("worktree_triage: MCP deep-equals plugin (needs git fixture)");
+  it.todo("tool_catalog: MCP deep-equals plugin (pure)");
+  it.todo("tool_describe: MCP deep-equals plugin (pure)");
+  it.todo("status: parity may be partial (host-probe fields non-deterministic)");
+
+  it("conformance coverage accounting: 1 of 13 tools currently deep-equal tested; 12 deferred to follow-up burst", () => {
+    // DDC5 target: ≥ 11 of 13 (≥ 80%). Current: 1 of 13 (~7.7%).
+    // Follow-up: add the 10 .todo cases above; status is likely the 1-2 skip
+    // (host-probe non-determinism). Once follow-up lands, this assertion
+    // should be updated to expect ≥ 11.
+    const currentCovered = 1;
+    const target = 11;
+    expect(currentCovered, "current conformance coverage").toBe(1);
+    expect(target, "DDC5 minimum").toBe(11);
+  });
+});

--- a/plugin/src/mcp-server/degradation.ts
+++ b/plugin/src/mcp-server/degradation.ts
@@ -1,0 +1,214 @@
+/**
+ * Per-tool runtime degradation wrapper (KD3).
+ *
+ * Detects Temporal/host-probe unavailability at call time and returns
+ * class-aware degraded response shapes for Tier-4 MCP read tools. This is the
+ * runtime complement to the static KD10 classification table in
+ * `tools/index.ts`: classifications decide *which* degradation path a tool
+ * takes, and this module decides *when* to take it by probing actual runtime
+ * state per call.
+ *
+ * Design invariants (DDC6 determinism):
+ *   - Same input + same Temporal state → same response.
+ *   - No tool silently returns stale data without tagging.
+ *   - Degraded envelopes are additive JSON objects; they never rewrite binary
+ *     or non-JSON tool output (that shape is reported and skipped).
+ */
+
+import type { Tier4ToolName, ToolClassification } from "./tools/index.js";
+
+export interface DegradationOptions {
+  /** Override Temporal reachability probe. */
+  temporalReachable?: () => Promise<boolean>;
+  /** Override host-probe availability probe. */
+  hostProbesAvailable?: () => Promise<boolean>;
+}
+
+const TEMPORAL_REACHABILITY_TIMEOUT_MS = 2_000;
+
+/**
+ * Host-probe fields surfaced by `adv_status` whose data originates from host
+ * probes (Temporal reachability, worker process lock, session-debt scan, etc.).
+ * When host probes are unavailable, these fields are tagged with
+ * `{ degraded: true, source: "host_probe_unavailable_in_mcp" }`.
+ */
+export const HOST_PROBE_FIELDS: readonly string[] = [
+  "temporal_health",
+  "queue_serviceability",
+  "worker_processes",
+  "search_attributes",
+  "opencode_session_debt",
+  "opencode_debt_counts",
+  "health_snapshot",
+  "snapshot_health",
+  "peer_sessions",
+  "worktree_census",
+];
+
+/**
+ * Probe whether the configured Temporal server is reachable right now.
+ * Returns `false` on any connection or timeout error.
+ */
+export async function isTemporalReachable(): Promise<boolean> {
+  try {
+    const { createTemporalClientBundle } = await import(
+      "../temporal/client.js"
+    );
+    const bundlePromise = createTemporalClientBundle();
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error("Temporal reachability timeout"));
+      }, TEMPORAL_REACHABILITY_TIMEOUT_MS);
+      // Node timers are not unref'd by default in all test runners; unref
+      // prevents this timer from keeping the process alive.
+      if (typeof timer === "number") {
+        // Node environment: setTimeout returns a number; no unref needed.
+      } else if (typeof timer === "object" && timer !== null) {
+        (timer as NodeJS.Timeout).unref?.();
+      }
+    });
+    const { connection } = await Promise.race([bundlePromise, timeoutPromise]);
+    try {
+      return true;
+    } finally {
+      await connection.close().catch(() => undefined);
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Probe whether representative host-side diagnostics are available right now.
+ * Uses the OpenCode session-debt scan as a canary because it exercises the
+ * same host resources (bun:sqlite, opencode DB) that other status probes need.
+ */
+export async function areHostProbesAvailable(): Promise<boolean> {
+  try {
+    const { scanOpenCodeSessionDebt } = await import(
+      "../utils/opencode-session-debt.js"
+    );
+    const result = await scanOpenCodeSessionDebt();
+    return result.available === true;
+  } catch {
+    return false;
+  }
+}
+
+function tryParseJson(raw: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Tag host-probe fields in a parsed status payload as degraded.
+ */
+export function tagHostProbeFields(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...payload };
+  for (const field of HOST_PROBE_FIELDS) {
+    if (!(field in result)) {
+      continue;
+    }
+    const value = result[field];
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      result[field] = {
+        ...(value as Record<string, unknown>),
+        degraded: true,
+        source: "host_probe_unavailable_in_mcp",
+      };
+    } else {
+      result[field] = {
+        value,
+        degraded: true,
+        source: "host_probe_unavailable_in_mcp",
+      };
+    }
+  }
+  return result;
+}
+
+/**
+ * Wrap a Tier-4 tool executor with class-aware runtime degradation.
+ *
+ * @param toolName            Tool name (e.g. "status").
+ * @param classifications     KD10 classifications for this tool.
+ * @param execute             Underlying tool executor returning JSON text.
+ * @param options             Optional probe overrides (used in tests).
+ */
+export function wrapTier4Tool(
+  toolName: Tier4ToolName,
+  classifications: ToolClassification[],
+  execute: (args: Record<string, unknown>) => Promise<string>,
+  options: DegradationOptions = {},
+): (args: Record<string, unknown>) => Promise<string> {
+  return async (args) => {
+    const needsTemporal = classifications.includes("needs-temporal");
+    const needsHostProbe = classifications.includes("needs-host-probe");
+
+    if (needsTemporal) {
+      const reachable = await (options.temporalReachable?.() ??
+        isTemporalReachable());
+      if (!reachable) {
+        const raw = await execute(args);
+        const payload = tryParseJson(raw);
+        if (payload === undefined) {
+          // Non-JSON tool output cannot safely accommodate the degraded
+          // envelope. STOP_WHEN: report and skip with rationale.
+          return JSON.stringify({
+            error: "DEGRADED_NON_JSON_OUTPUT",
+            tool: toolName,
+            degraded: true,
+            source: "disk_projection",
+            text: raw,
+          });
+        }
+        return JSON.stringify({
+          ...payload,
+          degraded: true,
+          source: "disk_projection",
+          tool: toolName,
+        });
+      }
+    }
+
+    const raw = await execute(args);
+
+    if (needsHostProbe) {
+      const available = await (options.hostProbesAvailable?.() ??
+        areHostProbesAvailable());
+      if (!available) {
+        const payload = tryParseJson(raw);
+        if (payload === undefined) {
+          return JSON.stringify({
+            error: "DEGRADED_NON_JSON_OUTPUT",
+            tool: toolName,
+            degraded: true,
+            source: "host_probe_unavailable_in_mcp",
+            text: raw,
+          });
+        }
+        return JSON.stringify({
+          ...tagHostProbeFields(payload),
+          degraded: true,
+          source: "host_probe_unavailable_in_mcp",
+          tool: toolName,
+        });
+      }
+    }
+
+    return raw;
+  };
+}

--- a/plugin/src/mcp-server/degradation.ts
+++ b/plugin/src/mcp-server/degradation.ts
@@ -51,9 +51,8 @@ export const HOST_PROBE_FIELDS: readonly string[] = [
  */
 export async function isTemporalReachable(): Promise<boolean> {
   try {
-    const { createTemporalClientBundle } = await import(
-      "../temporal/client.js"
-    );
+    const { createTemporalClientBundle } =
+      await import("../temporal/client.js");
     const bundlePromise = createTemporalClientBundle();
     const timeoutPromise = new Promise<never>((_, reject) => {
       const timer = setTimeout(() => {
@@ -85,9 +84,8 @@ export async function isTemporalReachable(): Promise<boolean> {
  */
 export async function areHostProbesAvailable(): Promise<boolean> {
   try {
-    const { scanOpenCodeSessionDebt } = await import(
-      "../utils/opencode-session-debt.js"
-    );
+    const { scanOpenCodeSessionDebt } =
+      await import("../utils/opencode-session-debt.js");
     const result = await scanOpenCodeSessionDebt();
     return result.available === true;
   } catch {

--- a/plugin/src/mcp-server/descriptors.test.ts
+++ b/plugin/src/mcp-server/descriptors.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Descriptor + catalog parity tests (DDC4).
+ *
+ * Gate for task tk-d1c59f0af2ca. Asserts every MCP tool descriptor carries
+ * the expected structural shape and that the catalog is complete (13 Tier-4
+ * tools + adv_handshake). Full inputSchema parity (ZodToJsonSchema projection
+ * matching PUBLIC_TOOL_ENTRIES[name].args) is partially covered here; the
+ * remaining 10 tools currently use passthrough schemas and require descriptor
+ * migration to use the canonical Zod args from PUBLIC_TOOL_ENTRIES.
+ *
+ * Coverage:
+ *   - Catalog completeness (14 entries; no removed tools) ✓
+ *   - Descriptor structural shape (name + description + inputSchema) ✓
+ *   - Pure-tool schema parity (project_context, tool_catalog, tool_describe) — sample
+ *
+ * Deferred to follow-up:
+ *   - needs-context / needs-temporal / needs-host-git tools currently use
+ *     z.object({}).passthrough(); migrating to per-tool canonical Zod args
+ *     requires touching tools/index.ts registration loop.
+ */
+import { describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { startServer } from "./index.js";
+import { HANDSHAKE_TIER4_TOOLS } from "./handshake.js";
+
+const REMOVED_TOOL_NAMES = [
+  "adv_reflect",
+  "adv_project_metadata",
+  "adv_conformance",
+  "adv_session_list",
+  "adv_session_show",
+  "reflect",
+  "project_metadata",
+  "conformance",
+  "session_list",
+  "session_show",
+] as const;
+
+async function connectToServer() {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await startServer({ transport: serverTransport });
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return { client, clientTransport, serverTransport };
+}
+
+async function closeClient(
+  client: Client,
+  clientTransport: InMemoryTransport,
+  serverTransport: InMemoryTransport,
+) {
+  await client.close();
+  await clientTransport.close();
+  await serverTransport.close();
+}
+
+describe("DDC4 — catalog completeness", () => {
+  it("tools/list returns exactly 14 entries (13 Tier-4 + adv_handshake)", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+    const tools = await client.listTools();
+    expect(tools.tools.length).toBe(14);
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("tools/list contains every Tier-4 name (unprefixed) + adv_handshake", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+    const tools = await client.listTools();
+    const names = new Set(tools.tools.map((t) => t.name));
+    for (const tier4 of HANDSHAKE_TIER4_TOOLS) {
+      expect(names.has(tier4), `expected Tier-4 tool ${tier4}`).toBe(true);
+    }
+    expect(names.has("adv_handshake")).toBe(true);
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("tools/list does NOT contain any removed tool name", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+    const tools = await client.listTools();
+    const names = new Set(tools.tools.map((t) => t.name));
+    for (const removed of REMOVED_TOOL_NAMES) {
+      expect(
+        names.has(removed),
+        `removed tool ${removed} must not appear in catalog`,
+      ).toBe(false);
+    }
+    await closeClient(client, clientTransport, serverTransport);
+  });
+});
+
+describe("DDC4 — descriptor structural shape", () => {
+  it("every catalog tool has non-empty name, description, and inputSchema", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+    const tools = await client.listTools();
+    for (const t of tools.tools) {
+      expect(typeof t.name, `name is string: ${t.name}`).toBe("string");
+      expect(t.name.length, `name non-empty: ${t.name}`).toBeGreaterThan(0);
+      expect(typeof t.description, `description is string: ${t.name}`).toBe(
+        "string",
+      );
+      expect(
+        t.description!.length,
+        `description non-empty: ${t.name}`,
+      ).toBeGreaterThan(0);
+      expect(t.inputSchema, `inputSchema present: ${t.name}`).toBeDefined();
+      expect(typeof t.inputSchema, `inputSchema is object: ${t.name}`).toBe(
+        "object",
+      );
+    }
+    await closeClient(client, clientTransport, serverTransport);
+  });
+});

--- a/plugin/src/mcp-server/handshake.ts
+++ b/plugin/src/mcp-server/handshake.ts
@@ -1,0 +1,61 @@
+/**
+ * ADV capability handshake meta-tool.
+ *
+ * ServerInfo is reserved for MCP `name` + `version` only (KD7). ADV-specific
+ * compatibility data (Tier-4 tool inventory, contract version) is surfaced
+ * through this dedicated tool so hosts can project names and negotiate
+ * behavior without overloading serverInfo.
+ */
+
+/**
+ * Tier-4 read surface exposed by the ADV MCP server. These are the local
+ * (unprefixed) tool names returned by `tools/list` when projected by
+ * OpenCode as `tools.adv.*`.
+ *
+ * Source: KD9 — read-oriented ADV tools. The list below is the exact
+ * inventory communicated in the handshake response.
+ */
+export const HANDSHAKE_TIER4_TOOLS = [
+  "status",
+  "spec",
+  "wisdom_list",
+  "reflection_list",
+  "project_context",
+  "backlog_list",
+  "backlog_show",
+  "epic_list",
+  "epic_show",
+  "wip_state",
+  "worktree_triage",
+  "tool_catalog",
+  "tool_describe",
+] as const;
+
+/**
+ * ADV MCP handshake schema version.
+ *
+ * Semantic: tracks the shape of `HandshakeResult` (tier4_tools list +
+ * adv_contract_version). Bump on breaking changes to the handshake payload
+ * (e.g. tool removed from tier4_tools, field renamed, semantic redefined).
+ * Does NOT track plugin version, SDK version, or individual tool schema
+ * changes — only the handshake contract itself.
+ *
+ * History:
+ *   1 — initial release (KD9 13-tool catalog; AMEND-3 dynamic-import pattern)
+ */
+export const ADV_CONTRACT_VERSION = 1;
+
+export interface HandshakeResult {
+  tier4_tools: readonly string[];
+  adv_contract_version: number;
+}
+
+/**
+ * Return the ADV capability handshake payload.
+ */
+export function handleHandshake(): HandshakeResult {
+  return {
+    tier4_tools: HANDSHAKE_TIER4_TOOLS,
+    adv_contract_version: ADV_CONTRACT_VERSION,
+  };
+}

--- a/plugin/src/mcp-server/index.ts
+++ b/plugin/src/mcp-server/index.ts
@@ -18,7 +18,9 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { getProjectId } from "../utils/project-id.js";
 import { handleHandshake } from "./handshake.js";
+import { HANDSHAKE_TIER4_TOOLS } from "./handshake.js";
 import { handleProjectContext } from "./tools/project_context.js";
+import { executeTier4Tool, TIER4_TOOL_DESCRIPTIONS } from "./tools/index.js";
 import { formatArgRejection, rejectMutationShapedArgs } from "./security.js";
 
 export interface StartServerOptions {
@@ -113,6 +115,35 @@ export async function startServer(
       };
     },
   );
+
+  for (const toolName of HANDSHAKE_TIER4_TOOLS) {
+    if (toolName === "project_context") continue;
+    mcp.registerTool(
+      toolName,
+      {
+        description: TIER4_TOOL_DESCRIPTIONS[toolName],
+        inputSchema: anyArgsSchema,
+      },
+      async (args) => {
+        const check = rejectMutationShapedArgs(args);
+        if (check.rejected) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: formatArgRejection(check.arg),
+              },
+            ],
+          };
+        }
+
+        const text = await executeTier4Tool(cwd, toolName, args);
+        return {
+          content: [{ type: "text" as const, text }],
+        };
+      },
+    );
+  }
 
   const transport =
     options.transport ??

--- a/plugin/src/mcp-server/index.ts
+++ b/plugin/src/mcp-server/index.ts
@@ -1,0 +1,125 @@
+/**
+ * ADV MCP stdio server entry point.
+ *
+ * Exposes a minimal read surface over the Model Context Protocol:
+ *   - adv_handshake: capability/version meta-tool
+ *   - project_context: read project.md via the plugin tool registry
+ *
+ * The server resolves the project id at startup, uses the plugin version as
+ * its serverInfo.version, and never accepts per-call project_root overrides
+ * (AC6 minimum, enforced by the security wrapper).
+ */
+
+import { readFile } from "fs/promises";
+import type { Readable, Writable } from "node:stream";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { getProjectId } from "../utils/project-id.js";
+import { handleHandshake } from "./handshake.js";
+import { handleProjectContext } from "./tools/project_context.js";
+import { formatArgRejection, rejectMutationShapedArgs } from "./security.js";
+
+export interface StartServerOptions {
+  stdin?: Readable;
+  stdout?: Writable;
+  /** Optional transport override for tests. When omitted, stdio is used. */
+  transport?: Transport;
+}
+
+async function loadVersion(): Promise<string> {
+  try {
+    const pkg = JSON.parse(
+      await readFile(new URL("../../package.json", import.meta.url), "utf-8"),
+    );
+    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/**
+ * Start the ADV MCP server on stdio (or the provided streams).
+ *
+ * Resolves the project id from `process.cwd()` and binds the two read tools.
+ * Does not block on Temporal at startup; the project_context tool lazily
+ * creates a disk-only store when invoked.
+ */
+export async function startServer(
+  options: StartServerOptions = {},
+): Promise<void> {
+  const cwd = process.cwd();
+  const projectId = await getProjectId(cwd);
+  if (!projectId) {
+    console.warn(`[adv] Could not resolve project id for ${cwd}`);
+  }
+
+  const version = await loadVersion();
+  const mcp = new McpServer({ name: "adv", version });
+
+  /** Accept any args so the security wrapper can inspect and reject them. */
+  const anyArgsSchema = z.object({}).passthrough();
+
+  mcp.registerTool(
+    "adv_handshake",
+    {
+      description:
+        "ADV capability handshake: returns the Tier-4 tool inventory and contract version.",
+      inputSchema: anyArgsSchema,
+    },
+    async (args) => {
+      const check = rejectMutationShapedArgs(args);
+      if (check.rejected) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatArgRejection(check.arg),
+            },
+          ],
+        };
+      }
+      const result = handleHandshake();
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      };
+    },
+  );
+
+  mcp.registerTool(
+    "project_context",
+    {
+      description:
+        "Read the project context file (project.md) containing tech stack, conventions, domain knowledge, and constraints.",
+      inputSchema: anyArgsSchema,
+    },
+    async (args) => {
+      const check = rejectMutationShapedArgs(args);
+      if (check.rejected) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatArgRejection(check.arg),
+            },
+          ],
+        };
+      }
+
+      const text = await handleProjectContext(cwd, args);
+      return {
+        content: [{ type: "text" as const, text }],
+      };
+    },
+  );
+
+  const transport =
+    options.transport ??
+    new StdioServerTransport(
+      options.stdin ?? process.stdin,
+      options.stdout ?? process.stdout,
+    );
+
+  await mcp.server.connect(transport);
+}

--- a/plugin/src/mcp-server/sdk-exports.test.ts
+++ b/plugin/src/mcp-server/sdk-exports.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Smoke test: verifies that `@modelcontextprotocol/sdk` v1.x exposes the
+ * server-side primitives the ADV MCP server depends on.
+ *
+ * This is the gate for task tk-58f607bd3ba1 (Phase A0 — SDK install). It must
+ * fail before `pnpm add @modelcontextprotocol/sdk@^1` and pass after.
+ *
+ * Verified against SDK v1.x docs:
+ *   - https://github.com/modelcontextprotocol/typescript-sdk/blob/v1.x/docs/server.md
+ *   - https://github.com/modelcontextprotocol/typescript-sdk/blob/v1.x/README.md
+ *
+ * Per docs (v1.29.0 verified):
+ *   - `Server` (low-level) — exported from `@modelcontextprotocol/sdk/server/index.js`.
+ *     Has `setRequestHandler` (protocol-level). Does NOT have `registerTool`.
+ *   - `McpServer` (high-level) — exported from `@modelcontextprotocol/sdk/server/mcp.js`.
+ *     Wraps `Server`; provides `registerTool`/`tool` (deprecated → registerTool)
+ *     with schema validation. The ADV MCP server uses McpServer.
+ *   - `StdioServerTransport` — exported from `@modelcontextprotocol/sdk/server/stdio.js`.
+ *   - `registerTool` is a method on `McpServer`, NOT on `Server`.
+ */
+import { describe, expect, it } from "vitest";
+
+describe("@modelcontextprotocol/sdk v1.x server exports", () => {
+  it("exports Server class from server/index.js", async () => {
+    const mod = await import("@modelcontextprotocol/sdk/server/index.js");
+    expect(typeof mod.Server).toBe("function");
+    const s = new mod.Server(
+      { name: "smoke", version: "0.0.0" },
+      { capabilities: { tools: {} } },
+    );
+    expect(s).toBeInstanceOf(mod.Server);
+    // Low-level Server uses setRequestHandler, NOT registerTool
+    expect(typeof (s as unknown as { setRequestHandler: unknown }).setRequestHandler).toBe("function");
+  });
+
+  it("exports StdioServerTransport from server/stdio.js", async () => {
+    const mod = await import("@modelcontextprotocol/sdk/server/stdio.js");
+    expect(typeof mod.StdioServerTransport).toBe("function");
+    const t = new mod.StdioServerTransport({
+      stdin: process.stdin,
+      stdout: process.stdout,
+    });
+    expect(t).toBeInstanceOf(mod.StdioServerTransport);
+  });
+
+  it("exports McpServer (high-level) from server/mcp.js", async () => {
+    const mod = await import("@modelcontextprotocol/sdk/server/mcp.js");
+    expect(typeof mod.McpServer).toBe("function");
+  });
+
+  it("McpServer.registerTool accepts (name, schema, handler) with Zod inputSchema", async () => {
+    const { McpServer } = await import("@modelcontextprotocol/sdk/server/mcp.js");
+    const { z } = await import("zod");
+    const mcp = new McpServer({ name: "smoke", version: "0.0.0" });
+    // Should not throw — registers a tool with Zod schema (the API the ADV MCP server uses)
+    expect(() =>
+      mcp.registerTool(
+        "smoke-tool",
+        {
+          description: "smoke",
+          inputSchema: { value: z.number() },
+        },
+        async ({ value }) => ({
+          content: [{ type: "text" as const, text: String(value) }],
+        }),
+      ),
+    ).not.toThrow();
+    // McpServer.server exposes the low-level Server for transport.connect()
+    expect(mcp.server).toBeDefined();
+    expect(typeof mcp.server.setRequestHandler).toBe("function");
+  });
+});

--- a/plugin/src/mcp-server/sdk-exports.test.ts
+++ b/plugin/src/mcp-server/sdk-exports.test.ts
@@ -30,7 +30,9 @@ describe("@modelcontextprotocol/sdk v1.x server exports", () => {
     );
     expect(s).toBeInstanceOf(mod.Server);
     // Low-level Server uses setRequestHandler, NOT registerTool
-    expect(typeof (s as unknown as { setRequestHandler: unknown }).setRequestHandler).toBe("function");
+    expect(
+      typeof (s as unknown as { setRequestHandler: unknown }).setRequestHandler,
+    ).toBe("function");
   });
 
   it("exports StdioServerTransport from server/stdio.js", async () => {
@@ -49,7 +51,8 @@ describe("@modelcontextprotocol/sdk v1.x server exports", () => {
   });
 
   it("McpServer.registerTool accepts (name, schema, handler) with Zod inputSchema", async () => {
-    const { McpServer } = await import("@modelcontextprotocol/sdk/server/mcp.js");
+    const { McpServer } =
+      await import("@modelcontextprotocol/sdk/server/mcp.js");
     const { z } = await import("zod");
     const mcp = new McpServer({ name: "smoke", version: "0.0.0" });
     // Should not throw — registers a tool with Zod schema (the API the ADV MCP server uses)

--- a/plugin/src/mcp-server/security.test.ts
+++ b/plugin/src/mcp-server/security.test.ts
@@ -1,0 +1,210 @@
+/**
+ * DDC7 exhaustive rejection tests for the ADV MCP read surface.
+ *
+ * Verifies that every Tier-4 catalog tool (13 HANDSHAKE_TIER4_TOOLS) plus
+ * adv_handshake rejects every mutation-shaped argument with the same typed
+ * error schema, while valid read args pass through unchanged.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import { startServer } from "./index.js";
+import { HANDSHAKE_TIER4_TOOLS } from "./handshake.js";
+import {
+  REJECTED_MUTATION_ARG_NAMES,
+  REJECTED_ARG_PREFIXES,
+  MUTATING_KIND_ACTION_VALUES,
+  formatArgRejection,
+  rejectMutationShapedArgs,
+} from "./security.js";
+import {
+  createTempDir,
+  cleanupTempDir,
+  createTestProject,
+} from "../__tests__/setup.js";
+
+const ALL_TIER4_TOOLS = ["adv_handshake", ...HANDSHAKE_TIER4_TOOLS];
+
+/**
+ * Valid read args for each tool. These must be accepted by the security
+ * wrapper (they may still fail downstream with not-found/no-data errors).
+ */
+const POSITIVE_ARGS: Record<string, Record<string, unknown>> = {
+  adv_handshake: {},
+  status: { view: "summary" },
+  spec: { action: "list" },
+  wisdom_list: { changeId: "ch-test" },
+  reflection_list: {},
+  project_context: {},
+  backlog_list: { include_archived: true },
+  backlog_show: { id: "backlog-1" },
+  epic_list: { status: "active" },
+  epic_show: { epic_id: "myEpic" },
+  wip_state: {},
+  worktree_triage: {},
+  tool_catalog: { limit: 10 },
+  tool_describe: { name: "adv_status" },
+};
+
+interface RejectedCase {
+  name: string;
+  args: Record<string, unknown>;
+  expectedArg: string;
+}
+
+const REJECTED_CASES: RejectedCase[] = [];
+
+for (const arg of REJECTED_MUTATION_ARG_NAMES) {
+  REJECTED_CASES.push({
+    name: `exact-${arg}`,
+    args: { [arg]: "/evil" },
+    expectedArg: arg,
+  });
+}
+
+for (const prefix of REJECTED_ARG_PREFIXES) {
+  for (const suffix of ["", "Foo", "_bar"]) {
+    const arg = `${prefix}${suffix}`;
+    REJECTED_CASES.push({
+      name: `prefix-${arg}`,
+      args: { [arg]: "evil" },
+      expectedArg: arg,
+    });
+  }
+}
+
+for (const key of ["kind", "action"]) {
+  for (const value of MUTATING_KIND_ACTION_VALUES) {
+    REJECTED_CASES.push({
+      name: `${key}=${value}`,
+      args: { [key]: value },
+      expectedArg: key,
+    });
+  }
+}
+
+async function connectToServer(): Promise<{
+  client: Client;
+  close: () => Promise<void>;
+}> {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await startServer({ transport: serverTransport });
+  await clientTransport.start();
+  await serverTransport.start();
+
+  const client = new Client({ name: "adv-mcp-security", version: "1.0.0" });
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await clientTransport.close();
+      await serverTransport.close();
+    },
+  };
+}
+
+function extractText(result: {
+  content: Array<{ type: string; text?: string }>;
+}): string {
+  expect(result.content).toHaveLength(1);
+  expect(result.content[0].type).toBe("text");
+  return result.content[0].text ?? "";
+}
+
+describe("DDC7 mutation-shaped argument rejection", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tempDir = await createTempDir("adv-mcp-security-");
+    await createTestProject(tempDir, {
+      withSpecs: false,
+      withChanges: false,
+      withConfig: true,
+    });
+    await writeFile(
+      join(tempDir, "project.md"),
+      "# Security Test Project\n\nContext.",
+    );
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await cleanupTempDir(tempDir);
+  });
+
+  for (const toolName of ALL_TIER4_TOOLS) {
+    it(`rejects every mutation-shaped arg for ${toolName} and allows valid read args`, async () => {
+      const { client, close } = await connectToServer();
+      try {
+        for (const { name: caseName, args, expectedArg } of REJECTED_CASES) {
+          const result = await client.callTool({
+            name: toolName,
+            arguments: args,
+          });
+          const text = extractText(result);
+          expect(
+            JSON.parse(text),
+            `${toolName} + ${caseName} should reject with typed error`,
+          ).toEqual({
+            error: "ARG_REJECTED",
+            code: "MUTATION_SHAPED_ARGUMENT",
+            arg: expectedArg,
+          });
+        }
+
+        const positiveArgs = POSITIVE_ARGS[toolName] ?? {};
+        const positiveResult = await client.callTool({
+          name: toolName,
+          arguments: positiveArgs,
+        });
+        const positiveText = extractText(positiveResult);
+        expect(positiveText, `${toolName} valid args should not be rejected`).
+          not.toContain("ARG_REJECTED");
+      } finally {
+        await close();
+      }
+    });
+  }
+
+  it("formatArgRejection produces the exact typed schema", () => {
+    const text = formatArgRejection("target_path");
+    expect(JSON.parse(text)).toEqual({
+      error: "ARG_REJECTED",
+      code: "MUTATION_SHAPED_ARGUMENT",
+      arg: "target_path",
+    });
+  });
+});
+
+// Direct unit tests for the pure checker keep edge cases cheap and isolated.
+describe("rejectMutationShapedArgs (pure)", () => {
+  it("rejects the first mutation-shaped arg when multiple are present", () => {
+    const check = rejectMutationShapedArgs({
+      projectRoot: "/evil",
+      approvedByUser: true,
+    });
+    expect(check.rejected).toBe(true);
+    if (check.rejected) {
+      expect(check.arg).toBe("projectRoot");
+    }
+  });
+
+  it("allows read-only action values like spec list/show/search", () => {
+    expect(rejectMutationShapedArgs({ action: "list" }).rejected).toBe(false);
+    expect(rejectMutationShapedArgs({ action: "show" }).rejected).toBe(false);
+    expect(rejectMutationShapedArgs({ action: "search" }).rejected).toBe(false);
+  });
+
+  it("rejects mutating action values case-insensitively", () => {
+    expect(rejectMutationShapedArgs({ ACTION: "WRITE" }).rejected).toBe(true);
+    expect(rejectMutationShapedArgs({ KIND: "ARCHIVE" }).rejected).toBe(true);
+  });
+});

--- a/plugin/src/mcp-server/security.test.ts
+++ b/plugin/src/mcp-server/security.test.ts
@@ -166,8 +166,10 @@ describe("DDC7 mutation-shaped argument rejection", () => {
           arguments: positiveArgs,
         });
         const positiveText = extractText(positiveResult);
-        expect(positiveText, `${toolName} valid args should not be rejected`).
-          not.toContain("ARG_REJECTED");
+        expect(
+          positiveText,
+          `${toolName} valid args should not be rejected`,
+        ).not.toContain("ARG_REJECTED");
       } finally {
         await close();
       }

--- a/plugin/src/mcp-server/security.ts
+++ b/plugin/src/mcp-server/security.ts
@@ -1,0 +1,57 @@
+/**
+ * MCP server argument sanitization (AC6 minimum).
+ *
+ * Rejects args that smell like cross-project mutation or approval-bypass
+ * surfaces. The full DDC7 contract is implemented in task tk-0c486f2813ef;
+ * this file only enforces the minimum set required by AC6.
+ */
+
+/** Arg names that must never be accepted by the MCP read surface. */
+export const REJECTED_MUTATION_ARG_NAMES = [
+  "project_root",
+  "projectRoot",
+  "target_path",
+  "approvedByUser",
+  "approvalEvidence",
+  "approval_evidence",
+  "confirmationEvidence",
+] as const;
+
+export type RejectedMutationArg = (typeof REJECTED_MUTATION_ARG_NAMES)[number];
+
+export interface RejectedMutationArgResult {
+  rejected: true;
+  arg: RejectedMutationArg;
+}
+
+export interface AcceptedArgsResult {
+  rejected: false;
+}
+
+export type MutationArgCheck = RejectedMutationArgResult | AcceptedArgsResult;
+
+/**
+ * Check whether any argument key matches a mutation-shaped arg name.
+ * Returns the first rejected key found, or `{ rejected: false }`.
+ */
+export function rejectMutationShapedArgs(
+  args: Record<string, unknown>,
+): MutationArgCheck {
+  for (const key of Object.keys(args)) {
+    if (REJECTED_MUTATION_ARG_NAMES.includes(key as RejectedMutationArg)) {
+      return { rejected: true, arg: key as RejectedMutationArg };
+    }
+  }
+  return { rejected: false };
+}
+
+/**
+ * Format a rejected arg as the typed MCP text response required by AC6.
+ */
+export function formatArgRejection(arg: string): string {
+  return JSON.stringify({
+    error: "ARG_REJECTED",
+    code: "MUTATION_SHAPED_ARGUMENT",
+    arg,
+  });
+}

--- a/plugin/src/mcp-server/security.ts
+++ b/plugin/src/mcp-server/security.ts
@@ -1,23 +1,52 @@
 /**
- * MCP server argument sanitization (AC6 minimum).
+ * MCP server argument sanitization (DDC7).
  *
- * Rejects args that smell like cross-project mutation or approval-bypass
- * surfaces. The full DDC7 contract is implemented in task tk-0c486f2813ef;
- * this file only enforces the minimum set required by AC6.
+ * Rejects args that smell like cross-project mutation, approval bypass,
+ * recovery override, signal-style mutation, or lifecycle mutation on the
+ * ADV MCP read surface. The full contract below is enforced by the security
+ * wrapper around every Tier-4 tool and `adv_handshake`.
  */
 
-/** Arg names that must never be accepted by the MCP read surface. */
+/** Exact arg names that must never be accepted by the MCP read surface. */
 export const REJECTED_MUTATION_ARG_NAMES = [
   "project_root",
   "projectRoot",
   "target_path",
+  "targetPath",
+  "target_confirmed",
+  "targetConfirmed",
   "approvedByUser",
   "approvalEvidence",
   "approval_evidence",
   "confirmationEvidence",
+  "recoveryMode",
+  "recoveryEvidence",
+  "recovery_evidence",
+  "userApproved",
+  "closeIssue",
+  "noCloseIssue",
+  "supersededBy",
+  "parent_change_id",
+  "parentChangeId",
 ] as const;
 
-export type RejectedMutationArg = (typeof REJECTED_MUTATION_ARG_NAMES)[number];
+/** Argument-key prefixes that are always rejected (e.g. any signal-shaped arg). */
+export const REJECTED_ARG_PREFIXES = ["signal"] as const;
+
+/** Values for `kind` or `action` args that imply mutation and are rejected. */
+export const MUTATING_KIND_ACTION_VALUES = [
+  "write",
+  "init",
+  "lock",
+  "unlock",
+  "override",
+  "cancel",
+  "close",
+  "archive",
+  "purge",
+] as const;
+
+export type RejectedMutationArg = string;
 
 export interface RejectedMutationArgResult {
   rejected: true;
@@ -30,23 +59,45 @@ export interface AcceptedArgsResult {
 
 export type MutationArgCheck = RejectedMutationArgResult | AcceptedArgsResult;
 
+function isRejectedArgName(key: string): boolean {
+  const names = REJECTED_MUTATION_ARG_NAMES as readonly string[];
+  if (names.includes(key)) return true;
+  for (const prefix of REJECTED_ARG_PREFIXES) {
+    if (key.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function isMutatingKindOrAction(key: string, value: unknown): boolean {
+  const lowerKey = key.toLowerCase();
+  if (lowerKey !== "kind" && lowerKey !== "action") return false;
+  const lowerValue = String(value).toLowerCase();
+  return (MUTATING_KIND_ACTION_VALUES as readonly string[]).includes(
+    lowerValue,
+  );
+}
+
 /**
- * Check whether any argument key matches a mutation-shaped arg name.
+ * Check whether any argument key matches a mutation-shaped arg name, starts
+ * with a rejected prefix, or carries a mutating `kind`/`action` value.
  * Returns the first rejected key found, or `{ rejected: false }`.
  */
 export function rejectMutationShapedArgs(
   args: Record<string, unknown>,
 ): MutationArgCheck {
   for (const key of Object.keys(args)) {
-    if (REJECTED_MUTATION_ARG_NAMES.includes(key as RejectedMutationArg)) {
-      return { rejected: true, arg: key as RejectedMutationArg };
+    if (isRejectedArgName(key)) {
+      return { rejected: true, arg: key };
+    }
+    if (isMutatingKindOrAction(key, args[key])) {
+      return { rejected: true, arg: key };
     }
   }
   return { rejected: false };
 }
 
 /**
- * Format a rejected arg as the typed MCP text response required by AC6.
+ * Format a rejected arg as the typed MCP text response required by DDC7.
  */
 export function formatArgRejection(arg: string): string {
   return JSON.stringify({

--- a/plugin/src/mcp-server/server.test.ts
+++ b/plugin/src/mcp-server/server.test.ts
@@ -93,14 +93,48 @@ describe("adv mcp server", () => {
     await closeClient(client, clientTransport, serverTransport);
   });
 
-  it("tools/list returns exactly adv_handshake and project_context", async () => {
+  it("tools/list returns exactly the 14 expected Tier-4 tools", async () => {
     const { client, clientTransport, serverTransport } =
       await connectToServer();
 
     const tools = await client.listTools();
     expect(tools.tools.map((t) => t.name).sort()).toEqual(
-      ["adv_handshake", "project_context"].sort(),
+      [
+        "adv_handshake",
+        "project_context",
+        "status",
+        "spec",
+        "wisdom_list",
+        "reflection_list",
+        "backlog_list",
+        "backlog_show",
+        "epic_list",
+        "epic_show",
+        "wip_state",
+        "worktree_triage",
+        "tool_catalog",
+        "tool_describe",
+      ].sort(),
     );
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("tools/list does not expose removed tools", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const tools = await client.listTools();
+    const names = new Set(tools.tools.map((t) => t.name));
+    for (const removed of [
+      "reflect",
+      "project_metadata",
+      "conformance",
+      "session_list",
+      "session_show",
+    ]) {
+      expect(names).not.toContain(removed);
+    }
 
     await closeClient(client, clientTransport, serverTransport);
   });
@@ -223,6 +257,22 @@ describe("adv mcp server", () => {
       code: "MUTATION_SHAPED_ARGUMENT",
       arg: "target_path",
     });
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("tool_describe delegates to the plugin handler", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const result = await client.callTool({
+      name: "tool_describe",
+      arguments: { name: "adv_project_context" },
+    });
+    const text = extractText(result);
+    const parsed = JSON.parse(text);
+    expect(parsed.name).toBe("adv_project_context");
+    expect(parsed.description).toBeDefined();
 
     await closeClient(client, clientTransport, serverTransport);
   });

--- a/plugin/src/mcp-server/server.test.ts
+++ b/plugin/src/mcp-server/server.test.ts
@@ -1,0 +1,284 @@
+/**
+ * ADV MCP server end-to-end tests.
+ *
+ * Uses the MCP SDK Client + InMemoryTransport to verify the skeleton read
+ * surface: serverInfo, tools/list, adv_handshake, project_context parity, and
+ * AC6 mutation-shaped arg rejection.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import { startServer } from "./index.js";
+import { handleProjectContext } from "./tools/project_context.js";
+import { HANDSHAKE_TIER4_TOOLS, ADV_CONTRACT_VERSION } from "./handshake.js";
+import { createDiskStore } from "../storage/store-disk.js";
+import { projectTools } from "../tools/project.js";
+import {
+  createTempDir,
+  cleanupTempDir,
+  createTestProject,
+} from "../__tests__/setup.js";
+
+async function connectToServer(): Promise<{
+  client: Client;
+  clientTransport: InMemoryTransport;
+  serverTransport: InMemoryTransport;
+}> {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await startServer({
+    transport: serverTransport,
+  });
+  await clientTransport.start();
+  await serverTransport.start();
+
+  const client = new Client({ name: "adv-mcp-test", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return { client, clientTransport, serverTransport };
+}
+
+async function closeClient(
+  client: Client,
+  clientTransport: InMemoryTransport,
+  serverTransport: InMemoryTransport,
+): Promise<void> {
+  await client.close();
+  await clientTransport.close();
+  await serverTransport.close();
+}
+
+function extractText(result: {
+  content: Array<{ type: string; text?: string }>;
+}): string {
+  expect(result.content).toHaveLength(1);
+  expect(result.content[0].type).toBe("text");
+  return result.content[0].text ?? "";
+}
+
+describe("adv mcp server", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tempDir = await createTempDir("adv-mcp-server-");
+    await createTestProject(tempDir, {
+      withSpecs: false,
+      withChanges: false,
+      withConfig: true,
+    });
+    await writeFile(
+      join(tempDir, "project.md"),
+      "# Test Project\n\nThis is the project context.",
+    );
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await cleanupTempDir(tempDir);
+  });
+
+  it("boots and exposes serverInfo with name adv and plugin version", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    expect(client.getServerVersion()).toEqual({
+      name: "adv",
+      version: "1.0.0",
+    });
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("tools/list returns exactly adv_handshake and project_context", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const tools = await client.listTools();
+    expect(tools.tools.map((t) => t.name).sort()).toEqual(
+      ["adv_handshake", "project_context"].sort(),
+    );
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("adv_handshake returns tier4 tool list and contract version", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const result = await client.callTool({
+      name: "adv_handshake",
+      arguments: {},
+    });
+    const text = extractText(result);
+    const parsed = JSON.parse(text);
+    expect(parsed).toEqual({
+      tier4_tools: HANDSHAKE_TIER4_TOOLS,
+      adv_contract_version: ADV_CONTRACT_VERSION,
+    });
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("HANDSHAKE_TIER4_TOOLS count is exactly 13 (KD9 catalog invariant)", () => {
+    // Count-guard: prevents silent drift if a tool is added/removed without
+    // updating the design. Per AMEND-1 (AC2 → AC2'): the catalog was reduced
+    // from 18 to 13 tools. Any future change to this count MUST be accompanied
+    // by a design amendment + AC2' update.
+    expect(HANDSHAKE_TIER4_TOOLS.length).toBe(13);
+    // Explicit membership check (catches wrong-tool substitution)
+    expect(new Set(HANDSHAKE_TIER4_TOOLS)).toEqual(
+      new Set([
+        "status",
+        "spec",
+        "wisdom_list",
+        "reflection_list",
+        "project_context",
+        "backlog_list",
+        "backlog_show",
+        "epic_list",
+        "epic_show",
+        "wip_state",
+        "worktree_triage",
+        "tool_catalog",
+        "tool_describe",
+      ]),
+    );
+  });
+
+  it("project_context returns the same output as the direct plugin tool", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const mcpResult = await client.callTool({
+      name: "project_context",
+      arguments: {},
+    });
+    const mcpText = extractText(mcpResult);
+
+    const store = await createDiskStore(tempDir);
+    try {
+      const directResult = await projectTools.adv_project_context.execute(
+        {},
+        store,
+      );
+      expect(mcpText).toBe(directResult);
+    } finally {
+      store.close();
+    }
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("rejects project_root argument", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const result = await client.callTool({
+      name: "project_context",
+      arguments: { project_root: "/evil" },
+    });
+    const text = extractText(result);
+    expect(JSON.parse(text)).toEqual({
+      error: "ARG_REJECTED",
+      code: "MUTATION_SHAPED_ARGUMENT",
+      arg: "project_root",
+    });
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("rejects projectRoot argument", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const result = await client.callTool({
+      name: "project_context",
+      arguments: { projectRoot: "/evil" },
+    });
+    const text = extractText(result);
+    expect(JSON.parse(text)).toEqual({
+      error: "ARG_REJECTED",
+      code: "MUTATION_SHAPED_ARGUMENT",
+      arg: "projectRoot",
+    });
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("rejects target_path argument", async () => {
+    const { client, clientTransport, serverTransport } =
+      await connectToServer();
+
+    const result = await client.callTool({
+      name: "project_context",
+      arguments: { target_path: "/evil" },
+    });
+    const text = extractText(result);
+    expect(JSON.parse(text)).toEqual({
+      error: "ARG_REJECTED",
+      code: "MUTATION_SHAPED_ARGUMENT",
+      arg: "target_path",
+    });
+
+    await closeClient(client, clientTransport, serverTransport);
+  });
+
+  it("cold starts in under 2 seconds", async () => {
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const start = performance.now();
+    await startServer({
+      transport: serverTransport,
+    });
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(2000);
+    await clientTransport.close();
+    await serverTransport.close();
+  });
+});
+
+// Also verify the project_context handler directly so parity failures are
+// isolated from transport wiring.
+describe("handleProjectContext", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tempDir = await createTempDir("adv-mcp-handle-");
+    await createTestProject(tempDir, {
+      withSpecs: false,
+      withChanges: false,
+      withConfig: true,
+    });
+    await writeFile(
+      join(tempDir, "project.md"),
+      "# Direct Project\n\nDirect context.",
+    );
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await cleanupTempDir(tempDir);
+  });
+
+  it("matches the direct plugin tool output", async () => {
+    const text = await handleProjectContext(tempDir, {});
+
+    const store = await createDiskStore(tempDir);
+    try {
+      const directResult = await projectTools.adv_project_context.execute(
+        {},
+        store,
+      );
+      expect(text).toBe(directResult);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/plugin/src/mcp-server/tools/index.ts
+++ b/plugin/src/mcp-server/tools/index.ts
@@ -69,9 +69,17 @@ export async function executeTier4Tool(
   args: Record<string, unknown>,
   options?: DegradationOptions,
 ): Promise<string> {
-  const classifications =
-    TOOL_CLASSIFICATIONS[toolName as Tier4ToolName] ??
-    (["pure"] as ToolClassification[]);
+  const classifications = TOOL_CLASSIFICATIONS[toolName as Tier4ToolName];
+  if (!classifications) {
+    // Harden fix (review suggestion #4): fail loud on unknown tool name.
+    // Silent fallback to ["pure"] would let typos in HANDSHAKE_TIER4_TOOLS
+    // dispatch through the wrong degradation path.
+    return JSON.stringify({
+      error: "UNKNOWN_TIER4_TOOL",
+      tool: toolName,
+      hint: "Add the tool to TOOL_CLASSIFICATIONS in plugin/src/mcp-server/tools/index.ts",
+    });
+  }
 
   const run = async (): Promise<string> => {
     const { createToolMap } = await import("../../tool-registry.js");

--- a/plugin/src/mcp-server/tools/index.ts
+++ b/plugin/src/mcp-server/tools/index.ts
@@ -7,10 +7,7 @@
  */
 
 import type { Store } from "../../storage/store-types.js";
-import {
-  wrapTier4Tool,
-  type DegradationOptions,
-} from "../degradation.js";
+import { wrapTier4Tool, type DegradationOptions } from "../degradation.js";
 
 export type ToolClassification =
   | "pure"

--- a/plugin/src/mcp-server/tools/index.ts
+++ b/plugin/src/mcp-server/tools/index.ts
@@ -1,0 +1,116 @@
+/**
+ * MCP Tier-4 tool dispatcher.
+ *
+ * Table-driven registry for the 12 read tools added in SCOUT-3. Each handler
+ * delegates to the plugin's `adv_*` tool via dynamic import so the MCP server is
+ * not statically coupled to the SDK-bound tool registry.
+ */
+
+import type { Store } from "../../storage/store-types.js";
+
+export type ToolClassification =
+  | "pure"
+  | "needs-context"
+  | "needs-temporal"
+  | "needs-host-git"
+  | "needs-host-probe";
+
+/**
+ * KD10 classification for every Tier-4 read tool. This table drives the
+ * per-tool runtime degradation wrapper added in task tk-951c84c42397.
+ */
+export const TOOL_CLASSIFICATIONS = {
+  status: ["needs-temporal", "needs-host-probe"],
+  spec: ["needs-context"],
+  wisdom_list: ["needs-context"],
+  reflection_list: ["needs-context"],
+  backlog_list: ["needs-context"],
+  backlog_show: ["needs-context"],
+  epic_list: ["needs-temporal"],
+  epic_show: ["needs-temporal"],
+  wip_state: ["needs-temporal"],
+  worktree_triage: ["needs-host-git"],
+  tool_catalog: ["pure"],
+  tool_describe: ["pure"],
+  project_context: ["needs-context"],
+} as const satisfies Record<string, ToolClassification[]>;
+
+export type Tier4ToolName = keyof typeof TOOL_CLASSIFICATIONS;
+
+export const TIER4_TOOL_DESCRIPTIONS: Record<Tier4ToolName, string> = {
+  status:
+    "Project status overview: active changes, specs, recommendations, and optional health probes.",
+  spec: "Manage and query specifications (list, show, search).",
+  wisdom_list: "List or search accumulated project wisdom and learnings.",
+  reflection_list: "List archived change reflections.",
+  backlog_list: "List backlog items.",
+  backlog_show: "Show a single backlog item.",
+  epic_list: "List ADV epics.",
+  epic_show: "Show a single ADV epic.",
+  wip_state: "Aggregated work-in-progress state across active changes.",
+  worktree_triage: "Triage ADV worktrees for the current project.",
+  tool_catalog: "Catalog of all ADV tool names and metadata.",
+  tool_describe: "Describe a single ADV tool by name.",
+  project_context:
+    "Read the project context file (project.md) containing tech stack, conventions, domain knowledge, and constraints.",
+};
+
+/**
+ * Execute a Tier-4 read tool by dispatching to the plugin's registered
+ * `adv_<toolName>` handler.
+ *
+ * The store is created per-call as a disk-only backend and closed in `finally`
+ * so the MCP server never holds a Temporal connection between calls.
+ */
+export async function executeTier4Tool(
+  cwd: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const { createToolMap } = await import("../../tool-registry.js");
+  const { createDiskStore } = await import("../../storage/store-disk.js");
+
+  const store = (await createDiskStore(cwd)) as Store;
+  try {
+    const tools = createToolMap(store, cwd) as Record<
+      string,
+      { execute?: (args: Record<string, unknown>, ctx?: unknown) => unknown }
+    >;
+    const hostName = `adv_${toolName}`;
+    const toolDef = tools[hostName];
+    if (!toolDef) {
+      return JSON.stringify({
+        error: "TOOL_NOT_FOUND",
+        tool: toolName,
+        hostName,
+      });
+    }
+
+    const execute = toolDef.execute as (
+      args: Record<string, unknown>,
+      ctx?: unknown,
+    ) => Promise<unknown>;
+    const result = await execute(args);
+
+    if (typeof result === "string") {
+      return result;
+    }
+    if (
+      result &&
+      typeof result === "object" &&
+      "output" in result &&
+      typeof (result as { output?: unknown }).output === "string"
+    ) {
+      return (result as { output: string }).output;
+    }
+    return JSON.stringify(result);
+  } catch (err) {
+    return JSON.stringify({
+      error: "TOOL_EXECUTION_ERROR",
+      tool: toolName,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    store.close();
+  }
+}

--- a/plugin/src/mcp-server/tools/index.ts
+++ b/plugin/src/mcp-server/tools/index.ts
@@ -7,6 +7,10 @@
  */
 
 import type { Store } from "../../storage/store-types.js";
+import {
+  wrapTier4Tool,
+  type DegradationOptions,
+} from "../degradation.js";
 
 export type ToolClassification =
   | "pure"
@@ -66,51 +70,65 @@ export async function executeTier4Tool(
   cwd: string,
   toolName: string,
   args: Record<string, unknown>,
+  options?: DegradationOptions,
 ): Promise<string> {
-  const { createToolMap } = await import("../../tool-registry.js");
-  const { createDiskStore } = await import("../../storage/store-disk.js");
+  const classifications =
+    TOOL_CLASSIFICATIONS[toolName as Tier4ToolName] ??
+    (["pure"] as ToolClassification[]);
 
-  const store = (await createDiskStore(cwd)) as Store;
-  try {
-    const tools = createToolMap(store, cwd) as Record<
-      string,
-      { execute?: (args: Record<string, unknown>, ctx?: unknown) => unknown }
-    >;
-    const hostName = `adv_${toolName}`;
-    const toolDef = tools[hostName];
-    if (!toolDef) {
+  const run = async (): Promise<string> => {
+    const { createToolMap } = await import("../../tool-registry.js");
+    const { createDiskStore } = await import("../../storage/store-disk.js");
+
+    const store = (await createDiskStore(cwd)) as Store;
+    try {
+      const tools = createToolMap(store, cwd) as Record<
+        string,
+        { execute?: (args: Record<string, unknown>, ctx?: unknown) => unknown }
+      >;
+      const hostName = `adv_${toolName}`;
+      const toolDef = tools[hostName];
+      if (!toolDef) {
+        return JSON.stringify({
+          error: "TOOL_NOT_FOUND",
+          tool: toolName,
+          hostName,
+        });
+      }
+
+      const execute = toolDef.execute as (
+        args: Record<string, unknown>,
+        ctx?: unknown,
+      ) => Promise<unknown>;
+      const result = await execute(args);
+
+      if (typeof result === "string") {
+        return result;
+      }
+      if (
+        result &&
+        typeof result === "object" &&
+        "output" in result &&
+        typeof (result as { output?: unknown }).output === "string"
+      ) {
+        return (result as { output: string }).output;
+      }
+      return JSON.stringify(result);
+    } catch (err) {
       return JSON.stringify({
-        error: "TOOL_NOT_FOUND",
+        error: "TOOL_EXECUTION_ERROR",
         tool: toolName,
-        hostName,
+        message: err instanceof Error ? err.message : String(err),
       });
+    } finally {
+      store.close();
     }
+  };
 
-    const execute = toolDef.execute as (
-      args: Record<string, unknown>,
-      ctx?: unknown,
-    ) => Promise<unknown>;
-    const result = await execute(args);
-
-    if (typeof result === "string") {
-      return result;
-    }
-    if (
-      result &&
-      typeof result === "object" &&
-      "output" in result &&
-      typeof (result as { output?: unknown }).output === "string"
-    ) {
-      return (result as { output: string }).output;
-    }
-    return JSON.stringify(result);
-  } catch (err) {
-    return JSON.stringify({
-      error: "TOOL_EXECUTION_ERROR",
-      tool: toolName,
-      message: err instanceof Error ? err.message : String(err),
-    });
-  } finally {
-    store.close();
-  }
+  return wrapTier4Tool(
+    toolName as Tier4ToolName,
+    classifications,
+    run,
+    options,
+  )(args);
 }

--- a/plugin/src/mcp-server/tools/project_context.ts
+++ b/plugin/src/mcp-server/tools/project_context.ts
@@ -1,0 +1,31 @@
+/**
+ * MCP project_context tool handler.
+ *
+ * Wires `adv_project_context` through the plugin tool registry without
+ * statically importing the SDK-coupled registry at module load time.
+ * The store is created on-demand as a disk-only backend so the MCP server
+ * never blocks on Temporal during initialization.
+ */
+
+export async function handleProjectContext(
+  cwd: string,
+  _args: Record<string, unknown>,
+): Promise<string> {
+  const { createToolMap } = await import("../../tool-registry.js");
+  const { createDiskStore } = await import("../../storage/store-disk.js");
+
+  const store = await createDiskStore(cwd);
+  try {
+    const tools = createToolMap(store, cwd);
+    const execute = tools.adv_project_context.execute as (
+      args: Record<string, unknown>,
+      ctx?: unknown,
+    ) => Promise<unknown>;
+    const result = await execute({});
+    return typeof result === "string"
+      ? result
+      : (result as { output: string }).output;
+  } finally {
+    store.close();
+  }
+}

--- a/plugin/src/plugin-bundle-manifest.test.ts
+++ b/plugin/src/plugin-bundle-manifest.test.ts
@@ -145,7 +145,10 @@ describe("plugin bundle manifest", () => {
       JSON.stringify({
         schema_version: 1,
         generation: generatePluginBundleGeneration(),
-        files: { index: generatePluginBundleGeneration(), "mcp-server": "short" },
+        files: {
+          index: generatePluginBundleGeneration(),
+          "mcp-server": "short",
+        },
         built_at: NOW.toISOString(),
       }),
     );
@@ -163,9 +166,7 @@ describe("plugin bundle manifest", () => {
         built_at: NOW.toISOString(),
       }),
     );
-    await expect(
-      readPluginBundleManifest(unsupportedDir),
-    ).resolves.toBeNull();
+    await expect(readPluginBundleManifest(unsupportedDir)).resolves.toBeNull();
 
     const invalidTimestampDir = await tempDistDir();
     await writeFile(
@@ -173,7 +174,10 @@ describe("plugin bundle manifest", () => {
       JSON.stringify({
         schema_version: 1,
         generation: generatePluginBundleGeneration(),
-        files: { index: generatePluginBundleGeneration(), "mcp-server": generatePluginBundleGeneration() },
+        files: {
+          index: generatePluginBundleGeneration(),
+          "mcp-server": generatePluginBundleGeneration(),
+        },
         built_at: "not-an-iso-timestamp",
       }),
     );
@@ -270,7 +274,10 @@ describe("plugin bundle manifest", () => {
       const manifest = {
         schema_version: 1 as const,
         generation: generatePluginBundleGeneration(),
-        files: { index: indexHash, "mcp-server": generatePluginBundleGeneration() },
+        files: {
+          index: indexHash,
+          "mcp-server": generatePluginBundleGeneration(),
+        },
         built_at: NOW.toISOString(),
       };
       const result = comparePluginBundleGenerations(loaded, manifest);

--- a/plugin/src/plugin-bundle-manifest.test.ts
+++ b/plugin/src/plugin-bundle-manifest.test.ts
@@ -30,11 +30,12 @@ afterEach(async () => {
   tempDirs = [];
 });
 
-const tempDistDir = async (withIndex = true) => {
+const tempDistDir = async (withFiles = true) => {
   const dir = await createTempDir("plugin-bundle-manifest-");
   tempDirs.push(dir);
-  if (withIndex) {
+  if (withFiles) {
     await writeFile(join(dir, "index.js"), "// plugin bundle v1\n");
+    await writeFile(join(dir, "mcp-server.js"), "// mcp server bundle v1\n");
   }
   return dir;
 };
@@ -46,7 +47,7 @@ describe("plugin bundle manifest", () => {
     expect(generatePluginBundleGeneration()).not.toBe(gen);
   });
 
-  test("write produces schema-v1 manifest with generation and index SHA-256", async () => {
+  test("write produces schema-v1 manifest with generation and both file hashes", async () => {
     const dir = await tempDistDir();
     const generation = generatePluginBundleGeneration();
     const manifest = await writePluginBundleManifest(dir, generation, {
@@ -56,6 +57,9 @@ describe("plugin bundle manifest", () => {
     expect(manifest.schema_version).toBe(1);
     expect(manifest.generation).toBe(generation);
     expect(manifest.files.index).toBe(sha256("// plugin bundle v1\n"));
+    expect(manifest.files["mcp-server"]).toBe(
+      sha256("// mcp server bundle v1\n"),
+    );
     expect(manifest.built_at).toBe(NOW.toISOString());
 
     const raw = await readFile(
@@ -65,6 +69,7 @@ describe("plugin bundle manifest", () => {
     const parsed = JSON.parse(raw);
     expect(parsed.schema_version).toBe(1);
     expect(parsed.files.index).toBe(manifest.files.index);
+    expect(parsed.files["mcp-server"]).toBe(manifest.files["mcp-server"]);
   });
 
   test("write is atomic via temp+rename and leaves no temp files", async () => {
@@ -83,6 +88,15 @@ describe("plugin bundle manifest", () => {
     await expect(
       writePluginBundleManifest(dir, generatePluginBundleGeneration()),
     ).rejects.toThrow(/index\.js/);
+  });
+
+  test("write refuses when mcp-server.js is missing", async () => {
+    const dir = await createTempDir("plugin-bundle-manifest-");
+    tempDirs.push(dir);
+    await writeFile(join(dir, "index.js"), "// index only\n");
+    await expect(
+      writePluginBundleManifest(dir, generatePluginBundleGeneration()),
+    ).rejects.toThrow(/mcp-server\.js/);
   });
 
   test("read round-trips a written manifest", async () => {
@@ -117,12 +131,26 @@ describe("plugin bundle manifest", () => {
       JSON.stringify({
         schema_version: 1,
         generation: "short",
-        files: { index: "also-short" },
+        files: { index: "also-short", "mcp-server": "also-short" },
         built_at: NOW.toISOString(),
       }),
     );
     await expect(
       readPluginBundleManifest(badGenerationDir),
+    ).resolves.toBeNull();
+
+    const badMcpServerHashDir = await tempDistDir();
+    await writeFile(
+      join(badMcpServerHashDir, PLUGIN_BUNDLE_MANIFEST_FILENAME),
+      JSON.stringify({
+        schema_version: 1,
+        generation: generatePluginBundleGeneration(),
+        files: { index: generatePluginBundleGeneration(), "mcp-server": "short" },
+        built_at: NOW.toISOString(),
+      }),
+    );
+    await expect(
+      readPluginBundleManifest(badMcpServerHashDir),
     ).resolves.toBeNull();
 
     const unsupportedDir = await tempDistDir();
@@ -135,7 +163,9 @@ describe("plugin bundle manifest", () => {
         built_at: NOW.toISOString(),
       }),
     );
-    await expect(readPluginBundleManifest(unsupportedDir)).resolves.toBeNull();
+    await expect(
+      readPluginBundleManifest(unsupportedDir),
+    ).resolves.toBeNull();
 
     const invalidTimestampDir = await tempDistDir();
     await writeFile(
@@ -143,7 +173,7 @@ describe("plugin bundle manifest", () => {
       JSON.stringify({
         schema_version: 1,
         generation: generatePluginBundleGeneration(),
-        files: { index: generatePluginBundleGeneration() },
+        files: { index: generatePluginBundleGeneration(), "mcp-server": generatePluginBundleGeneration() },
         built_at: "not-an-iso-timestamp",
       }),
     );
@@ -152,13 +182,34 @@ describe("plugin bundle manifest", () => {
     ).resolves.toBeNull();
   });
 
+  test("read accepts a legacy manifest that lacks mcp-server.js", async () => {
+    const dir = await tempDistDir();
+    const generation = generatePluginBundleGeneration();
+    await writeFile(
+      join(dir, PLUGIN_BUNDLE_MANIFEST_FILENAME),
+      JSON.stringify({
+        schema_version: 1,
+        generation,
+        files: { index: generatePluginBundleGeneration() },
+        built_at: NOW.toISOString(),
+      }),
+    );
+    const read = await readPluginBundleManifest(dir);
+    expect(read).not.toBeNull();
+    expect(read?.generation).toBe(generation);
+    expect(read?.files["mcp-server"]).toBeUndefined();
+  });
+
   describe("comparePluginBundleGenerations", () => {
     test("returns current when loaded and deployed generations match", () => {
       const generation = generatePluginBundleGeneration();
       const manifest = {
         schema_version: 1 as const,
         generation,
-        files: { index: generatePluginBundleGeneration() },
+        files: {
+          index: generatePluginBundleGeneration(),
+          "mcp-server": generatePluginBundleGeneration(),
+        },
         built_at: NOW.toISOString(),
       };
       const result = comparePluginBundleGenerations(generation, manifest);
@@ -175,7 +226,10 @@ describe("plugin bundle manifest", () => {
       const manifest = {
         schema_version: 1 as const,
         generation: deployed,
-        files: { index: generatePluginBundleGeneration() },
+        files: {
+          index: generatePluginBundleGeneration(),
+          "mcp-server": generatePluginBundleGeneration(),
+        },
         built_at: NOW.toISOString(),
       };
       const result = comparePluginBundleGenerations(loaded, manifest);
@@ -190,7 +244,10 @@ describe("plugin bundle manifest", () => {
       const manifest = {
         schema_version: 1 as const,
         generation: generatePluginBundleGeneration(),
-        files: { index: generatePluginBundleGeneration() },
+        files: {
+          index: generatePluginBundleGeneration(),
+          "mcp-server": generatePluginBundleGeneration(),
+        },
         built_at: NOW.toISOString(),
       };
       const result = comparePluginBundleGenerations(null, manifest);
@@ -213,7 +270,7 @@ describe("plugin bundle manifest", () => {
       const manifest = {
         schema_version: 1 as const,
         generation: generatePluginBundleGeneration(),
-        files: { index: indexHash },
+        files: { index: indexHash, "mcp-server": generatePluginBundleGeneration() },
         built_at: NOW.toISOString(),
       };
       const result = comparePluginBundleGenerations(loaded, manifest);
@@ -289,6 +346,11 @@ describe("plugin bundle path resolution", () => {
   test("getPluginRoot resolves plugin root from bundled dist chunk module", () => {
     const chunkUrl = "file:///home/user/advance/plugin/dist/chunk-PL7DRBOO.js";
     expect(getPluginRoot(chunkUrl)).toBe("/home/user/advance/plugin");
+  });
+
+  test("getPluginRoot resolves plugin root from bundled dist/mcp-server.js module", () => {
+    const mcpUrl = "file:///home/user/advance/plugin/dist/mcp-server.js";
+    expect(getPluginRoot(mcpUrl)).toBe("/home/user/advance/plugin");
   });
 
   test("getPluginBundleDistDir resolves plugin/dist from source module", () => {

--- a/plugin/src/plugin-bundle-manifest.ts
+++ b/plugin/src/plugin-bundle-manifest.ts
@@ -105,20 +105,16 @@ export async function writePluginBundleManifest(
   const mcpServerPath = join(distDir, "mcp-server.js");
 
   const [indexSha256, mcpServerSha256] = await Promise.all([
-    hashFileSha256(indexPath).catch(
-      (err: NodeJS.ErrnoException) => {
-        throw new Error(
-          `Cannot write plugin bundle manifest: index.js is missing from ${distDir} (${err.code ?? err.message}).`,
-        );
-      },
-    ),
-    hashFileSha256(mcpServerPath).catch(
-      (err: NodeJS.ErrnoException) => {
-        throw new Error(
-          `Cannot write plugin bundle manifest: mcp-server.js is missing from ${distDir} (${err.code ?? err.message}).`,
-        );
-      },
-    ),
+    hashFileSha256(indexPath).catch((err: NodeJS.ErrnoException) => {
+      throw new Error(
+        `Cannot write plugin bundle manifest: index.js is missing from ${distDir} (${err.code ?? err.message}).`,
+      );
+    }),
+    hashFileSha256(mcpServerPath).catch((err: NodeJS.ErrnoException) => {
+      throw new Error(
+        `Cannot write plugin bundle manifest: mcp-server.js is missing from ${distDir} (${err.code ?? err.message}).`,
+      );
+    }),
   ]);
 
   const builtAt = (options.now ?? (() => new Date()))().toISOString();

--- a/plugin/src/plugin-bundle-manifest.ts
+++ b/plugin/src/plugin-bundle-manifest.ts
@@ -1,20 +1,23 @@
 /**
  * Plugin bundle generation manifest.
  *
- * The host-loaded plugin bundle (`dist/index.js`) is evaluated once per OpenCode
- * session. The build emits a generation *before* bundling, embeds it into the
- * bundle via a tsup `define`, and then records the final `index.js` SHA-256 in
- * an atomic sidecar manifest (`dist/plugin-bundle-manifest.json`). At runtime
- * the embedded generation is compared against the deployed manifest generation
- * to detect stale plugin bundles without relying on filesystem timestamps.
+ * The host-loaded plugin bundle (`dist/index.js`) and the ADV MCP server
+ * (`dist/mcp-server.js`) are evaluated by the OpenCode host and Vision's
+ * Node process respectively. The build emits a generation *before* bundling,
+ * embeds it into the bundles via a tsup `define`, and then records the final
+ * `index.js` and `mcp-server.js` SHA-256s in an atomic sidecar manifest
+ * (`dist/plugin-bundle-manifest.json`). At runtime the embedded generation is
+ * compared against the deployed manifest generation to detect stale bundles.
  *
  * Generation contract:
  *   - `generation` is an opaque pre-bundle token (64-char hex). It is defined
  *     before the bundler runs and never recomputed from the final bytes.
  *   - `files.index` is the SHA-256 of the final `index.js` and is diagnostic
  *     only; equality of `generation` is the staleness authority.
- *   - The manifest is written LAST (after `index.js` exists) via temp-file +
- *     rename so concurrent readers never observe a partial write.
+ *   - `files.mcp-server` is the SHA-256 of the final `mcp-server.js` and is
+ *     diagnostic only.
+ *   - The manifest is written LAST (after both bundle files exist) via temp-file
+ *     + rename so concurrent readers never observe a partial write.
  */
 
 import { createHash, randomBytes, randomUUID } from "node:crypto";
@@ -27,7 +30,7 @@ export const PLUGIN_BUNDLE_MANIFEST_SCHEMA_VERSION = 1;
 
 export const PLUGIN_BUNDLE_STALE_ADVISORY = "PLUGIN_BUNDLE_STALE";
 
-export type PluginBundleFile = "index";
+export type PluginBundleFile = "index" | "mcp-server";
 
 export interface PluginBundleManifest {
   schema_version: typeof PLUGIN_BUNDLE_MANIFEST_SCHEMA_VERSION;
@@ -87,11 +90,11 @@ async function hashFileSha256(path: string): Promise<string> {
 }
 
 /**
- * Hash the plugin bundle's `index.js` and atomically write the manifest into
- * `distDir`. Must run AFTER the bundler has finished writing `index.js` (the
- * manifest is the LAST write of the plugin build). Throws when `index.js` is
- * missing — a build that cannot produce the plugin bundle must not produce a
- * manifest.
+ * Hash the plugin bundle's `index.js` and `mcp-server.js` and atomically write
+ * the manifest into `distDir`. Must run AFTER the bundler has finished writing
+ * both artifacts (the manifest is the LAST write of the plugin build). Throws
+ * when either artifact is missing — a build that cannot produce both bundles
+ * must not produce a manifest.
  */
 export async function writePluginBundleManifest(
   distDir: string,
@@ -99,19 +102,30 @@ export async function writePluginBundleManifest(
   options: WritePluginBundleManifestOptions = {},
 ): Promise<PluginBundleManifest> {
   const indexPath = join(distDir, "index.js");
-  const indexSha256 = await hashFileSha256(indexPath).catch(
-    (err: NodeJS.ErrnoException) => {
-      throw new Error(
-        `Cannot write plugin bundle manifest: index.js is missing from ${distDir} (${err.code ?? err.message}).`,
-      );
-    },
-  );
+  const mcpServerPath = join(distDir, "mcp-server.js");
+
+  const [indexSha256, mcpServerSha256] = await Promise.all([
+    hashFileSha256(indexPath).catch(
+      (err: NodeJS.ErrnoException) => {
+        throw new Error(
+          `Cannot write plugin bundle manifest: index.js is missing from ${distDir} (${err.code ?? err.message}).`,
+        );
+      },
+    ),
+    hashFileSha256(mcpServerPath).catch(
+      (err: NodeJS.ErrnoException) => {
+        throw new Error(
+          `Cannot write plugin bundle manifest: mcp-server.js is missing from ${distDir} (${err.code ?? err.message}).`,
+        );
+      },
+    ),
+  ]);
 
   const builtAt = (options.now ?? (() => new Date()))().toISOString();
   const manifest: PluginBundleManifest = {
     schema_version: PLUGIN_BUNDLE_MANIFEST_SCHEMA_VERSION,
     generation,
-    files: { index: indexSha256 },
+    files: { index: indexSha256, "mcp-server": mcpServerSha256 },
     built_at: builtAt,
   };
 
@@ -153,11 +167,22 @@ export async function readPluginBundleManifest(
   ) {
     return null;
   }
+  const files = candidate.files as Record<string, unknown> | undefined;
   if (
-    !candidate.files ||
-    typeof candidate.files !== "object" ||
-    typeof (candidate.files as Record<string, unknown>).index !== "string" ||
-    !/^[0-9a-f]{64}$/.test((candidate.files as Record<string, string>).index)
+    !files ||
+    typeof files !== "object" ||
+    typeof files.index !== "string" ||
+    !/^[0-9a-f]{64}$/.test(files.index)
+  ) {
+    return null;
+  }
+  // The manifest is produced atomically with both hashes; if an older
+  // manifest lacks mcp-server.js, preserve backward compatibility by
+  // accepting it as a partial record. If the key is present, validate it.
+  if (
+    "mcp-server" in files &&
+    (typeof files["mcp-server"] !== "string" ||
+      !/^[0-9a-f]{64}$/.test(files["mcp-server"]))
   ) {
     return null;
   }

--- a/plugin/src/tool-catalog-entries.test.ts
+++ b/plugin/src/tool-catalog-entries.test.ts
@@ -14,10 +14,7 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-const MODULE_PATH = resolve(
-  import.meta.dirname,
-  "tool-catalog-entries.ts",
-);
+const MODULE_PATH = resolve(import.meta.dirname, "tool-catalog-entries.ts");
 
 describe("plugin/src/tool-catalog-entries.ts — SDK-free boundary", () => {
   it("source contains no @opencode-ai/plugin import", () => {

--- a/plugin/src/tool-catalog-entries.test.ts
+++ b/plugin/src/tool-catalog-entries.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Import-deps + parity test for the SDK-free catalog module.
+ *
+ * Gate for task tk-9ad1a04909a2 (Phase A1 — SDK-free catalog extraction).
+ * The new `tool-catalog-entries.ts` module MUST be SDK-free (zero
+ * `@opencode-ai/plugin` imports) so the future MCP server can consume it
+ * without coupling to the OpenCode plugin SDK.
+ *
+ * Per KD2 (design.md): the MCP descriptors module imports ONLY this SDK-free
+ * module — never `tool-registry.ts`. This test enforces that boundary
+ * structurally (P33 — structural correctness over heuristic).
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const MODULE_PATH = resolve(
+  import.meta.dirname,
+  "tool-catalog-entries.ts",
+);
+
+describe("plugin/src/tool-catalog-entries.ts — SDK-free boundary", () => {
+  it("source contains no @opencode-ai/plugin import", () => {
+    const source = readFileSync(MODULE_PATH, "utf-8");
+    expect(source).not.toMatch(/from\s+["']@opencode-ai\/plugin["']/);
+    expect(source).not.toMatch(/import\s*\(\s*["']@opencode-ai\/plugin["']\)/);
+  });
+
+  it("source contains no ./tools/* import (those are SDK-coupled)", () => {
+    const source = readFileSync(MODULE_PATH, "utf-8");
+    expect(source).not.toMatch(/from\s+["']\.\/tools\//);
+    expect(source).not.toMatch(/from\s+["']\.\.\/tools\//);
+  });
+
+  it("source contains no ./storage/* import (those are SDK-coupled)", () => {
+    const source = readFileSync(MODULE_PATH, "utf-8");
+    expect(source).not.toMatch(/from\s+["']\.\/storage\//);
+  });
+});
+
+describe("tool-catalog-entries — exported API", () => {
+  it("exports the expected types, functions, and constants", async () => {
+    const mod = await import("./tool-catalog-entries");
+    // Functions
+    expect(typeof mod.collectPublicToolEntries).toBe("function");
+    expect(typeof mod.renderToolInputSchema).toBe("function");
+    expect(typeof mod.getToolSurface).toBe("function");
+    expect(typeof mod.deriveToolRealm).toBe("function");
+    expect(typeof mod.deriveToolMetadata).toBe("function");
+    // Constants
+    expect(mod.ADV_PUBLIC_TOOL_BASELINE_COUNT).toBe(80);
+    // Realms/groups data structures
+    expect(Array.isArray(mod.REALM_PREFIXES)).toBe(true);
+    expect(mod.REALM_PREFIXES.length).toBeGreaterThan(0);
+    expect(typeof mod.REALM_OVERRIDES).toBe("object");
+    expect(typeof mod.GROUP_OVERRIDES).toBe("object");
+    expect(typeof mod.LIFECYCLE_BY_REALM).toBe("object");
+    expect(Array.isArray(mod.REPAIR_LIFECYCLE)).toBe(true);
+  });
+
+  it("collectPublicToolEntries preserves order across groups", async () => {
+    const { collectPublicToolEntries } = await import("./tool-catalog-entries");
+    const entries = collectPublicToolEntries([
+      {
+        alpha: {
+          description: "first",
+          args: {} as never,
+        },
+      },
+      {
+        beta: {
+          description: "second",
+          args: {} as never,
+        },
+      },
+    ]);
+    expect(entries.map((e) => e.name)).toEqual(["alpha", "beta"]);
+  });
+
+  it("deriveToolMetadata returns a complete metadata record", async () => {
+    const { deriveToolMetadata } = await import("./tool-catalog-entries");
+    const meta = deriveToolMetadata("adv_status");
+    expect(meta.realm).toBe("status");
+    expect(meta.group).toBe("read");
+    expect(meta.lifecycle).toContain("execution");
+    expect(["low", "medium", "high", "operator"]).toContain(meta.risk);
+    expect(meta.recoveryOnly).toBe(false);
+  });
+
+  it("deriveToolMetadata classifies repair tools as operator/recoveryOnly", async () => {
+    const { deriveToolMetadata } = await import("./tool-catalog-entries");
+    const meta = deriveToolMetadata("adv_archive_purge");
+    expect(meta.group).toBe("repair");
+    expect(meta.risk).toBe("operator");
+    expect(meta.recoveryOnly).toBe(true);
+  });
+});
+
+describe("tool-registry re-exports — parity preserved", () => {
+  it("PUBLIC_TOOL_ENTRIES is now exported from tool-registry", async () => {
+    const reg = await import("./tool-registry");
+    expect(reg.PUBLIC_TOOL_ENTRIES).toBeDefined();
+    expect(Array.isArray(reg.PUBLIC_TOOL_ENTRIES)).toBe(true);
+    expect(reg.PUBLIC_TOOL_ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  it("collectPublicToolEntries identity is the same function in both modules", async () => {
+    const cat = await import("./tool-catalog-entries");
+    const reg = await import("./tool-registry");
+    // tool-registry re-exports collectPublicToolEntries from tool-catalog-entries
+    expect(reg.collectPublicToolEntries).toBe(cat.collectPublicToolEntries);
+  });
+});

--- a/plugin/src/tool-catalog-entries.ts
+++ b/plugin/src/tool-catalog-entries.ts
@@ -1,0 +1,444 @@
+/**
+ * SDK-free ADV tool catalog entries (task tk-9ad1a04909a2 / KD2).
+ *
+ * Pure types, pure functions, and pure derivation tables for the canonical
+ * ADV tool surface. This module has ZERO `@opencode-ai/plugin` imports and
+ * ZERO imports from `./tools/*` or `./storage/*` — it depends only on Zod
+ * (already a peer of the plugin). The future MCP server (plugin/src/mcp-server/)
+ * consumes these types and functions to build tool descriptors without
+ * coupling to the OpenCode plugin SDK.
+ *
+ * The actual PUBLIC_TOOL_ENTRIES / ADV_TOOL_NAMES / ADV_TOOL_METADATA data
+ * remain in `tool-registry.ts` because they are derived from PUBLIC_TOOL_GROUPS,
+ * which imports tool-group modules (./tools/*) that ARE SDK-coupled. The MCP
+ * server accesses that data via dynamic import (`await import("../tool-registry.js")`)
+ * — same pattern as `adv_contract_mint` (see comment at tool-registry.ts:1330-1332).
+ *
+ * Boundary test: `tool-catalog-entries.test.ts` enforces the SDK-free property
+ * structurally (P33 — structural correctness over heuristic inference).
+ */
+
+import { z } from "zod";
+
+// =============================================================================
+// ToolArgsSchema — Zod-only schema map type
+// =============================================================================
+
+export type ToolArgsSchema = Record<string, z.ZodTypeAny>;
+
+// =============================================================================
+// PublicToolGroup / PublicToolEntry — canonical definition records
+// =============================================================================
+
+/** One retained public `*Tools` export group (data-only view). */
+export type PublicToolGroup = Readonly<
+  Record<string, { description: string; args: ToolArgsSchema }>
+>;
+
+/** Canonical definition record: name, required description, original Zod args. */
+export interface PublicToolEntry {
+  readonly name: string;
+  readonly description: string;
+  readonly args: ToolArgsSchema;
+}
+
+/**
+ * Flatten retained public groups into ordered definition records.
+ *
+ * DDC2: a duplicate exported public name across groups is rejected BEFORE any
+ * Set/Map construction can collapse it — a collision throws instead of
+ * silently dropping one of the colliding tools.
+ *
+ * SC4: every record must carry a non-empty description and the original Zod
+ * args; the silent `args ?? {}` fallback is removed (addAdvanceMetadata).
+ */
+export function collectPublicToolEntries(
+  groups: readonly PublicToolGroup[],
+): PublicToolEntry[] {
+  const entries: PublicToolEntry[] = [];
+  const firstGroupIndex = new Map<string, number>();
+  groups.forEach((group, groupIndex) => {
+    for (const [name, def] of Object.entries(group)) {
+      const first = firstGroupIndex.get(name);
+      if (first !== undefined) {
+        throw new Error(
+          `Duplicate public tool name "${name}" exported by public tool inventory groups at index ${first} and ${groupIndex}. Public names must be unique across retained groups before any Set/Map construction (consolidateAdvToolSurface2 DDC2).`,
+        );
+      }
+      if (typeof def.description !== "string" || def.description.length === 0) {
+        throw new Error(
+          `Public tool "${name}" is missing a required description. Every canonical definition record must carry a non-empty description (addAdvanceMetadata SC4).`,
+        );
+      }
+      if (
+        !def.args ||
+        typeof def.args !== "object" ||
+        Array.isArray(def.args)
+      ) {
+        throw new Error(
+          `Public tool "${name}" is missing required original Zod args. Every canonical definition record must carry its args schema (addAdvanceMetadata SC4).`,
+        );
+      }
+      firstGroupIndex.set(name, groupIndex);
+      entries.push({ name, description: def.description, args: def.args });
+    }
+  });
+  return entries;
+}
+
+// =============================================================================
+// Tool catalog projections (addAdvanceMetadata AC3/C3/C4)
+// =============================================================================
+
+/** One entry in the read-only ADV tool catalog. */
+export interface ToolCatalogItem {
+  readonly name: string;
+  readonly description: string;
+  readonly argKeys: readonly string[];
+  readonly visibility: ToolMetadataV1;
+}
+
+/** Result of converting a tool's canonical Zod args to JSON Schema. */
+export type ToolInputSchemaResult =
+  | { readonly ok: true; readonly schema: Record<string, unknown> }
+  | { readonly ok: false; readonly code: string; readonly error: string };
+
+/**
+ * Render the input JSON Schema for a canonical tool definition using Zod's
+ * native `toJSONSchema` with input semantics. Failures are surfaced as typed
+ * projection errors rather than falling back to argument names (AC4).
+ */
+export function renderToolInputSchema(
+  entry: PublicToolEntry,
+): ToolInputSchemaResult {
+  try {
+    const schema = z.toJSONSchema(z.object(entry.args), {
+      io: "input",
+      unrepresentable: "throw",
+    }) as Record<string, unknown>;
+    return { ok: true, schema };
+  } catch (err) {
+    return {
+      ok: false,
+      code: "SCHEMA_CONVERSION_FAILED",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Live tool-surface lookup (addAcWarrantGuard): tool name → set of declared
+ * argument keys, derived from a PublicToolEntry list (data only — no `execute`
+ * invocation). This is the source of truth used to verify capability warrants
+ * at contract mint. Because it operates on the typed inventory, the warrant
+ * surface cannot drift from the canonical list (DDC1), and per-tool argument
+ * keys always equal the declared definition keys (DDC3).
+ */
+export function getToolSurface(
+  entries: readonly PublicToolEntry[],
+): Map<string, Set<string>> {
+  const surface = new Map<string, Set<string>>();
+  for (const entry of entries) {
+    surface.set(entry.name, new Set(Object.keys(entry.args)));
+  }
+  return surface;
+}
+
+// =============================================================================
+// ADV_PUBLIC_TOOL_BASELINE_COUNT
+// =============================================================================
+
+/**
+ * SC1 source baseline: the number of registered public ADV tools recorded at
+ * the start of consolidateAdvToolSurface2 implementation (2026-07-15). The
+ * final canonical count must be strictly lower once a change's contracted
+ * public removals land; the baseline/final exact-accounting assertion lives
+ * in tool-registry.inventory.test.ts.
+ */
+export const ADV_PUBLIC_TOOL_BASELINE_COUNT = 80;
+
+// =============================================================================
+// Descriptive visibility metadata (addAdvanceMetadata AC1/AC5/C1/C2/C5)
+// =============================================================================
+
+export type ToolRealm =
+  | "archive"
+  | "backlog"
+  | "change"
+  | "conformance"
+  | "contract"
+  | "design"
+  | "epic"
+  | "followup"
+  | "gate"
+  | "lightweight"
+  | "ops"
+  | "project"
+  | "reflection"
+  | "report"
+  | "session"
+  | "snapshot"
+  | "spec"
+  | "status"
+  | "store"
+  | "task"
+  | "temporal"
+  | "test"
+  | "tool"
+  | "verification"
+  | "wisdom"
+  | "worktree";
+
+export type ToolGroup =
+  | "bulk"
+  | "diagnostics"
+  | "lifecycle"
+  | "metadata"
+  | "read"
+  | "repair"
+  | "write";
+
+export type ToolLifecycleGate =
+  | "proposal"
+  | "discovery"
+  | "design"
+  | "planning"
+  | "execution"
+  | "acceptance"
+  | "release";
+
+/**
+ * Canonical descriptive metadata for every retained ADV tool.
+ *
+ * Owned facts only: realm, group, lifecycle gates, risk, and recovery-only
+ * flag. This table does NOT copy authority from TOOL_ROLE_POLICY (class,
+ * agentActions, operatorActions, rationale) or manifest grants from
+ * AGENT_TOOL_POLICY (allowed, explicitBlocked, denyWildcard). It is a
+ * descriptive, non-authorizing source used by catalog/describe projections
+ * and profile authoring (addAdvanceMetadata SC4/AC1/AC5/C1/C2/C5).
+ */
+export interface ToolMetadataV1 {
+  readonly realm: ToolRealm;
+  readonly group: ToolGroup;
+  readonly lifecycle: ReadonlyArray<ToolLifecycleGate>;
+  readonly risk: "low" | "medium" | "high" | "operator";
+  readonly recoveryOnly: boolean;
+}
+
+// =============================================================================
+// Realm / Group / Lifecycle derivation tables (pure data + pure functions)
+// =============================================================================
+
+export const REALM_OVERRIDES: Readonly<Record<string, ToolRealm>> = {
+  adv_conformance: "conformance",
+  adv_delta_add: "spec",
+  adv_delta_modify: "spec",
+  adv_design_concern_disposition: "design",
+  adv_followup_promote: "followup",
+  adv_report_followup_promote: "report",
+  adv_subagent_report_submit: "report",
+  adv_run_test: "test",
+  adv_snapshot_health: "snapshot",
+  adv_spec: "spec",
+  adv_status: "status",
+  adv_wip_state: "status",
+  adv_lightweight_profile_evaluate: "lightweight",
+  adv_verification_evidence_disposition: "verification",
+  adv_reflect: "reflection",
+  adv_reflection_list: "reflection",
+};
+
+export const REALM_PREFIXES: ReadonlyArray<readonly [string, ToolRealm]> = [
+  ["adv_archive_", "archive"],
+  ["adv_backlog_", "backlog"],
+  ["adv_change_", "change"],
+  ["adv_contract_", "contract"],
+  ["adv_epic_", "epic"],
+  ["adv_gate_", "gate"],
+  ["adv_ops_", "ops"],
+  ["adv_project_", "project"],
+  ["adv_session_", "session"],
+  ["adv_store_", "store"],
+  ["adv_task_", "task"],
+  ["adv_temporal_", "temporal"],
+  ["adv_tool_", "tool"],
+  ["adv_worktree_", "worktree"],
+  ["adv_wisdom_", "wisdom"],
+];
+
+export function deriveToolRealm(name: string): ToolRealm {
+  const override = REALM_OVERRIDES[name];
+  if (override) return override;
+  for (const [prefix, realm] of REALM_PREFIXES) {
+    if (name.startsWith(prefix)) return realm;
+  }
+  return "change";
+}
+
+export const GROUP_OVERRIDES: Readonly<Record<string, ToolGroup>> = {
+  // Repair / operator-only recovery surface
+  adv_archive_purge: "repair",
+  adv_archive_repair: "repair",
+  adv_change_repair_origin: "repair",
+  adv_change_status_repair: "repair",
+  adv_change_workflow_terminate: "repair",
+  adv_store_cleanup: "repair",
+  adv_store_consolidate: "repair",
+  adv_temporal_reconnect: "repair",
+  adv_temporal_register_search_attributes: "repair",
+  adv_temporal_worker_restart: "repair",
+
+  // Diagnostics / read-heavy analysis surface
+  adv_change_validate: "diagnostics",
+  adv_conformance: "diagnostics",
+  adv_design_concern_disposition: "diagnostics",
+  adv_lightweight_profile_evaluate: "diagnostics",
+  adv_run_test: "diagnostics",
+  adv_snapshot_health: "diagnostics",
+  adv_temporal_diagnose: "diagnostics",
+  adv_verification_evidence_disposition: "diagnostics",
+
+  // Metadata / submission surface
+  adv_project_metadata: "metadata",
+  adv_reflect: "metadata",
+  adv_subagent_report_submit: "metadata",
+
+  // Read surface
+  adv_backlog_list: "read",
+  adv_backlog_show: "read",
+  adv_change_list: "read",
+  adv_change_show: "read",
+  adv_epic_list: "read",
+  adv_epic_show: "read",
+  adv_gate_status: "read",
+  adv_project_context: "read",
+  adv_reflection_list: "read",
+  adv_session_list: "read",
+  adv_session_show: "read",
+  adv_spec: "read",
+  adv_status: "read",
+  adv_task_list: "read",
+  adv_task_ready: "read",
+  adv_task_show: "read",
+  adv_tool_catalog: "read",
+  adv_tool_describe: "read",
+  adv_wip_state: "read",
+  adv_wisdom_list: "read",
+  adv_worktree_triage: "read",
+
+  // Lifecycle transitions
+  adv_backlog_promote: "lifecycle",
+  adv_change_archive: "lifecycle",
+  adv_change_reenter: "lifecycle",
+  adv_epic_add_shell: "lifecycle",
+  adv_epic_promote_shell: "lifecycle",
+  adv_followup_promote: "lifecycle",
+  adv_gate_complete: "lifecycle",
+  adv_report_followup_promote: "lifecycle",
+  adv_worktree_resume: "lifecycle",
+
+  // Bulk operations
+  adv_change_bulk_close: "bulk",
+};
+
+export const LIFECYCLE_BY_REALM: Readonly<
+  Record<ToolRealm, ReadonlyArray<ToolLifecycleGate>>
+> = {
+  archive: ["release"],
+  backlog: ["proposal", "discovery"],
+  change: [
+    "proposal",
+    "discovery",
+    "design",
+    "planning",
+    "execution",
+    "acceptance",
+    "release",
+  ],
+  conformance: ["acceptance"],
+  contract: ["discovery", "planning"],
+  design: ["execution"],
+  epic: ["proposal", "discovery", "planning", "execution"],
+  followup: ["execution", "acceptance"],
+  gate: ["acceptance", "release"],
+  lightweight: ["execution"],
+  ops: ["execution"],
+  project: [
+    "proposal",
+    "discovery",
+    "design",
+    "planning",
+    "execution",
+    "acceptance",
+    "release",
+  ],
+  reflection: ["release"],
+  report: ["execution", "acceptance"],
+  session: [
+    "proposal",
+    "discovery",
+    "design",
+    "planning",
+    "execution",
+    "acceptance",
+    "release",
+  ],
+  snapshot: [
+    "proposal",
+    "discovery",
+    "design",
+    "planning",
+    "execution",
+    "acceptance",
+    "release",
+  ],
+  spec: ["proposal", "discovery"],
+  status: [
+    "proposal",
+    "discovery",
+    "design",
+    "planning",
+    "execution",
+    "acceptance",
+    "release",
+  ],
+  store: ["release"],
+  task: ["planning", "execution"],
+  temporal: ["execution", "acceptance", "release"],
+  test: ["execution", "acceptance"],
+  tool: [
+    "proposal",
+    "discovery",
+    "design",
+    "planning",
+    "execution",
+    "acceptance",
+    "release",
+  ],
+  verification: ["acceptance"],
+  wisdom: ["execution", "acceptance", "release"],
+  worktree: ["execution"],
+};
+
+export const REPAIR_LIFECYCLE: ReadonlyArray<ToolLifecycleGate> = [
+  "execution",
+  "acceptance",
+  "release",
+];
+
+export function deriveToolMetadata(name: string): ToolMetadataV1 {
+  const realm = deriveToolRealm(name);
+  const group = GROUP_OVERRIDES[name] ?? "write";
+  const lifecycle: ReadonlyArray<ToolLifecycleGate> =
+    group === "repair" ? REPAIR_LIFECYCLE : LIFECYCLE_BY_REALM[realm];
+  const risk: ToolMetadataV1["risk"] =
+    group === "repair"
+      ? "operator"
+      : group === "bulk" || group === "write"
+        ? "high"
+        : group === "diagnostics"
+          ? "medium"
+          : "low";
+  const recoveryOnly = group === "repair";
+  return { realm, group, lifecycle, risk, recoveryOnly };
+}

--- a/plugin/src/tool-registry.ts
+++ b/plugin/src/tool-registry.ts
@@ -1109,7 +1109,6 @@ export function createToolMap(
  * pre-consolidation surface omitted them).
  */
 
-
 /**
  * Read-only catalog and describe tools for the canonical ADV tool surface.
  * They project the existing definition inventory and metadata; they never
@@ -1271,7 +1270,6 @@ export function getToolSurface(): Map<string, Set<string>> {
   return getToolSurfaceFromEntries(PUBLIC_TOOL_ENTRIES);
 }
 
-
 /**
  * Canonical list of all ADV tool names, derived from PUBLIC_TOOL_GROUPS.
  * Duplicates are rejected at module load by collectPublicToolEntries before
@@ -1282,7 +1280,6 @@ export function getToolSurface(): Map<string, Set<string>> {
 export const ADV_TOOL_NAMES: readonly string[] = Object.freeze(
   PUBLIC_TOOL_ENTRIES.map((entry) => entry.name),
 );
-
 
 export const ADV_TOOL_METADATA: Readonly<Record<string, ToolMetadataV1>> =
   Object.freeze(

--- a/plugin/src/tool-registry.ts
+++ b/plugin/src/tool-registry.ts
@@ -28,6 +28,43 @@ import { formatToolOutput, paginate } from "./utils/tool-output";
 import type { Store } from "./storage/store-types";
 import type { OpencodeClient } from "./utils/opencode-types";
 
+// Re-export SDK-free catalog types/functions/constants so existing imports
+// from tool-registry keep working (KD2 — task tk-9ad1a04909a2).
+// The canonical definitions live in ./tool-catalog-entries; tool-registry
+// consumes them and layers the SDK-coupled PUBLIC_TOOL_GROUPS data on top.
+export {
+  type ToolArgsSchema,
+  type PublicToolGroup,
+  type PublicToolEntry,
+  type ToolCatalogItem,
+  type ToolInputSchemaResult,
+  type ToolRealm,
+  type ToolGroup,
+  type ToolLifecycleGate,
+  type ToolMetadataV1,
+  ADV_PUBLIC_TOOL_BASELINE_COUNT,
+  REALM_OVERRIDES,
+  REALM_PREFIXES,
+  GROUP_OVERRIDES,
+  LIFECYCLE_BY_REALM,
+  REPAIR_LIFECYCLE,
+  collectPublicToolEntries,
+  renderToolInputSchema,
+  deriveToolRealm,
+  deriveToolMetadata,
+} from "./tool-catalog-entries";
+import {
+  collectPublicToolEntries,
+  renderToolInputSchema,
+  getToolSurface as getToolSurfaceFromEntries,
+  deriveToolMetadata,
+  type ToolArgsSchema,
+  type PublicToolGroup,
+  type PublicToolEntry,
+  type ToolCatalogItem,
+  type ToolMetadataV1,
+} from "./tool-catalog-entries";
+
 import { specTools } from "./tools/spec";
 import { specDeltaTools } from "./tools/spec-delta";
 import { backlogTools, WIP_CALLER_TIMEOUT_MS } from "./tools/backlog";
@@ -61,7 +98,6 @@ import { storeConsolidateTools } from "./tools/store-consolidate";
 import { storeCleanupTools } from "./tools/store-cleanup";
 import { lightweightProfileTools } from "./tools/lightweight-profile";
 import { advInvokeTools } from "./tools/adv-invoke";
-type ToolArgsSchema = Record<string, z.ZodTypeAny>;
 type ToolExecute<TArgs> = (
   args: TArgs,
   contextOrExtra?: unknown,
@@ -1073,101 +1109,6 @@ export function createToolMap(
  * pre-consolidation surface omitted them).
  */
 
-/** One retained public `*Tools` export group (data-only view). */
-export type PublicToolGroup = Readonly<
-  Record<string, { description: string; args: ToolArgsSchema }>
->;
-
-/** Canonical definition record: name, required description, original Zod args. */
-export interface PublicToolEntry {
-  readonly name: string;
-  readonly description: string;
-  readonly args: ToolArgsSchema;
-}
-
-/**
- * Flatten retained public groups into ordered definition records.
- *
- * DDC2: a duplicate exported public name across groups is rejected BEFORE any
- * Set/Map construction can collapse it — a collision throws instead of
- * silently dropping one of the colliding tools.
- *
- * SC4: every record must carry a non-empty description and the original Zod
- * args; the silent `args ?? {}` fallback is removed (addAdvanceMetadata).
- */
-export function collectPublicToolEntries(
-  groups: readonly PublicToolGroup[],
-): PublicToolEntry[] {
-  const entries: PublicToolEntry[] = [];
-  const firstGroupIndex = new Map<string, number>();
-  groups.forEach((group, groupIndex) => {
-    for (const [name, def] of Object.entries(group)) {
-      const first = firstGroupIndex.get(name);
-      if (first !== undefined) {
-        throw new Error(
-          `Duplicate public tool name "${name}" exported by public tool inventory groups at index ${first} and ${groupIndex}. Public names must be unique across retained groups before any Set/Map construction (consolidateAdvToolSurface2 DDC2).`,
-        );
-      }
-      if (typeof def.description !== "string" || def.description.length === 0) {
-        throw new Error(
-          `Public tool "${name}" is missing a required description. Every canonical definition record must carry a non-empty description (addAdvanceMetadata SC4).`,
-        );
-      }
-      if (
-        !def.args ||
-        typeof def.args !== "object" ||
-        Array.isArray(def.args)
-      ) {
-        throw new Error(
-          `Public tool "${name}" is missing required original Zod args. Every canonical definition record must carry its args schema (addAdvanceMetadata SC4).`,
-        );
-      }
-      firstGroupIndex.set(name, groupIndex);
-      entries.push({ name, description: def.description, args: def.args });
-    }
-  });
-  return entries;
-}
-
-// =============================================================================
-// Tool Catalog / Describe Projections (addAdvanceMetadata AC3/C3/C4)
-// =============================================================================
-
-/** One entry in the read-only ADV tool catalog. */
-export interface ToolCatalogItem {
-  readonly name: string;
-  readonly description: string;
-  readonly argKeys: readonly string[];
-  readonly visibility: ToolMetadataV1;
-}
-
-/** Result of converting a tool's canonical Zod args to JSON Schema. */
-export type ToolInputSchemaResult =
-  | { readonly ok: true; readonly schema: Record<string, unknown> }
-  | { readonly ok: false; readonly code: string; readonly error: string };
-
-/**
- * Render the input JSON Schema for a canonical tool definition using Zod's
- * native `toJSONSchema` with input semantics. Failures are surfaced as typed
- * projection errors rather than falling back to argument names (AC4).
- */
-export function renderToolInputSchema(
-  entry: PublicToolEntry,
-): ToolInputSchemaResult {
-  try {
-    const schema = z.toJSONSchema(z.object(entry.args), {
-      io: "input",
-      unrepresentable: "throw",
-    }) as Record<string, unknown>;
-    return { ok: true, schema };
-  } catch (err) {
-    return {
-      ok: false,
-      code: "SCHEMA_CONVERSION_FAILED",
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
-}
 
 /**
  * Read-only catalog and describe tools for the canonical ADV tool surface.
@@ -1314,40 +1255,22 @@ const PUBLIC_TOOL_GROUPS = [
   advInvokeTools,
 ] as const satisfies readonly PublicToolGroup[];
 
-const PUBLIC_TOOL_ENTRIES: readonly PublicToolEntry[] = Object.freeze(
+export const PUBLIC_TOOL_ENTRIES: readonly PublicToolEntry[] = Object.freeze(
   collectPublicToolEntries(PUBLIC_TOOL_GROUPS),
 );
 
 /**
  * Live tool-surface lookup (addAcWarrantGuard): tool name → set of declared
  * argument keys, derived from PUBLIC_TOOL_ENTRIES (data only — no `execute`
- * invocation). This is the source of truth used to verify capability warrants
- * at contract mint. Because it derives from the same typed inventory as
- * ADV_TOOL_NAMES, the warrant surface cannot drift from the canonical list
- * (DDC1), and per-tool argument keys always equal the declared definition
- * keys (DDC3).
- *
- * Consumed by `adv_contract_mint` via a runtime dynamic import so the pure
- * `validator/contract-mint.ts` / `validator/warrant.ts` never statically import
- * the registry (no import cycle).
+ * invocation). Backward-compat wrapper: the imported pure function takes
+ * entries explicitly; this wrapper binds PUBLIC_TOOL_ENTRIES for the legacy
+ * no-arg API. The pure function is re-exported from ./tool-catalog-entries
+ * for new MCP consumers.
  */
 export function getToolSurface(): Map<string, Set<string>> {
-  const surface = new Map<string, Set<string>>();
-  for (const entry of PUBLIC_TOOL_ENTRIES) {
-    surface.set(entry.name, new Set(Object.keys(entry.args)));
-  }
-  return surface;
+  return getToolSurfaceFromEntries(PUBLIC_TOOL_ENTRIES);
 }
 
-/**
- * SC1 source baseline: the number of registered public ADV tools recorded at
- * the start of consolidateAdvToolSurface2 implementation (2026-07-15). The
- * final canonical count must be strictly lower once this change's contracted
- * public removals (adv_backlog_state, adv_project_wisdom_list) land; the
- * baseline/final exact-accounting assertion lives in
- * tool-registry.inventory.test.ts.
- */
-export const ADV_PUBLIC_TOOL_BASELINE_COUNT = 80;
 
 /**
  * Canonical list of all ADV tool names, derived from PUBLIC_TOOL_GROUPS.
@@ -1360,284 +1283,6 @@ export const ADV_TOOL_NAMES: readonly string[] = Object.freeze(
   PUBLIC_TOOL_ENTRIES.map((entry) => entry.name),
 );
 
-/**
- * Canonical descriptive metadata for every retained ADV tool.
- *
- * Owned facts only: realm, group, lifecycle gates, risk, and recovery-only
- * flag. This table does NOT copy authority from TOOL_ROLE_POLICY (class,
- * agentActions, operatorActions, rationale) or manifest grants from
- * AGENT_TOOL_POLICY (allowed, explicitBlocked, denyWildcard). It is a
- * descriptive, non-authorizing source used by catalog/describe projections
- * and profile authoring (addAdvanceMetadata SC4/AC1/AC5/C1/C2/C5).
- */
-
-export type ToolRealm =
-  | "archive"
-  | "backlog"
-  | "change"
-  | "conformance"
-  | "contract"
-  | "design"
-  | "epic"
-  | "followup"
-  | "gate"
-  | "lightweight"
-  | "ops"
-  | "project"
-  | "reflection"
-  | "report"
-  | "session"
-  | "snapshot"
-  | "spec"
-  | "status"
-  | "store"
-  | "task"
-  | "temporal"
-  | "test"
-  | "tool"
-  | "verification"
-  | "wisdom"
-  | "worktree";
-
-export type ToolGroup =
-  | "bulk"
-  | "diagnostics"
-  | "lifecycle"
-  | "metadata"
-  | "read"
-  | "repair"
-  | "write";
-
-export type ToolLifecycleGate =
-  | "proposal"
-  | "discovery"
-  | "design"
-  | "planning"
-  | "execution"
-  | "acceptance"
-  | "release";
-
-export interface ToolMetadataV1 {
-  readonly realm: ToolRealm;
-  readonly group: ToolGroup;
-  readonly lifecycle: ReadonlyArray<ToolLifecycleGate>;
-  readonly risk: "low" | "medium" | "high" | "operator";
-  readonly recoveryOnly: boolean;
-}
-
-const REALM_OVERRIDES: Record<string, ToolRealm> = {
-  adv_conformance: "conformance",
-  adv_delta_add: "spec",
-  adv_delta_modify: "spec",
-  adv_design_concern_disposition: "design",
-  adv_followup_promote: "followup",
-  adv_report_followup_promote: "report",
-  adv_subagent_report_submit: "report",
-  adv_run_test: "test",
-  adv_snapshot_health: "snapshot",
-  adv_spec: "spec",
-  adv_status: "status",
-  adv_wip_state: "status",
-  adv_lightweight_profile_evaluate: "lightweight",
-  adv_verification_evidence_disposition: "verification",
-  adv_reflect: "reflection",
-  adv_reflection_list: "reflection",
-};
-
-const REALM_PREFIXES: ReadonlyArray<readonly [string, ToolRealm]> = [
-  ["adv_archive_", "archive"],
-  ["adv_backlog_", "backlog"],
-  ["adv_change_", "change"],
-  ["adv_contract_", "contract"],
-  ["adv_epic_", "epic"],
-  ["adv_gate_", "gate"],
-  ["adv_ops_", "ops"],
-  ["adv_project_", "project"],
-  ["adv_session_", "session"],
-  ["adv_store_", "store"],
-  ["adv_task_", "task"],
-  ["adv_temporal_", "temporal"],
-  ["adv_tool_", "tool"],
-  ["adv_worktree_", "worktree"],
-  ["adv_wisdom_", "wisdom"],
-];
-
-function deriveToolRealm(name: string): ToolRealm {
-  const override = REALM_OVERRIDES[name];
-  if (override) return override;
-  for (const [prefix, realm] of REALM_PREFIXES) {
-    if (name.startsWith(prefix)) return realm;
-  }
-  return "change";
-}
-
-const GROUP_OVERRIDES: Record<string, ToolGroup> = {
-  // Repair / operator-only recovery surface
-  adv_archive_purge: "repair",
-  adv_archive_repair: "repair",
-  adv_change_repair_origin: "repair",
-  adv_change_status_repair: "repair",
-  adv_change_workflow_terminate: "repair",
-  adv_store_cleanup: "repair",
-  adv_store_consolidate: "repair",
-  adv_temporal_reconnect: "repair",
-  adv_temporal_register_search_attributes: "repair",
-  adv_temporal_worker_restart: "repair",
-
-  // Diagnostics / read-heavy analysis surface
-  adv_change_validate: "diagnostics",
-  adv_conformance: "diagnostics",
-  adv_design_concern_disposition: "diagnostics",
-  adv_lightweight_profile_evaluate: "diagnostics",
-  adv_run_test: "diagnostics",
-  adv_snapshot_health: "diagnostics",
-  adv_temporal_diagnose: "diagnostics",
-  adv_verification_evidence_disposition: "diagnostics",
-
-  // Metadata / submission surface
-  adv_project_metadata: "metadata",
-  adv_reflect: "metadata",
-  adv_subagent_report_submit: "metadata",
-
-  // Read surface
-  adv_backlog_list: "read",
-  adv_backlog_show: "read",
-  adv_change_list: "read",
-  adv_change_show: "read",
-  adv_epic_list: "read",
-  adv_epic_show: "read",
-  adv_gate_status: "read",
-  adv_project_context: "read",
-  adv_reflection_list: "read",
-  adv_session_list: "read",
-  adv_session_show: "read",
-  adv_spec: "read",
-  adv_status: "read",
-  adv_task_list: "read",
-  adv_task_ready: "read",
-  adv_task_show: "read",
-  adv_tool_catalog: "read",
-  adv_tool_describe: "read",
-  adv_wip_state: "read",
-  adv_wisdom_list: "read",
-  adv_worktree_triage: "read",
-
-  // Lifecycle transitions
-  adv_backlog_promote: "lifecycle",
-  adv_change_archive: "lifecycle",
-  adv_change_reenter: "lifecycle",
-  adv_epic_add_shell: "lifecycle",
-  adv_epic_promote_shell: "lifecycle",
-  adv_followup_promote: "lifecycle",
-  adv_gate_complete: "lifecycle",
-  adv_report_followup_promote: "lifecycle",
-  adv_worktree_resume: "lifecycle",
-
-  // Bulk operations
-  adv_change_bulk_close: "bulk",
-};
-
-const LIFECYCLE_BY_REALM: Readonly<
-  Record<ToolRealm, ReadonlyArray<ToolLifecycleGate>>
-> = {
-  archive: ["release"],
-  backlog: ["proposal", "discovery"],
-  change: [
-    "proposal",
-    "discovery",
-    "design",
-    "planning",
-    "execution",
-    "acceptance",
-    "release",
-  ],
-  conformance: ["acceptance"],
-  contract: ["discovery", "planning"],
-  design: ["execution"],
-  epic: ["proposal", "discovery", "planning", "execution"],
-  followup: ["execution", "acceptance"],
-  gate: ["acceptance", "release"],
-  lightweight: ["execution"],
-  ops: ["execution"],
-  project: [
-    "proposal",
-    "discovery",
-    "design",
-    "planning",
-    "execution",
-    "acceptance",
-    "release",
-  ],
-  reflection: ["release"],
-  report: ["execution", "acceptance"],
-  session: [
-    "proposal",
-    "discovery",
-    "design",
-    "planning",
-    "execution",
-    "acceptance",
-    "release",
-  ],
-  snapshot: [
-    "proposal",
-    "discovery",
-    "design",
-    "planning",
-    "execution",
-    "acceptance",
-    "release",
-  ],
-  spec: ["proposal", "discovery"],
-  status: [
-    "proposal",
-    "discovery",
-    "design",
-    "planning",
-    "execution",
-    "acceptance",
-    "release",
-  ],
-  store: ["release"],
-  task: ["planning", "execution"],
-  temporal: ["execution", "acceptance", "release"],
-  test: ["execution", "acceptance"],
-  tool: [
-    "proposal",
-    "discovery",
-    "design",
-    "planning",
-    "execution",
-    "acceptance",
-    "release",
-  ],
-  verification: ["acceptance"],
-  wisdom: ["execution", "acceptance", "release"],
-  worktree: ["execution"],
-};
-
-const REPAIR_LIFECYCLE: ReadonlyArray<ToolLifecycleGate> = [
-  "execution",
-  "acceptance",
-  "release",
-];
-
-function deriveToolMetadata(name: string): ToolMetadataV1 {
-  const realm = deriveToolRealm(name);
-  const group = GROUP_OVERRIDES[name] ?? "write";
-  const lifecycle: ReadonlyArray<ToolLifecycleGate> =
-    group === "repair" ? REPAIR_LIFECYCLE : LIFECYCLE_BY_REALM[realm];
-  const risk: ToolMetadataV1["risk"] =
-    group === "repair"
-      ? "operator"
-      : group === "bulk" || group === "write"
-        ? "high"
-        : group === "diagnostics"
-          ? "medium"
-          : "low";
-  const recoveryOnly = group === "repair";
-  return { realm, group, lifecycle, risk, recoveryOnly };
-}
 
 export const ADV_TOOL_METADATA: Readonly<Record<string, ToolMetadataV1>> =
   Object.freeze(

--- a/plugin/tsup.config.ts
+++ b/plugin/tsup.config.ts
@@ -1,8 +1,15 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  // Object form flattens output: src/mcp-server/index.ts → dist/mcp-server.js
+  // (array form preserves source path structure → dist/mcp-server/index.js,
+  // which breaks the bundle-manifest + deploy paths expecting dist/mcp-server.js).
+  entry: {
+    index: "src/index.ts",
+    "mcp-server": "src/mcp-server/index.ts",
+  },
   format: ["esm"],
+  splitting: false,
   dts: true,
   clean: true,
   external: ["@opencode-ai/plugin"],

--- a/scripts/check-release-gate.sh
+++ b/scripts/check-release-gate.sh
@@ -56,11 +56,31 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # Active changes include draft + in-flight. If prerequisite appears here, gate fails.
-STATUS_JSON="$("$ADV_BIN" status --json 2>/dev/null || printf '{"changes":[]}')"
+# Fail-closed: if `adv status` itself fails (Temporal down, ADV_BIN broken, parse error),
+# the shell substitution returns non-zero and `set -e` aborts before we reach the
+# IS_ACTIVE check. Never fall back to empty-changes (that would incorrectly pass the gate).
+ADV_STATUS_OUTPUT="$("$ADV_BIN" status --json 2>&1 1>/dev/null)" || true
+STATUS_JSON="$("$ADV_BIN" status --json 2>/dev/null)" || STATUS_JSON=""
+if [ -z "$STATUS_JSON" ]; then
+  echo "RELEASE GATE UNKNOWN: adv status --json failed or produced no output" >&2
+  echo "  ADV_BIN: $ADV_BIN" >&2
+  echo "  stderr: $ADV_STATUS_OUTPUT" >&2
+  echo "  Cannot determine status of prerequisite $PREREQ." >&2
+  echo "  Dependent: $DEPENDENT -- refuse release until prerequisite status is verifiable." >&2
+  exit 2
+fi
 
-IS_ACTIVE="$(printf '%s' "$STATUS_JSON" | jq -r --arg id "$PREREQ" '
-  if (.changes // []) | any(.id == $id) then "yes" else "no" end
-')"
+# Sanity: parsed JSON must have a `changes` array; otherwise the schema changed and we
+# cannot safely interpret absence as "not active". Fail-closed on schema drift.
+if ! printf '%s' "$STATUS_JSON" | jq -e '.changes | type == "array"' >/dev/null 2>&1; then
+  echo "RELEASE GATE UNKNOWN: adv status --json output schema drift (no .changes array)" >&2
+  echo "  Cannot safely determine status of $PREREQ." >&2
+  echo "  Dependent: $DEPENDENT -- refuse release until ADV status schema is reconciled." >&2
+  exit 2
+fi
+
+IS_ACTIVE="$(printf '%s' "$STATUS_JSON" | jq -r --arg id "$PREREQ" \
+  '.changes | map(.id) | index($id) | if . then "yes" else "no" end')"
 
 case "$IS_ACTIVE" in
   yes)

--- a/scripts/check-release-gate.sh
+++ b/scripts/check-release-gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# scripts/check-release-gate.sh
+#
+# Static-check gate: refuse release of a dependent change until its prerequisite
+# sibling change has shipped (no longer in the ADV active-changes list).
+#
+# Usage:
+#   scripts/check-release-gate.sh <prerequisite-change-id> <dependent-change-id>
+#
+# Examples:
+#   scripts/check-release-gate.sh slimMutationToolSurface addAdvMcpReadSurface
+#
+# Exit codes:
+#   0 — prerequisite is no longer active; safe to release dependent
+#   1 — prerequisite is still active; refuse dependent release
+#   2 — unable to determine prerequisite status (tooling missing / parse failure)
+#
+# Environment:
+#   ADV_BIN — override adv CLI path (default: `adv` on PATH, or ~/dev/advance/bin/adv)
+#
+# Used by:
+#   - Release-evidence collection for changes with constraint C1 (release-after
+#     sibling). Example: addAdvMcpReadSurface AC11 / C1 depends on
+#     slimMutationToolSurface shipping first.
+
+set -euo pipefail
+
+PREREQ="${1:-}"
+DEPENDENT="${2:-}"
+
+if [ -z "$PREREQ" ] || [ -z "$DEPENDENT" ]; then
+  echo "Usage: $0 <prerequisite-change-id> <dependent-change-id>" >&2
+  echo "Example: $0 slimMutationToolSurface addAdvMcpReadSurface" >&2
+  exit 2
+fi
+
+# Resolve adv CLI
+ADV_BIN="${ADV_BIN:-}"
+if [ -z "$ADV_BIN" ]; then
+  if command -v adv >/dev/null 2>&1; then
+    ADV_BIN="adv"
+  elif [ -x "$HOME/dev/advance/bin/adv" ]; then
+    ADV_BIN="$HOME/dev/advance/bin/adv"
+  fi
+fi
+
+if [ -z "$ADV_BIN" ]; then
+  echo "RELEASE GATE ERROR: adv CLI not found on PATH or at ~/dev/advance/bin/adv" >&2
+  echo "  Set ADV_BIN to override." >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "RELEASE GATE ERROR: jq not found on PATH (required for JSON parsing)" >&2
+  exit 2
+fi
+
+# Active changes include draft + in-flight. If prerequisite appears here, gate fails.
+STATUS_JSON="$("$ADV_BIN" status --json 2>/dev/null || printf '{"changes":[]}')"
+
+IS_ACTIVE="$(printf '%s' "$STATUS_JSON" | jq -r --arg id "$PREREQ" '
+  if (.changes // []) | any(.id == $id) then "yes" else "no" end
+')"
+
+case "$IS_ACTIVE" in
+  yes)
+    echo "RELEASE GATE FAILED: $PREREQ is still active (not shipped)" >&2
+    echo "  Required by: $DEPENDENT (constraint C1 — release-after-sibling)" >&2
+    echo "  Resolution: complete + archive $PREREQ before releasing $DEPENDENT." >&2
+    exit 1
+    ;;
+  no)
+    echo "RELEASE GATE OK: $PREREQ is no longer in the active changes list"
+    echo "  Dependent ($DEPENDENT) is clear to release."
+    exit 0
+    ;;
+  *)
+    echo "RELEASE GATE UNKNOWN: could not parse adv status output for $PREREQ" >&2
+    echo "  Raw adv status output (first 200 chars): $(printf '%s' "$STATUS_JSON" | head -c 200)" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -215,7 +215,7 @@ plugin_dist_stale_reason() {
 	fi
 
 	local output_rel output
-	for output_rel in dist/index.js dist/plugin-bundle-manifest.json dist/temporal/worker.js dist/temporal/workflows.js dist/temporal/bundle-manifest.json; do
+	for output_rel in dist/index.js dist/mcp-server.js dist/plugin-bundle-manifest.json dist/temporal/worker.js dist/temporal/workflows.js dist/temporal/bundle-manifest.json; do
 		output="$ADV_SOURCE_PLUGIN_PATH/$output_rel"
 		if [ ! -f "$output" ]; then
 			printf '%s\n' "plugin dist output is missing: $output_rel"
@@ -278,12 +278,13 @@ check_rsync() {
 
 PLUGIN_BUNDLE_MANIFEST_BASENAME="plugin-bundle-manifest.json"
 
-# Validate that the copied plugin bundle index matches the SHA-256 recorded in
-# the manifest. Requires jq and sha256sum (or shasum on macOS). Returns non-zero
-# on mismatch, missing manifest, or missing tools.
+# Validate that the copied plugin bundle artifacts match the SHA-256s recorded
+# in the manifest. Requires jq and sha256sum (or shasum on macOS). Returns
+# non-zero on mismatch, missing manifest, or missing tools. Older manifests
+# that lack files.mcp-server are still validated for files.index.
 validate_plugin_bundle_manifest() {
 	local manifest_path="$1"
-	local index_path="$2"
+	local dist_dir="$2"
 
 	if [ ! -f "$manifest_path" ]; then
 		echo "    ✗  plugin bundle manifest missing: $manifest_path"
@@ -296,28 +297,46 @@ validate_plugin_bundle_manifest() {
 		return 1
 	fi
 
+	__validate_file_hash() {
+		local file_path="$1" expected_hash="$2" label="$3"
+		local actual_hash
+		if command -v sha256sum &>/dev/null; then
+			actual_hash="$(sha256sum "$file_path" | awk '{print $1}')"
+		elif command -v shasum &>/dev/null; then
+			actual_hash="$(shasum -a 256 "$file_path" | awk '{print $1}')"
+		else
+			echo "    ✗  sha256sum or shasum required to validate plugin bundle"
+			return 1
+		fi
+		if [ "$expected_hash" != "$actual_hash" ]; then
+			echo "    ✗  plugin bundle $label hash mismatch"
+			echo "       manifest: $expected_hash"
+			echo "       actual:   $actual_hash"
+			return 1
+		fi
+		return 0
+	}
+
 	local expected_hash
 	expected_hash="$(jq -r '.files.index // empty' "$manifest_path" 2>/dev/null)"
 	if [ -z "$expected_hash" ] || ! [[ "$expected_hash" =~ ^[0-9a-f]{64}$ ]]; then
 		echo "    ✗  plugin bundle manifest has no valid files.index hash: $manifest_path"
 		return 1
 	fi
-
-	local actual_hash
-	if command -v sha256sum &>/dev/null; then
-		actual_hash="$(sha256sum "$index_path" | awk '{print $1}')"
-	elif command -v shasum &>/dev/null; then
-		actual_hash="$(shasum -a 256 "$index_path" | awk '{print $1}')"
-	else
-		echo "    ✗  sha256sum or shasum required to validate plugin bundle"
+	if ! __validate_file_hash "$dist_dir/index.js" "$expected_hash" "index"; then
 		return 1
 	fi
 
-	if [ "$expected_hash" != "$actual_hash" ]; then
-		echo "    ✗  plugin bundle index hash mismatch"
-		echo "       manifest: $expected_hash"
-		echo "       actual:   $actual_hash"
-		return 1
+	local expected_mcp_hash
+	expected_mcp_hash="$(jq -r '.files["mcp-server"] // empty' "$manifest_path" 2>/dev/null)"
+	if [ -n "$expected_mcp_hash" ]; then
+		if ! [[ "$expected_mcp_hash" =~ ^[0-9a-f]{64}$ ]]; then
+			echo "    ✗  plugin bundle manifest has no valid files.mcp-server hash: $manifest_path"
+			return 1
+		fi
+		if ! __validate_file_hash "$dist_dir/mcp-server.js" "$expected_mcp_hash" "mcp-server"; then
+			return 1
+		fi
 	fi
 
 	return 0


### PR DESCRIPTION
## Summary

Adds a managed MCP server exposing ADV Tier-4 read-only tools as `tools.adv.*` in OpenCode Code Mode. Combined with sibling `slimMutationToolSurface` (pending), reduces per-prompt tool-schema weight ~83% (83 → 14 top-level tools).

## What's in this PR

- **NEW MCP server** (`plugin/src/mcp-server/`) — stdio subprocess using `@modelcontextprotocol/sdk` v1.29.0, deployed per-project under Vision HTTP termination
- **13 Tier-4 read tools**: status, spec, wisdom_list, reflection_list, project_context, backlog_list/show, epic_list/show, wip_state, worktree_triage, tool_catalog, tool_describe
- **SDK-free catalog module** (`plugin/src/tool-catalog-entries.ts`) — types + pure functions extracted from `tool-registry.ts`; MCP decoupled from `@opencode-ai/plugin`
- **Per-tool runtime degradation wrapper** — detects Temporal/host-probe unavailability at call time; tags responses with `{degraded:true, source:...}`
- **Security-boundary rejection** — 19 mutation-shaped arg names + signal* prefix + 9 mutating kind/action values rejected with identical typed error schema
- **Deploy pipeline** — bundle manifest extended to hash both `dist/index.js` + `dist/mcp-server.js` atomically; `scripts/deploy-local.sh` deploys both
- **Release gate** (`scripts/check-release-gate.sh`) — refuses release until sibling `slimMutationToolSurface` ships (constraint C1)
- **ADR 0008** — documents stdio-via-Vision topology + operator deployment runbook

## Test plan

- [x] `bin/oc-test smoke` — 87/87 pass (schemas + typecheck + manifests + isolation + lockfile + lint + format + tests)
- [x] `pnpm run build` — produces `dist/index.js` + `dist/mcp-server.js` + atomic manifest
- [x] `pnpm vitest run src/mcp-server/` — 40/40 pass
- [x] Merge compatibility — clean dry-run with origin/trunk
- [ ] CI green (this PR)
- [ ] Post-merge: operator deploys per ADR 0008 runbook (Vision entry + OpenCode config)
- [ ] Post-merge: archive blocked on C1 until `slimMutationToolSurface` ships

## Contract

- 25/25 contract items pass/respected (4 SC + 11 AC + 5 C + 5 DONT)
- AMEND-1: catalog reduced 18→13 tools (validator surfaced DONT1 conflicts in reflect/project_metadata/conformance + host-PID ACL in session_list/show)
- AMEND-3: SDK-free extraction deviation — types/functions only; runtime data via dynamic import (matches `adv_contract_mint` pattern)
- AMEND-4: `adv_contract_version=1` tracks handshake schema shape, not plugin/SDK version

## Follow-ups (deferred, non-blocking)

- DDC5 conformance corpus depth (1/13 → target 11/13)
- Per-tool Zod schema migration (currently passthrough)
- design.md AMEND-3/4 formal propagation (captured in ADR 0008 + wisdom ws-61TO7q)

## Cross-MCP compatibility

Verified structurally isolated from existing MCP servers (episode Rust, lgrep/context7/exa/svelte/notion TS). Distinct namespaces (`tools.adv.*` vs `tools.episode.*`), distinct ports (6298+ vs episode=6297/lgrep=6278), distinct storage. Episode reads `~/.local/share/opencode-projects/{id}/wisdom.jsonl` + `reflections.jsonl` for indexing — this design preserves those paths/formats (read/read overlap only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)