### PR TITLE
Fix release-durability false-negative (rq-releaseProjectionDurability01)

### DIFF
--- a/plugin/src/tools/change.archive-phase9.test.ts
+++ b/plugin/src/tools/change.archive-phase9.test.ts
@@ -555,10 +555,102 @@ describe("adv_change_archive Phase 9 behavior", () => {
     }
   });
 
-  test("blocks existing-bundle retry when stored release done lacks matching Phase 9 evidence", async () => {
+  describe("finalizationShipped reconciliation (fixReleaseDurabilityFalse)", () => {
+    const structuredEvidence =
+      "Phase 9 finalization shipped; defaultBranch=trunk; mainCheckout=/tmp/main; pushStatus=pushed; mergeCommitSha=abc123";
+
+    const makeReleaseDoneStore = (approvalEvidence: string): Store =>
+      ({
+        paths: { changes: "/nonexistent-durability-test" },
+        gates: {
+          get: async () => ({
+            proposal: { status: "done" },
+            discovery: { status: "done" },
+            design: { status: "done" },
+            planning: { status: "done" },
+            execution: { status: "done" },
+            acceptance: { status: "done" },
+            release: {
+              status: "done",
+              completed_at: "2026-01-01T00:00:00Z",
+              completed_by: "user",
+              approval_evidence: approvalEvidence,
+            },
+          }),
+        },
+      }) as unknown as Store;
+
+    test("AC4: manual free-text gate evidence + finalizationShipped accepts the durable proof", async () => {
+      // The operator completed the release gate manually with a free-text
+      // note that does NOT contain the structured completion evidence.
+      const store = makeReleaseDoneStore(
+        "PR #282 admin-merged to trunk (commit a10f2bc1)",
+      );
+      const proof = await verifyReleaseGateDurableForArchive({
+        store,
+        changeId: "example",
+        evidence: structuredEvidence,
+        finalizationShipped: true,
+      });
+      expect(proof.ok).toBe(true);
+    });
+
+    test("AC2 (guard preserved): non-matching evidence + NOT shipped still fails", async () => {
+      const store = makeReleaseDoneStore(
+        "PR #282 admin-merged to trunk (commit a10f2bc1)",
+      );
+      const proof = await verifyReleaseGateDurableForArchive({
+        store,
+        changeId: "example",
+        evidence: structuredEvidence,
+        finalizationShipped: false,
+      });
+      expect(proof.ok).toBe(false);
+      expect(proof).toMatchObject({
+        error: expect.stringContaining("lacks matching Phase 9 evidence"),
+      });
+    });
+
+    test("AC3 (backward compat): matching structured evidence accepts even when finalizationShipped is false", async () => {
+      // archive-completed gate: stored approval_evidence contains the
+      // structured completion string, so the evidence path matches.
+      const store = makeReleaseDoneStore(`release done; ${structuredEvidence}`);
+      const proof = await verifyReleaseGateDurableForArchive({
+        store,
+        changeId: "example",
+        evidence: structuredEvidence,
+        finalizationShipped: false,
+      });
+      expect(proof.ok).toBe(true);
+    });
+
+    test("squash-supersession regression: superseded SHA in gate evidence + finalizationShipped accepts", async () => {
+      const store = makeReleaseDoneStore(
+        "release done; mergeCommitSha=OLDSQUASHSHA111",
+      );
+      const proof = await verifyReleaseGateDurableForArchive({
+        store,
+        changeId: "example",
+        evidence:
+          "Phase 9 finalization shipped; mergeCommitSha=NEWBUNDLEMERGE222",
+        finalizationShipped: true,
+      });
+      expect(proof.ok).toBe(true);
+    });
+  });
+
+  test("archives a shipped change whose done release gate lacks matching Phase 9 evidence (fixReleaseDurabilityFalse — no false-negative)", async () => {
     // T10 readArtifact fallback may call findArchiveBundle before the archive
     // flow; use a stable default so the existing-bundle path is actually hit.
     mocks.findArchiveBundle.mockResolvedValue("/tmp/archive/example");
+    // Genuinely-shipped change (default finalizeRelease → status: "shipped")
+    // whose release gate is done but carries NO matching structured evidence
+    // (createMockStore sets release done with no approval_evidence — the same
+    // shape produced by a manual free-text gate completion or a squash-merge
+    // SHA supersession). Pre-fix this produced the rq-releaseProjectionDurability01
+    // false-negative that forced an adv_change_status_repair fallback. The
+    // fresh shipped finalization is authoritative proof the change reached the
+    // default branch, so archival now succeeds on the first call.
     const store = createMockStore({ status: "archived", releaseDone: true });
 
     const result = await changeTools.adv_change_archive.execute(
@@ -567,11 +659,8 @@ describe("adv_change_archive Phase 9 behavior", () => {
     );
 
     const parsed = JSON.parse(result);
-    expect(parsed.success).toBe(false);
-    expect(parsed.requirement).toBe("rq-releaseProjectionDurability01");
-    expect(parsed.error).toContain("durable release gate proof");
-    expect(store.changes.save).not.toHaveBeenCalled();
-    expect(mocks.closeLinkedIssue).not.toHaveBeenCalled();
+    expect(parsed.success).toBe(true);
+    expect(parsed.error).toBeUndefined();
   });
 
   test("skips finalization when phase9=skip", async () => {

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -3487,6 +3487,7 @@ export const changeTools = {
             store,
             changeId,
             evidence: releaseEvidence,
+            finalizationShipped: finalization.status === "shipped",
           });
           if (!durableProof.ok) {
             return formatToolOutput({

--- a/plugin/src/tools/change/archive-gate.ts
+++ b/plugin/src/tools/change/archive-gate.ts
@@ -408,6 +408,7 @@ export async function reconcileArchivedBundleRetry(input: {
     store: input.store,
     changeId: input.changeId,
     evidence: releaseEvidence,
+    finalizationShipped: finalization.status === "shipped",
   });
   let releaseResult: Extract<
     ArchiveReleaseGateResult,
@@ -444,6 +445,7 @@ export async function reconcileArchivedBundleRetry(input: {
       store: input.store,
       changeId: input.changeId,
       evidence: releaseEvidence,
+      finalizationShipped: finalization.status === "shipped",
     });
     if (!durableProof.ok) {
       return formatToolOutput({
@@ -891,6 +893,20 @@ export async function verifyReleaseGateDurableForArchive(input: {
   store: Store;
   changeId: string;
   evidence: string;
+  /**
+   * True when the archive's fresh Phase 9 git finalization reported
+   * `status: "shipped"` (rq-releaseProjectionDurability01 reconciliation,
+   * fixReleaseDurabilityFalse). `shipped` is returned by git-finalize only
+   * on confirmed reachability/merge (PR pr_merged, no_remote local merge, or
+   * direct merge+push), so it is authoritative proof the change reached the
+   * default branch. When true, the durable proof is accepted for a `done`
+   * release gate even if the stored gate evidence does not substring-match
+   * the structured completion evidence — this covers manually-completed gates
+   * (free-text approval notes) and admin/squash-merge SHA supersession. The
+   * evidence-string path is preserved for archive-completed gates (backward
+   * compatible). Absent/false preserves the strict evidence-match behavior.
+   */
+  finalizationShipped?: boolean;
 }): Promise<DurableReleaseGateProofResult> {
   let gates: Gates | null;
   try {
@@ -916,7 +932,17 @@ export async function verifyReleaseGateDurableForArchive(input: {
       stuckReason: releaseGate?.stuck_reason,
     };
   }
-  if (!releaseGateEvidenceMatches(releaseGate, input.evidence)) {
+  // rq-releaseProjectionDurability01 reconciliation: accept the durable proof
+  // when the stored gate evidence corroborates finalization OR the archive's
+  // fresh finalization is authoritatively shipped. finalizationShipped is only
+  // set from finalization.status === "shipped", which git-finalize returns
+  // exclusively on confirmed reachability/merge — so this cannot accept an
+  // unshipped change (guard preserved: unshipped → blocked/pending_merge →
+  // finalizationShipped false → strict evidence match still required).
+  if (
+    !releaseGateEvidenceMatches(releaseGate, input.evidence) &&
+    input.finalizationShipped !== true
+  ) {
     return {
       ok: false,
       error:


### PR DESCRIPTION
## Summary

`adv_change_archive` now archives genuinely-shipped changes on the first call instead of a false-negative that forces `adv_change_status_repair`. Fired 3× consecutively today (PRs #278, #281, #282).

## Root cause

When the release gate is completed **manually** (`adv_gate_complete gateId:release`, the normal sign-off flow) the stored `approval_evidence` is a free-text note. The archive's durable-proof check (`releaseGateEvidenceMatches`) required that note to **substring-contain** the structured `buildReleaseCompletionEvidence(finalization)` string — which it never does (and `--admin --squash` HEAD movement changes the SHA anyway). False-negative.

## Fix

The archive already re-runs git finalization; a `status: "shipped"` result is authoritative proof the change reached the default branch. `verifyReleaseGateDurableForArchive` gains an optional `finalizationShipped` flag; when the release gate is `done` and finalization is shipped, the durable proof is accepted regardless of evidence-string match. Evidence-string path preserved for archive-completed gates.

## Safety (guard preserved)

`finalization.status === "shipped"` is returned by git-finalize **only** on confirmed reachability/merge (PR `pr_merged`, `no_remote` local merge, direct merge+push). `shipped ⟹ reached default branch`, so an unshipped change (→ `blocked`/`pending_merge`) still fails the proof. An explicit AC2 unit test asserts this.

## Test plan

- [x] TDD red→green (AC4 manual-evidence + squash-supersession regression)
- [x] AC2 guard-preservation test (unshipped + non-matching evidence still blocks)
- [x] AC3 backward-compat (archive-completed gate evidence match)
- [x] 41/41 change.archive-phase9 + 155/155 archive-gate+change; pnpm run check green

Part of `hardenTemporalReliability` Epic (order-7 durability-guard shell); relates to #255.

🤓 Adv-generated