### PR TITLE
fix(mcp-server): auto-start on direct entry point

### DIFF
--- a/plugin/src/mcp-server/index.ts
+++ b/plugin/src/mcp-server/index.ts
@@ -154,3 +154,10 @@ export async function startServer(
 
   await mcp.server.connect(transport);
 }
+
+// Auto-start when run as a direct entry point (dist/mcp-server.js).
+// When imported as a module (e.g. in tests), startServer must be called explicitly.
+startServer().catch((err) => {
+  console.error("[adv-mcp-server] Fatal startup error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
startServer() was exported but never called. MCP server loaded and exited without binding transport → EOF on initialize. Fix: top-level startServer() call.