### PR TITLE
fix(archive): idempotent delta-apply (rq-releaseProjectionDurability01)

### DIFF
--- a/plugin/src/archive/delta-idempotency.test.ts
+++ b/plugin/src/archive/delta-idempotency.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Idempotent delta application (rq-releaseProjectionDurability01):
+ * an "add" delta whose requirement already exists with identical content is
+ * treated as already-applied, not a failure. A content-divergent duplicate
+ * still fails.
+ */
+import { describe, expect, it } from "vitest";
+import { applyDelta } from "./delta";
+import type { Spec, Delta, Requirement } from "../types";
+
+function specWith(requirements: Requirement[]): Spec {
+  return {
+    name: "cap-a",
+    title: "Capability A",
+    purpose: "p",
+    version: "1.0.0",
+    updated_at: "2026-01-01T00:00:00Z",
+    requirements,
+  };
+}
+
+function addDelta(
+  requirement: Requirement,
+): Extract<Delta, { operation: "add" }> {
+  return { id: `dl-${requirement.id}`, operation: "add", requirement };
+}
+
+function req(overrides: Partial<Requirement> = {}): Requirement {
+  return {
+    id: "rq-X",
+    title: "Title X",
+    body: "Body X",
+    priority: "must",
+    tags: ["worker", "recovery"],
+    scenarios: [
+      {
+        id: "rq-X.1",
+        title: "scenario one",
+        given: ["a precondition"],
+        when: "something happens",
+        then: ["an outcome"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("applyDelta add idempotency (rq-releaseProjectionDurability01)", () => {
+  it("accepts a re-apply of an identical requirement (idempotent success, no duplication)", () => {
+    const requirement = req();
+    const spec = specWith([requirement]);
+    const result = applyDelta(spec, addDelta(requirement));
+    expect(result.success).toBe(true);
+    // The requirement is not duplicated.
+    expect(spec.requirements.filter((r) => r.id === "rq-X")).toHaveLength(1);
+  });
+
+  it("accepts an idempotent re-apply even when scenario/tag order differs", () => {
+    const existing = req();
+    const reordered: Requirement = {
+      ...req(),
+      tags: ["recovery", "worker"], // different order
+      scenarios: [{ ...existing.scenarios![0] }].reverse(),
+    };
+    const spec = specWith([existing]);
+    const result = applyDelta(spec, addDelta(reordered));
+    expect(result.success).toBe(true);
+    expect(spec.requirements.filter((r) => r.id === "rq-X")).toHaveLength(1);
+  });
+
+  it("fails on a content-divergent duplicate (same id, different body)", () => {
+    const spec = specWith([req({ body: "original body" })]);
+    const result = applyDelta(spec, addDelta(req({ body: "divergent body" })));
+    expect(result.success).toBe(false);
+    expect(result.operation).toBe("add");
+  });
+
+  it("fails on a content-divergent duplicate (same id, different title)", () => {
+    const spec = specWith([req({ title: "Original" })]);
+    const result = applyDelta(spec, addDelta(req({ title: "Different" })));
+    expect(result.success).toBe(false);
+  });
+
+  it("ignores meta provenance when comparing (merged_from differs but content matches)", () => {
+    const spec = specWith([req({ meta: { merged_from: "change-A" } })]);
+    const result = applyDelta(
+      spec,
+      addDelta(req({ meta: { merged_from: "change-B" } })),
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/plugin/src/archive/delta.ts
+++ b/plugin/src/archive/delta.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Spec, Delta } from "../types";
+import { requirementsContentEqual } from "../types/specs";
 import { appendDebugLog, createLogger } from "../utils/debug-log";
 import { SPEC_SCHEMA_URL } from "../schema-registry";
 
@@ -50,6 +51,19 @@ function applyAddDelta(
   // Check for duplicate ID
   const existing = spec.requirements.find((r) => r.id === requirement.id);
   if (existing) {
+    // rq-releaseProjectionDurability01 idempotency: a prior partial-archive may
+    // have already applied this requirement. If the existing requirement is
+    // content-equal to the delta's, accept idempotently instead of failing —
+    // the archive is the sole global-spec writer, so an identical duplicate is
+    // a re-apply, not a conflict.
+    if (requirementsContentEqual(existing, requirement)) {
+      return {
+        success: true,
+        deltaId: delta.id,
+        operation: "add",
+        newId: requirement.id,
+      };
+    }
     return {
       success: false,
       deltaId: delta.id,

--- a/plugin/src/tools/change/archive-gate.ts
+++ b/plugin/src/tools/change/archive-gate.ts
@@ -915,17 +915,17 @@ async function loadAuditedDiskReleaseGate(input: {
 }): Promise<GateCompletion | null> {
   const disk = await loadChange(input.store.paths.changes, input.changeId);
   if (!disk.success || !disk.data?.gates) return null;
-	const gate = disk.data.gates.release;
-	// Resilience (rq-releaseProjectionDurability01): when the store-backed gate
-	// read is stale — a poisoned/missing workflow returns a pre-completion
-	// projection — a disk release gate that ADV genuinely completed is still
-	// authoritative. Require `done`; accept without a recovery audit only when
-	// the archive's fresh finalization is git-verified `shipped` (finalization
-	// sets `shipped` exclusively on confirmed default-branch reachability/merge,
-	// which cannot be forged without a real merge). Recovery-audit remains
-	// required for non-shipped disk fallbacks, preserving the strict guard.
-	if (gate?.status !== "done") return null;
-	if (!hasGateRecoveryAudit(gate) && !input.shipped) return null;
+  const gate = disk.data.gates.release;
+  // Resilience (rq-releaseProjectionDurability01): when the store-backed gate
+  // read is stale — a poisoned/missing workflow returns a pre-completion
+  // projection — a disk release gate that ADV genuinely completed is still
+  // authoritative. Require `done`; accept without a recovery audit only when
+  // the archive's fresh finalization is git-verified `shipped` (finalization
+  // sets `shipped` exclusively on confirmed default-branch reachability/merge,
+  // which cannot be forged without a real merge). Recovery-audit remains
+  // required for non-shipped disk fallbacks, preserving the strict guard.
+  if (gate?.status !== "done") return null;
+  if (!hasGateRecoveryAudit(gate) && !input.shipped) return null;
   // Shipped reconciliation: a change whose git work reached the default branch
   // (finalization shipped — git-verified reachability that cannot be forged
   // without a real merge) but whose workflow terminated is recovered on disk

--- a/plugin/src/types/specs.ts
+++ b/plugin/src/types/specs.ts
@@ -65,6 +65,40 @@ export const RequirementSchema = z
 
 export type Requirement = z.infer<typeof RequirementSchema>;
 
+/**
+ * Content equality for two requirements, excluding provenance `meta` and
+ * normalizing tag/scenario order. Used for idempotent delta application
+ * (rq-releaseProjectionDurability01): an "add" delta whose requirement already
+ * exists with identical content is treated as already-applied, not a conflict.
+ */
+export function requirementsContentEqual(
+  a: Requirement,
+  b: Requirement,
+): boolean {
+  if (a.id !== b.id) return false;
+  if (a.title !== b.title) return false;
+  if (a.body !== b.body) return false;
+  if (a.priority !== b.priority) return false;
+  const aTags = [...(a.tags ?? [])].sort().join("\n");
+  const bTags = [...(b.tags ?? [])].sort().join("\n");
+  if (aTags !== bTags) return false;
+  const norm = (s: Scenario) =>
+    JSON.stringify({
+      id: s.id,
+      title: s.title,
+      given: s.given,
+      when: s.when,
+      then: s.then,
+    });
+  const aScn = [...(a.scenarios ?? [])]
+    .sort((x, y) => x.id.localeCompare(y.id))
+    .map(norm);
+  const bScn = [...(b.scenarios ?? [])]
+    .sort((x, y) => x.id.localeCompare(y.id))
+    .map(norm);
+  return aScn.length === bScn.length && aScn.every((n, i) => n === bScn[i]);
+}
+
 // =============================================================================
 // Spec (The Law)
 // =============================================================================

--- a/plugin/src/validator/conflicts-idempotency.test.ts
+++ b/plugin/src/validator/conflicts-idempotency.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Conflict-detection idempotency (rq-releaseProjectionDurability01):
+ * an "add" delta whose requirement already exists in specs with matching
+ * id+title+priority is accepted (already-applied), not flagged as a duplicate.
+ * A content-divergent duplicate (different title/priority) remains a conflict.
+ *
+ * The validator's existingSpecs carry only minimal fields (id/title/priority);
+ * the full content guard lives in archive/delta.ts (covered by
+ * delta-idempotency.test.ts).
+ */
+import { describe, expect, it } from "vitest";
+import type { Change, Delta } from "../types";
+import type { Requirement } from "../types/specs";
+import { runConflictChecks } from "./conflicts";
+import type { ValidationContext } from "./types";
+
+function addDelta(
+  capability: string,
+  requirement: Requirement,
+): {
+  capability: string;
+  delta: Extract<Delta, { operation: "add" }>;
+} {
+  return {
+    capability,
+    delta: { id: `dl-${requirement.id}`, operation: "add", requirement },
+  };
+}
+
+function contextWith(
+  capability: string,
+  existing: Array<{ id: string; title: string; priority: string }>,
+): ValidationContext {
+  return {
+    existingSpecs: new Map([
+      [capability, { name: capability, requirements: existing }],
+    ]),
+    existingRequirementIds: new Set(existing.map((r) => r.id)),
+    requirementReferences: new Map(),
+  };
+}
+
+describe("runConflictChecks add idempotency (rq-releaseProjectionDurability01)", () => {
+  it("does NOT flag a duplicate when existing matches id+title+priority", () => {
+    const cap = "cap-a";
+    const { delta } = addDelta(cap, {
+      id: "rq-X",
+      title: "Title X",
+      body: "Body X",
+      priority: "must",
+    });
+    const change: Change = {
+      id: "test-change",
+      title: "Test",
+      status: "active",
+      created_at: "2026-01-01T00:00:00Z",
+      tasks: [],
+      deltas: { [cap]: [delta] },
+    };
+    const context = contextWith(cap, [
+      { id: "rq-X", title: "Title X", priority: "must" },
+    ]);
+    const issues = runConflictChecks(change, context);
+    expect(
+      issues.filter((i) => i.code === "DUPLICATE_REQUIREMENT_ID"),
+    ).toHaveLength(0);
+  });
+
+  it("flags a duplicate when existing matches id but diverges in title", () => {
+    const cap = "cap-a";
+    const { delta } = addDelta(cap, {
+      id: "rq-X",
+      title: "New Title",
+      body: "Body X",
+      priority: "must",
+    });
+    const change: Change = {
+      id: "test-change",
+      title: "Test",
+      status: "active",
+      created_at: "2026-01-01T00:00:00Z",
+      tasks: [],
+      deltas: { [cap]: [delta] },
+    };
+    const context = contextWith(cap, [
+      { id: "rq-X", title: "Old Title", priority: "must" },
+    ]);
+    const issues = runConflictChecks(change, context);
+    expect(
+      issues.filter((i) => i.code === "DUPLICATE_REQUIREMENT_ID"),
+    ).toHaveLength(1);
+  });
+
+  it("flags a duplicate when existing matches id but diverges in priority", () => {
+    const cap = "cap-a";
+    const { delta } = addDelta(cap, {
+      id: "rq-X",
+      title: "Title X",
+      body: "Body X",
+      priority: "should",
+    });
+    const change: Change = {
+      id: "test-change",
+      title: "Test",
+      status: "active",
+      created_at: "2026-01-01T00:00:00Z",
+      tasks: [],
+      deltas: { [cap]: [delta] },
+    };
+    const context = contextWith(cap, [
+      { id: "rq-X", title: "Title X", priority: "must" },
+    ]);
+    const issues = runConflictChecks(change, context);
+    expect(
+      issues.filter((i) => i.code === "DUPLICATE_REQUIREMENT_ID"),
+    ).toHaveLength(1);
+  });
+});

--- a/plugin/src/validator/conflicts.ts
+++ b/plugin/src/validator/conflicts.ts
@@ -9,6 +9,22 @@ import type { ValidationIssue, ValidationContext } from "./types";
 import { ValidationCodes } from "./types";
 
 /**
+ * Find an existing requirement (minimal shape) by ID across all existing specs.
+ * Used for the idempotency identity check; the validator's existingSpecs carry
+ * only id/title/priority, so the full-content guard lives in archive/delta.ts.
+ */
+function findExistingRequirement(
+  context: ValidationContext,
+  reqId: string,
+): { id: string; title: string; priority: string } | undefined {
+  for (const spec of context.existingSpecs.values()) {
+    const found = spec.requirements.find((r) => r.id === reqId);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/**
  * Check for duplicate requirement IDs across all deltas and existing specs
  */
 function checkDuplicateRequirementIds(
@@ -25,13 +41,26 @@ function checkDuplicateRequirementIds(
 
         // Check against existing specs
         if (context.existingRequirementIds.has(reqId)) {
-          issues.push({
-            code: ValidationCodes.DUPLICATE_REQUIREMENT_ID,
-            severity: "error",
-            message: `Requirement ID "${reqId}" already exists in specs`,
-            path: `deltas.${capability}.${delta.id}`,
-            details: { requirementId: reqId },
-          });
+          // rq-releaseProjectionDurability01 idempotency: if the existing
+          // requirement matches the delta's id+title+priority, a prior
+          // partial-archive likely already applied it — accept rather than
+          // blocking. The validator's existingSpecs carry only minimal fields;
+          // the apply stage (archive/delta.ts) does the full content guard, so
+          // a content-divergent duplicate still fails there.
+          const existingReq = findExistingRequirement(context, reqId);
+          const sameIdentity =
+            existingReq !== undefined &&
+            existingReq.title === delta.requirement.title &&
+            existingReq.priority === delta.requirement.priority;
+          if (!sameIdentity) {
+            issues.push({
+              code: ValidationCodes.DUPLICATE_REQUIREMENT_ID,
+              severity: "error",
+              message: `Requirement ID "${reqId}" already exists in specs`,
+              path: `deltas.${capability}.${delta.id}`,
+              details: { requirementId: reqId },
+            });
+          }
         }
 
         // Check against other deltas in this change


### PR DESCRIPTION
Makes the archive's add-delta path idempotent: an already-applied requirement (content-equal) is accepted on retry instead of deadlocking the release gate with DUPLICATE_REQUIREMENT_ID. Layered: validator accepts on id+title+priority match; apply (delta.ts) is the full-content guard. Recurring defect rq-releaseProjectionDurability01. 8 new tests green; pnpm check clean.