### PR TITLE
fix(events): session-key active-change state to prevent cross-session clobber

### DIFF
--- a/plugin/src/events/status.test.ts
+++ b/plugin/src/events/status.test.ts
@@ -5,13 +5,22 @@
  * and getEffectiveDoomLoopInfo persistence merging.
  */
 
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, vi } from "vitest";
 import {
   trackRetry,
   clearRetry,
   getDoomLoopInfo,
   getEffectiveDoomLoopInfo,
+  getStatus,
+  setActiveChange,
+  initializeStatus,
+  resetStatusForTest,
 } from "./status";
+import { getCurrentSessionId } from "../utils/session-id";
+
+vi.mock("../utils/session-id", () => ({
+  getCurrentSessionId: vi.fn(),
+}));
 
 describe("trackRetry", () => {
   beforeEach(() => {
@@ -152,5 +161,32 @@ describe("getEffectiveDoomLoopInfo", () => {
     });
     expect(info.attempts).toBe(2);
     expect(info.lastError).toBe("persisted error message");
+  });
+});
+
+describe("session-keyed status state", () => {
+  beforeEach(() => {
+    resetStatusForTest();
+    vi.clearAllMocks();
+  });
+
+  test("isolated activeChangeId per session", () => {
+    const sessionId = getCurrentSessionId as unknown as ReturnType<
+      typeof vi.fn
+    >;
+
+    sessionId.mockReturnValue("session-A");
+    initializeStatus("Project A");
+    setActiveChange("change-A");
+
+    sessionId.mockReturnValue("session-B");
+    initializeStatus("Project B");
+    setActiveChange("change-B");
+
+    sessionId.mockReturnValue("session-A");
+    expect(getStatus().activeChangeId).toBe("change-A");
+
+    sessionId.mockReturnValue("session-B");
+    expect(getStatus().activeChangeId).toBe("change-B");
   });
 });

--- a/plugin/src/events/status.ts
+++ b/plugin/src/events/status.ts
@@ -7,6 +7,7 @@
 import type { StatusMarker } from "../types";
 import { STATUS_MARKERS } from "../types";
 import { updateTerminalStatus, cleanupTerminal } from "./terminal";
+import { getCurrentSessionId } from "../utils/session-id";
 
 // =============================================================================
 // State
@@ -21,14 +22,24 @@ interface StatusState {
   lastUpdated: number;
 }
 
-let state: StatusState = {
-  currentStatus: "IDLE",
-  projectName: "Unknown",
-  activeChangeId: null,
-  activeEpicId: null,
-  taskProgress: null,
-  lastUpdated: Date.now(),
-};
+const sessions = new Map<string, StatusState>();
+
+function getOrCreateSessionState(): StatusState {
+  const sessionId = getCurrentSessionId() ?? "__default__";
+  let sessionState = sessions.get(sessionId);
+  if (!sessionState) {
+    sessionState = {
+      currentStatus: "IDLE",
+      projectName: "Unknown",
+      activeChangeId: null,
+      activeEpicId: null,
+      taskProgress: null,
+      lastUpdated: Date.now(),
+    };
+    sessions.set(sessionId, sessionState);
+  }
+  return sessionState;
+}
 
 /**
  * Tracks whether initializeStatus has been called at least once in this
@@ -78,17 +89,17 @@ export const getStatusMarker = (status: StatusMarker): string => {
  */
 export const initializeStatus = (projectName: string): void => {
   if (initialized) {
-    state.lastUpdated = Date.now();
+    const s = getOrCreateSessionState();
+    s.lastUpdated = Date.now();
     return;
   }
-  state = {
-    currentStatus: "IDLE",
-    projectName,
-    activeChangeId: null,
-    activeEpicId: null,
-    taskProgress: null,
-    lastUpdated: Date.now(),
-  };
+  const s = getOrCreateSessionState();
+  s.currentStatus = "IDLE";
+  s.projectName = projectName;
+  s.activeChangeId = null;
+  s.activeEpicId = null;
+  s.taskProgress = null;
+  s.lastUpdated = Date.now();
   initialized = true;
   updateTerminal();
 };
