### PR TITLE
fix(archive): disk release-gate fallback accepts shipped without recovery audit

### DIFF
--- a/plugin/src/tools/change.archive-phase9.test.ts
+++ b/plugin/src/tools/change.archive-phase9.test.ts
@@ -732,7 +732,7 @@ describe("adv_change_archive Phase 9 behavior", () => {
       }
     });
 
-    test("AC2b (forge guard): shipped + unknown (non-allowlisted) recovery reason + non-matching evidence → blocked", async () => {
+    test("AC2b: shipped + unknown recovery reason + non-matching evidence → accepted (shipped is authoritative; forge-guard preserved for unshipped via AC2a)", async () => {
       const { store, cleanup } = await makeDiskFallbackStore({
         releaseGate: {
           status: "done",
@@ -752,7 +752,13 @@ describe("adv_change_archive Phase 9 behavior", () => {
           evidence: structuredEvidence,
           finalizationStatus: "shipped",
         });
-        expect(proof.ok).toBe(false);
+        // rq-releaseProjectionDurability01: `shipped` is git-verified proof
+        // (finalization.status === "shipped" = confirmed default-branch
+        // reachability — unforgeable without a real merge). A done disk gate +
+        // shipped is accepted regardless of recovery_audit reason. The
+        // forge-guard for UN-shipped changes is preserved by the evidence-match
+        // requirement (AC2a).
+        expect(proof.ok).toBe(true);
       } finally {
         await cleanup();
       }

--- a/plugin/src/tools/change/archive-gate.test.ts
+++ b/plugin/src/tools/change/archive-gate.test.ts
@@ -46,6 +46,18 @@ vi.mock("../_recovery-writers", () => ({
   saveRecoveredGateCompletion: recoveryWriterMocks.saveRecoveredGateCompletion,
 }));
 
+const diskLoadMocks = vi.hoisted(() => ({
+  loadChange: vi.fn(),
+}));
+
+vi.mock("../../storage/json", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../storage/json")>(
+      "../../storage/json",
+    );
+  return { ...actual, loadChange: diskLoadMocks.loadChange };
+});
+
 function createStore(mainCheckout: string): Store {
   return {
     paths: {
@@ -844,12 +856,10 @@ describe("verifyReleaseGateDurableForArchive — forge-guard regression (AC4)", 
   });
 
   it("accepts a shipped change whose release gate is done via shipped bypass (store path, no audit required)", async () => {
-    // Two-path forge guard (validator-confirmed): the LIVE STORE path accepts a
-    // done release gate when finalization is shipped (git-confirmed
-    // reachability is authoritative) WITHOUT requiring a recovery audit or
-    // allowlisted reason — even when the approval evidence does NOT substring-
-    // match the structured completion evidence. Only the disk fallback
-    // (loadAuditedDiskReleaseGate) requires audited + allowlisted reason.
+    // Forge guard: the LIVE STORE path accepts a done release gate when
+    // finalization is shipped (git-confirmed reachability is authoritative)
+    // WITHOUT requiring a recovery audit — even when the approval evidence does
+    // NOT substring-match the structured completion evidence.
     const doneNoAudit = {
       status: "done",
       completed_at: "2026-01-01T00:00:00Z",
@@ -871,5 +881,46 @@ describe("verifyReleaseGateDurableForArchive — forge-guard regression (AC4)", 
     });
 
     expect(durableProof).toMatchObject({ ok: true, source: "store" });
+  });
+
+  it("accepts a shipped change whose store gate lags pending but disk gate is done (rq-releaseProjectionDurability01)", async () => {
+    // Repro (fixArchiveMissingWorkflow): a healthy manual
+    // adv_gate_complete(release) persisted release=done to disk, but the
+    // store-backed projection (store.gates.get) returns a stale pre-completion
+    // pending snapshot — changeCache was poisoned by the old
+    // fireSignalAndRefresh re-readback (getTemporalChange reads changeCache
+    // first). finalization is git-verified shipped (merge commit already on the
+    // default branch). The disk fallback must reconcile: shipped + done disk
+    // gate = released. The free-text approval_evidence does NOT substring-match
+    // the structured Phase 9 evidence, and there is no recovery_audit — so the
+    // pre-fix code rejected this at loadAuditedDiskReleaseGate
+    // (shippedReconcile false, evidence false → returns null).
+    const stalePendingStoreGate = { status: "pending" };
+    const doneDiskGate = {
+      status: "done",
+      completed_at: "2026-01-01T00:00:00Z",
+      completed_by: "agent",
+      approval_evidence: "free-text-manual-approval-notes",
+    };
+    const store = {
+      ...createStore("/repo"),
+      gates: {
+        get: vi.fn(async () => ({ release: stalePendingStoreGate })),
+      },
+    } as unknown as Store;
+
+    diskLoadMocks.loadChange.mockResolvedValue({
+      success: true,
+      data: { gates: { release: doneDiskGate } },
+    });
+
+    const durableProof = await verifyReleaseGateDurableForArchive({
+      store,
+      changeId: "staleStoreShippedDiskDone",
+      evidence: "structured-phase9-evidence",
+      finalizationStatus: "shipped",
+    });
+
+    expect(durableProof).toMatchObject({ ok: true, source: "disk" });
   });
 });

--- a/plugin/src/tools/change/archive-gate.ts
+++ b/plugin/src/tools/change/archive-gate.ts
@@ -877,30 +877,6 @@ export function releaseGateEvidenceMatches(
   );
 }
 
-/**
- * Bounded allowlist of the recovery-audit reasons ADV's own release-gate
- * recovery paths stamp on a disk release gate. The shipped disk reconciliation
- * below accepts ONLY these provenances so a forged/unrecognized recovery audit
- * cannot bypass the evidence-match guard on the strength of `finalizationStatus`
- * alone (fixDurableProofFallback, design-validation hardening + live-repro fix).
- *
- * - `completed_workflow_release_gate_recovery`: archive's own release-gate
- *   recovery (recoverReleaseGateViaDiskProjection).
- * - `missing_workflow`: generic gate recovery when the change workflow has
- *   terminated (adv_gate_complete release recovery; recovery-classification).
- * - `poisoned_history`: poisoned-history disk recovery (adv_gate_complete /
- *   verification-evidence disposition).
- *
- * A single-reason binding was insufficient: a terminated-workflow change whose
- * release gate was recovered via generic gate recovery carries `missing_workflow`
- * (or `poisoned_history`), not the archive reason, and was wrongly rejected.
- */
-const RELEASE_GATE_RECOVERY_REASONS = new Set<string>([
-  "completed_workflow_release_gate_recovery",
-  "missing_workflow",
-  "poisoned_history",
-]);
-
 async function loadAuditedDiskReleaseGate(input: {
   store: Store;
   changeId: string;
@@ -916,28 +892,28 @@ async function loadAuditedDiskReleaseGate(input: {
   const disk = await loadChange(input.store.paths.changes, input.changeId);
   if (!disk.success || !disk.data?.gates) return null;
   const gate = disk.data.gates.release;
-  // Resilience (rq-releaseProjectionDurability01): when the store-backed gate
-  // read is stale — a poisoned/missing workflow returns a pre-completion
-  // projection — a disk release gate that ADV genuinely completed is still
-  // authoritative. Require `done`; accept without a recovery audit only when
-  // the archive's fresh finalization is git-verified `shipped` (finalization
-  // sets `shipped` exclusively on confirmed default-branch reachability/merge,
-  // which cannot be forged without a real merge). Recovery-audit remains
-  // required for non-shipped disk fallbacks, preserving the strict guard.
+  // rq-releaseProjectionDurability01 resilience: when the store-backed gate
+  // read is stale — a poisoned/missing workflow or a stale changeCache entry
+  // (getTemporalChange reads changeCache first) returns a pre-completion
+  // pending projection — a disk release gate that ADV genuinely completed
+  // (status done) is still authoritative. Require `done`; accept without a
+  // recovery audit only when the archive's fresh finalization is git-verified
+  // `shipped` (finalization sets `shipped` exclusively on confirmed
+  // default-branch reachability/merge, which cannot be forged without a real
+  // merge). Recovery-audit remains required for non-shipped disk fallbacks,
+  // preserving the strict guard.
   if (gate?.status !== "done") return null;
   if (!hasGateRecoveryAudit(gate) && !input.shipped) return null;
-  // Shipped reconciliation: a change whose git work reached the default branch
-  // (finalization shipped — git-verified reachability that cannot be forged
-  // without a real merge) but whose workflow terminated is recovered on disk
-  // with a release-gate recovery provenance. Its recovery-audit evidence text
-  // need not substring-match the freshly computed finalization evidence — this
-  // mirrors the store-backed `shipped` bypass so a terminated-workflow shipped
-  // change is not permanently unarchivable. Guarded by the bounded release-gate
-  // recovery allowlist so a forged/unrecognized recovery audit cannot bypass.
-  const shippedReconcile =
-    input.shipped === true &&
-    RELEASE_GATE_RECOVERY_REASONS.has(gate.recovery_audit?.reason ?? "");
-  if (shippedReconcile || releaseGateEvidenceMatches(gate, input.evidence)) {
+  // Shipped reconciliation: `shipped` is derived INSIDE the verifier from
+  // finalization.status === "shipped" (confirmed default-branch reachability —
+  // cannot be forged without a real merge). A done disk gate + git-verified
+  // shipped is authoritative proof the change is released, covering both a
+  // healthy manual completion (free-text notes, no recovery audit) whose store
+  // projection lags behind a done disk gate, and a terminated-workflow disk
+  // recovery. This does NOT weaken the un-shipped guard: unshipped changes have
+  // input.shipped === false and fall through to the strict evidence-match
+  // requirement below.
+  if (input.shipped || releaseGateEvidenceMatches(gate, input.evidence)) {
     return gate;
   }
   return null;


### PR DESCRIPTION
## Problem

`verifyReleaseGateDurableForArchive` rejected a healthy shipped change whose store-backed gate projection lagged behind a done disk gate. The incomplete `shippedReconcile` guard required an allowlisted `recovery_audit.reason` that a manual `adv_gate_complete(release)` (free-text notes) never carries, so the archive returned `'Store-backed durable release gate proof did not observe release done'` and the change was stuck active/un-retired — even though its archive bundle was already merged to trunk.

**Repro:** `fixArchiveMissingWorkflow` — archive bundle merged to trunk (`3ddd9d15`), all 7 gates read `done` via `adv_gate_status`, but `adv_change_archive` kept failing because `store.gates.get` returned `release=pending` (stale `changeCache` entry from the old `fireSignalAndRefresh` re-readback, which `getTemporalChange` reads first).

## Root cause

`getTemporalChange` (store-temporal/index.ts:842) reads `changeCache` **before** querying the workflow. A stale cache entry poisoned by the old `fireSignalAndRefresh` re-readback makes `store.gates.get` return a pre-completion `pending` projection even though the workflow and disk both show `done`.

The write-path fix (invalidating cache after every gate completion, PR #309) prevents future poisoning. But the **read-path** disk fallback (`loadAuditedDiskReleaseGate`) still had an incomplete `shippedReconcile` guard: it required `RELEASE_GATE_RECOVERY_REASONS.has(gate.recovery_audit?.reason)` — a reason a healthy manual completion never carries.

## Fix

Accept a done disk gate when `shipped` (`finalization.status === "shipped"` = git-verified default-branch reachability, unforgeable without a real merge). The `recovery_audit` provenance is irrelevant once the change is genuinely merged. Removed the now-dead `RELEASE_GATE_RECOVERY_REASONS` allowlist + `shippedReconcile` variable.

**Forge-guard preserved:** un-shipped changes (`input.shipped === false`) still require `releaseGateEvidenceMatches` — a forged disk gate cannot produce `shipped` without a real merge to the default branch.

## Testing

- TDD: failing test reproducing store=pending / disk=done / shipped → now passes
- AC2b updated: shipped + forged recovery reason → accepted (shipped is authoritative); forge-guard for un-shipped preserved via AC2a
- 153 tests pass incl. replay-determinism safety gate
- Typecheck, lint, format: clean
