### PR TITLE
fix(agents): correct morph_edit worktree-authorization directive (Part A)

### DIFF
--- a/.opencode/agents/adv-designer.md
+++ b/.opencode/agents/adv-designer.md
@@ -119,7 +119,7 @@ If the Designer Apply or remediation Context Packet omits `TASK` or `ATTEMPT`, r
 
 Every tool call you make MUST target the working directory specified in the Designer Apply Context Packet. This is how the orchestrator ensures your file operations land in the correct location (typically a per-change worktree, NOT the default project root).
 
-**Directive:** Extract `WORKING DIRECTORY` from the Designer Apply Context Packet. Pass it as `workdir` to `bash`, `read`, `write`, `edit`, and `adv_run_test`. For `morph_edit`, pass both `workdir: WORKING DIRECTORY` and `taskId: TASK`; ADV authorizes this pair before Morph can use the external root.
+**Directive:** Extract `WORKING DIRECTORY` from the Designer Apply Context Packet. Pass it as `workdir` to `bash`, `read`, `write`, `edit`, and `adv_run_test`. For `morph_edit`: it confines files to the session repo root (`context.worktree ?? context.directory`) and cannot reach ADV per-change worktrees today. For ADV-worktree edits, use `edit`/`write` with the worktree path. You may pass `workdir`+`taskId` to `morph_edit` only when editing inside the session repo (the ADV capability path); if `morph_edit` rejects a worktree path, fall back to `edit`/`write` immediately — do not retry `morph_edit`.
 
 **If WORKING DIRECTORY is missing or empty:** Refuse to begin work. Return a structured packet-defect failure to the orchestrator with `packet_defect: missing WORKING DIRECTORY`. Do NOT call `question` and do NOT ask the user for packet identity values.
 

--- a/.opencode/agents/adv-engineer.md
+++ b/.opencode/agents/adv-engineer.md
@@ -105,7 +105,7 @@ If the Apply or remediation Context Packet omits `TASK` or `ATTEMPT`, return a s
 
 Every tool call you make MUST target the working directory specified in the Apply Context Packet. This is how the orchestrator ensures your file operations land in the correct location (typically a per-change worktree, NOT the default project root).
 
-**Directive:** Extract `WORKING DIRECTORY` from the Apply Context Packet. Pass it as `workdir` to `bash`, `read`, `write`, `edit`, and `adv_run_test`. For `morph_edit`, pass both `workdir: WORKING DIRECTORY` and `taskId: TASK`; ADV authorizes this pair before Morph can use the external root.
+**Directive:** Extract `WORKING DIRECTORY` from the Apply Context Packet. Pass it as `workdir` to `bash`, `read`, `write`, `edit`, and `adv_run_test`. For `morph_edit`: it confines files to the session repo root (`context.worktree ?? context.directory`) and cannot reach ADV per-change worktrees today. For ADV-worktree edits, use `edit`/`write` with the worktree path. You may pass `workdir`+`taskId` to `morph_edit` only when editing inside the session repo (the ADV capability path); if `morph_edit` rejects a worktree path, fall back to `edit`/`write` immediately — do not retry `morph_edit`.
 
 **If WORKING DIRECTORY is missing or empty:** Refuse to begin work. Return a structured packet-defect failure to the orchestrator with `packet_defect: missing WORKING DIRECTORY`. Do NOT call `question` and do NOT ask the user for packet identity values.
 

--- a/.opencode/agents/adv-reviewer.md
+++ b/.opencode/agents/adv-reviewer.md
@@ -113,7 +113,7 @@ You may not begin analysis until scope is locked AND path preflight is complete.
 
 Every tool call you make MUST target the working directory specified in the Context Packet. This ensures your reads, edits, and test runs land in the correct worktree (typically a per-change worktree, NOT the default project root).
 
-**Directive:** Extract `WORKING DIRECTORY` from the Context Packet. Pass it as `workdir` to `bash`, `read`, `write`, `edit`, and `adv_run_test`. For `morph_edit`, pass both `workdir: WORKING DIRECTORY` and `taskId: TASK`; ADV authorizes this pair before Morph can use the external root.
+**Directive:** Extract `WORKING DIRECTORY` from the Context Packet. Pass it as `workdir` to `bash`, `read`, `write`, `edit`, and `adv_run_test`. For `morph_edit`: it confines files to the session repo root (`context.worktree ?? context.directory`) and cannot reach ADV per-change worktrees today. For ADV-worktree edits, use `edit`/`write` with the worktree path. You may pass `workdir`+`taskId` to `morph_edit` only when editing inside the session repo (the ADV capability path); if `morph_edit` rejects a worktree path, fall back to `edit`/`write` immediately — do not retry `morph_edit`.
 
 **If WORKING DIRECTORY is missing or empty:** Refuse to begin. Return a structured packet-defect failure to the orchestrator with `packet_defect: missing WORKING DIRECTORY`. Do NOT call `question` and do NOT ask the user for packet identity values.
 

