### PR TITLE
docs(tools): point adv_subagent_report_submit description at canonical REVIEWER_REPORT examples

### DIFF
--- a/plugin/src/tools/subagent-report.ts
+++ b/plugin/src/tools/subagent-report.ts
@@ -1007,7 +1007,7 @@ export const subagentReportTools = {
       "Submit a typed, Zod-validated sub-agent report and persist it on the owning ADV change/task scope.",
     args: {
       report: ScopedSubagentReportSchema.describe(
-        "Typed sub-agent report payload. v1 supports adv-engineer, adv-reviewer, adv-designer, adv-researcher, adv-tron, orchestrator-submitted adv-scanner-bundle reports, and orchestrator-submitted adv-verification-triage-bundle reports.",
+        "Typed sub-agent report payload. v1 supports adv-engineer, adv-reviewer, adv-designer, adv-researcher, adv-tron, orchestrator-submitted adv-scanner-bundle reports, and orchestrator-submitted adv-verification-triage-bundle reports. For canonical REVIEWER_REPORT shapes (READY + CONFLICT), see .opencode/agents/adv-reviewer.md § REVIEWER_REPORT Payload — discrimination is by `agent` field; each variant has distinct required fields (e.g., adv-reviewer requires scope, verification, scope_drift, required_main_agent_actions).",
       ),
       dryRun: z
         .boolean()


### PR DESCRIPTION
## Summary

The `adv_subagent_report_submit` tool description was a bare one-liner naming supported agents but did not reference the canonical payload shapes documented in `.opencode/agents/adv-reviewer.md § REVIEWER_REPORT Payload`.

This created a discoverability gap: agents + orchestrators attempting to submit reports for the common case (READY verdict, no scope drift) had no in-tool pointer to the example showing the required shape — leading to repeated schema-rejection cycles during acceptance gates.

## Repro (the gap, not a bug)

An orchestrator (this author) hit this during the `hardenAdvHealthNondeterminism` archive:

1. Spawned `adv-reviewer` for acceptance review — reviewer performed the review correctly but its `adv_subagent_report_submit` calls failed 3 times with cumulative schema errors (wrong `scope` shape, wrong `scope_drift` shape, wrong `verification` field names).
2. Reviewer gave up: *"Submission failed: deployed adv_subagent_report_submit schema rejects independent acceptance-review payloads. Three attempts exhausted."*
3. Orchestrator attempted 3 more direct submissions (with full schema visibility via `adv_tool_describe`) — all failed for similar reasons.

Root cause on investigation: the reviewer + orchestrator were constructing payloads from memory rather than from a canonical example. The canonical READY example existed at `.opencode/agents/adv-reviewer.md:368-406` all along — but neither party looked there, because the tool description gave no pointer.

## Fix

One-line addition to the existing tool description in `plugin/src/tools/subagent-report.ts:1010`:

> "For canonical REVIEWER_REPORT shapes (READY + CONFLICT), see `.opencode/agents/adv-reviewer.md § REVIEWER_REPORT Payload` — discrimination is by `agent` field; each variant has distinct required fields (e.g., adv-reviewer requires `scope`, `verification`, `scope_drift`, `required_main_agent_actions`)."

Makes the canonical examples discoverable from the tool itself, not just from the agent prompt.

## What this does NOT change

- **Schema** is untouched — `ScopedSubagentReportSchema` behavior identical.
- **Validation** is untouched — same Zod discriminated union.
- **No code paths** changed.

Pure documentation enrichment of a `.describe()` string.

## Test plan

- `pnpm run build` succeeds (`.describe()` strings are runtime metadata only)
- Existing test suite (`subagent-report.test.ts`) passes — no behavioral change
- Manual: invoke `adv_tool_describe name: "adv_subagent_report_submit"` from an ADV session and confirm the new pointer appears in the description

## Related

- Closes #276 (filed originally with overstated premise — READY example existed; closing as not-planned with correction comment).
