### PR TITLE
Make session-health banner one-shot (fixSessionHealthBannerNoise)

### DIFF
--- a/ADV_INSTRUCTIONS.md
+++ b/ADV_INSTRUCTIONS.md
@@ -244,6 +244,8 @@ Each finding carries a label from `/adv-coordinate`'s inherited taxonomy: `repo_
 
 **Single HIGH-confidence `resume:archived_duplicate` action:** surface a copy-pasteable `adv_change_close ... supersededBy: <current>` snippet. User must run explicitly with their own approval evidence. **ADV does not auto-execute close.** Wording: "one-command accept (copy-paste and run)" — never "one-click" or any phrasing implying button-click auto-execution.
 
+**Session hygiene — one session per major change.** Prefer a fresh OpenCode session for each major change rather than chaining multiple `/adv-archive` cycles in one long-lived session. Long sessions accumulate large tool outputs and diffs; ADV compacts any prompt entry over the size threshold and surfaces a one-shot `[ADV:SESSION_HEALTH]` banner (`message-history` kind) warning that prior chat history is truncated and not a source of truth. The banner is informational (fires once per compaction event), but its appearance is the signal to start fresh and resume by `changeId` — durable ADV state (changes, tasks, gates, contracts) is the source of truth, not chat scrollback.
+
 
 ### MCP Tool Name Contract
 

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1317,6 +1317,19 @@ const advancePluginImpl: Plugin = async (input) => {
         if (result.consumedWisdomPrompt) {
           state.lastCompletedTask = null;
         }
+
+        // fixSessionHealthBannerNoise: mark a message-history session-health
+        // issue as surfaced once its banner has been emitted, so the one-shot
+        // banner does not repeat every turn. A subsequent compaction event
+        // replaces lastSessionHealthIssue with a fresh (unsurfaced) issue,
+        // which re-emits once. session.error banners stay sticky and are
+        // never marked surfaced here.
+        if (
+          result.surfacedMessageHistoryHealth &&
+          state.lastSessionHealthIssue?.kind === "message-history"
+        ) {
+          state.lastSessionHealthIssue.surfaced = true;
+        }
       } catch (e) {
         debugLog(`experimental.chat.system.transform error: ${e}`);
       }

--- a/plugin/src/utils/system-block.test.ts
+++ b/plugin/src/utils/system-block.test.ts
@@ -602,6 +602,102 @@ describe("applyAdvSystemBlock", () => {
     expect(result.consumedWisdomPrompt).toBe(false);
   });
 
