### PR TITLE
fix(adv): C2 describe-only poison authority remediation

### DIFF
--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -4445,9 +4445,13 @@ describe("change tools — signal-driven lifecycle", () => {
       }
     });
 
-    test("does not archive-status recover from poisoned signal-error text without describe evidence", async () => {
+    test("recovers archive status from poisoned signal-error class without describe evidence (C2)", async () => {
+      // C2 (fixPoisonedRecovery reviewer-block remediation): describe() is NOT
+      // required for recovery. Poisoned-history error class in saveError text
+      // + precise recoveryEvidence is sufficient authority. The previous
+      // behavior required describe() confirmation — that violated C2.
       const tempDir = await createTempDir(
-        "adv-change-archive-poisoned-signal-only-no-recovery-",
+        "adv-change-archive-poisoned-signal-only-recovery-",
       );
       try {
         await prepareNoRemoteReleaseProof(tempDir);
@@ -4482,12 +4486,58 @@ describe("change tools — signal-driven lifecycle", () => {
         );
         const parsed = JSON.parse(result);
 
-        expect(parsed.success).toBe(false);
+        expect(parsed.success).toBe(true);
+        expect(parsed._recoveryMutation).toBe(true);
+        expect(mocks.saveRecoveredChangeStatus).toHaveBeenCalled();
+      } finally {
+        await cleanupTempDir(tempDir);
+      }
+    });
+
+    test("does not recover archive status when saveError is generic and evidence is missing (C2)", async () => {
+      // C2: without precise operator evidence AND without poisoned/completed
+      // error class, recovery MUST NOT fire. describe() cannot authorize.
+      const tempDir = await createTempDir(
+        "adv-change-archive-no-recovery-generic-error-",
+      );
+      try {
+        await prepareNoRemoteReleaseProof(tempDir);
+        const store = createMockStore({ gates: allDoneGates });
+        store.paths.root = tempDir;
+        store.paths.changes = `${tempDir}/changes`;
+        store.paths.archive = `${tempDir}/archive`;
+        await mkdir(`${tempDir}/changes/test-change`, { recursive: true });
+        await writeFile(
+          `${tempDir}/changes/test-change/change.json`,
+          JSON.stringify((await store.changes.get("test-change")).data),
+        );
+        vi.mocked(store.changes.save).mockRejectedValueOnce(
+          new Error("Failed to query Workflow"),
+        );
+        (
+          mocks.handleMock as typeof mocks.handleMock & {
+            describe: ReturnType<typeof vi.fn>;
+          }
+        ).describe = vi.fn(async () => ({
+          rawDescription: "TMPRL1100 Nondeterminism error",
+        }));
+        mocks.queryMock.mockResolvedValueOnce(allDoneGates);
+
+        const result = await changeTools.adv_change_archive.execute(
+          {
+            changeId: "test-change",
+            phase9: "skip",
+            recoveryMode: "poisoned_history",
+            recoveryEvidence: "Failed to query Workflow",
+          },
+          store,
+        );
+        const parsed = JSON.parse(result);
+
+        expect(parsed.success).toBeFalsy();
         expect(parsed._recoveryMutation).toBeUndefined();
         expect(mocks.saveRecoveredChangeStatus).not.toHaveBeenCalled();
-        expect(parsed.error).toContain(
-          "TMPRL1100 nondeterminism while saving archive status",
-        );
+        expect(parsed.error).toMatch(/Failed to query Workflow|TMPRL1100/i);
       } finally {
         await cleanupTempDir(tempDir);
       }

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -3638,25 +3638,28 @@ export const changeTools = {
               // rq-extend-poisoned-recovery AC5: poisoned-workflow disk fallback
               // for final status. Bundle is already written; only the workflow
               // signal that flips the status field fails. Probe + recover.
+              //
+              // C2 (fixPoisonedRecovery reviewer-block remediation): describe()
+              // must NOT be the sole poison authority. Operator-supplied
+              // precise recoveryEvidence is primary; signal saveError class
+              // is secondary. describe() is NOT consulted here.
               if (recoveryMode === "poisoned_history") {
                 try {
                   const {
                     RECOVERY_RECONCILIATION_WARNING,
+                    isPoisonedHistoryError,
                     isWorkflowCompletedError,
+                    isPreciseWorkflowRecoveryEvidence,
                   } = await import("../temporal/recovery-classification");
                   const completedWorkflow = isWorkflowCompletedError(saveError);
-                  let poisoned = false;
-                  if (!completedWorkflow) {
-                    const { workflowHasPoisonedRecoveryEvidence } =
-                      await import("./recovery-probe");
-                    const handle = await getChangeWorkflowHandleForStore(
-                      store,
-                      changeId,
-                    );
-                    poisoned = handle
-                      ? await workflowHasPoisonedRecoveryEvidence(handle)
-                      : false;
-                  }
+                  const operatorEvidenceAuthority =
+                    typeof recoveryEvidence === "string" &&
+                    isPreciseWorkflowRecoveryEvidence(recoveryEvidence);
+                  // C2: error class OR operator evidence — never describe alone.
+                  const poisoned =
+                    !completedWorkflow &&
+                    (operatorEvidenceAuthority ||
+                      isPoisonedHistoryError(saveError));
                   if (completedWorkflow || poisoned) {
                     const { saveRecoveredChangeStatus } =
                       await import("./_recovery-writers");

--- a/plugin/src/tools/gate.test.ts
+++ b/plugin/src/tools/gate.test.ts
@@ -1856,6 +1856,11 @@ describe("gate tools — signal-driven lifecycle", () => {
   describe("adv_gate_status", () => {
     test("falls back to disk gates with _recovery annotation on poisoned workflow", async () => {
       // rq-fix-gate-tools-recovery AC1.
+      //
+      // C2 (fixPoisonedRecovery reviewer-block remediation): describe() is no
+      // longer consulted as poison authority in this path — the queryError
+      // must carry poisoned-history markers (TMPRL1100 / Nondeterminism /
+      // No command scheduled for event) for poisonedFallback to flip.
       const gates = {
         proposal: { status: "done" },
         discovery: { status: "done" },
@@ -1877,6 +1882,38 @@ describe("gate tools — signal-driven lifecycle", () => {
         } as Partial<import("../types").Change>,
       });
 
+      // C2: error CLASS authority — TMPRL1100 marker in error text.
+      mocks.querySignal.mockRejectedValueOnce(
+        new Error("Failed to query Workflow: TMPRL1100 Nondeterminism error"),
+      );
+
+      const result = await gateTools.adv_gate_status.execute(
+        { changeId: "test-change" },
+        store,
+      );
+
+      const parsed = JSON.parse(result);
+      expect(parsed.gates.planning.status).toBe("pending");
+      expect(parsed.gates.discovery.status).toBe("done");
+      expect(parsed._recovery).toEqual({ reason: "poisoned_history" });
+      // C2: describe() is no longer consulted in this path.
+    });
+
+    test("propagates query errors when error class is not poisoned/completed (C2)", async () => {
+      // C2 (fixPoisonedRecovery reviewer-block remediation): a generic query
+      // error must propagate even if describe() would carry poisoned markers.
+      // describe() is not authoritative for the poisonedFallback decision.
+      const gates = {
+        proposal: { status: "done" },
+        discovery: { status: "pending" },
+        design: { status: "pending" },
+        planning: { status: "pending" },
+        execution: { status: "pending" },
+        acceptance: { status: "pending" },
+        release: { status: "pending" },
+      } as import("../types").Gates;
+      const store = createMockStore({ gates });
+
       mocks.querySignal.mockRejectedValueOnce(
         new Error("Failed to query Workflow"),
       );
@@ -1889,16 +1926,11 @@ describe("gate tools — signal-driven lifecycle", () => {
       }));
       mocks.handleMock.describe = describeMock;
 
-      const result = await gateTools.adv_gate_status.execute(
-        { changeId: "test-change" },
-        store,
-      );
-
-      const parsed = JSON.parse(result);
-      expect(parsed.gates.planning.status).toBe("pending");
-      expect(parsed.gates.discovery.status).toBe("done");
-      expect(parsed._recovery).toEqual({ reason: "poisoned_history" });
-      expect(describeMock).toHaveBeenCalled();
+      await expect(
+        gateTools.adv_gate_status.execute({ changeId: "test-change" }, store),
+      ).rejects.toThrow(/Failed to query Workflow/);
+      // describe() may still be called for advisory diagnostics elsewhere,
+      // but it MUST NOT authorize recovery. The thrown error proves it didn't.
 
       delete (mocks.handleMock as { describe?: unknown }).describe;
     });

--- a/plugin/src/tools/gate.ts
+++ b/plugin/src/tools/gate.ts
@@ -95,7 +95,9 @@ import { checkPlanRoutingGuard } from "../migration/routing-guard";
 import { createLogger } from "../utils/debug-log";
 import type { ChangeWorkflowState } from "../temporal/contracts";
 import {
+  isPoisonedHistoryError,
   isPreciseWorkflowRecoveryEvidence,
+  isWorkflowCompletedError,
   RECOVERY_RECONCILIATION_WARNING,
 } from "../temporal/recovery-classification";
 import { hasGateRecoveryAudit } from "./recovery-audit";
@@ -103,7 +105,6 @@ import {
   classifyCompletedOrPoisonedRecovery,
   logRecoveryProbeDiagnostics,
   shouldTakeRecoveryBranch,
-  workflowHasPoisonedRecoveryEvidence,
 } from "./recovery-probe";
 import { saveRecoveredGateCompletion } from "./_recovery-writers";
 import { evaluateLightweightProfileAndSignal } from "./lightweight-profile";
@@ -1289,10 +1290,18 @@ export const gateTools = {
                 // rq-fix-gate-tools-recovery AC1: poisoned-history fallback.
                 // The store's changes.get already returned a disk projection
                 // (likely via temporal_query_fallback). Honour that disk
-                // projection when the workflow describe carries poisoned
-                // evidence, instead of propagating the generic
-                // "Failed to query Workflow" error.
-                if (await workflowHasPoisonedRecoveryEvidence(handle)) {
+                // projection when the workflow is poisoned/completed, instead
+                // of propagating the generic "Failed to query Workflow" error.
+                //
+                // C2 (fixPoisonedRecovery reviewer-block remediation):
+                // describe() must NOT be consulted for poison authority —
+                // even as a fallback. Error class is the sole authority here.
+                // describe() remains in use elsewhere for run identity /
+                // open-closed detection only.
+                if (
+                  isPoisonedHistoryError(queryError) ||
+                  isWorkflowCompletedError(queryError)
+                ) {
                   poisonedFallback = true;
                 } else {
                   throw queryError;

--- a/plugin/src/tools/worktree/state-session-lifecycle.test.ts
+++ b/plugin/src/tools/worktree/state-session-lifecycle.test.ts
@@ -362,7 +362,9 @@ describe("cross-change worktree visibility helpers (T22)", () => {
           },
         },
       })
-      .mockRejectedValueOnce(new Error("Failed to query Workflow"));
+      .mockRejectedValueOnce(
+        new Error("Failed to query Workflow: TMPRL1100 Nondeterminism error"),
+      );
     changeWorkflowDescribe.mockResolvedValueOnce({
       workflowExecutionInfo: {
         closeStatus: null,
@@ -403,6 +405,42 @@ describe("cross-change worktree visibility helpers (T22)", () => {
     ]);
   });
 
+  it("does not classify as poisoned when error class is generic even if describe matches (C2)", async () => {
+    // C2 (fixPoisonedRecovery reviewer-block remediation): describe() must NOT
+    // authorize poison classification alone. A generic query error must NOT
+    // produce recoveryReason=poisoned_history even when describe() carries
+    // poisoned markers — error class is the sole authority.
+    workflowList.mockImplementationOnce(() =>
+      (async function* () {
+        yield { workflowId: "adv/change/test-id/generic-error" };
+      })(),
+    );
+    changeWorkflowQuery.mockRejectedValueOnce(
+      new Error("Failed to query Workflow"),
+    );
+    changeWorkflowDescribe.mockResolvedValueOnce({
+      workflowExecutionInfo: {
+        closeStatus: null,
+        taskQueue: "advance-test-id",
+      },
+      lastFailure: {
+        message:
+          "WorkflowTaskFailedCauseNonDeterministicError [TMPRL1100] Nondeterminism error",
+      },
+    });
+
+    const result = await listWorktreesAcrossChanges(access);
+
+    expect(result.poisonedWorkflows).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        changeId: "generic-error",
+        source: "worktree_workflow",
+      }),
+    ]);
+    expect(result.warnings[0]?.recoveryReason).toBeUndefined();
+  });
+
   it("keeps 250 healthy owners while surfacing one poisoned workflow", async () => {
     const healthyIds = Array.from(
       { length: 250 },
@@ -420,7 +458,9 @@ describe("cross-change worktree visibility helpers (T22)", () => {
       if (changeId === "poisoned-scale") {
         return {
           query: vi.fn(async () => {
-            throw new Error("Failed to query Workflow");
+            throw new Error(
+              "Failed to query Workflow: TMPRL1100 Nondeterminism error",
+            );
           }),
           describe: vi.fn(async () => ({
             workflowExecutionInfo: {

--- a/plugin/src/tools/worktree/state.ts
+++ b/plugin/src/tools/worktree/state.ts
@@ -46,7 +46,6 @@ import {
   isPoisonedHistoryError,
   isWorkflowCompletedError,
 } from "../../temporal/recovery-classification";
-import { workflowPoisonedDescriptionEvidence } from "../recovery-probe";
 import {
   escapeVisibilityValue,
   openLifecycleVisibilityClauses,
@@ -282,13 +281,11 @@ async function classifyWorktreeWorkflowFailure(
   recoveryReason?: WorktreeWorkflowRecoveryReason;
   evidenceSummary?: string;
 }> {
-  const describeEvidence = await workflowPoisonedDescriptionEvidence(handle);
-  if (describeEvidence) {
-    return {
-      recoveryReason: "poisoned_history",
-      evidenceSummary: describeEvidence,
-    };
-  }
+  // C2 (fixPoisonedRecovery reviewer-block remediation): describe() must NOT
+  // be the sole poison authority. Error class is primary; describe() no
+  // longer classifies alone. The `handle` param is retained for signature
+  // stability but no longer probed for poison evidence here.
+  void handle;
   if (isPoisonedHistoryError(error)) {
     return {
       recoveryReason: "poisoned_history",


### PR DESCRIPTION
## Summary

Reviewer-blocked AC6 evidence on `fixPoisonedRecovery` (#266): 3 sites in shipped code used `describe()` as sole poison authority, violating agreement constraint C2:

> "describe() is used only for run identity + open/closed detection; never as sole poison authority."

User decision: agreement C2 wins over design non-goal ("leave describe()-based recovery as defense-in-depth").

## Sites fixed

- `plugin/src/tools/change.ts:3657` (archive recovery catch): operator-supplied precise `recoveryEvidence` is primary authority; signal `saveError` class is secondary. `describe()` NOT consulted.
- `plugin/src/tools/gate.ts:1295` (status query fallback): error class (`isPoisonedHistoryError | isWorkflowCompletedError`) is the sole authority; `describe()` no longer consulted.
- `plugin/src/tools/worktree/state.ts:285` (`classifyWorktreeWorkflowFailure`): error class checked first; `describe()` no longer classifies alone. Removed unused `workflowPoisonedDescriptionEvidence` import.

## Tests

- Regression tests added per site (3 new tests).
- Existing tests updated to encode new C2-compliant behavior:
  - `gate.test.ts` "falls back to disk gates on poisoned workflow": queryError carries TMPRL1100 marker (error class authority).
  - `change.test.ts` "does not archive-status recover from poisoned signal-error text without describe evidence": reframed as "recovers archive status from poisoned signal-error class without describe evidence".
  - `worktree/state-session-lifecycle.test.ts`: query error carries TMPRL1100 marker.
- Verification: `pnpm run check` green; 414/414 tests pass across 11 recovery-touching files (run `tr_mruqwco7_8968572d`).

## Follow-up (out of scope)

5 additional describe-only sites exist in `task.ts` (L1090, L1485, L1765 — catch blocks) and `contract.ts` (L441, L678 — post-signal defense-in-depth). Reviewer missed these. Same C2 violation pattern. Will be addressed in a separate change if user approves scope expansion.

## Related

- Follows PR #266 (`fixPoisonedRecovery`)
- Linked to Epic `hardenTemporalReliability`
- Reviewer report: `fixPoisonedRecovery|change:review:acceptance|adv-reviewer|1`