### PR TITLE
fix(archive): recover changes with missing Temporal workflows

### DIFF
--- a/plugin/src/temporal/recovery-classification.ts
+++ b/plugin/src/temporal/recovery-classification.ts
@@ -70,6 +70,20 @@ const COMPLETED_WORKFLOW_NAMES: ReadonlySet<string> = new Set([
   "workflownotfounderror",
 ]);
 
+/**
+ * Whether an error has an exact Temporal completed/absent error name.
+ *
+ * Unlike isWorkflowCompletedError(), this deliberately excludes message text
+ * so probe-first recovery never treats an untyped describe failure as proof
+ * that the workflow is absent.
+ */
+export function isWorkflowAbsentByExactName(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    COMPLETED_WORKFLOW_NAMES.has(err.name?.toLowerCase() ?? "")
+  );
+}
+
 // Case-insensitive SUBSTRING (mid-string) patterns for the real Temporal
 // message phrasings. NOT line-anchored: the phrasings appear embedded in
 // larger messages (e.g. "...Cannot signal a completed workflow handle").
@@ -89,8 +103,7 @@ const MISSING_WORKFLOW_TEXT_RE = /not[_ ]found|NOT_FOUND/i;
 
 export function isWorkflowCompletedError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  const name = err.name?.toLowerCase() ?? "";
