### PR TITLE
feat(delta): add adv_delta_list + adv_delta_show read tools

### DIFF
--- a/.opencode/agents/adv.md
+++ b/.opencode/agents/adv.md
@@ -61,56 +61,58 @@ tools:
   adv_contract_review_matrix_set: true
   adv_delta_add: true
   adv_delta_amend: true
+  adv_delta_list: true
   adv_delta_modify: true
   adv_delta_remove: true
   adv_delta_rename: true
   adv_delta_retract: true
-  adv_design_concern_disposition: true
   # Tasks
+  adv_delta_show: true
+  adv_design_concern_disposition: true
   adv_epic_add_shell: true
   adv_epic_create: true
   adv_epic_link_change: true
   adv_epic_list: true
   adv_epic_move_change: true
   adv_epic_promote_shell: true
+  # Wisdom
   adv_epic_reorder: true
   adv_epic_repair_membership: true
-  # Wisdom
+  # Gates
   adv_epic_retire: true
   adv_epic_show: true
-  # Gates
   adv_epic_unlink_change: true
   adv_epic_update: true
   adv_followup_promote: true
   adv_gate_complete: true
-  adv_gate_status: true
-  adv_lightweight_profile_evaluate: true
   # Sub-agent reports
-  adv_ops_evidence_add: true
+  adv_gate_status: true
   # Ops follow-ups
+  adv_lightweight_profile_evaluate: true
+  adv_ops_evidence_add: true
   adv_ops_run_evidence_add: true
   adv_ops_run_upsert: true
   adv_project_context: true
+  # Temporal / workflow ops
   adv_project_metadata: true
   adv_reflect: true
-  # Temporal / workflow ops
   adv_reflection_list: true
   adv_report_followup_promote: true
+  # Store maintenance (operator-only)
   adv_run_test: true
   adv_session_list: true
-  # Store maintenance (operator-only)
-  adv_session_show: true
-  adv_snapshot_health: true
   # Snapshot health diagnostics
-  adv_spec: true
+  adv_session_show: true
   # Reflection
+  adv_snapshot_health: true
+  adv_spec: true
   adv_status: true
+  # Project metadata
   adv_store_cleanup: true
   adv_store_consolidate: true
-  # Project metadata
+  # === Epics — optional initiative containers ===
   adv_subagent_report_submit: true
   adv_task_add: true
-  # === Epics — optional initiative containers ===
   adv_task_cancel: true
   adv_task_checkpoint: true
   adv_task_list: true
@@ -122,9 +124,9 @@ tools:
   adv_temporal_reconnect: true
   adv_temporal_register_search_attributes: true
   adv_temporal_worker_restart: true
+  # === Worktree — orchestrator owns lifecycle ===
   adv_tool_catalog: true
   adv_tool_describe: true
