### PR TITLE
fix(scripts): install-git-hooks.sh refuses wrong cwd

### DIFF
--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -12,6 +12,23 @@
 #   ./scripts/install-git-hooks.sh --uninstall # revert to default hooks dir
 set -euo pipefail
 
+# Refuse to run if not inside the ADV repo. Otherwise `git rev-parse
+# --show-toplevel` resolves to the cwd's enclosing repo and the script
+# silently operates on the wrong repo (e.g., toolbox, not advance) —
+# `--check` false-negatives from outside ADV root.
+# Use `cd && pwd` subshell canonicalization (POSIX-portable; `realpath`
+# may not exist on minimal systems; `dirname BASH_SOURCE` alone does not
+# resolve symlinks).
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+expected_repo_root="$(cd -- "$script_dir/.." && pwd)"
+current_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+current_root_canonical="$( [ -n "$current_root" ] && cd -- "$current_root" && pwd || echo "")"
+if [ "$current_root_canonical" != "$expected_repo_root" ]; then
+  echo "install-git-hooks: must run inside ADV repo ($expected_repo_root)" >&2
+  echo "currently in: ${current_root:-(not a git repo)}" >&2
+  exit 2
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 HOOKS_DIR="$REPO_ROOT/.githooks"
 


### PR DESCRIPTION
## Summary

`install-git-hooks.sh` used `git rev-parse --show-toplevel` to locate the ADV repo root, which resolves against the **cwd's enclosing repo**, not the script's location. When invoked from outside ADV (e.g., `bash ~/dev/advance/scripts/install-git-hooks.sh --check` from another repo), the script silently operated on the wrong repo:

- `--check` reported the wrong repo's `core.hooksPath` (typically empty) → false-negative
- `--install` / `--uninstall` would mutate the wrong repo's `git config` → silent corruption

Now refuses to run with exit 2 + clear message naming both the expected ADV repo path and the current (wrong) location.

## Repro (pre-fix)

```
$ cd ~/toolbox  # any non-ADV git repo
$ bash ~/dev/advance/scripts/install-git-hooks.sh --check
[adv-hooks] core.hooksPath = '' (expected: .githooks)   # ← false-negative; checked toolbox, not advance
[adv-hooks] run: ./scripts/install-git-hooks.sh
exit=1
```

## Post-fix

```
$ cd ~/toolbox
$ bash ~/dev/advance/scripts/install-git-hooks.sh --check
install-git-hooks: must run inside ADV repo (/home/jon/dev/advance)
currently in: /home/jon/toolbox
exit=2
```

From ADV root (happy path preserved):

```
$ cd ~/dev/advance
$ bash scripts/install-git-hooks.sh --check
[adv-hooks] core.hooksPath = .githooks ✓
exit=0
```

## Implementation notes

- Insertion point: after `set -euo pipefail`, before `REPO_ROOT=$(...)`.
- Canonicalization uses `cd && pwd` subshell rather than `realpath` (POSIX-portable; `realpath` may not exist on minimal systems / BSD / containers).
- `dirname BASH_SOURCE[0]` alone does not resolve symlinks; the `cd && pwd` subshell canonicalizes both the script dir and the current-root for comparison.
- Assertion fires before any `git config` mutation, so install/uninstall/check modes all get the guard.

## Test plan

Manual verification from 3 cwys (no bats suite exists for this script):

| cwd | expected | verified |
|---|---|---|
| `~/dev/advance/` | exit 0 with `core.hooksPath = .githooks ✓` | ✓ |
| `~/toolbox/` (other git repo) | exit 2 with "must run inside ADV repo" | ✓ |
| `/tmp` (non-git) | exit 2 with "currently in: (not a git repo)" | ✓ |

## Backward compatibility

Previously working invocations (from inside ADV repo) continue to work — assertion passes, existing logic runs unchanged. Previously silent-broken invocations (from outside ADV) now fail loudly instead of silently — that's the fix.

## Audit context

Finding #3 from the 2026-07-21 ADV install audit (verdict OPTIMAL). Tracked in toolbox ADV change `addAdvAuditFollowupGuards`.
