### PR TITLE
fix(gate-readiness): tolerate optional-item rows in acceptance review matrix

### DIFF
--- a/plugin/src/temporal/gate-readiness.test.ts
+++ b/plugin/src/temporal/gate-readiness.test.ts
@@ -559,6 +559,47 @@ describe("gate readiness", () => {
     );
   });
 
+  it("allows an acceptance review matrix row for an optional out-of-scope item", () => {
+    const contract = passingContract();
+    contract.items.push({
+      id: "AC_OOS",
+      kind: "out_of_scope",
+      text: "This work is intentionally out of scope.",
+      sourceArtifact: "agreement",
+      verificationRequired: false,
+      evidencePolicy: "test",
+      status: "approved",
+    });
+    contract.reviewMatrix!.rows.push({
+      ...contract.reviewMatrix!.rows[0],
+      contractId: "AC_OOS",
+      kind: "out_of_scope",
+    });
+
+    const result = evaluateGateReadiness(
+      makeState({
+        gates: acceptanceReadyGates(),
+        projectionChangesDir: "/tmp/changes",
+        contract,
+        artifacts: {
+          executiveSummary: {
+            path: "/tmp/changes/change-1/executive-summary.md",
+            updatedAt: "2026-05-20T00:00:00.000Z",
+            contentHash: "a".repeat(64),
+          },
+        },
+      }),
+      "acceptance",
+    );
+
+    expect(result.ready).toBe(true);
+    expect(result.blockers).not.toContainEqual(
+      expect.objectContaining({
+        code: "ACCEPTANCE_REVIEW_MATRIX_INVALID",
+      }),
+    );
+  });
+
   it("fails closed when an acceptance review matrix includes an unknown row", () => {
     const contract = passingContract();
     contract.reviewMatrix!.rows.push({

--- a/plugin/src/temporal/gate-readiness.ts
+++ b/plugin/src/temporal/gate-readiness.ts
@@ -1037,6 +1037,7 @@ function validateReviewMatrixRowCoverage(
     (item) => item.verificationRequired !== false,
   );
   const expectedIds = new Set(expectedItems.map((item) => item.id));
+  const allContractIds = new Set(contract.items.map((item) => item.id));
   const seen = new Set<string>();
   const duplicates: string[] = [];
   for (const row of contract.reviewMatrix.rows) {
@@ -1048,11 +1049,9 @@ function validateReviewMatrixRowCoverage(
       seen.add(row.contractId);
     }
   }
-  const missing = expectedItems
-    .filter((item) => !seen.has(item.id))
-    .map((item) => item.id);
+  const missing = [...expectedIds].filter((id) => !seen.has(id));
   const unknown = contract.reviewMatrix.rows
-    .filter((row) => !expectedIds.has(row.contractId))
+    .filter((row) => !allContractIds.has(row.contractId))
     .map((row) => row.contractId);
 
   if (duplicates.length > 0 || missing.length > 0 || unknown.length > 0) {


### PR DESCRIPTION
## What
An ADV change whose contract contains an `out_of_scope` (`verificationRequired:false`) item can now pass the acceptance readiness check instead of being permanently blocked with `ACCEPTANCE_REVIEW_MATRIX_INVALID: unknown: <OOS>`.

## Root cause
`validateReviewMatrixRowCoverage` (gate-readiness.ts) computed the `unknown`-row set against `expectedIds` (required items only). A legitimate review row for an optional item is not in `expectedIds`, so it was flagged "unknown" regardless of status — and (empirically) omitting the row also failed. The `AC_UNKNOWN` regression test only covered a non-existent item, not an optional one.

## Fix
Compute the `unknown` set against **all** contract item IDs, so a row referencing any real item (required OR optional) is tolerated, while a row referencing a non-existent item is still flagged. The `missing` (required-only) and `duplicate` checks are unchanged.

## Verification
TDD RED→GREEN→VERIFY: 82 gate-readiness tests green (incl. new `AC_OOS` pass test + existing `AC_UNKNOWN`/missing/duplicate regression); `pnpm run check` green.

## Unblocks
`fixArchiveMissingWorkflow` (its acceptance gate was blocked by this OOS1 bug).

ADV change: `fixAcceptanceReviewMatrixOos`. Note: the write/read-convergence observation (facet 2) is deferred to `fixArchiveConvergence`.