### PR TITLE
fix(ci): record adv_resume_projection in tool inventory accounting

### DIFF
--- a/plugin/src/tool-registry.inventory.test.ts
+++ b/plugin/src/tool-registry.inventory.test.ts
@@ -115,6 +115,10 @@ const CONTRACTED_PUBLIC_ADDITIONS = [
   "adv_tool_invoke",
   // replaceRecoveryToolSprawl added the consolidated doctor entry point:
   "adv_doctor",
+  // resume-projection Phase E added the resume-projection MCP tool + bin
+  // adapter (feat 9f39317e); a legitimate registered public tool that was
+  // never recorded in this reintroduction-guard accounting.
+  "adv_resume_projection",
 ] as const;
 
 const VALID_RISKS = ["low", "medium", "high", "operator"] as const;
@@ -315,8 +319,14 @@ describe("public tool inventory — SC1 baseline/final counts", () => {
     // addLightweightChangeProfile then added the lightweight profile evaluate
     // tool (81 = 80 - 2 + 3); addAdvanceMetadata then added the bounded tool
     // catalog and describe tools (83 = 80 - 2 + 5); restoreDesignerFollowUp
-    // adds the typed modify writer (84 = 80 - 2 + 6); this change retires
-    // one additional public tool whose name is omitted per AC4 (83 = 80 - 3 + 6).
+    // adds the typed modify writer (84 = 80 - 2 + 6); the ROADMAP-retirement
+    // change removed one additional public tool whose name is omitted per AC4
+    // (83 = 80 - 3 + 6). Subsequent landed changes: replaceRecoveryToolSprawl
+    // removed 8 recovery tools (now in CONTRACTED_PUBLIC_REMOVALS) and added
+    // adv_doctor; the staged-delta write/read vocabulary + adv_tool_invoke
+    // landed as additions; and resume-projection Phase E added
+    // adv_resume_projection. Net tracked totals: 10 named removals + 1 unnamed
+    // (roadmap) removal, 15 additions => 84 = 80 - 10 - 1 + 15.
     expect(ADV_TOOL_NAMES.length).toBe(
       (baseline as number) -
         landedRemovals -


### PR DESCRIPTION
## Root cause
tool-registry.inventory asserted final canonical count 83 but ADV_TOOL_NAMES has 84. Investigation traced the gap to adv_resume_projection (feat 9f39317e, resume-projection Phase E) — a legitimate, fully-integrated public tool (adapter in resume-projection.ts, bin adapter, registration, tool-ownership matrix row, passes description/classification inventory checks) that was never recorded in CONTRACTED_PUBLIC_ADDITIONS.

This is the last of the trunk Test debt (bl-jisCDJH1). Notably it is NOT slimMutationToolSurface's doing — that change is manifest-exposure-only (removes nothing from tool-registry.ts per its C2/DONT1/OOS3). The unnamed-removal (roadmap, #264) correctly landed; the +1 was this untracked legitimate addition.

## Fix
Record adv_resume_projection in CONTRACTED_PUBLIC_ADDITIONS and reconcile the accounting comment: 80 baseline - 10 named removals - 1 unnamed (roadmap) + 15 additions = 84. Non-masking — it records a real intended tool the reintroduction-guard missed.

## Verification
- pnpm run check green.
- Full unit suite: 7038 passed, 0 failed (1 expected-fail, 1 skipped, 12 todo). Trunk Test fully green.