-  # === Worktree — orchestrator owns lifecycle ===
   adv_tool_invoke: true
   adv_verification_evidence_disposition: true
   adv_wip_state: true

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -623,6 +623,8 @@ const advancePluginImpl: Plugin = async (input) => {
     "adv_delta_remove",
     "adv_delta_rename",
     "adv_delta_retract",
+    "adv_delta_list",
+    "adv_delta_show",
     "adv_contract_mint",
     "adv_contract_review_matrix_set",
     "adv_subagent_report_submit",

--- a/plugin/src/tool-catalog-entries.ts
+++ b/plugin/src/tool-catalog-entries.ts
@@ -237,6 +237,8 @@ export const REALM_OVERRIDES: Readonly<Record<string, ToolRealm>> = {
   adv_delta_remove: "spec",
   adv_delta_rename: "spec",
   adv_delta_retract: "spec",
+  adv_delta_list: "spec",
+  adv_delta_show: "spec",
   adv_design_concern_disposition: "design",
   adv_followup_promote: "followup",
   adv_report_followup_promote: "report",

--- a/plugin/src/tool-registry.inventory.test.ts
+++ b/plugin/src/tool-registry.inventory.test.ts
@@ -95,6 +95,8 @@ const CONTRACTED_PUBLIC_ADDITIONS = [
   "adv_delta_retract",
   "adv_delta_remove",
   "adv_delta_rename",
+  "adv_delta_list",
+  "adv_delta_show",
   "adv_change_workflow_terminate",
   "adv_verification_evidence_disposition",
   "adv_lightweight_profile_evaluate",

--- a/plugin/src/tool-registry.ts
+++ b/plugin/src/tool-registry.ts
@@ -378,6 +378,16 @@ export function createToolMap(
       "adv_delta_rename",
       store,
     ),
+    adv_delta_list: bindTool(
+      specDeltaTools.adv_delta_list,
+      "adv_delta_list",
+      store,
+    ),
+    adv_delta_show: bindTool(
+      specDeltaTools.adv_delta_show,
+      "adv_delta_show",
+      store,
+    ),
 
     // adv_wip_state — fixTriageTimeouts.
     //

--- a/plugin/src/tool-role-policy.ts
+++ b/plugin/src/tool-role-policy.ts
@@ -268,6 +268,14 @@ export const TOOL_ROLE_POLICY: Readonly<Record<string, ToolRoleEntry>> = {
     rationale:
       "Change-scoped rename-operation spec delta; archive remains sole global-spec writer.",
   },
+  adv_delta_list: {
+    class: "orchestrator",
+    rationale: "Staged spec-delta read (bounded list).",
+  },
+  adv_delta_show: {
+    class: "orchestrator",
+    rationale: "Staged spec-delta read (single delta).",
+  },
   adv_design_concern_disposition: {
     class: "orchestrator",
     rationale: "Design-concern disposition.",
@@ -547,10 +555,12 @@ export const AGENT_TOOL_POLICY: readonly AgentToolPolicy[] = [
       "adv_contract_review_matrix_set",
       "adv_delta_add",
       "adv_delta_amend",
+      "adv_delta_list",
       "adv_delta_modify",
       "adv_delta_remove",
       "adv_delta_rename",
       "adv_delta_retract",
+      "adv_delta_show",
       "adv_design_concern_disposition",
       "adv_epic_add_shell",
       "adv_epic_create",

--- a/plugin/src/tools/spec-delta.test.ts
+++ b/plugin/src/tools/spec-delta.test.ts
@@ -1121,3 +1121,164 @@ describe("adv_delta_rename — schema + target validation", () => {
     expect(mocks.specDeltasRename).not.toHaveBeenCalled();
   });
 });
+
+describe("adv_delta_list — read staged deltas", () => {
+  function storeWithDeltas(): Store {
+    return makeStore({
+      changes: {
+        get: vi.fn(async () => ({
+          success: true,
+          data: {
+            id: "addFeature",
+            title: "Add feature",
+            status: "draft",
+            deltas: {
+              "cap-one": [
+                {
+                  id: "dl-AAA11111",
+                  operation: "add",
+                  requirement: {
+                    id: "rq-one01",
+                    title: "One",
+                    body: "b",
+                    priority: "must",
+                  },
+                },
+                {
+                  id: "dl-MOD11111",
+                  operation: "modify",
+                  target_id: "rq-existing01",
+                  changes: { title: "Updated" },
+                },
+              ],
+              "cap-two": [
+                {
+                  id: "dl-REM11111",
+                  operation: "remove",
+                  target_id: "rq-two01",
+                  reason: "obsolete",
+                },
+              ],
+            },
+          },
+        })),
+      },
+    });
+  }
+
+  it("lists staged deltas across capabilities with ids, operation, target, title", async () => {
+    const result = await specDeltaTools.adv_delta_list.execute(
+      { changeId: "addFeature" },
+      storeWithDeltas(),
+    );
+    const parsed = parse(result);
+    expect(parsed.success).toBe(true);
+    const rows = parsed.rows as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(3);
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+    expect(byId["dl-AAA11111"]).toMatchObject({
+      operation: "add",
+      capability: "cap-one",
+      target: "rq-one01",
+      title: "One",
+    });
+    expect(byId["dl-MOD11111"]).toMatchObject({
+      operation: "modify",
+      target: "rq-existing01",
+      title: "Updated",
+    });
+    expect(byId["dl-REM11111"]).toMatchObject({
+      operation: "remove",
+      capability: "cap-two",
+      target: "rq-two01",
+    });
+    expect((parsed.pagination as Record<string, unknown>).total).toBe(3);
+  });
+
+  it("filters by capability", async () => {
+    const result = await specDeltaTools.adv_delta_list.execute(
+      { changeId: "addFeature", capability: "cap-two" },
+      storeWithDeltas(),
+    );
+    const parsed = parse(result);
+    const rows = parsed.rows as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("dl-REM11111");
+  });
+
+  it("paginates with offset + limit and reports hasMore", async () => {
+    const result = await specDeltaTools.adv_delta_list.execute(
+      { changeId: "addFeature", offset: 0, limit: 2 },
+      storeWithDeltas(),
+    );
+    const parsed = parse(result);
+    expect((parsed.rows as unknown[]).length).toBe(2);
+    const pg = parsed.pagination as Record<string, unknown>;
+    expect(pg.total).toBe(3);
+    expect(pg.returned).toBe(2);
+    expect(pg.hasMore).toBe(true);
+  });
+
+  it("returns empty rows for a change with no deltas", async () => {
+    const result = await specDeltaTools.adv_delta_list.execute(
+      { changeId: "addFeature" },
+      makeStore(),
+    );
+    const parsed = parse(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.rows).toEqual([]);
+    expect((parsed.pagination as Record<string, unknown>).total).toBe(0);
+  });
+});
+
+describe("adv_delta_show — read one staged delta", () => {
+  function storeWithDeltas(): Store {
+    return makeStore({
+      changes: {
+        get: vi.fn(async () => ({
+          success: true,
+          data: {
+            id: "addFeature",
+            title: "Add feature",
+            status: "draft",
+            deltas: {
+              "cap-one": [
+                {
+                  id: "dl-AAA11111",
+                  operation: "add",
+                  requirement: {
+                    id: "rq-one01",
+                    title: "One",
+                    body: "b",
+                    priority: "must",
+                  },
+                },
+              ],
+            },
+          },
+        })),
+      },
+    });
+  }
+
+  it("returns the full staged delta by id", async () => {
+    const result = await specDeltaTools.adv_delta_show.execute(
+      { changeId: "addFeature", capability: "cap-one", deltaId: "dl-AAA11111" },
+      storeWithDeltas(),
+    );
+    const parsed = parse(result);
+    expect(parsed.success).toBe(true);
+    expect((parsed.delta as Record<string, unknown>).id).toBe("dl-AAA11111");
+    expect((parsed.delta as Record<string, unknown>).operation).toBe("add");
+  });
+
+  it("returns typed not-found for an unknown delta id", async () => {
+    const result = await specDeltaTools.adv_delta_show.execute(
+      { changeId: "addFeature", capability: "cap-one", deltaId: "dl-UNKNOWN0" },
+      storeWithDeltas(),
+    );
+    const parsed = parse(result);
+    expect(parsed.success).not.toBe(true);
+    expect(String(parsed.error)).toContain("dl-UNKNOWN0");
+  });
+});

--- a/plugin/src/tools/spec-delta.ts
+++ b/plugin/src/tools/spec-delta.ts
@@ -633,6 +633,126 @@ async function runRetract(
   }
 }
 
+// Read-only: enumerate staged deltas as bounded summary rows. Reads
+// change.deltas[] disk-first (survives orphaned workflows); no mutation.
+// Fixes the adv_change_show truncation gap for delta-heavy changes and
+// surfaces the delta ids that adv_delta_amend/retract require.
+async function runList(
+  activeStore: Store,
+  input: {
+    changeId: string;
+    capability?: string;
+    offset?: number;
+    limit?: number;
+  },
+): Promise<string> {
+  try {
+    const change = await activeStore.changes.get(input.changeId);
+    if (!change.success) {
+      throw new Error(
+        `Unable to load change ${input.changeId}: ${change.error}`,
+      );
+    }
+    if (!change.data) throw new Error(`Change ${input.changeId} not found`);
+    const deltasByCap = change.data.deltas ?? {};
+    const rows: Array<{
+      id: string;
+      operation: string;
+      capability: string;
+      target?: string;
+      title?: string;
+    }> = [];
+    for (const [cap, entries] of Object.entries(deltasByCap)) {
+      if (input.capability && cap !== input.capability) continue;
+      for (const d of entries) {
+        rows.push({
+          id: d.id,
+          operation: d.operation,
+          capability: cap,
+          target:
+            "target_id" in d
+              ? d.target_id
+              : "requirement" in d
+                ? d.requirement.id
+                : undefined,
+          title:
+            "requirement" in d
+              ? d.requirement.title
+              : "new_title" in d
+                ? d.new_title
+                : "changes" in d
+                  ? d.changes.title
+                  : undefined,
+        });
+      }
+    }
+    const total = rows.length;
+    const offset = input.offset ?? 0;
+    const limit = Math.min(input.limit ?? 25, 100);
+    const page = rows.slice(offset, offset + limit);
+    return formatToolOutput({
+      success: true,
+      changeId: input.changeId,
+      ...(input.capability ? { capability: input.capability } : {}),
+      rows: page,
+      pagination: {
+        total,
+        returned: page.length,
+        offset,
+        limit,
+        hasMore: offset + page.length < total,
+      },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to list spec deltas";
+    return formatToolOutput({
+      success: false,
+      error: message,
+      changeId: input.changeId,
+    });
+  }
+}
+
+// Read-only: return the full staged delta by id under a capability. Typed
+// not-found on unknown id; no mutation.
+async function runShow(
+  activeStore: Store,
+  input: { changeId: string; capability: string; deltaId: string },
+): Promise<string> {
+  try {
+    const change = await activeStore.changes.get(input.changeId);
+    if (!change.success) {
+      throw new Error(
+        `Unable to load change ${input.changeId}: ${change.error}`,
+      );
+    }
+    if (!change.data) throw new Error(`Change ${input.changeId} not found`);
+    const capabilityDeltas = change.data.deltas?.[input.capability] ?? [];
+    const delta = capabilityDeltas.find((entry) => entry.id === input.deltaId);
+    if (!delta) {
+      throw new Error(
+        `Spec delta ${input.deltaId} not found under capability ${input.capability}`,
+      );
+    }
+    return formatToolOutput({
+      success: true,
+      changeId: input.changeId,
+      capability: input.capability,
+      delta,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to show spec delta";
+    return formatToolOutput({
+      success: false,
+      error: message,
+      changeId: input.changeId,
+      capability: input.capability,
+    });
+  }
+}
+
 async function runRemove(
   activeStore: Store,
   input: {
@@ -1595,6 +1715,76 @@ export const specDeltaTools = {
         recoveryEvidence,
         recoveryReason,
       });
+    },
+  },
+  adv_delta_list: {
+    description:
+      "List staged spec deltas on a change as bounded, paginated summary rows under `change.deltas[capability]`. Read-only: surfaces each staged delta's id, operation, capability, target (requirement id), and title so their ids can be passed to adv_delta_amend/retract. Fixes the adv_change_show truncation gap for delta-heavy changes. Reads disk-first and works even when the change workflow is orphaned.",
+    args: {
+      changeId: z
+        .string()
+        .min(1)
+        .describe("Change ID whose staged deltas to list"),
+      capability: CapabilityKeySchema.optional().describe(
+        "Optional capability filter; when omitted, lists deltas across all capabilities.",
+      ),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe("Pagination offset (default 0)."),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe("Max rows to return (default 25, cap 100)."),
+    },
+    execute: async (
+      {
+        changeId,
+        capability,
+        offset,
+        limit,
+      }: {
+        changeId: string;
+        capability?: string;
+        offset?: number;
+        limit?: number;
+      },
+      store: Store,
+    ) => {
+      return runList(store, { changeId, capability, offset, limit });
+    },
+  },
+  adv_delta_show: {
+    description:
+      "Show the full content of a single staged spec delta by id under `change.deltas[capability]`. Read-only: returns the complete delta object for exact-postimage verification; typed not-found error on unknown delta id. Reads disk-first and works even when the change workflow is orphaned.",
+    args: {
+      changeId: z
+        .string()
+        .min(1)
+        .describe("Change ID whose staged delta to show"),
+      capability: CapabilityKeySchema.describe(
+        "Capability key containing the delta.",
+      ),
+      deltaId: z.string().min(1).describe("Id of the staged delta to show."),
+    },
+    execute: async (
+      {
+        changeId,
+        capability,
+        deltaId,
+      }: {
+        changeId: string;
+        capability: string;
+        deltaId: string;
+      },
+      store: Store,
+    ) => {
+      return runShow(store, { changeId, capability, deltaId });
     },
   },
 };

--- a/plugin/src/utils/banner.ts
+++ b/plugin/src/utils/banner.ts
@@ -33,6 +33,8 @@ const COMMAND_EMOJIS: Record<string, string> = {
   adv_delta_modify: "📝",
   adv_delta_amend: "📝",
   adv_delta_retract: "📝",
+  adv_delta_list: "🔍",
+  adv_delta_show: "🔍",
   adv_delta_remove: "📝",
   adv_delta_rename: "📝",
 

--- a/plugin/src/utils/tool-arg-preflight.ts
+++ b/plugin/src/utils/tool-arg-preflight.ts
@@ -139,6 +139,11 @@ const FIELD_POLICIES: Record<string, FieldPolicyMap> = {
     recoveryEvidence: { blank: "omit" },
     recoveryReason: { blank: "omit" },
   },
+  adv_delta_list: {
+    capability: { blank: "omit" },
+    offset: { blank: "omit" },
+    limit: { blank: "omit" },
+  },
   adv_change_create: {
     // Optional artifact content — strict-mode providers fill with "" defaults.
     proposal: { blank: "omit" },

--- a/plugin/src/utils/tool-title.ts
+++ b/plugin/src/utils/tool-title.ts
@@ -84,6 +84,10 @@ const TITLE_BUILDERS: Record<string, TitleBuilder> = {
     write(`Remove spec delta${suffix(args, "changeId", "capability")}`),
   adv_delta_rename: (args) =>
     write(`Rename spec delta${suffix(args, "changeId", "capability")}`),
+  adv_delta_list: (args) =>
+    read(`List spec deltas${suffix(args, "changeId", "capability")}`),
+  adv_delta_show: (args) =>
+    read(`Show spec delta${suffix(args, "changeId", "capability")}`),
   adv_backlog_add: (args) => write(`Add backlog item${suffix(args, "title")}`),
   adv_backlog_list: () => read("List backlog"),
   adv_backlog_show: (args) => read(`Show backlog item${suffix(args, "id")}`),


### PR DESCRIPTION
## Problem

Completes the read side of the staged-delta vocabulary. `adv_delta_amend`/`adv_delta_retract` require a `deltaId`, but there was no way to enumerate or read staged deltas: `adv_change_show` truncates past its ~21k budget for delta-heavy changes, and prior-session delta ids were unrecoverable. The other agent hit exactly this — 3 prior-session staged deltas unreadable/unfixable.

## Fix (read-only)

- **`adv_delta_list(changeId, capability?, offset?, limit?)`** — bounded paginated summary rows `{id, operation, capability, target, title}`. Surfaces the ids amend/retract need without blowing the budget.
- **`adv_delta_show(changeId, capability, deltaId)`** — full single delta for exact-postimage verification; typed not-found on unknown id.

Read-only: **no signal, no reducer, no workflows.ts edit** → no replay-determinism concern, low merge-conflict risk with the in-flight replaceRecoveryToolSprawl (only additive parity surfaces). Disk-first read — works even when the change workflow is orphaned. No migration.

## Verification
- 52 spec-delta tests (6 new read tests) + 26 inventory tests pass
- `pnpm run check` green (typecheck/lint/format/schemas/manifests)
- Wired across all 8 parity surfaces + inventory baseline (88→90)