### PR TITLE
fix(trunk): align stale retry test to circuit-breaker + dep-floor hygiene

### DIFF
--- a/plugin/pnpm-lock.yaml
+++ b/plugin/pnpm-lock.yaml
@@ -11,12 +11,12 @@ overrides:
   vite: '>=8.0.5'
   picomatch: '>=4.0.4'
   brace-expansion: '>=5.0.7'
-  protobufjs: '>=8.6.6'
+  protobufjs: ^7.6.5
   uuid: '>=14.0.0'
   fast-uri: '>=3.1.3'
   esbuild: '>=0.28.1'
   zod: 4.4.3
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.18'
   '@hono/node-server': '>=2.0.5'
 
 importers:
@@ -34,7 +34,7 @@ importers:
         version: 1.17.2
       '@temporalio/worker':
         specifier: ^1.16.0
-        version: 1.17.2(esbuild@0.28.1)(postcss@8.5.15)(tslib@2.8.1)
+        version: 1.17.2(esbuild@0.28.1)(postcss@8.5.22)(tslib@2.8.1)
       '@temporalio/workflow':
         specifier: ^1.16.0
         version: 1.17.2
@@ -59,7 +59,7 @@ importers:
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       '@temporalio/testing':
         specifier: ^1.16.0
-        version: 1.17.2(esbuild@0.28.1)(postcss@8.5.15)(tslib@2.8.1)
+        version: 1.17.2(esbuild@0.28.1)(postcss@8.5.22)(tslib@2.8.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.9.2
@@ -86,7 +86,7 @@ importers:
         version: 3.8.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.20.6
         version: 4.22.4
@@ -873,6 +873,33 @@ packages:
     resolution: {integrity: sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==}
     cpu: [x64]
     os: [win32]
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -2348,7 +2375,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.18'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -2361,8 +2388,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2378,8 +2405,8 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@8.7.1:
-    resolution: {integrity: sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -2677,7 +2704,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.18'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -3122,7 +3149,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 8.7.1
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@hono/node-server@2.0.11(hono@4.12.31)':
@@ -3494,6 +3521,26 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.21.3':
     optional: true
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -3721,16 +3768,16 @@ snapshots:
   '@temporalio/proto@1.17.2':
     dependencies:
       long: 5.3.2
-      protobufjs: 8.7.1
+      protobufjs: 7.6.5
 
-  '@temporalio/testing@1.17.2(esbuild@0.28.1)(postcss@8.5.15)(tslib@2.8.1)':
+  '@temporalio/testing@1.17.2(esbuild@0.28.1)(postcss@8.5.22)(tslib@2.8.1)':
     dependencies:
       '@temporalio/activity': 1.17.2
       '@temporalio/client': 1.17.2
       '@temporalio/common': 1.17.2
       '@temporalio/core-bridge': 1.17.2
       '@temporalio/proto': 1.17.2
-      '@temporalio/worker': 1.17.2(esbuild@0.28.1)(postcss@8.5.15)(tslib@2.8.1)
+      '@temporalio/worker': 1.17.2(esbuild@0.28.1)(postcss@8.5.22)(tslib@2.8.1)
       '@temporalio/workflow': 1.17.2
       abort-controller: 3.0.0
     transitivePeerDependencies:
@@ -3749,7 +3796,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@temporalio/worker@1.17.2(esbuild@0.28.1)(postcss@8.5.15)(tslib@2.8.1)':
+  '@temporalio/worker@1.17.2(esbuild@0.28.1)(postcss@8.5.22)(tslib@2.8.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@swc/core': 1.15.40
@@ -3765,14 +3812,14 @@ snapshots:
       memfs: 4.57.6(tslib@2.8.1)
       nexus-rpc: 0.0.2
       proto3-json-serializer: 2.0.2
-      protobufjs: 8.7.1
+      protobufjs: 7.6.5
       rxjs: 7.8.2
       source-map: 0.7.6
-      source-map-loader: 4.0.2(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15))
+      source-map-loader: 4.0.2(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22))
       supports-color: 8.1.1
