### PR TITLE
fix(deploy): pass dist dir to validate_plugin_bundle_manifest

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1416,7 +1416,7 @@ else
 	mkdir -p "$ADV_RUNTIME_PLUGIN_PATH"
 	rsync -a --delete --exclude="dist/$PLUGIN_BUNDLE_MANIFEST_BASENAME" "$ADV_SOURCE_PLUGIN_PATH/" "$ADV_RUNTIME_PLUGIN_PATH/"
 	echo "    synced runtime plugin payload: $ADV_RUNTIME_PLUGIN_PATH"
-	if ! validate_plugin_bundle_manifest "$PLUGIN_BUNDLE_MANIFEST" "$ADV_RUNTIME_PLUGIN_PATH/dist/index.js"; then
+	if ! validate_plugin_bundle_manifest "$PLUGIN_BUNDLE_MANIFEST" "$ADV_RUNTIME_PLUGIN_PATH/dist"; then
 		echo "    ✗  refusing to publish plugin bundle manifest: copied index validation failed"
 		exit 1
 	fi


### PR DESCRIPTION
One-line fix for deploy regression from #268. validate_plugin_bundle_manifest was refactored to take dist_dir (directory) + append /index.js internally, but call site at line 1419 was not updated — still passed dist/index.js (file path). Result: sha256sum tried to hash dist/index.js/index.js → 'Not a directory'.

Fix: pass $ADV_RUNTIME_PLUGIN_PATH/dist (directory).