### PR TITLE
fix(gate-readiness): revert non-replay-safe review-matrix OOS coverage (#313)

### DIFF
--- a/plugin/src/temporal/gate-readiness.test.ts
+++ b/plugin/src/temporal/gate-readiness.test.ts
@@ -559,47 +559,6 @@ describe("gate readiness", () => {
     );
   });
 
-  it("allows an acceptance review matrix row for an optional out-of-scope item", () => {
-    const contract = passingContract();
-    contract.items.push({
-      id: "AC_OOS",
-      kind: "out_of_scope",
-      text: "This work is intentionally out of scope.",
-      sourceArtifact: "agreement",
-      verificationRequired: false,
-      evidencePolicy: "test",
-      status: "approved",
-    });
-    contract.reviewMatrix!.rows.push({
-      ...contract.reviewMatrix!.rows[0],
-      contractId: "AC_OOS",
-      kind: "out_of_scope",
-    });
-
-    const result = evaluateGateReadiness(
-      makeState({
-        gates: acceptanceReadyGates(),
-        projectionChangesDir: "/tmp/changes",
-        contract,
-        artifacts: {
-          executiveSummary: {
-            path: "/tmp/changes/change-1/executive-summary.md",
-            updatedAt: "2026-05-20T00:00:00.000Z",
-            contentHash: "a".repeat(64),
-          },
-        },
-      }),
-      "acceptance",
-    );
-
-    expect(result.ready).toBe(true);
-    expect(result.blockers).not.toContainEqual(
-      expect.objectContaining({
-        code: "ACCEPTANCE_REVIEW_MATRIX_INVALID",
-      }),
-    );
-  });
-
   it("fails closed when an acceptance review matrix includes an unknown row", () => {
     const contract = passingContract();
     contract.reviewMatrix!.rows.push({

--- a/plugin/src/temporal/gate-readiness.ts
+++ b/plugin/src/temporal/gate-readiness.ts
@@ -1037,7 +1037,6 @@ function validateReviewMatrixRowCoverage(
     (item) => item.verificationRequired !== false,
   );
   const expectedIds = new Set(expectedItems.map((item) => item.id));
-  const allContractIds = new Set(contract.items.map((item) => item.id));
   const seen = new Set<string>();
   const duplicates: string[] = [];
   for (const row of contract.reviewMatrix.rows) {
@@ -1049,9 +1048,11 @@ function validateReviewMatrixRowCoverage(
       seen.add(row.contractId);
     }
   }
-  const missing = [...expectedIds].filter((id) => !seen.has(id));
+  const missing = expectedItems
+    .filter((item) => !seen.has(item.id))
+    .map((item) => item.id);
   const unknown = contract.reviewMatrix.rows
-    .filter((row) => !allContractIds.has(row.contractId))
+    .filter((row) => !expectedIds.has(row.contractId))
     .map((row) => row.contractId);
 
   if (duplicates.length > 0 || missing.length > 0 || unknown.length > 0) {


### PR DESCRIPTION
## Incident revert

**#313 (fixAcceptanceReviewMatrixOos) is not replay-safe and is poisoning Temporal workflows cross-project.**

`validateReviewMatrixRowCoverage` runs inside `changeWorkflow` (via `evaluateGateReadiness`, workflows.ts:1123) and its result drives command emission at the acceptance gate. #313 flipped acceptance gates with an out-of-scope row from **not-ready** (no commands — as recorded in existing histories) to **ready** (emits `writeArtifactActivity` + `upsertSearchAttributes`) **without a `wf.patched()` guard**.

Every workflow replaying a pre-#313 history now diverges:
`[TMPRL1100] Nondeterminism error: Activity machine does not handle this event: UpsertWorkflowSearchAttributes` → poisoned workflow. Confirmed live in advance, pokeedge (1), pokeedge-web (2).

### Verification
- `dade124c` (pre-#313) replays fixture 9 **3/3 pass**; HEAD (with #313) **3/3 fail**.
- After revert: `replay-determinism.test.ts` **13/13 pass**; `pnpm run check` green; gate-readiness suite 81 pass.
- Poisoned workflows **self-heal on redeploy** (histories replay the pre-#313 branch again).

### Scope / follow-ups
- Incident mitigation only. OOS1 acceptance is intentionally blocked again until the proper fix lands.
- OOS-tolerance will be re-landed behind `wf.patched("review-matrix-oos-coverage-v1")` as a clean, replay-safe change.
- Unrelated pre-existing red: `store-temporal/shared.test.ts` retry test (from 1879fb64) — tracked separately, not part of this revert.