@@ -99,14 +110,7 @@ export const initializeStatus = (projectName: string): void => {
  */
 export const resetStatusForTest = (): void => {
   initialized = false;
-  state = {
-    currentStatus: "IDLE",
-    projectName: "Unknown",
-    activeChangeId: null,
-    activeEpicId: null,
-    taskProgress: null,
-    lastUpdated: Date.now(),
-  };
+  sessions.clear();
 };
 
 /**
@@ -115,8 +119,9 @@ export const resetStatusForTest = (): void => {
  * Bell logic in terminal.ts independently tracks transitions.
  */
 export const setStatus = (status: StatusMarker): void => {
-  state.currentStatus = status;
-  state.lastUpdated = Date.now();
+  const s = getOrCreateSessionState();
+  s.currentStatus = status;
+  s.lastUpdated = Date.now();
   updateTerminal();
 };
 
@@ -133,8 +138,9 @@ export const setActiveChange = (
   changeId: string | null,
   context?: { epicId?: string },
 ): void => {
-  state.activeChangeId = changeId;
-  state.activeEpicId = changeId ? (context?.epicId ?? null) : null;
+  const s = getOrCreateSessionState();
+  s.activeChangeId = changeId;
+  s.activeEpicId = changeId ? (context?.epicId ?? null) : null;
   updateTerminal();
 };
 
@@ -142,7 +148,8 @@ export const setActiveChange = (
  * Update task progress display.
  */
 export const setTaskProgress = (completed: number, total: number): void => {
-  state.taskProgress = total > 0 ? `${completed}/${total}` : null;
+  const s = getOrCreateSessionState();
+  s.taskProgress = total > 0 ? `${completed}/${total}` : null;
   updateTerminal();
 };
 
@@ -154,10 +161,11 @@ export const setTaskProgress = (completed: number, total: number): void => {
  * project name, status marker, or progress text.
  */
 const updateTerminal = (): void => {
+  const s = getOrCreateSessionState();
   updateTerminalStatus(
-    state.currentStatus,
-    state.activeChangeId ?? undefined,
-    state.activeEpicId ?? undefined,
+    s.currentStatus,
+    s.activeChangeId ?? undefined,
+    s.activeEpicId ?? undefined,
   );
 };
 
@@ -165,21 +173,20 @@ const updateTerminal = (): void => {
  * Get current status state.
  */
 export const getStatus = (): Readonly<StatusState> => {
-  return { ...state };
+  const s = getOrCreateSessionState();
+  return { ...s };
 };
 
 /**
  * Reset status to idle state.
  */
 export const resetStatus = (): void => {
-  state = {
-    ...state,
-    currentStatus: "IDLE",
-    activeChangeId: null,
-    activeEpicId: null,
-    taskProgress: null,
-    lastUpdated: Date.now(),
-  };
+  const s = getOrCreateSessionState();
+  s.currentStatus = "IDLE";
+  s.activeChangeId = null;
+  s.activeEpicId = null;
+  s.taskProgress = null;
+  s.lastUpdated = Date.now();
   updateTerminal();
 };
 
@@ -190,14 +197,7 @@ export const resetStatus = (): void => {
 export const cleanup = (): void => {
   cleanupTerminal();
   initialized = false;
-  state = {
-    currentStatus: "IDLE",
-    projectName: "Unknown",
-    activeChangeId: null,
-    activeEpicId: null,
-    taskProgress: null,
-    lastUpdated: Date.now(),
-  };
+  sessions.delete(getCurrentSessionId() ?? "__default__");
   retryTrackers.clear();
 };
 


### PR DESCRIPTION
## Problem

ADV's plugin state tracking the active change is a **process-scoped singleton** (`let state: StatusState` in `events/status.ts:24`). Multiple OpenCode sessions on the same repo directory share it. One session's `setActiveChange()` silently clobbers `activeChangeId` for all peer sessions — corrupting the session-health banner, active-change overlay, and worktree-session marker.

**Observed**: during a 3-session run, the `[ADV:SESSION_HEALTH]` banner named the wrong change because a peer session's `setActiveChange` overwrote the shared pointer.

## Fix

Replace the module-level singleton with a **session-keyed `Map<string, StatusState>`** using `getCurrentSessionId()` from `utils/session-id.ts` (same memoized per-process ID the Temporal worker uses).

- All public functions (`getStatus`, `setActiveChange`, `setStatus`, etc.) read/write through `getOrCreateSessionState()` keyed on the current session
- `cleanup()` deletes only the current session's entry (peer state survives)
- `resetStatusForTest()` clears the entire map
- `initialized` flag preserved (warp/duplicate-instance protection)
- No API changes — callers use the same function signatures

## Testing

- 12 tests pass including new session-isolation regression test (two sessions keep distinct `activeChangeId`)
- `pnpm run check` green
- 115 related tests pass (no regressions)
