### PR TITLE
Disk-authoritative active reads: eliminate the change-list N+1 query (bl-HiZJbUuy)

### DIFF
--- a/plugin/src/storage/store-temporal/bounded-read-deadline.test.ts
+++ b/plugin/src/storage/store-temporal/bounded-read-deadline.test.ts
@@ -260,14 +260,13 @@ describe("bounded one-pass change-list resolution", () => {
     ]);
     expect(result.warnings).toBeUndefined();
 
-    // Regression guard: the removed second classification pass used to
-    // re-run the whole load chain per candidate. closedOne went through
-    // the terminal-projection disk read exactly once; activeOne once for
-    // the terminal-dominance check plus once for the owner guard inside
-    // the live query.
+    // Regression guard: each candidate is loaded exactly once. bl-HiZJbUuy /
+    // disk-first reads: both closedOne (terminal) and activeOne (active) resolve
+    // from a single change.json read with NO workflow query — no owner-guard
+    // second read, no live query during enumeration.
     expect(diskGetCalls.get("closedOne")).toBe(1);
-    expect(diskGetCalls.get("activeOne")).toBe(2);
-    expect(queryCount).toBe(1);
+    expect(diskGetCalls.get("activeOne")).toBe(1);
+    expect(queryCount).toBe(0);
   });
 
   it("returns typed deadline degradation when the visibility source hangs", async () => {
@@ -688,7 +687,7 @@ describe("bounded one-pass change-list resolution", () => {
     });
   }, 15_000);
 