--- a/plugin/src/adv-engineer-assets.test.ts
+++ b/plugin/src/adv-engineer-assets.test.ts
@@ -190,17 +190,22 @@ describe("adv-engineer assets", () => {
     }
   });
 
-  test("Working Directory Lock section pins morph_edit workdir+taskId pair", () => {
+  test("Working Directory Lock section honestly describes morph_edit confinement and routes worktree edits to edit/write", () => {
     const content = readFileSync(AGENT_PATH, "utf8");
     const wdSection =
       content.split("## Working Directory Lock")[1]?.split("## ")[0] ?? "";
-    // Regression guard: deployment must never regress to workdir-only Morph
-    // calls — the directive must state BOTH tokens, tied to morph_edit.
-    expect(wdSection).toContain("`workdir: WORKING DIRECTORY`");
-    expect(wdSection).toContain("`taskId: TASK`");
-    expect(wdSection).toContain(
-      "For `morph_edit`, pass both `workdir: WORKING DIRECTORY` and `taskId: TASK`",
+    // Truth guard (replaces a false-wording pin). morph_edit confines files to
+    // the session repo root (context.worktree ?? context.directory) and cannot
+    // reach ADV per-change worktrees today — the global capability ADV attaches
+    // is consumed by nothing until the morph-side Part B lands. The directive
+    // must NOT claim ADV authorizes morph_edit for external worktree roots;
+    // worktree edits route to edit/write with an immediate fallback.
+    expect(wdSection).not.toContain(
+      "ADV authorizes this pair before Morph can use the external root",
     );
+    expect(wdSection).toContain("`morph_edit`");
+    expect(wdSection).toContain("`edit`/`write`");
+    expect(wdSection).toContain("fall back to `edit`/`write`");
   });
 
   test("Scope Lock section mentions WORKING DIRECTORY", () => {


### PR DESCRIPTION
## Problem
Sub-agents (adv-engineer / adv-designer / adv-reviewer) waffle and fail on `morph_edit` when editing ADV per-change worktree files. The directives claimed `morph_edit` could authorize external worktree roots by passing `workdir`+`taskId` — but that claim was false: morph never reads ADV's `ADV_MORPH_WORKTREE_CAPABILITY` (dead code), and morph's root is `context.worktree ?? context.directory` (the session repo, never the change worktree). Every worktree `morph_edit` call hit *"Path is outside allowed root"* and agents recovered only by falling back to `edit`/`write`.

## Change (Part A — ADV-only, no runtime change)
- Rewrite the `morph_edit` directive in `adv-engineer.md`, `adv-designer.md`, `adv-reviewer.md` from the false *"ADV authorizes this pair before Morph can use the external root"* claim to honest, forward-compatible wording: `morph_edit` confines to the session repo root; ADV-worktree edits use `edit`/`write`; fall back immediately if `morph_edit` rejects.
- Rewrite the regression-guard test (`plugin/src/adv-engineer-assets.test.ts`) from a false-wording pin to a truth guard.
- ADV's `authorizeMorphWorktree` / `ADV_MORPH_WORKTREE_CAPABILITY` validator deliberately **unchanged** — it is correct and is the foundation Part B consumes.

## Verification
- TDD: RED → GREEN; full assets suite **26/26** green.
- Independent review: verdict READY; AC1–AC4 pass; ADV validator diff empty (untouched); constraints + avoidances respected.

## Part B (separate follow-up)
AC5 — making morph read the global `Symbol.for(\"advance.morph-worktree-capability.v1\")` ADV attaches and use `capability.root` for confinement + adding `workdir`/`taskId` to morph's schema — is a **separate cross-project change** in `~/dev/opencode-morph-fast-apply`. Independent design validation confirmed the symbol survives into morph's `execute` on OpenCode 1.18.4 (same-object dispatch; zod's `safeParse` is boolean-only), so Part B is unblocked.