### PR TITLE
chore(opencode): add per-project mcp.adv config

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.opencode.ai/config.json",
+  "mcp": {
+    "adv": {
+      "type": "remote",
+      "url": "http://localhost:6298/mcp",
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
Per-project .opencode/opencode.json adding mcp.adv remote entry pointing to Vision port 6298. Only advance-project sessions get tools.adv.*. See ADR 0008.