### PR TITLE
fix(ci): remediate pre-existing trunk Test failures (#293/slim tail)

### DIFF
--- a/plugin/src/__tests__/backlog-epic-bridge.test.ts
+++ b/plugin/src/__tests__/backlog-epic-bridge.test.ts
@@ -32,8 +32,16 @@ function createMockStore(
       config: join(root, "project.json"),
       external: null,
     },
+    changes: {
+      // buildD3ContextFromStore (D3 shell-add enforcement, added by #293)
+      // queries the store for the work graph; provide an empty graph so the
+      // shell-add proceeds without D3 blockers in this unit context.
+      list: async () => ({ changes: [] }),
+      get: async () => ({ success: false, error: "not found" }),
+    },
     epics: {
       addShell,
+      list: async () => [],
     },
   } as unknown as Store;
 }

--- a/plugin/src/__tests__/human-checkpoints-assets.test.ts
+++ b/plugin/src/__tests__/human-checkpoints-assets.test.ts
@@ -45,7 +45,13 @@ describe("rq-autonomy01 human checkpoint assets", () => {
 
   test("acceptance checkpoint preserves accept-before-gate ordering (inline Tier A)", () => {
     const review = readCommand("adv-review.md");
-    const mergedGateIdx = review.search(/adv_gate_complete[\s\S]*acceptance/);
+    // Target the ACTUAL acceptance gate-completion invocation (gateId: acceptance
+    // on the same line), not earlier prose mentions of adv_gate_complete (e.g.
+    // the poisoned-history recovery note), so the ordering assertion reflects the
+    // real workflow step rather than an incidental reference.
+    const mergedGateIdx = review.search(
+      /adv_gate_complete[^\n]*gateId:\s*['"]?acceptance/,
+    );
     // Inline approval prompt now precedes gate completion (replaces question tool)
     const inlineApprovalIdx = review.search(/Inline Approval prompt/);
     expect(inlineApprovalIdx).toBeGreaterThanOrEqual(0);

--- a/plugin/src/plugin-bundle-manifest.test.ts
+++ b/plugin/src/plugin-bundle-manifest.test.ts
@@ -84,7 +84,12 @@ describe("plugin bundle manifest", () => {
   });
 
   test("write refuses when index.js is missing", async () => {
-    const dir = await tempDistDir(false);
+    // Provide mcp-server.js so only index.js is absent — isolating the
+    // index.js check (the writer requires both bundles; with neither present
+    // it would report mcp-server.js first).
+    const dir = await createTempDir("plugin-bundle-manifest-");
+    tempDirs.push(dir);
+    await writeFile(join(dir, "mcp-server.js"), "// mcp only\n");
     await expect(
       writePluginBundleManifest(dir, generatePluginBundleGeneration()),
     ).rejects.toThrow(/index\.js/);

--- a/plugin/src/storage/store-temporal/creation-hash.ts
+++ b/plugin/src/storage/store-temporal/creation-hash.ts
@@ -179,6 +179,7 @@ export type CreationIdempotencyDecision =
  *
  * Pure: depends only on its arguments.
  */
+// rq-provenMutationOutcome01: reconcile creation request hash to avoid duplicate application.
 export function resolveCreationIdempotency(args: {
   existingHash?: string;
   computedHash: string;

--- a/plugin/src/tools/_recovery-writers.ts
+++ b/plugin/src/tools/_recovery-writers.ts
@@ -129,6 +129,7 @@ export async function saveRecoveredTaskAdd(input: {
  * The caller supplies the full completion record (status + completed_at +
  * completed_by + approval_evidence + optional artifact_evidence).
  */
+// rq-releaseRepairRecovery01: disk-direct gate completion write with audited recovery authorization.
 export async function saveRecoveredGateCompletion(input: {
   store: Store;
   change: Change;

--- a/plugin/src/tools/doctor.ts
+++ b/plugin/src/tools/doctor.ts
@@ -25,6 +25,7 @@
  * adv_change_status_repair, adv_epic_repair_membership, adv_change_forget)
  * were retired and consolidated here (design D6 / rq-recoverySurfaceParity01).
  */
+// rq-recoverySurfaceRetirement01: per-operation recovery tools retired and consolidated into adv_doctor.
 import { z } from "zod";
 import type { Store } from "../storage/store";
 import { getService, getStslStats, reinitStsl } from "../temporal/service";
@@ -113,6 +114,7 @@ interface DoctorInput {
 }
 
 // rq-doctorConsolidation01 option B: phantom-pointer safe-fix.
+// rq-doctorPhantomPointer01: module-level provider interface for clearing the active-change session pointer.
 // Module-level provider following the getCurrentSessionId pattern.
 // Injected by plugin-host (index.ts) only; tests and MCP-server see null,
 // so the phantom_pointer check is skipped in those contexts.

--- a/plugin/src/tools/epic-convergence.ts
+++ b/plugin/src/tools/epic-convergence.ts
@@ -131,6 +131,7 @@ function buildExpectedMembership(
  *  Entry unlinked + child still has matching projection
  *                               → conflict, repair=clear_child_projection
  */
+// rq-epicMembershipConvergence01: classify Epic change entry vs child membership and emit repairable convergence.
 export function convergeEpicMembership(
   input: EpicMembershipConvergenceInput,
 ): EpicMembershipConvergenceResult {

--- a/plugin/src/tools/monotonic-recovery.ts
+++ b/plugin/src/tools/monotonic-recovery.ts
@@ -99,6 +99,7 @@ export interface ClassifyMutationRecoveryArgs {
  * or via the disk-projection recovery writer. See module docstring for the
  * full authority model.
  */
+// rq-directMonotonicRecovery01: classify whether recovery can proceed via disk without operator.
 export async function classifyMutationRecoveryDecision(
   args: ClassifyMutationRecoveryArgs,
 ): Promise<MonotonicRecoveryDecision> {

--- a/plugin/src/tools/spec-delta.ts
+++ b/plugin/src/tools/spec-delta.ts
@@ -821,6 +821,7 @@ async function runRename(
   }
 }
 
+// rq-stagedDeltaCrud01: staged spec-delta tool group (add/modify/amend/retract/remove/rename/list/show).
 export const specDeltaTools = {
   adv_delta_add: {
     description:

--- a/plugin/src/tools/target-project.ts
+++ b/plugin/src/tools/target-project.ts
@@ -227,6 +227,7 @@ function formatTargetMutationReadinessError(
   ].join("; ");
 }
 
+// rq-targetWorkerLifecycle01: ensure target project Temporal task queue is serviceable before mutation.
 export async function ensureTargetMutationQueueReady(input: {
   projectId: string;
   temporalBundle: NonNullable<ReturnType<typeof getService>>;

--- a/plugin/src/utils/tool-arg-preflight.test.ts
+++ b/plugin/src/utils/tool-arg-preflight.test.ts
@@ -703,6 +703,22 @@ const AUDITED_PREFLIGHT_POLICY_REQUIREMENTS: ExpectedFieldPolicy[] = [
     policy: "blank",
     action: "omit",
   },
+  {
+    // Optional capability filter: strict-mode blank fills normalize to omitted
+    // so the handler lists deltas across all capabilities.
+    toolName: "adv_delta_list",
+    field: "capability",
+    policy: "blank",
+    action: "omit",
+  },
+  {
+    // Optional page limit: 0 placeholder fills normalize to omitted so the
+    // handler default (25) applies; bounded read, no safety impact.
+    toolName: "adv_delta_list",
+    field: "limit",
+    policy: "zero",
+    action: "omit",
+  },
 ];
 
 const CREATE_SCHEMA = {

--- a/plugin/src/utils/tool-arg-preflight.ts
+++ b/plugin/src/utils/tool-arg-preflight.ts
@@ -105,37 +105,29 @@ const FIELD_POLICIES: Record<string, FieldPolicyMap> = {
     target_path: { blank: "omit" },
     target_confirmed: { blank: "omit" },
     confirmationEvidence: { blank: "omit" },
-    recoveryEvidence: { blank: "omit" },
-    recoveryReason: { blank: "omit" },
   },
   adv_delta_retract: {
     retractedBy: { blank: "omit" },
     target_path: { blank: "omit" },
     target_confirmed: { blank: "omit" },
     confirmationEvidence: { blank: "omit" },
-    recoveryEvidence: { blank: "omit" },
-    recoveryReason: { blank: "omit" },
   },
   adv_delta_remove: {
     removedBy: { blank: "omit" },
     target_path: { blank: "omit" },
     target_confirmed: { blank: "omit" },
     confirmationEvidence: { blank: "omit" },
-    recoveryEvidence: { blank: "omit" },
-    recoveryReason: { blank: "omit" },
   },
   adv_delta_rename: {
     renamedBy: { blank: "omit" },
     target_path: { blank: "omit" },
     target_confirmed: { blank: "omit" },
     confirmationEvidence: { blank: "omit" },
-    recoveryEvidence: { blank: "omit" },
-    recoveryReason: { blank: "omit" },
   },
   adv_delta_list: {
     capability: { blank: "omit" },
     offset: { blank: "omit" },
-    limit: { blank: "omit" },
+    limit: { blank: "omit", zero: "omit" },
   },
   adv_change_create: {
     // Optional artifact content — strict-mode providers fill with "" defaults.


### PR DESCRIPTION
## Problem
Trunk Test(24.x) has carried pre-existing failures from the recovery-tool-sprawl (#293) and slimMutationToolSurface tool-surface refactors, which merged with red/ignored CI (trunk has no required status checks). These were masked earlier because the OSV gate fail-fasted and cancelled the Test job. Tracked as bl-jisCDJH1.

## Fixed (6 of 7)
- **spec-citation-invariant**: added citations for 8 implemented-but-uncited requirements.
- **tool-arg-preflight**: removed stale FIELD_POLICIES entries (recoveryEvidence/recoveryReason on adv_delta_amend/retract/remove/rename no longer exist); added reviewed-omission coverage for adv_delta_list capability(blank)/limit(zero).
- **backlog-epic-bridge**: fixed stale mock store (provide empty changes.list/get + epics.list) for the D3-context dependency added to adv_epic_add_shell.
- **human-checkpoints-assets**: made the acceptance-ordering regex target the actual gate-completion invocation instead of an earlier prose mention (command ordering was already correct).
- **plugin-bundle-manifest**: fixed stale test setup (create mcp-server.js so the index.js-missing case isolates the index.js check).

Each was root-caused as stale-test / config-drift / genuine-citation-gap. No production regressions; no tests weakened (reviewed-omission list is the intended allowlist mechanism; the human-checkpoints regex was made more precise, not looser).

## Not fixed here (needs slim's context)
- **tool-registry.inventory** (84 vs 83): slimMutationToolSurface contracted to retire one more public tool whose name is intentionally omitted per its AC4 (count-only guard), but the tool is still registered. Resolving safely requires that change's AC4 intent (which tool) — guessing a removal would risk breaking functionality, and flipping the count would mask slim's incomplete landing. Left for separate resolution.

## Verification
- pnpm run check green.
- Full unit suite: 7026 passed, 1 failed (tool-registry.inventory, above), 1 expected-fail, 12 todo.

Takes trunk Test from 7+ failures to 1.