### PR TITLE
fix(adv): adv-ci-waiter never remediates — parent owns fix (fixAdvCiWaiterRemediation)

### DIFF
--- a/.adv/specs/advance-workflow/spec.json
+++ b/.adv/specs/advance-workflow/spec.json
@@ -787,7 +787,7 @@
           "id": "rq-releaseFinalization04.2",
           "title": "Blocked (no PR / no auth / red CI) preserves active state",
           "given": [
-            "The waiter reports blocked: no PR exists, GitHub auth is missing, or red CI cannot be remediated after the waiter’s bounded attempt budget"
+            "The waiter reports blocked: no PR exists, GitHub auth is missing, or red CI is reported by the waiter and remediation is the parent orchestrator's responsibility (the waiter has `edit: deny` and no bounded attempt budget)"
           ],
           "when": "ADV concludes the auto-drive",
           "then": [

--- a/.opencode/agents/adv-ci-waiter.md
+++ b/.opencode/agents/adv-ci-waiter.md
@@ -45,6 +45,17 @@ Rules:
 
 `oc-ci-wait` reports CI terminal states. Its `conclusion` is CI success or failure, not PR merge state. Do not report `MERGED` based on `oc-ci-wait` output alone. PR `MERGED` requires separate PR-state evidence (`gh pr view <number> --json state,mergedAt,mergeCommit`). When CI success is reported but PR state is not `MERGED`, hand back honestly with a `Pending auto-merge.`-shaped terminal so the parent flow can keep the change active.
 
+## On red CI: return, do not remediate
+
+You have `edit: deny`, `morph_edit: deny`, `task: deny`. You cannot remediate anything. When CI concludes `failure`:
+
+1. Stop polling immediately (do not retry the failing run).
+2. Classify the failing checks: name, URL, and a brief log excerpt (≤500 chars total across all failing checks).
+3. Return to the parent with: `conclusion: failure`, the failing-checks list, and `next action: parent classifies and remediates in the PR worktree`.
+4. Do NOT attempt to fix code, push commits, edit files, or re-spawn yourself. Do NOT call `question` to ask the user how to remediate.
+
+Remediation is the parent orchestrator's responsibility, not yours. The parent reads your classification, inspects logs/artifacts as needed, fixes in the PR worktree, pushes, and re-spawns you to watch the next run.
+
 ## Bounded output
 
 - Do not dump raw logs unless needed for failing-check summary.

--- a/.opencode/command/adv-archive.md
+++ b/.opencode/command/adv-archive.md
@@ -509,7 +509,7 @@ Emit `GIT FINALIZATION COMPLETE` only after Step 6 final proof. Include: commit 
    ```
    Read the nested fields from `finalization.*`, not top-level.
 
-2. **Spawn the waiter.** Use the Task tool to spawn `adv-ci-waiter` with `{ repo, prNumber, prUrl }`. Cite `~/.config/opencode/instructions/oc-ci-wait.md` for the polling contract — the **main agent never polls CI itself** (P37). `oc-ci-wait` (called by `adv-ci-waiter`) owns GitHub API polling and rate-limit backoff; the sub-agent samples `oc-ci-wait result --watch-id <id> --json` every 20–30 seconds. CI terminal statuses are `completed`, `timeout`, `cancelled`, `error`; `conclusion` is CI success/failure, NOT PR merge state.
+2. **Spawn the waiter.** Use the Task tool to spawn `adv-ci-waiter` with `{ repo, prNumber, prUrl }`. Cite `~/.config/opencode/instructions/oc-ci-wait.md` for the polling contract — the **main agent never polls CI itself** (P37). `oc-ci-wait` (called by `adv-ci-waiter`) owns GitHub API polling and rate-limit backoff; the sub-agent samples `oc-ci-wait result --watch-id <id> --json` every 20–30 seconds. CI terminal statuses are `completed`, `timeout`, `cancelled`, `error`; `conclusion` is CI success/failure, NOT PR merge state. The waiter polls and reports only — it has `edit: deny` and cannot remediate. If CI fails, the waiter returns to the parent (you) with classification (failing check names, URLs, log excerpt); the parent classifies the cause, remediates in the PR worktree, pushes the fix, and re-spawns the waiter. Do not ask the waiter to remediate.
 
 3. **Branch on the terminal result.**
    - **CI success, `PR state == MERGED`** (verified via `gh pr view <number> --json state,mergedAt,mergeCommit`):

--- a/docs/specs/advance-workflow.md
+++ b/docs/specs/advance-workflow.md
@@ -710,7 +710,7 @@ When the spawned “adv-ci-waiter” returns a non-terminal outcome (timeout, bl
 **Blocked (no PR / no auth / red CI) preserves active state** (`rq-releaseFinalization04.2`)
 
 **Given:**
-- The waiter reports blocked: no PR exists, GitHub auth is missing, or red CI cannot be remediated after the waiter’s bounded attempt budget
+- The waiter reports blocked: no PR exists, GitHub auth is missing, or red CI is reported by the waiter and remediation is the parent orchestrator's responsibility (the waiter has `edit: deny` and no bounded attempt budget)
 
 **When:** ADV concludes the auto-drive
 

--- a/plugin/src/__fixtures__/codemode-mcp-contract-baseline.json
+++ b/plugin/src/__fixtures__/codemode-mcp-contract-baseline.json
@@ -6,7 +6,7 @@
   "contractBytes": 305,
   "prompts": {
     "adv-ci-waiter": {
-      "bytes": 4223,
+      "bytes": 5060,
       "mcpCapable": false,
       "grants": []
     },
@@ -95,7 +95,10 @@
     "adv-temporal-repair": {
       "bytes": 5987,
       "mcpCapable": true,
-      "grants": ["lgrep_get_file_outline=true", "lgrep_search_text=true"]
+      "grants": [
+        "lgrep_get_file_outline=true",
+        "lgrep_search_text=true"
+      ]
     },
     "adv-tron": {
       "bytes": 10295,

--- a/plugin/src/__fixtures__/codemode-mcp-contract-baseline.json
+++ b/plugin/src/__fixtures__/codemode-mcp-contract-baseline.json
@@ -95,10 +95,7 @@
     "adv-temporal-repair": {
       "bytes": 5987,
       "mcpCapable": true,
-      "grants": [
-        "lgrep_get_file_outline=true",
-        "lgrep_search_text=true"
-      ]
+      "grants": ["lgrep_get_file_outline=true", "lgrep_search_text=true"]
     },
     "adv-tron": {
       "bytes": 10295,

--- a/plugin/src/adv-ci-waiter-assets.test.ts
+++ b/plugin/src/adv-ci-waiter-assets.test.ts
@@ -96,4 +96,29 @@ describe("adv-ci-waiter assets", () => {
       /(PR\s+state\s*==\s*MERGED|MERGED[^.\n]*PR\s+state|state[^.\n]*MERGED|PR[^.\n]*MERGED|MERGED[^.\n]*PR)/i,
     );
   });
+
+  test("on red CI: returns to parent with classification, does NOT remediate", () => {
+    // The waiter has edit: deny, morph_edit: deny, task: deny. It cannot
+    // remediate anything. The previous spec implied it had a "bounded
+    // remediation budget" — that was wrong. The agent manifest must make
+    // the boundary explicit so parents don't hand off remediation to it.
+    const content = readFileSync(AGENT_PATH, "utf8");
+
+    // Must have a dedicated section calling out red-CI behavior.
+    expect(content).toMatch(/## .*red CI/i);
+
+    // Must explicitly tell the waiter NOT to remediate.
+    expect(content).toMatch(/do\s+not\s+(?:attempt\s+to\s+)?remediate/i);
+
+    // Must classify failing checks (name + URL + log excerpt) so the parent
+    // has enough info to remediate without re-running CI discovery.
+    expect(content).toMatch(/classif/i);
+    expect(content).toMatch(/failing\s+checks?/i);
+
+    // Must state that remediation is the parent's job.
+    expect(content).toMatch(/parent/i);
+    expect(content).toMatch(
+      /parent[^.\n]{0,40}(?:responsibility|orchestrator)/i,
+    );
+  });
 });

--- a/plugin/src/adv-ci-waiter-assets.test.ts
+++ b/plugin/src/adv-ci-waiter-assets.test.ts
@@ -121,4 +121,19 @@ describe("adv-ci-waiter assets", () => {
       /parent[^.\n]{0,40}(?:responsibility|orchestrator)/i,
     );
   });
+
+  test("adv-archive.md spawn language assigns remediation to parent, not waiter", () => {
+    // The archive command spawns adv-ci-waiter. Its spawn language must
+    // reflect the corrected policy: waiter reports; parent remediates.
+    const content = readFileSync(ARCHIVE_COMMAND, "utf8");
+
+    // Must state the waiter cannot remediate.
+    expect(content).toMatch(/cannot remediate/i);
+
+    // Must direct the parent (you) to remediate.
+    expect(content).toMatch(/parent[^.\n]{0,40}(?:remediat|classif)/i);
+
+    // Must NOT instruct anyone to "ask the waiter to remediate".
+    expect(content).toMatch(/do not ask the waiter to remediate/i);
+  });
 });

--- a/plugin/src/archive-release-finalization-assets.test.ts
+++ b/plugin/src/archive-release-finalization-assets.test.ts
@@ -89,4 +89,35 @@ describe("archive release-finalization docs/spec assets", () => {
     expect(instructions).toContain("adv_archive_repair");
     expect(instructions).not.toMatch(/PR-mode branch-push handoff/i);
   });
+
+  test("rq-releaseFinalization04.2 does NOT grant the waiter remediation authority", () => {
+    // The waiter has edit: deny, morph_edit: deny, task: deny — it cannot
+    // remediate anything. Earlier spec wording ("the waiter's bounded
+    // attempt budget") implied the waiter had remediation authority; that
+    // was wrong and caused parents to hand off remediation to a worker
+    // that could not act. The spec must now state that remediation is the
+    // parent orchestrator's responsibility, not the waiter's.
+    const spec = JSON.parse(read(SPEC_JSON));
+    const requirement = spec.requirements.find(
+      (r: { id: string }) => r.id === "rq-releaseFinalization04",
+    );
+    expect(requirement, "rq-releaseFinalization04 must exist").toBeTruthy();
+
+    // The misleading phrase must be gone from every requirement body and
+    // scenario in the spec. Match only the old possessive form
+    // ("waiter's bounded attempt budget") so the regex doesn't false-positive
+    // on the new wording ("no bounded attempt budget").
+    const specJson = read(SPEC_JSON);
+    expect(specJson).not.toMatch(/waiter['']s bounded attempt budget/i);
+    expect(specJson).not.toMatch(/cannot be remediated after the waiter/i);
+
+    // The spec must affirmatively assign remediation to the parent.
+    expect(specJson).toMatch(/parent[^.\n]{0,60}(?:remediat|responsibility)/i);
+
+    // The docs/specs mirror must match.
+    const specDoc = read(SPEC_DOC);
+    expect(specDoc).not.toMatch(/waiter['']s bounded attempt budget/i);
+    expect(specDoc).not.toMatch(/cannot be remediated after the waiter/i);
+    expect(specDoc).toMatch(/parent[^.\n]{0,60}(?:remediat|responsibility)/i);
+  });
 });


### PR DESCRIPTION
## Summary

Aligns five policy surfaces on one rule: **adv-ci-waiter polls and reports; the parent orchestrator owns remediation.** The waiter has \`edit: deny\` / \`morph_edit: deny\` / \`task: deny\` — it cannot remediate anything. The previous spec wording (\"waiter's bounded attempt budget\") implied otherwise and caused parents to hand off remediation to a worker that could not act.

## Motivation

Observed incident: PR #269 had red CI. Parent spawned adv-ci-waiter with a remediation prompt. The waiter has no edit tools. User had to cancel and direct the parent to fix it inline. The contradiction between the agent's tool grants and the spec/instruction wording was the root cause.

## Changes

- **\`.opencode/agents/adv-ci-waiter.md\`**: new \"On red CI: return, do not remediate\" section. Explicitly references the waiter's deny grants. Requires classification (failing check name + URL + log excerpt ≤500 chars). Returns to parent with \`conclusion: failure\` + suggested next action.
- **\`.adv/specs/advance-workflow/spec.json\` \`rq-releaseFinalization04.2\`**: removed \"waiter's bounded attempt budget\" wording. New text assigns remediation to parent orchestrator and notes the waiter has \`edit: deny\`.
- **\`docs/specs/advance-workflow.md\`**: mirror updated identically.
- **\`.opencode/command/adv-archive.md\`**: spawn language clarified — \"waiter polls and reports only... Do not ask the waiter to remediate.\"
- **\`~/.config/opencode/instructions/oc-ci-wait.md\`** line 27: host-instruction rewrite (out-of-repo; user-applied).
- **Tests**: 3 new assertions across \`adv-ci-waiter-assets.test.ts\` + \`archive-release-finalization-assets.test.ts\`.
- **Baseline**: bumped adv-ci-waiter byte budget baseline (+837 bytes for the new section).

## Verification

- 13/13 adv-ci-waiter-assets tests pass.
- 5/5 archive-release-finalization tests pass.
- 1/1 mode-guidance byte budget test passes.
- Pre-existing trunk failures (\`ADV_INSTRUCTIONS.md: adv_roadmap\` ref + 3 spec-citation-invariant rq IDs) remain red. These are addressed by parallel PR #269 (fixPacketDefectWorkDiscard, commit 17efce84). They will resolve after #269 merges and this branch rebases.

## Out of scope

- Spawn-time structural validation (rejecting waiter spawn prompts that contain remediation instructions).
- Changes to polling cadence or \`oc-ci-wait\` ownership.
- Removing adv-ci-waiter entirely.

## Dependencies

Rebase after #269 merges to clear pre-existing CI failures.