-      swc-loader: 0.2.7(@swc/core@1.15.40)(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15))
+      swc-loader: 0.2.7(@swc/core@1.15.40)(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22))
       unionfs: 4.6.0
-      webpack: 5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -4969,16 +5016,16 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.15
+      postcss: 8.5.22
       tsx: 4.22.4
       yaml: 2.9.0
 
-  postcss@8.5.15:
+  postcss@8.5.22:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -4990,10 +5037,20 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 8.7.1
+      protobufjs: 7.6.5
 
-  protobufjs@8.7.1:
+  protobufjs@7.6.5:
     dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 25.9.2
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -5173,11 +5230,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@4.0.2(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)):
+  source-map-loader@4.0.2(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)
 
   source-map-support@0.5.21:
     dependencies:
@@ -5224,25 +5281,25 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  swc-loader@0.2.7(@swc/core@1.15.40)(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)):
+  swc-loader@0.2.7(@swc/core@1.15.40)(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)):
     dependencies:
       '@swc/core': 1.15.40
       '@swc/counter': 0.1.3
-      webpack: 5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)
     optionalDependencies:
       '@swc/core': 1.15.40
       esbuild: 0.28.1
-      postcss: 8.5.15
+      postcss: 8.5.22
 
   terser@5.48.0:
     dependencies:
@@ -5294,7 +5351,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -5305,7 +5362,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.22.4)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.61.1
       source-map: 0.7.6
@@ -5315,7 +5372,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       '@swc/core': 1.15.40
-      postcss: 8.5.15
+      postcss: 8.5.22
       typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
@@ -5382,7 +5439,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.22
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -5431,7 +5488,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15):
+  webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -5453,7 +5510,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22)(webpack@5.107.2(@swc/core@1.15.40)(esbuild@0.28.1)(postcss@8.5.22))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/plugin/pnpm-workspace.yaml
+++ b/plugin/pnpm-workspace.yaml
@@ -16,15 +16,24 @@ overrides:
   vite: '>=8.0.5'
   picomatch: '>=4.0.4'
   brace-expansion: '>=5.0.7'
-  protobufjs: '>=8.6.6'
+  # Align protobufjs to the 7.x line the @temporalio/* SDK is built against
+  # (@temporalio/common depends on protobufjs ^7.x). The prior '>=8.6.6' floor
+  # force-resolved protobufjs 8.x — a major-version mismatch that fights the
+  # SDK's own range and breaks @temporalio/common's ProtobufJsonPayloadConverter
+  # on 1.18+ (extstore-helpers instanceof check). 7.6.5 is the maintained 7.x
+  # tip and pnpm audit is clean.
+  protobufjs: ^7.6.5
   uuid: '>=14.0.0'
   fast-uri: '>=3.1.3'
   esbuild: '>=0.28.1'
   zod: 4.4.3
   # Security floor: relocated from a direct devDependency pin. postcss is only
   # pulled transitively (tsup/vite/postcss-load-config); this override keeps the
-  # patched floor without a phantom direct dependency. See CHANGELOG postcss XSS.
-  postcss: '>=8.5.10'
+  # patched floor without a phantom direct dependency. Floor raised to 8.5.18 to
+  # patch the postcss path-traversal advisory (vulnerable <=8.5.17); the prior
+  # >=8.5.10 floor resolved 8.5.15 (vulnerable). See CHANGELOG postcss XSS +
+  # path-traversal-in-previous-source-map.
+  postcss: '>=8.5.18'
   # Security floor: @hono/node-server is pulled transitively by
   # @modelcontextprotocol/sdk (HTTP server transport, which this plugin does
   # not use — only StdioServerTransport). Floor to the patched release for

--- a/plugin/src/storage/store-temporal/shared.test.ts
+++ b/plugin/src/storage/store-temporal/shared.test.ts
@@ -341,37 +341,28 @@ describe("runTemporalQuery aggregate deadline", () => {
     expect(reinitStsl).not.toHaveBeenCalled();
   });
 
