### PR TITLE
fix(deps): floor @hono/node-server to 2.0.5+ (OSV GHSA-frvp-7c67-39w9)

### DIFF
--- a/plugin/pnpm-lock.yaml
+++ b/plugin/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   esbuild: '>=0.28.1'
   zod: 4.4.3
   postcss: '>=8.5.10'
+  '@hono/node-server': '>=2.0.5'
 
 importers:
 
@@ -402,9 +403,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -3110,7 +3111,7 @@ snapshots:
       protobufjs: 8.7.1
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.12.31)':
     dependencies:
       hono: 4.12.31
 
@@ -3280,7 +3281,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5

--- a/plugin/pnpm-workspace.yaml
+++ b/plugin/pnpm-workspace.yaml
@@ -25,3 +25,8 @@ overrides:
   # pulled transitively (tsup/vite/postcss-load-config); this override keeps the
   # patched floor without a phantom direct dependency. See CHANGELOG postcss XSS.
   postcss: '>=8.5.10'
+  # Security floor: @hono/node-server is pulled transitively by
+  # @modelcontextprotocol/sdk (HTTP server transport, which this plugin does
+  # not use — only StdioServerTransport). Floor to the patched release for
+  # GHSA-frvp-7c67-39w9 (CVSS 5.9). v2 peer (hono ^4) + engine (node >=20) hold.
+  '@hono/node-server': '>=2.0.5'


### PR DESCRIPTION
## Problem
Trunk CI Security-gates OSV dependency scan fails on GHSA-frvp-7c67-39w9 (CVSS 5.9 medium): @hono/node-server@1.19.14 (fixed in 2.0.5), pulled transitively by @modelcontextprotocol/sdk. This blocks all trunk pushes.

## Fix
Add a pnpm-workspace.yaml overrides security floor for @hono/node-server (2.0.5 or newer; resolves 2.0.11) — same pattern as the existing postcss / brace-expansion transitive floors.

## Safety
- The plugin uses only StdioServerTransport; zero @hono/node-server imports in src/ (verified). It never takes the HTTP-server path that touches it.
- v2 constraints satisfied: peer hono ^4 (tree has 4.12.31), engine node 20+ (CI Node 24).
- pnpm run check + pnpm run build (SDK + worker) + src/mcp-server tests (40 pass) all green.

Lockfile-only + workspace override; no source or behavior change.