+  // ─── session-health banner one-shot (fixSessionHealthBannerNoise) ─────────
+  describe("session-health banner one-shot", () => {
+    it("AC2: fresh message-history issue emits the banner and flags surfacedMessageHistoryHealth", () => {
+      const output = { system: [] as string[] };
+      const result = applyAdvSystemBlock(output, {
+        state: cleanState({
+          lastSessionHealthIssue: {
+            kind: "message-history",
+            message: "compacted 33 oversized diff(s)",
+            detectedAt: 0,
+          },
+        }),
+        initError: null,
+        storeAvailable: true,
+      });
+      expect(result.emitted).toBe(true);
+      expect(output.system[0]).toContain("[ADV:SESSION_HEALTH]");
+      expect(output.system[0]).toContain("message-history");
+      expect(result.surfacedMessageHistoryHealth).toBe(true);
+    });
+
+    it("AC1: already-surfaced message-history issue does NOT re-emit the banner", () => {
+      const output = { system: [] as string[] };
+      const result = applyAdvSystemBlock(output, {
+        state: cleanState({
+          lastSessionHealthIssue: {
+            kind: "message-history",
+            message: "compacted 33 oversized diff(s)",
+            detectedAt: 0,
+            surfaced: true,
+          },
+        }),
+        initError: null,
+        storeAvailable: true,
+      });
+      expect(output.system[0] ?? "").not.toContain("[ADV:SESSION_HEALTH]");
+      expect(result.surfacedMessageHistoryHealth).toBe(false);
+    });
+
+    it("AC1: surfaced message-history is suppressed but other sections still emit", () => {
+      const output = { system: [] as string[] };
+      applyAdvSystemBlock(output, {
+        state: cleanState({
+          activeChange: { id: "c1" },
+          lastSessionHealthIssue: {
+            kind: "message-history",
+            message: "compacted diffs",
+            detectedAt: 0,
+            surfaced: true,
+          },
+        }),
+        initError: null,
+        storeAvailable: true,
+      });
+      expect(output.system[0]).toContain("[ADV] Active change: c1");
+      expect(output.system[0]).not.toContain("[ADV:SESSION_HEALTH]");
+    });
+
+    it("AC3: session.error banner is sticky — emits even when surfaced=true", () => {
+      const output = { system: [] as string[] };
+      const result = applyAdvSystemBlock(output, {
+        state: cleanState({
+          lastSessionHealthIssue: {
+            kind: "session.error",
+            message: "session crashed",
+            detectedAt: 0,
+            surfaced: true,
+          },
+        }),
+        initError: null,
+        storeAvailable: true,
+      });
+      expect(output.system[0]).toContain("[ADV:SESSION_HEALTH]");
+      expect(output.system[0]).toContain("session.error");
+      // session.error never counts as message-history surfacing
+      expect(result.surfacedMessageHistoryHealth).toBe(false);
+    });
+
+    it("AC4: absent surfaced flag behaves as unsurfaced (emits + flags)", () => {
+      const output = { system: [] as string[] };
+      const result = applyAdvSystemBlock(output, {
+        state: cleanState({
+          lastSessionHealthIssue: {
+            kind: "message-history",
+            message: "compacted diffs",
+            detectedAt: 0,
+          },
+        }),
+        initError: null,
+        storeAvailable: true,
+      });
+      expect(output.system[0]).toContain("[ADV:SESSION_HEALTH]");
+      expect(result.surfacedMessageHistoryHealth).toBe(true);
+    });
+  });
+
   it("emits degraded banner via single entry when storeAvailable is false", () => {
     const output = { system: [] as string[] };
     applyAdvSystemBlock(output, {

--- a/plugin/src/utils/system-block.ts
+++ b/plugin/src/utils/system-block.ts
@@ -43,6 +43,15 @@ export interface SessionHealthIssue {
   kind: "session.error" | "message-history";
   message: string;
   detectedAt: number;
+  /**
+   * True once the banner for this issue has been surfaced in a system block.
+   * `message-history` banners are one-shot: after they surface once, they are
+   * suppressed on subsequent turns (fixSessionHealthBannerNoise). A new
+   * compaction event replaces the issue with a fresh (unsurfaced) one, which
+   * re-emits once. `session.error` banners ignore this flag and stay sticky.
+   * Absent/false means "not yet surfaced" (backward-compatible default).
+   */
+  surfaced?: boolean;
 }
 
 /** State shape this module reads from. Subset of plugin state. */
@@ -191,6 +200,10 @@ function degradedSection(input: AssembleSystemBlockInput): string | null {
 function healthSection(input: AssembleSystemBlockInput): string | null {
   const issue = input.state.lastSessionHealthIssue;
   if (!issue) return null;
+  // fixSessionHealthBannerNoise: `message-history` banners are one-shot —
+  // once surfaced they are suppressed so they don't repeat every turn.
+  // `session.error` stays sticky (safety-critical; drives BLOCKED status).
+  if (issue.kind === "message-history" && issue.surfaced) return null;
   return formatSessionHealthBanner(issue, input.state.activeChange.id);
 }
 
@@ -274,6 +287,11 @@ export interface ApplyAdvSystemBlockResult {
    *  `state.lastCompletedTask` after a successful emission so the prompt
    *  doesn't repeat on subsequent turns. */
   consumedWisdomPrompt: boolean;
+  /** True when a `message-history` session-health banner was emitted this
+   *  assembly; caller should set `lastSessionHealthIssue.surfaced = true`
+   *  so the one-shot banner does not repeat on subsequent turns
+   *  (fixSessionHealthBannerNoise). Never true for `session.error` (sticky). */
+  surfacedMessageHistoryHealth: boolean;
 }
 
 /**
@@ -292,14 +310,24 @@ export function applyAdvSystemBlock(
   const existingSystem = output.system[0] ?? null;
   const block = assembleSystemBlock({ ...input, existingSystem });
   if (block === null) {
-    return { emitted: false, consumedWisdomPrompt: false };
+    return {
+      emitted: false,
+      consumedWisdomPrompt: false,
+      surfacedMessageHistoryHealth: false,
+    };
   }
   output.system[0] = existingSystem ? `${existingSystem}\n\n${block}` : block;
+  const healthIssue = input.state.lastSessionHealthIssue;
   return {
     emitted: true,
     consumedWisdomPrompt:
       input.state.lastCompletedTask !== null ||
       (input.state.pendingWisdomDraftTasks?.length ?? 0) > 0,
+    // Mirrors healthSection's message-history one-shot gate: the banner
+    // emitted this assembly iff the issue is message-history and not yet
+    // surfaced. (block !== null here, so the section was included.)
+    surfacedMessageHistoryHealth:
+      healthIssue?.kind === "message-history" && !healthIssue.surfaced,
   };
 }
 


### PR DESCRIPTION
## Summary

The `[ADV:SESSION_HEALTH]` message-history banner now emits **once per compaction event** instead of repeating every turn. `session.error` banners stay sticky.

## Root cause

`compactPromptMessages` truncates oversized diffs/tool-outputs in place, so on later turns the already-truncated text is <24K and no new compaction fires — but `healthSection` re-emitted the banner every turn because `lastSessionHealthIssue` was never cleared.

## Changes

- `plugin/src/utils/system-block.ts` — `SessionHealthIssue` gains optional `surfaced`; `healthSection` suppresses `message-history` once surfaced; `applyAdvSystemBlock` returns `surfacedMessageHistoryHealth`.
- `plugin/src/index.ts` — system-transform hook sets `surfaced=true` after emission (mirrors `consumedWisdomPrompt`).
- `ADV_INSTRUCTIONS.md` — 'one session per major change' hygiene note.
- `plugin/src/utils/system-block.test.ts` — 5 tests (one-shot suppress, fresh re-emit, session.error sticky, absent-flag).

## Test plan

- [x] TDD red (5 failures) → green (60/60)
- [x] 97/97 regression (system-block + ac.verification + integration)
- [x] pnpm run check green
- [x] session.error stickiness + BLOCKED-status diagnostic preserved

🤓 Adv-generated