### PR TITLE
Disk-first hydration in listSummary — finish the change-list N+1 fix (bl-HiZJbUuy)

### DIFF
--- a/plugin/src/storage/store-temporal/changes.ts
+++ b/plugin/src/storage/store-temporal/changes.ts
@@ -1392,6 +1392,74 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
           markDeadline("workflow_query");
           continue;
         }
+
+        // bl-HiZJbUuy: disk-first summary hydration. On a cache+memo miss,
+        // resolve the row from the durable active change.json projection BEFORE
+        // any per-workflow Temporal query. This is the path adv_change_list /
+        // adv_status take; keeping it disk-first makes enumeration O(disk) and
+        // off the single shared worker under multi-session load (the N+1 query
+        // here was the residual change-list timeout after the listResolvedChanges
+        // fix). The getTemporalChange query below is retained ONLY as a bounded
+        // fallback for Temporal/memo-only IDs with no active disk projection.
+        // Mutation preconditions still call getTemporalChange directly
+        // (Temporal-fresh); this reorder is scoped to the read-only listSummary.
+        try {
+          const diskLoaded = await raceWithTemporalDeadline(
+            loadChange(legacy.paths.changes, id),
+            ctx.deadline,
+          );
+          if (isSchemaError(diskLoaded)) {
+            throw new Error(diskLoaded.error);
+          }
+          if (diskLoaded.success && diskLoaded.data) {
+            let change = diskLoaded.data;
+            // Archive-bundle terminal override: a non-terminal disk status with
+            // a present bundle IS archived; it is filtered from the warm path.
+            // (Properly-archived changes have their active dir removed, so they
+            // miss the disk read above and fall through to getTemporalChange;
+            // this covers the rare best-effort removeChangeDir residue.)
+            if (
+              change.status !== "archived" &&
+              change.status !== "closed" &&
+              legacy.paths.archive &&
+              (await hasArchiveBundle(legacy.paths.archive, id))
+            ) {
+              change = { ...change, status: "archived" as const };
+            }
+            fromHydration += 1;
+            rows.push({
+              id: change.id,
+              title: change.title,
+              status: change.status,
+              currentGate: firstOpenGate(change.gates),
+              lifecycleState: change.lifecycleState,
+              created_at: change.created_at,
+              lastActivityAt: computeLastActivity(change),
+              taskCount: change.tasks.length,
+              completedTasks: change.tasks.filter((t) => t.status === "done")
+                .length,
+              fast_follow_of: change.fast_follow_of,
+              ops_followup: change.ops_followup,
+              ops_followup_links: change.ops_followup_links,
+              epic_membership: change.epic_membership,
+            });
+            continue;
+          }
+        } catch (err) {
+          if (err instanceof TemporalQueryTimeoutError || expired()) {
+            markDeadline("workflow_query");
+            continue;
+          }
+          // Disk miss / unreadable (not a deadline) — fall through to the
+          // bounded workflow-query fallback below.
+        }
+
+        // If the disk-first read exhausted the budget, do not begin a workflow
+        // query (which would reject expired and orphan its rejection).
+        if (expired()) {
+          markDeadline("workflow_query");
+          continue;
+        }
         try {
           const loaded = await raceWithTemporalDeadline(
             getTemporalChange(id, { context: ctx }),

--- a/plugin/src/storage/store-temporal/index.test.ts
+++ b/plugin/src/storage/store-temporal/index.test.ts
@@ -1652,10 +1652,12 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
     const result = await store.changes.listSummary!({});
     const found = result.changes.find((c) => c.id === "fastPathActive");
     expect(found).toBeDefined();
-    expect(found!.status).toBe("active");
-    // Active-only summary path should not have needed terminal reconciliation.
+    // bl-HiZJbUuy: listSummary serves the active change disk-first — canonical
+    // "draft" (legacy "active" normalizes at the disk load path) with NO
+    // workflow query. Active-only summary needs no terminal reconciliation.
+    expect(found!.status).toBe("draft");
     expect(result.hydrationStats?.fromHydration).toBeGreaterThan(0);
-    expect(queryCount).toBe(1);
+    expect(queryCount).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Why

Follow-up to #284. That PR made `listResolvedChanges` disk-first, but `adv_change_list` and `adv_status` route through **`listSummary`** — a *second* read model. Its cache+memo miss-branch (`changes.ts`) called `getTemporalChange` directly and **N+1-queried the worker**. After a cold restart, every candidate misses cache+memo and falls to the 5s workflow query; with 90+ workflows and a 4-slot worker the 8s aggregate deadline trips (`SOURCE_DEADLINE_EXCEEDED`, `fromHydration` stalls at ~7/94). So the change-list/create starvation persisted despite #284.

## What changes

Same scoped disk-first pattern, applied to the `listSummary` miss-branch:

- On a cache+memo miss, resolve the row from the durable active `change.json` projection (`loadChange`) **before** any per-workflow query.
- `getTemporalChange` is retained **only** as a bounded fallback for Temporal/memo-only IDs with no active disk projection.
- Skip the fallback query if the disk read already exhausted the budget (avoids an expired-reject orphan).
- Archive-bundle terminal override for the rare best-effort-`removeChangeDir` residue.
- **Mutation preconditions untouched** — `getTemporalChange`/`store.changes.get()` stay Temporal-fresh.

Result: `adv_change_list`/`adv_status` become O(disk), unblocking read/create under multi-session load.

## Verification

- store-temporal dir: **181/181**
- consumers (change/status-enrich/gate/task/epic): **386/386**
- Full unit suite: **6800 passed**, 0 unexpected failures
- `pnpm run check` green

Updated one test (`index.test.ts` "summary fast path") to the disk-first contract: served from disk as canonical `draft` (legacy `active` normalizes at the disk load path) with zero queries.

## Context

Completes prong #1 of the `hardenTemporalReliability` re-architecture (`bl-HiZJbUuy`). Prongs #2–#4 (`bl-MsU7dzK0`: retire-on-terminal, hibernation, Continue-As-New) follow via normal ADV ceremony once this deploys and restores read/create responsiveness.