### PR TITLE
fix(build): bundle @modelcontextprotocol/sdk into mcp-server.js

### DIFF
--- a/plugin/tsup.config.ts
+++ b/plugin/tsup.config.ts
@@ -13,4 +13,9 @@ export default defineConfig({
   dts: true,
   clean: true,
   external: ["@opencode-ai/plugin"],
+  // Bundle @modelcontextprotocol/sdk into dist/mcp-server.js so the deployed
+  // artifact is self-contained (no node_modules needed at runtime path).
+  // tsup externalizes all dependencies by default; this overrides for the SDK
+  // which mcp-server.js imports via subpath exports.
+  noExternal: ["@modelcontextprotocol/sdk"],
 });


### PR DESCRIPTION
tsup externalizes all dependencies by default. Deployed runtime has no node_modules/ so mcp-server.js failed with ERR_MODULE_NOT_FOUND. Fix: noExternal for the SDK.