-  if (COMPLETED_WORKFLOW_NAMES.has(name)) return true;
+  if (isWorkflowAbsentByExactName(err)) return true;
   const msg = err.message ?? "";
   return COMPLETED_WORKFLOW_MESSAGE_PATTERNS.some((pattern) =>
     pattern.test(msg),

--- a/plugin/src/tools/change.archive-phase9.test.ts
+++ b/plugin/src/tools/change.archive-phase9.test.ts
@@ -1897,31 +1897,111 @@ describe("adv_change_archive Phase 9 behavior", () => {
     delete (mocks.workflow.handle as { describe?: unknown }).describe;
   });
 
-  test("absent workflow without recovery mode still throws on archive read", async () => {
+  test("absent workflow recovers from a complete disk projection and archives", async () => {
     const store = createMockStore();
     mocks.findArchiveBundle.mockResolvedValue(null);
-    const loadChangeSpy = vi.spyOn(storageJson, "loadChange");
+    const change = (await store.changes.get("example")).data as Change;
+    const loadChangeSpy = vi
+      .spyOn(storageJson, "loadChange")
+      .mockResolvedValue({ success: true, data: change });
     vi.mocked(store.changes.get).mockRejectedValue(
       Object.assign(new Error("Failed to query Workflow"), {
         name: "WorkflowNotFoundError",
       }),
     );
+    (
+      mocks.workflow.handle as typeof mocks.workflow.handle & {
+        describe: ReturnType<typeof vi.fn>;
+      }
+    ).describe = vi.fn(async () => {
+      throw Object.assign(new Error("Workflow not found"), {
+        name: "WorkflowNotFoundError",
+      });
+    });
 
-    await expect(
-      changeTools.adv_change_archive.execute(
-        {
-          changeId: "example",
-          worktreePath: "/tmp/worktree",
-          phase9: "run",
-        },
-        store,
-      ),
-    ).rejects.toThrow("Failed to query Workflow");
+    const result = await changeTools.adv_change_archive.execute(
+      {
+        changeId: "example",
+        worktreePath: "/tmp/worktree",
+        phase9: "run",
+      },
+      store,
+    );
 
-    expect(loadChangeSpy).not.toHaveBeenCalled();
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(loadChangeSpy).toHaveBeenCalledWith(store.paths.changes, "example");
+    expect(mocks.archiveChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        change: expect.objectContaining({ id: "example" }),
+      }),
+    );
+
+    loadChangeSpy.mockRestore();
+    delete (mocks.workflow.handle as { describe?: unknown }).describe;
+  });
+
+  test("absent workflow refuses an incomplete disk projection without writing a bundle", async () => {
+    const store = createMockStore();
+    mocks.findArchiveBundle.mockResolvedValue(null);
+    const completeChange = (await store.changes.get("example")).data as Change;
+    const incompleteChange = {
+      ...completeChange,
+      gates: {
+        proposal: { status: "pending" },
+        discovery: { status: "pending" },
+        design: { status: "pending" },
+        planning: { status: "pending" },
+        execution: { status: "pending" },
+        acceptance: { status: "pending" },
+        release: { status: "pending" },
+      } as Gates,
+    };
+    mocks.workflow.gates = incompleteChange.gates;
+    const loadChangeSpy = vi
+      .spyOn(storageJson, "loadChange")
+      .mockResolvedValue({ success: true, data: incompleteChange });
+    vi.mocked(store.changes.get).mockRejectedValue(
+      Object.assign(new Error("Failed to query Workflow"), {
+        name: "WorkflowNotFoundError",
+      }),
+    );
+    (
+      mocks.workflow.handle as typeof mocks.workflow.handle & {
+        describe: ReturnType<typeof vi.fn>;
+      }
+    ).describe = vi.fn(async () => {
+      throw Object.assign(new Error("Workflow not found"), {
+        name: "WorkflowNotFoundError",
+      });
+    });
+
+    const result = await changeTools.adv_change_archive.execute(
+      {
+        changeId: "example",
+        worktreePath: "/tmp/worktree",
+        phase9: "run",
+      },
+      store,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toBe(
+      "Cannot archive: incomplete gates. Complete all quality gates before archiving.",
+    );
+    expect(parsed.incompleteGates).toEqual([
+      "proposal",
+      "discovery",
+      "design",
+      "planning",
+      "execution",
+      "acceptance",
+    ]);
+    expect(loadChangeSpy).toHaveBeenCalledWith(store.paths.changes, "example");
     expect(mocks.archiveChange).not.toHaveBeenCalled();
 
     loadChangeSpy.mockRestore();
+    delete (mocks.workflow.handle as { describe?: unknown }).describe;
   });
 
   // AC4: phase9_status visible in adv_change_show

--- a/plugin/src/tools/monotonic-recovery.test.ts
+++ b/plugin/src/tools/monotonic-recovery.test.ts
@@ -168,6 +168,43 @@ describe("classifyMutationRecoveryDecision", () => {
       expect(decision.kind).toBe("proceed_with_signal");
     });
 
+    it("recovers via disk when describe reports a typed missing workflow", async () => {
+      const error = new Error("workflow not found");
+      error.name = "WorkflowNotFoundError";
+      const decision = await classifyMutationRecoveryDecision({
+        handle: makeFailingHandle(error),
+      });
+      expect(decision.kind).toBe("recover_via_disk");
+      if (decision.kind === "recover_via_disk") {
+        expect(decision.reason).toBe("missing_workflow");
+        expect(decision.authority).toBe("workflow_completed");
+      }
+    });
+
+    it.each(["workflow not found", "NOT_FOUND from a downstream service"])(
+      "proceeds with signal when an untyped describe error message says %s",
+      async (message) => {
+        const decision = await classifyMutationRecoveryDecision({
+          handle: makeFailingHandle(new Error(message)),
+        });
+        expect(decision).toEqual({ kind: "proceed_with_signal" });
+      },
+    );
+
+    it.each([
+      "workflow execution already completed",
+      "workflow is not running",
+      "cannot signal a completed workflow",
+    ])(
+      "proceeds with signal when an untyped describe error message says %s",
+      async (message) => {
+        const decision = await classifyMutationRecoveryDecision({
+          handle: makeFailingHandle(new Error(message)),
+        });
+        expect(decision).toEqual({ kind: "proceed_with_signal" });
+      },
+    );
+
     it("proceeds with signal when handle has no describe function", async () => {
       const decision = await classifyMutationRecoveryDecision({
         handle: {},

--- a/plugin/src/tools/monotonic-recovery.ts
+++ b/plugin/src/tools/monotonic-recovery.ts
@@ -27,11 +27,13 @@
  * monotonicity check; this only decides which path they should take.
  */
 import {
+  isWorkflowAbsentByExactName,
   isWorkflowCompletedError,
   recoveryReasonFromError,
   type ProjectionRecoveryReason,
 } from "../temporal/recovery-classification";
 import {
+  poisonedDescriptionEvidence,
   workflowPoisonedDescriptionEvidence,
   type PoisonedDescribeProbeTarget,
 } from "./recovery-probe";
@@ -159,16 +161,29 @@ export async function classifyMutationRecoveryDecision(
     return { kind: "proceed_with_signal" };
   }
 
-  const describeEvidence = await probeDescribeEvidence(handle);
-  if (describeEvidence === null) {
+  try {
+    const description = await handle.describe();
+    const evidence = poisonedDescriptionEvidence(description);
+    if (evidence === null) {
+      return { kind: "proceed_with_signal" };
+    }
+    return {
+      kind: "recover_via_disk",
+      reason: "poisoned_history",
+      authority: "workflow_poisoned_describe",
+      evidence,
+    };
+  } catch (describeError) {
+    if (isWorkflowAbsentByExactName(describeError)) {
+      return {
+        kind: "recover_via_disk",
+        reason: "missing_workflow",
+        authority: "workflow_completed",
+        evidence: summarizeError(describeError),
+      };
+    }
     return { kind: "proceed_with_signal" };
   }
-  return {
-    kind: "recover_via_disk",
-    reason: "poisoned_history",
-    authority: "workflow_poisoned_describe",
-    evidence: describeEvidence,
-  };
 }
 
 async function probeDescribeEvidence(


### PR DESCRIPTION
Closes #253.

## What
An ADV change whose Temporal workflow is genuinely missing (`WorkflowNotFoundError`/completed) can now be archived via the durable disk projection instead of throwing `Failed to query Workflow`.

## Root cause
The recovery classifier's probe-first path swallowed all `describe()` failures as indeterminate and returned `proceed_with_signal`; archive then threw on `store.changes.get` before writing the bundle. The signal-error path already handled `missing_workflow` — the probe-first path was the sole gap.

## Fix
- Added `isWorkflowAbsentByExactName` (exact typed Temporal error-name recognition, no broad text matching) to `recovery-classification.ts`.
- Probe-first path catches the `describe()` error and routes a precise missing/completed workflow to the existing disk-projection archive branch (`recover_via_disk`/`missing_workflow`).
- Indeterminate/message-text errors still `proceed_with_signal` (no unsafe broadening).

Implements `rq-directMonotonicRecovery01.1` ("missing" explicitly listed). Independent design validation (3 rounds) drove the exact-name strictness.

## Verification
TDD RED→GREEN→VERIFY: 67 combined tests (monotonic-recovery + archive-phase9) green; `pnpm run check` green. Pinned archive test flipped from "throws" to "recovers via disk + writes bundle"; AC5 incomplete-disk refusal guard added.

ADV change: `fixArchiveMissingWorkflow`.