-  test("retries on the per-attempt query ceiling WITHOUT reconnecting (timeout is retryable, not reconnectable)", async () => {
-    let calls = 0;
-    const op = vi.fn(() => {
-      calls += 1;
-      if (calls === 1) return new Promise<never>(() => {});
-      return Promise.resolve("ok");
-    });
+  test("fails fast on the per-attempt query ceiling WITHOUT reconnecting (bounded-read cap is terminal, not reconnectable)", async () => {
+    const op = vi.fn(() => new Promise<never>(() => {}));
 
     // Explicit per-attempt ceiling (decoupled from the env-configurable
-    // QUERY_TIMEOUT_MS default so this test pins retry/reconnect semantics,
-    // not the default value).
+    // QUERY_TIMEOUT_MS default so this test pins the cap semantics, not the
+    // default value).
     const promise = runTemporalQuery(op, { timeoutMs: 5_000 });
-    const assertion = expect(promise).resolves.toBe("ok");
+    const assertion = expect(promise).rejects.toBeInstanceOf(
+      TemporalQueryTimeoutError,
+    );
 
-    // First attempt hangs until the 5s per-attempt ceiling.
-    await vi.advanceTimersByTimeAsync(4_999);
-    expect(op).toHaveBeenCalledTimes(1);
-    expect(reinitStsl).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(1);
-    // Two-axis semantics (#217): a bare query timeout is a slow/contended
-    // worker, not a broken transport channel — it is retryable but NOT
-    // reconnectable. The retry proceeds after backoff with NO reconnect, so
-    // one op's timeout never closes the shared connection under other
-    // sessions' in-flight ops (avoids reconnect churn).
-    expect(reinitStsl).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(250);
+    // The attempt hangs until the 5s per-attempt ceiling.
+    await vi.advanceTimersByTimeAsync(5_000);
     await assertion;
 
-    expect(op).toHaveBeenCalledTimes(2);
+    // rq-boundedAuthoritativeRead03 (per-member circuit-breaker, 1879fb64):
+    // our own per-attempt cap is terminal — a retry would burn the same cap
+    // again and defeat the bounded-read deadline, so the op runs exactly once
+    // (classifyTemporalError → "fatal"). #217 reconnect axis: a timeout is
+    // never a broken transport channel, so it must NOT close the shared
+    // connection (no reinit) — retryable-vs-reconnectable stays decoupled.
+    expect(op).toHaveBeenCalledTimes(1);
     expect(reinitStsl).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Three trunk-health fixes (all pre-existing on trunk, unrelated to the poisoning incident). Together with #314 (replay revert) this should return trunk CI to green.

### 1. shared.test retry test (stale, from 1879fb64)
The `per-attempt query ceiling` test asserted the **old #217 retry-on-timeout** behavior, but `1879fb64` deliberately made the per-member cap a **fail-fast circuit-breaker** (`classifyTemporalError → fatal`, `rq-boundedAuthoritativeRead03`: retrying burns the same cap and defeats the bounded-read deadline). Updated the test to assert terminal / not-retryable / not-reconnectable (op once, rejects `TemporalQueryTimeoutError`, no reinit). **Code was correct; the test was stale** — not a code regression.

### 2. protobufjs floor `>=8.6.6` → `^7.6.5`
The 8.x floor force-resolved a major-version mismatch against `@temporalio/*`'s protobufjs `^7.x` range (breaks `@temporalio/common` ProtobufJsonPayloadConverter on 1.18+). 7.6.5 is the maintained 7.x tip. `pnpm audit` clean.

### 3. postcss floor `>=8.5.10` → `>=8.5.18`
Pre-existing **HIGH** advisory (path traversal in previous source map, vulnerable `<=8.5.17`); old floor resolved 8.5.15. Now 8.5.22. `pnpm audit` clean.

### Verification
`pnpm run check` green; replay-determinism 13/13; store-temporal 33/33; shared.test 28/28; `pnpm audit --audit-level=high` clean.