-  it("bounds candidate disk fallback reads after fast Temporal failure", async () => {
+  it("bounds the disk-first candidate read against a hanging change.json read", async () => {
     // Fake only the timeout machinery; leave setImmediate real so fs reads
     // and async-generator enumeration drain deterministically.
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
@@ -696,7 +695,10 @@ describe("bounded one-pass change-list resolution", () => {
     const legacy = await createDiskStore(tempDir);
     await legacy.changes.save(activeChange("slowDiskFallback"));
 
-    // Temporal query fails fast — the fallback read path is exercised.
+    // bl-HiZJbUuy: reads resolve disk-first, so the candidate's change.json read
+    // IS the bounded read — there is no Temporal-query-then-disk-fallback
+    // sequence any more. The Temporal query mock stays available but is never
+    // reached because the disk-first read is admitted first.
     const temporal = {
       client: {
         workflow: {
@@ -715,27 +717,22 @@ describe("bounded one-pass change-list resolution", () => {
       },
     };
 
-    // Make the first disk fallback read hang indefinitely. The exact number of
-    // preparatory reads is intentionally not authority: optimized paths may
-    // reach the bounded fallback on their first read. The observable contract
-    // is one admitted hanging read, deadline termination, and typed omission.
+    // Make the disk-first loadCandidate read hang indefinitely. The observable
+    // contract is one admitted hanging read, deadline termination, and typed
+    // omission — never an unbounded hang.
     const diskGetCalls = new Map<string, number>();
     let resolveFallbackStarted: (() => void) | undefined;
     const fallbackStarted = new Promise<void>((resolve) => {
       resolveFallbackStarted = resolve;
     });
-    const realGet = legacy.changes.get.bind(legacy.changes);
     legacy.changes.get = (async (changeId: string) => {
       const count = (diskGetCalls.get(changeId) ?? 0) + 1;
       diskGetCalls.set(changeId, count);
-      if (count === 4 && resolveFallbackStarted) {
+      if (resolveFallbackStarted) {
         resolveFallbackStarted();
       }
-      if (count <= 3) {
-        // loadDiskTerminalProjection + getGuardedChangeHandle + reseedChangeFromDisk — fast
-        return realGet(changeId);
-      }
-      // loadCandidate fallback — hang indefinitely
+      // disk-first loadCandidate read — hang indefinitely so the aggregate
+      // deadline wrapper (raceWithTemporalDeadline) must reject it.
       return new Promise<never>(() => {});
     }) as typeof legacy.changes.get;
 
@@ -746,20 +743,16 @@ describe("bounded one-pass change-list resolution", () => {
     });
 
     const pending = store.changes.list({ includeArchived: true });
-    // Wait until the loadCandidate fallback read has actually started —
-    // source enumeration, the fast Temporal failure, the terminal-projection
-    // disk read, the owner-guard disk read, and the reseed disk read have
-    // already happened. The fourth diskGet call is the loadCandidate fallback.
+    // Wait until the disk-first candidate read has actually started.
     await fallbackStarted;
-    expect(diskGetCalls.get("slowDiskFallback")).toBe(4);
-    // Advance past the budget. The deadline wrapper (if present) rejects
-    // the fallback read. Without the wrapper, the read hangs and the test
-    // times out (RED).
+    expect(diskGetCalls.get("slowDiskFallback")).toBe(1);
+    // Advance past the budget. The deadline wrapper rejects the hanging read.
+    // Without the wrapper, the read hangs and the test times out (RED).
     await vi.advanceTimersByTimeAsync(TEMPORAL_READ_DEADLINE_BUDGET_MS + 1000);
     const result = await pending;
 
-    // The disk fallback read is bounded by the aggregate deadline.
-    // The candidate is omitted with typed incompleteness — never a hang.
+    // The disk-first read is bounded by the aggregate deadline. The candidate
+    // is omitted with typed incompleteness — never a hang.
     expect(result.changes.map((c) => c.id)).not.toContain("slowDiskFallback");
     expect(result.warnings).toEqual(
       expect.arrayContaining([
@@ -774,12 +767,11 @@ describe("bounded one-pass change-list resolution", () => {
     });
   }, 15_000);
 
-  it("regression: skips loadCandidate fallback once the aggregate deadline is exhausted", async () => {
-    // Regression guard for the flaky full-suite failure where the fallback
-    // stage was sometimes counted as after-expiry and skipped. This test
-    // freezes the stages before expiry (terminal-projection, owner-guard,
-    // reseed) and then advances the clock past the budget, proving that the
-    // fallback stage is correctly omitted while the earlier stages are not.
+  it("regression: does not retry a candidate's disk-first read after the deadline terminates it", async () => {
+    // bl-HiZJbUuy: under disk-first there is no Temporal-query → reseed →
+    // disk-fallback sequence. This regression guard proves that once the single
+    // disk-first change.json read is deadline-terminated, no second read is
+    // attempted for the same candidate (no post-expiry retry loop).
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     tempDir = await createTempDir();
     const legacy = await createDiskStore(tempDir);
@@ -796,29 +788,26 @@ describe("bounded one-pass change-list resolution", () => {
           list: async function* () {
             yield { workflowId: "adv/change/project-1/expiredBeforeFallback" };
           },
-          // Hang the reseed path after the third disk read so we can
-          // advance the fake clock and expire the budget before the
-          // loadCandidate fallback can begin.
-          start: async () => new Promise<never>(() => {}),
+          start: async () => {
+            throw new Error("start should not be called");
+          },
         },
       },
     };
 
     const diskGetCalls = new Map<string, number>();
-    let resolveThirdDiskGet: (() => void) | undefined;
-    const thirdDiskGet = new Promise<void>((resolve) => {
-      resolveThirdDiskGet = resolve;
+    let resolveFirstDiskGet: (() => void) | undefined;
+    const firstDiskGet = new Promise<void>((resolve) => {
+      resolveFirstDiskGet = resolve;
     });
-    const realGet = legacy.changes.get.bind(legacy.changes);
     legacy.changes.get = (async (changeId: string) => {
       const count = (diskGetCalls.get(changeId) ?? 0) + 1;
       diskGetCalls.set(changeId, count);
-      if (count === 3 && resolveThirdDiskGet) {
-        resolveThirdDiskGet();
+      if (count === 1 && resolveFirstDiskGet) {
+        resolveFirstDiskGet();
       }
-      if (count <= 3) {
-        return realGet(changeId);
-      }
+      // Hang the disk-first read so the deadline must terminate it. A correct
+      // implementation never re-reads the same candidate after termination.
       return new Promise<never>(() => {});
     }) as typeof legacy.changes.get;
 
@@ -829,15 +818,14 @@ describe("bounded one-pass change-list resolution", () => {
     });
 
     const pending = store.changes.list({ includeArchived: true });
-    await thirdDiskGet;
-    // The budget is still intact at this point. Expire it before the
-    // loadCandidate fallback can begin.
+    await firstDiskGet;
+    // The disk-first read is in flight; expire the budget to terminate it.
     await vi.advanceTimersByTimeAsync(TEMPORAL_READ_DEADLINE_BUDGET_MS + 1_000);
     const result = await pending;
 
-    // The pre-expiry stages produced three disk reads; the fallback stage
-    // was correctly suppressed once the budget expired.
-    expect(diskGetCalls.get("expiredBeforeFallback")).toBe(3);
+    // Exactly one disk-first read occurred; it was deadline-terminated and
+    // never retried. The candidate is a typed deadline omission.
+    expect(diskGetCalls.get("expiredBeforeFallback")).toBe(1);
     expect(result.changes.map((c) => c.id)).not.toContain(
       "expiredBeforeFallback",
     );

--- a/plugin/src/storage/store-temporal/bounded-status.test.ts
+++ b/plugin/src/storage/store-temporal/bounded-status.test.ts
@@ -136,7 +136,9 @@ describe("bounded summary status reads", () => {
 
     // The bound applies before deep hydration: at most 10 candidates were
     // loaded; the remaining 2 are typed omissions, never silently dropped.
-    expect(queried).toHaveLength(10);
+    // bl-HiZJbUuy: candidates hydrate disk-first, so no workflow queries fire;
+    // the bound is proven by resolvedChanges.size (10) + boundedOmitted (2).
+    expect(queried).toHaveLength(0);
     expect(status.changes.recent.length).toBeLessThanOrEqual(10);
     expect(status.warnings).toEqual(
       expect.arrayContaining([
@@ -172,10 +174,16 @@ describe("bounded summary status reads", () => {
 
     const status = await store.status({ recentLimit: 10 });
 
-    expect(queried).toHaveLength(3);
+    // bl-HiZJbUuy: disk-first hydration — 3 candidates resolve from disk with
+    // zero workflow queries; completeness proven by resolvedChanges.size (3).
+    expect(queried).toHaveLength(0);
     expect(status.warnings).toBeUndefined();
     expect(status.hydrationStats).toBeUndefined();
-    expect(status.changes.byStatus.active).toBe(3);
+    // bl-HiZJbUuy: disk-first returns the canonical normalized status — the
+    // disk load path normalizes legacy "active" to "draft" (the schema enum is
+    // draft/archived/closed), whereas the old Temporal query mock returned the
+    // un-normalized "active".
+    expect(status.changes.byStatus.draft).toBe(3);
     expect(status.changes.recent).toHaveLength(3);
     expect(status.resolvedChanges?.size).toBe(3);
   });
@@ -198,9 +206,13 @@ describe("bounded summary status reads", () => {
 
     const status = await store.status();
 
-    expect(queried).toHaveLength(12);
+    // bl-HiZJbUuy: full view hydrates all 12 candidates disk-first (no workflow
+    // queries); completeness proven by resolvedChanges.size (12).
+    expect(queried).toHaveLength(0);
     expect(status.warnings).toBeUndefined();
-    expect(status.changes.byStatus.active).toBe(12);
+    // bl-HiZJbUuy: disk-first returns canonical "draft" (legacy "active"
+    // normalizes at the disk load path), not the mock's un-normalized "active".
+    expect(status.changes.byStatus.draft).toBe(12);
     expect(status.changes.recent).toHaveLength(12);
     expect(status.resolvedChanges?.size).toBe(12);
   });
@@ -295,7 +307,9 @@ describe("bounded summary status reads", () => {
       )
       .slice(0, 10)
       .map((row) => row.id);
-    expect(queried).toHaveLength(10);
+    // bl-HiZJbUuy: source-ranked candidates hydrate disk-first (no workflow
+    // queries); the newest-10 ranking + 47 bounded omissions still hold.
+    expect(queried).toHaveLength(0);
     expect(status.changes.recent.map((row) => row.id)).toEqual(expected);
     expect(status.hydrationStats?.boundedOmitted).toBe(47);
     expect(

--- a/plugin/src/storage/store-temporal/index.test.ts
+++ b/plugin/src/storage/store-temporal/index.test.ts
@@ -520,7 +520,7 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     );
   });
 
-  it("list re-seeds active disk-only changes without resurrecting terminal changes", async () => {
+  it("serves active disk-only changes from disk without resurrecting any workflow", async () => {
     tempDir = await createTempDir();
     const active = activeChange("activeDiskOnlyList");
     const archived = archivedChange("archivedDiskOnlyList");
@@ -543,14 +543,16 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     expect(list.changes.map((change) => change.id)).not.toContain(
       "closedDiskOnlyList",
     );
-    expect(startInputs()).toEqual([
-      expect.objectContaining({ changeId: "activeDiskOnlyList" }),
-    ]);
-    // Poison read-resilience: both terminal statuses are now served from the
-    // disk terminal projection WITHOUT a live workflow query. Archived
-    // previously incurred one query (then reseed-to-disk); it is now consistent
-    // with closed at zero queries, so a poisoned/terminated terminal workflow is
-    // never touched during enumeration.
+    // bl-HiZJbUuy / disk-authoritative reads: enumeration is side-effect-free.
+    // The active change is served from its durable change.json projection
+    // WITHOUT re-seeding (resurrecting) its workflow. Orphan re-seed now happens
+    // on the next mutation (getTemporalChange), never during a read — so no
+    // workflow start occurs for ANY candidate during list.
+    expect(startInputs()).toEqual([]);
+    // All candidates (active + both terminal) resolve from disk with zero
+    // workflow queries, so a poisoned/terminated workflow is never touched
+    // during enumeration.
+    expect(queryCount("activeDiskOnlyList")).toBe(0);
     expect(queryCount("archivedDiskOnlyList")).toBe(0);
     expect(queryCount("closedDiskOnlyList")).toBe(0);
   });

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -1284,6 +1284,73 @@ export function createTemporalStoreBackend(
       changeId: string,
     ): Promise<{ change?: Change; resolution?: CandidateResolution }> => {
       const isArchiveCandidate = archiveIdSet.has(changeId);
+
+      // bl-HiZJbUuy / disk-authoritative active reads: resolve each NON-archive
+      // candidate from its durable on-disk change.json projection BEFORE any
+      // per-workflow Temporal query. The disk projection is the eventually-
+      // consistent read model the change workflow writes on every signal;
+      // enumeration (list/status/wip_state) tolerates its lag, and reading it
+      // first eliminates the per-workflow query N+1 that saturates the single
+      // project worker under multi-session load (94 workflows × cold replay >
+      // the 8s aggregate deadline). Mutation preconditions still call
+      // getTemporalChange/get directly (Temporal-fresh) — this disk-first
+      // reorder is scoped to the read-only listResolvedChanges path. A disk
+      // miss (brand-new change not yet projected, or a Temporal/memo-only
+      // entry) falls through to the getTemporalChange hydration below.
+      if (!isArchiveCandidate && !expired()) {
+        try {
+          const diskResult = await raceWithTemporalDeadline(
+            legacy.changes.get(changeId),
+            deadline,
+          );
+          if (isSchemaError(diskResult)) {
+            throw new Error(diskResult.error);
+          }
+          if (diskResult.success && diskResult.data) {
+            const terminalOnDisk =
+              diskResult.data.status === "archived" ||
+              diskResult.data.status === "closed";
+            // Layer A1 terminal override: a non-terminal disk status with a
+            // present archive bundle IS archived (the bundle is durable truth).
+            if (
+              !terminalOnDisk &&
+              (await raceWithTemporalDeadline(
+                checkArchiveBundle(changeId),
+                deadline,
+              ))
+            ) {
+              const archived = {
+                ...diskResult.data,
+                status: "archived" as const,
+              };
+              indexTasksFromChange(archived);
+              return {
+                change: archived,
+                resolution: {
+                  id: changeId,
+                  terminal: true,
+                  source: "archive",
+                  omitted: false,
+                },
+              };
+            }
+            indexTasksFromChange(diskResult.data);
+            return {
+              change: diskResult.data,
+              resolution: {
+                id: changeId,
+                terminal: terminalOnDisk,
+                source: "disk",
+                omitted: false,
+              },
+            };
+          }
+        } catch {
+          // Disk miss / unreadable — fall through to the getTemporalChange
+          // hydration below (covers Temporal/memo-only and cache-warm cases).
+        }
+      }
+
       try {
         const result = await raceWithTemporalDeadline(
           getTemporalChange(changeId, { context: ctx }),

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -1351,6 +1351,22 @@ export function createTemporalStoreBackend(
         }
       }
 
+      // If the disk-first read exhausted the aggregate budget, do NOT begin a
+      // workflow query: getTemporalChange would immediately reject as expired
+      // and, racing an already-expired deadline, orphan its rejection. Record
+      // typed incompleteness and stop (mirrors the post-query expiry guard).
+      if (expired()) {
+        markDeadline("workflow_query");
+        return {
+          resolution: {
+            id: changeId,
+            terminal: isArchiveCandidate,
+            omitted: true,
+            omissionReason: "deadline",
+          },
+        };
+      }
+
       try {
         const result = await raceWithTemporalDeadline(
           getTemporalChange(changeId, { context: ctx }),

--- a/plugin/src/storage/store-temporal/read-context.test.ts
+++ b/plugin/src/storage/store-temporal/read-context.test.ts
@@ -396,9 +396,13 @@ describe("Temporal read context — change/gate/status stages", () => {
 
     await store.status();
 
-    // One visibility-list RPC plus one query per change = 3 total RPCs.
-    expect(deadlineCalls.length).toBeGreaterThanOrEqual(3);
-    expect(abortCalls.length).toBeGreaterThanOrEqual(3);
+    // Disk-authoritative reads (bl-HiZJbUuy): status() enumerates via one
+    // visibility-list RPC and hydrates each change from its on-disk change.json
+    // projection, so the per-change workflow queries (the old N+1) are gone. The
+    // visibility RPC still threads the shared deadline + abort signal; the
+    // coherence invariant below holds for whatever Temporal RPCs occur.
+    expect(deadlineCalls.length).toBeGreaterThanOrEqual(1);
+    expect(abortCalls.length).toBeGreaterThanOrEqual(1);
 
     const firstDeadline = deadlineCalls[0].deadline;
     const firstSignal = abortCalls[0].signal;


### PR DESCRIPTION
## Why

Under multi-session load, ADV's own tools (`adv_change_create`, `adv_change_show`, `adv_change_list`, `adv_status`, `adv_wip_state`) time out. Root cause (full RCA in backlog `bl-HiZJbUuy`): **change-state reads hydrate each change via a per-workflow Temporal Query** — `adv_change_list` = 1 Visibility RPC + **N per-workflow queries** (`read-context.test.ts` asserted this literally). Each Query is a synchronous worker round-trip needing sticky-cache or full-history replay, consuming 1 of only **4** workflow-task slots (`worker-tuning.ts`). With ~90+ workflows in the namespace, the 8s aggregate read deadline trips (`SOURCE_DEADLINE_EXCEEDED`) and new-workflow start can't be serviced within budget. This is *using the workflow worker as a read database* — not a Temporal scale limit.

Terminal (archived/closed) changes were already disk-authoritative (`index.ts` `loadTerminalProjection`); **active changes still hit the Query.** This PR flips them.

## What changes

Scoped, single-hunk change in `store-temporal/index.ts` `loadCandidate` (the **read-only** `listResolvedChanges` enumeration path only):

- Resolve each non-archive candidate from its durable `change.json` projection **before** any per-workflow Temporal query. The disk projection is the eventually-consistent read model the change workflow writes on every signal; enumeration tolerates its lag.
- If the disk-first read exhausts the aggregate budget, skip the workflow query (which would reject `expired` and orphan its rejection) and record a typed deadline omission directly.
- **Mutation preconditions are untouched** — `getTemporalChange`/`store.changes.get()` (used by gate/task/contract read-modify-write) stay Temporal-fresh. No stale-state-mutation risk.

Result: `list`/`status`/`wip_state` become O(disk I/O), zero worker round-trips, immune to poisoned/orphaned-session-queue workflows, and unbounded in concurrent sessions.

### Approved behavior change
Enumeration is now **side-effect-free**: listing an orphaned active change no longer *re-seeds/resurrects* its workflow as a read side-effect. Orphan re-seed moves to the next **mutation** (`getTemporalChange` still re-seeds). Reads should be pure — a read starting workflows was itself part of the workflow churn.

## Verification

- `store-temporal/` full dir: **181/181**
- List/status consumers (change/status-enrich/gate/task/epic): **386/386**
- Full unit suite: **6800 passed**, 0 unexpected failures (1 intentional `it.fails`, 12 todo)
- `pnpm run check` green (schemas + typecheck + manifests + test-isolation + lockfile + lint + format)

9 existing tests that encoded the old Query-first contract were updated to the disk-first contract (documented per-hunk).

## Scope / follow-ups

This is **prong #1** of the `hardenTemporalReliability` re-architecture. Companion prongs (separate changes): workflow **retire-on-terminal** + dormant hibernation via Signal-With-Start + Continue-As-New history bounding (`bl-MsU7dzK0`), which collapse the namespace and fix the history-growth poisoning root. This PR is the keystone that restores ADV read/create responsiveness so those can proceed through normal ADV ceremony.