### PR TITLE
fix(temporal): auto-adopt orphaned session queues + route to project queue

### DIFF
--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -25,6 +25,10 @@ import {
 } from "./temporal/in-process-worker";
 import { createOutOfProcessWorker } from "./temporal/out-of-process-worker";
 import {
+  discoverOrphanedSessionQueues,
+  adoptOrphanedSessionQueues,
+} from "./temporal/orphan-queue-adoption";
+import {
   ensureTemporalRuntime,
   probeTemporalWorkerRuntime,
   resolveNodeExecutable,
@@ -381,6 +385,20 @@ export async function tryInitStore(
       });
       if (worker) {
         registerInProcessTemporalWorker(worker);
+        // rq-orphanSessionAdoption01: adopt orphaned session queues from
+        // dead sessions so their workflows become reachable again. Fire-
+        // and-forget — must not block plugin init.
+        if (temporalBundle) {
+          void adoptOrphanQueuesAtStartup(
+            temporalBundle.client,
+            worker,
+            projectId,
+          ).catch((err) => {
+            debugLog(
+              `orphan queue adoption failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+        }
       }
     }
 
@@ -463,6 +481,43 @@ async function handleWorkerExhausted(
 
   recordWorkerRunFailure("<all>", new Error("worker exhausted"));
   if (worker) inProcessTemporalWorkers.delete(worker);
+}
+
+/**
+ * Discover and adopt orphaned session-scoped task queues at worker startup.
+ *
+ * Queries Temporal Visibility for RUNNING change workflows on session
+ * queues that have no poller (dead sessions), then registers those queues
+ * with the live worker so mutations/signals can reach the orphaned
+ * workflows.
+ */
+async function adoptOrphanQueuesAtStartup(
+  client: import("@temporalio/client").Client,
+  worker: InProcessWorker,
+  projectId: string,
+): Promise<void> {
+  const registeredQueues = [...worker.queues];
+  const orphans = await discoverOrphanedSessionQueues(
+    client,
+    projectId,
+    registeredQueues,
+  );
+  if (orphans.length === 0) return;
+
+  debugLog(
+    `orphan queue adoption: discovered ${orphans.length} orphaned session queue(s): ${orphans.join(", ")}`,
+  );
+  const result = await adoptOrphanedSessionQueues(worker, orphans);
+  if (result.adopted.length > 0) {
+    debugLog(
+      `orphan queue adoption: adopted ${result.adopted.length} queue(s)`,
+    );
+  }
+  if (result.failed.length > 0) {
+    debugLog(
+      `orphan queue adoption: ${result.failed.length} queue(s) failed: ${result.failed.map((f) => f.queue).join(", ")}`,
+    );
+  }
 }
 
 /**

--- a/plugin/src/temporal/__tests__/session-routing.itest.ts
+++ b/plugin/src/temporal/__tests__/session-routing.itest.ts
@@ -1,12 +1,15 @@
 /**
  * AC1 + AC5 integration test: workflow task-queue routing.
  *
- * Verifies the per-session task-queue routing design from change
- * `isolateAdvWorkerTaskQueues` (KD-2 / KD-10):
+ * rq-orphanSessionAdoption01: change workflows now default-route to the
+ * permanent project queue (advance-{P}) to prevent orphaning when sessions
+ * die. Session-scoped queues are still created and polled by the worker,
+ * but new workflows are NOT routed to them. Existing orphaned workflows on
+ * session queues are adopted at worker startup.
  *
  *   AC1: When session S1 on project P starts a change workflow, the
- *        workflow's task queue is `advance-{P}-{S1}` (verified via Temporal
- *        workflow describe or task-queue inspection).
+ *        workflow's task queue is `advance-{P}` (project queue, not
+ *        session-scoped — prevents orphaning on session death).
  *
  *   AC5: Epic workflows route to `advance-{P}` (project queue), not a
  *        session queue.
@@ -25,7 +28,7 @@ import {
 } from "../workflow-start";
 import { createDefaultGates } from "../../types";
 import type { ChangeWorkflowInput, EpicWorkflowInput } from "../contracts";
-import { buildProjectTaskQueue, buildSessionTaskQueue } from "../client";
+import { buildProjectTaskQueue } from "../client";
 import { requiredAdvSearchAttributes } from "../observability";
 import type { TestWorkflowEnvironment } from "@temporalio/testing";
 
@@ -87,16 +90,16 @@ function makeEpicInput(epicId: string): EpicWorkflowInput {
   };
 }
 
-describe("AC1 + AC5: workflow task-queue routing (isolateAdvWorkerTaskQueues)", () => {
-  it("AC1: change workflow with sessionId routes to advance-{P}-{sess}", async () => {
+describe("AC1 + AC5: workflow task-queue routing (rq-orphanSessionAdoption01)", () => {
+  it("AC1: change workflow with sessionId routes to advance-{P} (project queue)", async () => {
     await withTimeSkippingTestWorkflowEnvironment(async (env) => {
       await registerAdvSearchAttributes(env);
 
-      const sessionQueue = buildSessionTaskQueue(PROJECT_ID, SESSION_ID);
+      const projectQueue = buildProjectTaskQueue(PROJECT_ID);
       const worker = await Worker.create({
         connection: env.nativeConnection,
         workflowsPath,
-        taskQueue: sessionQueue,
+        taskQueue: projectQueue,
       });
 
       await worker.runUntil(async () => {
@@ -105,12 +108,12 @@ describe("AC1 + AC5: workflow task-queue routing (isolateAdvWorkerTaskQueues)", 
           makeChangeInput("routing-ac1-change", SESSION_ID),
         );
 
-        // AC1 verification: the workflow's task queue is the session queue.
+        // AC1 verification: the workflow's task queue is the project queue,
+        // NOT the session queue — prevents orphaning on session death.
         const description = await handle.describe();
-        expect(description.taskQueue).toBe(sessionQueue);
-        expect(description.taskQueue).toBe(
-          `advance-${PROJECT_ID}-${SESSION_ID}`,
-        );
+        expect(description.taskQueue).toBe(projectQueue);
+        expect(description.taskQueue).toBe(`advance-${PROJECT_ID}`);
+        expect(description.taskQueue).not.toContain(SESSION_ID);
       });
     });
   });

--- a/plugin/src/temporal/orphan-queue-adoption.test.ts
+++ b/plugin/src/temporal/orphan-queue-adoption.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test, vi } from "vitest";
+import type { AsyncIterable } from "node:stream";
+import {
+  discoverOrphanedSessionQueues,
+  adoptOrphanedSessionQueues,
+} from "./orphan-queue-adoption";
+import { ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX } from "./contracts";
+
+/** Build a mock workflow list result entry. */
+function wf(workflowId: string, taskQueue: string, status = "RUNNING") {
+  return {
+    workflowId,
+    taskQueue,
+    status: { code: 1, name: status },
+  };
+}
+
+/** Wrap an array as an async iterable (mimics client.workflow.list). */
+function makeList(
+  entries: ReturnType<typeof wf>[],
+): (opts: { query: string }) => AsyncIterable<ReturnType<typeof wf>> {
+  return async function* () {
+    for (const e of entries) yield e;
+  };
+}
+
+const PROJECT_ID = "pid-abc";
+const PROJECT_QUEUE = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PROJECT_ID}`;
+const SESS_DEAD_1 = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PROJECT_ID}-sess_deadOne`;
+const SESS_DEAD_2 = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PROJECT_ID}-sess_deadTwo`;
+const SESS_LIVE = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PROJECT_ID}-sess_live`;
+
+describe("discoverOrphanedSessionQueues", () => {
+  test("discovers session-scoped queues not already polled (rq-orphanSessionAdoption01)", async () => {
+    const client = {
+      workflow: {
+        list: makeList([
+          wf("adv/change/pid-abc/changeA", SESS_DEAD_1),
+          wf("adv/change/pid-abc/changeB", SESS_DEAD_2),
+          wf("adv/change/pid-abc/changeC", PROJECT_QUEUE),
+          wf("adv/change/pid-abc/changeD", SESS_LIVE),
+        ]),
+      },
+    };
+
+    // Worker already polls the live session queue + project queue
+    const registered = [SESS_LIVE, PROJECT_QUEUE];
+
+    const orphans = await discoverOrphanedSessionQueues(
+      client,
+      PROJECT_ID,
+      registered,
+    );
+
+    // Dead session queues should be discovered; project + live should not
+    expect(orphans).toContain(SESS_DEAD_1);
+    expect(orphans).toContain(SESS_DEAD_2);
+    expect(orphans).not.toContain(PROJECT_QUEUE);
+    expect(orphans).not.toContain(SESS_LIVE);
+    expect(orphans).toHaveLength(2);
+  });
+
+  test("ignores non-change workflows (epic workflows use different prefix)", async () => {
+    const client = {
+      workflow: {
+        list: makeList([
+          wf("adv/change/pid-abc/changeA", SESS_DEAD_1),
+          wf("adv/epic/pid-abc/someEpic", SESS_DEAD_2),
+        ]),
+      },
+    };
+
+    const orphans = await discoverOrphanedSessionQueues(client, PROJECT_ID, [
+      PROJECT_QUEUE,
+    ]);
+
+    // Only the change workflow's queue should be discovered
+    expect(orphans).toEqual([SESS_DEAD_1]);
+  });
+
+  test("skips completed/terminated workflows (only RUNNING need pollers)", async () => {
+    const client = {
+      workflow: {
+        list: makeList([
+          wf("adv/change/pid-abc/running", SESS_DEAD_1, "RUNNING"),
+          wf("adv/change/pid-abc/completed", SESS_DEAD_2, "COMPLETED"),
+          wf("adv/change/pid-abc/terminated", SESS_DEAD_2, "TERMINATED"),
+        ]),
+      },
+    };
+
+    const orphans = await discoverOrphanedSessionQueues(client, PROJECT_ID, [
+      PROJECT_QUEUE,
+    ]);
+
+    expect(orphans).toEqual([SESS_DEAD_1]);
+  });
+
+  test("returns empty when all queues are already registered", async () => {
+    const client = {
+      workflow: {
+        list: makeList([
+          wf("adv/change/pid-abc/changeA", PROJECT_QUEUE),
+          wf("adv/change/pid-abc/changeB", SESS_LIVE),
+        ]),
+      },
+    };
+
+    const orphans = await discoverOrphanedSessionQueues(client, PROJECT_ID, [
+      PROJECT_QUEUE,
+      SESS_LIVE,
+    ]);
+
+    expect(orphans).toEqual([]);
+  });
+});
+
+describe("adoptOrphanedSessionQueues", () => {
+  test("registers each discovered queue via worker.registerQueue", async () => {
+    const registerQueue = vi.fn().mockResolvedValue(undefined);
+    const worker = { registerQueue };
+
+    const result = await adoptOrphanedSessionQueues(worker, [
+      SESS_DEAD_1,
+      SESS_DEAD_2,
+    ]);
+
+    expect(registerQueue).toHaveBeenCalledWith(SESS_DEAD_1);
+    expect(registerQueue).toHaveBeenCalledWith(SESS_DEAD_2);
+    expect(registerQueue).toHaveBeenCalledTimes(2);
+    expect(result.adopted).toEqual([SESS_DEAD_1, SESS_DEAD_2]);
+    expect(result.failed).toEqual([]);
+  });
+
+  test("records failed adoptions without throwing", async () => {
+    const registerQueue = vi.fn((q: string) => {
+      if (q === SESS_DEAD_2) {
+        return Promise.reject(new Error("connection refused"));
+      }
+      return Promise.resolve();
+    });
+    const worker = { registerQueue };
+
+    const result = await adoptOrphanedSessionQueues(worker, [
+      SESS_DEAD_1,
+      SESS_DEAD_2,
+    ]);
+
+    expect(result.adopted).toEqual([SESS_DEAD_1]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].queue).toBe(SESS_DEAD_2);
+    expect(result.failed[0].error).toBe("connection refused");
+  });
+
+  test("handles empty input gracefully", async () => {
+    const registerQueue = vi.fn();
+    const worker = { registerQueue };
+
+    const result = await adoptOrphanedSessionQueues(worker, []);
+
+    expect(registerQueue).not.toHaveBeenCalled();
+    expect(result.adopted).toEqual([]);
+    expect(result.failed).toEqual([]);
+  });
+});

--- a/plugin/src/temporal/orphan-queue-adoption.ts
+++ b/plugin/src/temporal/orphan-queue-adoption.ts
@@ -1,0 +1,133 @@
+/**
+ * Orphaned session-queue discovery and adoption
+ * (rq-orphanSessionAdoption01).
+ *
+ * When per-session task queues are used (advance-{P}-sess_{id}), workflows
+ * started on a session's queue become unreachable when that session's
+ * worker dies — no poller remains on the dead queue. This module
+ * discovers session-scoped queues that still have RUNNING change workflows
+ * but are not currently polled, and adopts them by registering them with
+ * the live worker.
+ *
+ * Discovery uses Temporal Visibility (client.workflow.list) to enumerate
+ * running change workflows for the project, extracts their taskQueue, and
+ * filters for session-scoped queues not in the already-registered set.
+ * Adoption calls worker.registerQueue for each discovered queue.
+ *
+ * Performance: bounded by the number of running workflows for the project
+ * (typically <100). The Visibility query paginates automatically via the
+ * SDK's async iterable. A hard cap prevents pathological cases.
+ */
+
+import {
+  ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX,
+  CHANGE_WORKFLOW_PREFIX,
+} from "./contracts";
+import { escapeVisibilityValue } from "./lifecycle-visibility";
+
+/** Hard cap on workflows inspected during discovery. */
+const DISCOVERY_LIMIT = 500;
+
+/**
+ * Minimal client shape for Visibility enumeration. The real
+ * `@temporalio/client` Client satisfies this structurally.
+ */
+export interface OrphanDiscoveryClient {
+  workflow: {
+    list: (opts: { query: string }) => AsyncIterable<{
+      workflowId: string;
+      taskQueue: string;
+      status: { name: string };
+    }>;
+  };
+}
+
+/** Minimal worker shape for queue adoption. */
+export interface QueueAdoptableWorker {
+  registerQueue(taskQueue: string): Promise<void>;
+}
+
+export interface OrphanQueueAdoptionResult {
+  discovered: string[];
+  adopted: string[];
+  failed: Array<{ queue: string; error: string }>;
+}
+
+/**
+ * Build the session-queue prefix for this project.
+ * Session queues follow the pattern: advance-{projectId}-sess_{sessionId}
+ */
+function buildSessionQueuePrefix(projectId: string): string {
+  return `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${projectId}-sess_`;
+}
+
+/**
+ * Discover session-scoped task queues that have RUNNING change workflows
+ * but are not currently being polled by any registered worker.
+ *
+ * @returns Array of orphaned session-queue names to adopt.
+ */
+export async function discoverOrphanedSessionQueues(
+  client: OrphanDiscoveryClient,
+  projectId: string,
+  registeredQueues: readonly string[],
+): Promise<string[]> {
+  const safeProjectId = escapeVisibilityValue(projectId);
+  const query = `AdvAffectedProjects = "${safeProjectId}"`;
+
+  const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
+  const sessionPrefix = buildSessionQueuePrefix(projectId);
+  const registered = new Set(registeredQueues);
+  const orphanQueues = new Set<string>();
+  let inspected = 0;
+
+  for await (const wf of client.workflow.list({ query })) {
+    if (inspected >= DISCOVERY_LIMIT) break;
+    inspected++;
+
+    // Only change workflows (exclude epic workflows with adv/epic/ prefix)
+    if (!wf.workflowId.startsWith(projectPrefix)) continue;
+
+    // Only RUNNING workflows need a poller
+    if (wf.status.name !== "RUNNING") continue;
+
+    // Only session-scoped queues can be orphaned
+    if (!wf.taskQueue.startsWith(sessionPrefix)) continue;
+
+    // Skip queues already being polled
+    if (registered.has(wf.taskQueue)) continue;
+
+    orphanQueues.add(wf.taskQueue);
+  }
+
+  return [...orphanQueues];
+}
+
+/**
+ * Adopt orphaned session queues by registering them with the live worker.
+ *
+ * Each queue adoption is independent — a failure on one queue does not
+ * prevent adoption of others. Results include both successful and failed
+ * adoptions for observability.
+ */
+export async function adoptOrphanedSessionQueues(
+  worker: QueueAdoptableWorker,
+  orphanQueues: readonly string[],
+): Promise<OrphanQueueAdoptionResult> {
+  const adopted: string[] = [];
+  const failed: Array<{ queue: string; error: string }> = [];
+
+  for (const queue of orphanQueues) {
+    try {
+      await worker.registerQueue(queue);
+      adopted.push(queue);
+    } catch (err) {
+      failed.push({
+        queue,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { discovered: [...orphanQueues], adopted, failed };
+}

--- a/plugin/src/temporal/workflow-start.test.ts
+++ b/plugin/src/temporal/workflow-start.test.ts
@@ -92,7 +92,10 @@ describe("ensureChangeWorkflowStarted", () => {
     );
   });
 
-  test("routes to session task queue when sessionId is present (rq-isolSessionTaskQueue01, KD-10)", async () => {
+  test("routes to project task queue even when sessionId is present (rq-orphanSessionAdoption01)", async () => {
+    // Change workflows now default-route to the permanent project queue to
+    // prevent orphaning when sessions die. Session-scoped queues are adopted
+    // at worker startup for legacy workflows still on them.
     const handle = { query: vi.fn() };
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };
@@ -108,12 +111,12 @@ describe("ensureChangeWorkflowStarted", () => {
     expect(start).toHaveBeenCalledWith(
       expect.any(Function),
       expect.objectContaining({
-        taskQueue: "advance-pid-abc-sess_RouteTest",
+        taskQueue: "advance-pid-abc",
       }),
     );
   });
 
-  test("falls back to project task queue when sessionId is absent (backward compat, KD-10)", async () => {
+  test("routes to project task queue when sessionId is absent (backward compat)", async () => {
     const handle = { query: vi.fn() };
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };

--- a/plugin/src/temporal/workflow-start.ts
+++ b/plugin/src/temporal/workflow-start.ts
@@ -3,7 +3,6 @@ import {
   buildChangeWorkflowId,
   buildEpicWorkflowId,
   buildProjectTaskQueue,
-  buildSessionTaskQueue,
 } from "./client";
 import type { ChangeWorkflowInput, EpicWorkflowInput } from "./contracts";
 import { changeSeedStateFromChange } from "./change-state";
@@ -41,15 +40,12 @@ export async function ensureChangeWorkflowStarted(
   input: ChangeWorkflowInput,
 ): Promise<WorkflowHandleLike> {
   const workflowId = buildChangeWorkflowId(input.projectId, input.changeId);
-  // KD-10 / rq-isolSessionTaskQueue01: route to per-session task queue when
-  // the caller provides a sessionId (production callers via changes.ts and
-  // store-temporal/index.ts thread `getCurrentSessionId()`). When absent
-  // (tests, re-import paths, epic-only callers, pre-init), fall back to the
-  // permanent project queue — the worker child co-polls it for migration
-  // and epic workflows live there.
-  const taskQueue = input.sessionId
-    ? buildSessionTaskQueue(input.projectId, input.sessionId)
-    : buildProjectTaskQueue(input.projectId);
+  // rq-orphanSessionAdoption01: always route change workflows to the
+  // permanent project queue. Per-session task queues caused workflows to
+  // be orphaned when sessions died (no poller on the dead session's
+  // queue). Existing orphaned workflows on session queues are adopted at
+  // worker startup by the orphan-queue-adoption module.
+  const taskQueue = buildProjectTaskQueue(input.projectId);
 
   // KD-5 workflow-start hydration: when starting a workflow for a pre-
   // migration change whose disk artifacts pre-date Temporal-first writes,


### PR DESCRIPTION
## Problem

Per-session task queues (`advance-{P}-sess_{id}`) cause workflows to be orphaned when sessions die — no poller remains on the dead session's queue. The change that fixes this (`autoAdoptOrphanSessionQueues`) was itself orphaned, blocking all ADV reads/mutations with `Failed to query Workflow`.

## Changes

- **`workflow-start.ts`**: Route change workflows to `buildProjectTaskQueue` unconditionally (`rq-orphanSessionAdoption01`). Per-session queues caused orphaning; project queue is always polled.
- **`orphan-queue-adoption.ts`** (new): `discoverOrphanedSessionQueues` queries Temporal Visibility for RUNNING change workflows on session-scoped queues not already polled. `adoptOrphanedSessionQueues` registers each via `worker.registerQueue` with per-queue error isolation.
- **`plugin-init.ts`**: Fire-and-forget adoption after worker registration. Must not block plugin init.
- **`session-routing.itest.ts`**: AC1 updated to assert project-queue routing even with sessionId.

## Verification

- Unit tests: 14 pass (7 routing + 7 adoption)
- Typecheck: clean
- Lint: clean
- Build: clean
- Integration tests (`.itest.ts`): AC1 updated; orphan-adoption itest deferred (requires deployed worker to test real adoption)