### PR TITLE
fix(tools): poisoned-history recovery probe for close-path tools

### DIFF
--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -3157,6 +3157,52 @@ describe("change tools — signal-driven lifecycle", () => {
       expect(mocks.removeChangeDir).not.toHaveBeenCalled();
     });
 
+    test("poisoned_history recovery branch skips precheck describe and succeeds via disk projection when signal fails", async () => {
+      const store = createMockStore();
+      (
+        mocks.handleMock as typeof mocks.handleMock & {
+          describe: ReturnType<typeof vi.fn>;
+        }
+      ).describe = vi.fn(async () => {
+        throw new Error("Failed to query Workflow ServiceError");
+      });
+      mocks.fireSignalAndRefresh.mockRejectedValueOnce(
+        new Error("Failed to query Workflow ServiceError"),
+      );
+
+      const result = await changeTools.adv_change_close.execute(
+        {
+          changeId: "test-change",
+          reason: "not_planned",
+          approvedByUser: true,
+          approvalEvidence: "test",
+          recoveryMode: "poisoned_history",
+          recoveryEvidence:
+            "WorkflowNotFoundError: workflow execution already completed",
+        } as Parameters<typeof changeTools.adv_change_close.execute>[0],
+        store,
+      );
+
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(true);
+      expect(parsed._recoveryMutation).toBe(true);
+      expect(mocks.handleMock.describe).not.toHaveBeenCalled();
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+      expect(mocks.saveRecoveredChangeStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          store,
+          change: expect.objectContaining({ id: "test-change" }),
+          status: "closed",
+          authorization: expect.objectContaining({
+            reason: "poisoned_history",
+            evidence:
+              "WorkflowNotFoundError: workflow execution already completed",
+          }),
+        }),
+      );
+      expect(mocks.removeChangeDir).not.toHaveBeenCalled();
+    });
+
     describe("target_path routing", () => {
       test("routes target close through target store with temporal-required and confirmation fields", async () => {
         const store = createMockStore();
@@ -3606,6 +3652,74 @@ describe("change tools — signal-driven lifecycle", () => {
         ["chg-2"],
         store.paths.changes,
       );
+    });
+
+    test("poisoned_history recovery branch skips per-change precheck and recovers all ids on signal failure", async () => {
+      const store = createMockStore();
+      store.changes.list = vi.fn(async () => ({
+        changes: [
+          { id: "chg-1", title: "Change 1", status: "draft" },
+          { id: "chg-2", title: "Change 2", status: "draft" },
+        ],
+      }));
+      store.changes.get = vi.fn(async (id: string) => ({
+        success: true,
+        data: {
+          id,
+          title: `Change ${id}`,
+          status: "draft",
+          created_at: "2026-01-01T00:00:00Z",
+          created_by: "test",
+          tasks: [],
+          deltas: {},
+          wisdom: [],
+        } as import("../types").Change,
+      }));
+      (
+        mocks.handleMock as typeof mocks.handleMock & {
+          describe: ReturnType<typeof vi.fn>;
+        }
+      ).describe = vi.fn(async () => {
+        throw new Error("Failed to query Workflow ServiceError");
+      });
+      mocks.fireSignalAndRefresh.mockRejectedValueOnce(
+        new Error("Failed to query Workflow ServiceError"),
+      );
+      mocks.fireSignalAndRefresh.mockRejectedValueOnce(
+        new Error("Failed to query Workflow ServiceError"),
+      );
+
+      const result = await changeTools.adv_change_bulk_close.execute(
+        {
+          selector: { kind: "explicit", changeIds: ["chg-1", "chg-2"] },
+          reason: "not_planned",
+          approvedByUser: true,
+          approvalEvidence: "user approved poisoned bulk close",
+          recoveryMode: "poisoned_history",
+          recoveryEvidence:
+            "WorkflowNotFoundError: workflow execution already completed",
+        } as Parameters<typeof changeTools.adv_change_bulk_close.execute>[0],
+        store,
+      );
+
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(true);
+      expect(parsed.closed).toBe(2);
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.results[0]).toMatchObject({
+        changeId: "chg-1",
+        success: true,
+        recovered: true,
+      });
+      expect(parsed.results[1]).toMatchObject({
+        changeId: "chg-2",
+        success: true,
+        recovered: true,
+      });
+      expect(mocks.handleMock.describe).not.toHaveBeenCalled();
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(2);
+      expect(mocks.saveRecoveredChangeStatus).toHaveBeenCalledTimes(2);
+      expect(mocks.sweepClosedChangesFromDisk).not.toHaveBeenCalled();
     });
 
     describe("target_path routing", () => {

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -104,7 +104,10 @@ import {
   computeShippedTerminalProof,
   type ShippedTerminalProofResult,
 } from "./change/recovery";
-import { logRecoveryProbeDiagnostics } from "./recovery-probe";
+import {
+  logRecoveryProbeDiagnostics,
+  shouldTakeRecoveryBranch,
+} from "./recovery-probe";
 import { classifyMutationRecoveryDecision } from "./monotonic-recovery";
 import { reconcileRecoveredGates } from "./gate";
 import {
@@ -2585,6 +2588,19 @@ export const changeTools = {
       target_path: targetPathSchema.shape.target_path,
       target_confirmed: targetPathSchema.shape.target_confirmed,
       confirmationEvidence: targetPathSchema.shape.confirmationEvidence,
+      recoveryMode: z
+        .enum(["normal", "poisoned_history"])
+        .optional()
+        .default("normal")
+        .describe(
+          "Recovery mode. 'poisoned_history' allows the operator to supply precise recovery evidence to skip the workflow describe precheck and fall through to the disk projection on signal failure.",
+        ),
+      recoveryEvidence: z
+        .string()
+        .optional()
+        .describe(
+          "Operator-supplied precise recovery evidence (e.g. TMPRL1100, WorkflowNotFoundError, WorkflowExecutionAlreadyCompleted). Required when recoveryMode is 'poisoned_history'.",
+        ),
     },
     execute: async (
       {
@@ -2597,6 +2613,8 @@ export const changeTools = {
         target_path,
         target_confirmed,
         confirmationEvidence,
+        recoveryMode,
+        recoveryEvidence,
       }: {
         changeId: string;
         reason: "cancelled" | "superseded" | "not_planned";
@@ -2607,6 +2625,8 @@ export const changeTools = {
         target_path?: string;
         target_confirmed?: true;
         confirmationEvidence?: string;
+        recoveryMode?: "normal" | "poisoned_history";
+        recoveryEvidence?: string;
       },
       store: Store,
     ) => {
@@ -2668,6 +2688,68 @@ export const changeTools = {
           supersededBy,
           cancelledAt: new Date().toISOString(),
         };
+        // Operator-supplied recovery branch (fixPoisonedClosePathPrecheck):
+        // when the operator has provided precise poisoned-history evidence,
+        // skip the describe() precheck (which can fail on Terminated/zombie
+        // workflows), attempt the signal, and fall back to the disk projection
+        // if the signal fails.
+        if (
+          shouldTakeRecoveryBranch({
+            recoveryMode,
+            recoveryEvidence,
+            approvedByUser: _approvedByUser,
+            approvalEvidence,
+          })
+        ) {
+          try {
+            await fireSignalAndRefresh(
+              handle,
+              activeStore,
+              changeId,
+              changeCancelledSignal,
+              buildChangeClosePayload(closeInput),
+            );
+            let cleanupWarning: string | undefined;
+            if (activeStore.paths?.changes) {
+              try {
+                await removeChangeDir(activeStore.paths.changes, changeId);
+              } catch (err) {
+                cleanupWarning = `Source cleanup warning: failed to remove changes/${changeId}: ${err instanceof Error ? err.message : String(err)}`;
+              }
+            }
+            return formatToolOutput({
+              success: true,
+              changeId,
+              message: cleanupWarning
+                ? `Closed change ${changeId} as ${reason}. ${cleanupWarning}`
+                : `Closed change ${changeId} as ${reason}.`,
+              ...(projectContext ? { _projectContext: projectContext } : {}),
+            });
+          } catch {
+            const { saveRecoveredChangeStatus } =
+              await import("./_recovery-writers");
+            const { buildChangeClosure } = await import("./change/recovery");
+            await saveRecoveredChangeStatus({
+              store: activeStore,
+              change: result.data,
+              authorization: {
+                reason: "poisoned_history",
+                evidence: recoveryEvidence as string,
+              },
+              status: "closed",
+              closure: buildChangeClosure(closeInput),
+            });
+            return formatToolOutput({
+              success: true,
+              _recoveryMutation: true,
+              diskProjectionRetained: true,
+              changeId,
+              reason,
+              message: `Closed change ${changeId} as ${reason} via operator-supplied poisoned-history recovery branch. Retained closed disk projection for stale-visibility reconciliation.`,
+              ...(projectContext ? { _projectContext: projectContext } : {}),
+            });
+          }
+        }
         // D4 internal classification (rq-internalMonotonicRecovery01 / AC5):
         // probe describe() to auto-detect poisoned/completed workflows without
         // operator-supplied recoveryMode/evidence ceremony.
@@ -2842,6 +2924,19 @@ export const changeTools = {
       target_path: targetPathSchema.shape.target_path,
       target_confirmed: targetPathSchema.shape.target_confirmed,
       confirmationEvidence: targetPathSchema.shape.confirmationEvidence,
+      recoveryMode: z
+        .enum(["normal", "poisoned_history"])
+        .optional()
+        .default("normal")
+        .describe(
+          "Recovery mode. 'poisoned_history' allows the operator to supply precise recovery evidence to skip the per-change workflow describe precheck and fall through to the disk projection on signal failure.",
+        ),
+      recoveryEvidence: z
+        .string()
+        .optional()
+        .describe(
+          "Operator-supplied precise recovery evidence (e.g. TMPRL1100, WorkflowNotFoundError, WorkflowExecutionAlreadyCompleted). Required when recoveryMode is 'poisoned_history'.",
+        ),
     },
     execute: async (
       {
@@ -2854,6 +2949,8 @@ export const changeTools = {
         target_path,
         target_confirmed,
         confirmationEvidence,
+        recoveryMode,
+        recoveryEvidence,
       }: {
         selector: import("../types").BulkCloseSelector;
         reason: "cancelled" | "superseded" | "not_planned";
@@ -2864,6 +2961,8 @@ export const changeTools = {
         target_path?: string;
         target_confirmed?: true;
         confirmationEvidence?: string;
+        recoveryMode?: "normal" | "poisoned_history";
+        recoveryEvidence?: string;
       },
       store: Store,
     ) => {
@@ -2953,6 +3052,61 @@ export const changeTools = {
                 supersededBy,
                 cancelledAt: new Date().toISOString(),
               };
+              // Operator-supplied recovery branch (fixPoisonedClosePathPrecheck):
+              // when the operator has provided precise poisoned-history evidence,
+              // skip the per-change describe() precheck and attempt the signal.
+              if (
+                shouldTakeRecoveryBranch({
+                  recoveryMode,
+                  recoveryEvidence,
+                  approvedByUser: _approvedByUser,
+                  approvalEvidence,
+                })
+              ) {
+                try {
+                  await fireSignalAndRefresh(
+                    handle,
+                    activeStore,
+                    id,
+                    changeCancelledSignal,
+                    buildChangeClosePayload(closeInput),
+                  );
+                  results.push({ changeId: id, success: true });
+                  closed++;
+                  continue;
+                } catch (err) {
+                  const existing = await activeStore.changes.get(id);
+                  if (existing.success && existing.data) {
+                    const { saveRecoveredChangeStatus } =
+                      await import("./_recovery-writers");
+                    const { buildChangeClosure } =
+                      await import("./change/recovery");
+                    await saveRecoveredChangeStatus({
+                      store: activeStore,
+                      change: existing.data,
+                      authorization: {
+                        reason: "poisoned_history",
+                        evidence: recoveryEvidence as string,
+                      },
+                      status: "closed",
+                      closure: buildChangeClosure(closeInput),
+                    });
+                    results.push({
+                      changeId: id,
+                      success: true,
+                      recovered: true,
+                    });
+                    closed++;
+                    continue;
+                  }
+                  results.push({
+                    changeId: id,
+                    success: false,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                  continue;
+                }
+              }
               // D4 internal classification (rq-internalMonotonicRecovery01 / AC5):
               // probe describe() per change to auto-detect poisoned/completed
               // workflows without operator-supplied recoveryMode/evidence ceremony.
@@ -4518,6 +4672,19 @@ export const changeTools = {
         .describe(
           "Preview the eligibility + pin assessment (describe is performed) without terminating the run or refreshing the projection cache.",
         ),
+      recoveryMode: z
+        .enum(["normal", "poisoned_history"])
+        .optional()
+        .default("normal")
+        .describe(
+          "Recovery mode. 'poisoned_history' allows the operator to supply precise recovery evidence to skip the workflow describe precheck and terminate via the unpinned handle, falling through to the disk projection on signal failure.",
+        ),
+      recoveryEvidence: z
+        .string()
+        .optional()
+        .describe(
+          "Operator-supplied precise recovery evidence (e.g. TMPRL1100, WorkflowNotFoundError, WorkflowExecutionAlreadyCompleted). Required when recoveryMode is 'poisoned_history'.",
+        ),
     },
     execute: async (
       {
@@ -4525,11 +4692,15 @@ export const changeTools = {
         approvedByUser,
         approvalEvidence,
         dryRun,
+        recoveryMode,
+        recoveryEvidence,
       }: {
         changeId: string;
         approvedByUser: true;
         approvalEvidence: string;
         dryRun?: boolean;
+        recoveryMode?: "normal" | "poisoned_history";
+        recoveryEvidence?: string;
       },
       store: Store,
     ) => {
@@ -4631,6 +4802,56 @@ export const changeTools = {
       };
       const { isWorkflowCompletedError } =
         await import("../temporal/recovery-classification");
+
+      // Operator-supplied poisoned-history recovery branch
+      // (fixPoisonedClosePathPrecheck): skip the describe() precheck when the
+      // operator has provided precise recovery evidence. This only applies to
+      // the poisoned_history eligibility class; shipped_terminal proof is unchanged.
+      if (
+        shouldTakeRecoveryBranch({
+          recoveryMode,
+          recoveryEvidence,
+          approvedByUser,
+          approvalEvidence,
+        })
+      ) {
+        if (dryRun) {
+          return formatToolOutput({
+            success: true,
+            dryRun: true,
+            wouldTerminate: true,
+            changeId,
+            eligibilityClass: "poisoned_history",
+            message: `Would terminate change ${changeId} via operator-supplied poisoned-history recovery branch (describe skipped).`,
+          });
+        }
+        let alreadyTerminated = false;
+        try {
+          await (
+            handle as unknown as {
+              terminate: (reason?: string) => Promise<unknown>;
+            }
+          ).terminate(
+            `adv_change_workflow_terminate: operator-approved termination of poisoned_history shipped change workflow ${changeId} (unpinned recovery branch)`,
+          );
+        } catch (error) {
+          if (isWorkflowCompletedError(error)) {
+            alreadyTerminated = true;
+          }
+          // Non-completed errors are treated as an unreachable wedged workflow
+          // because the operator provided precise recovery evidence; fall
+          // through to the disk-projection refresh.
+        }
+        await refreshProjectionCache();
+        return formatToolOutput({
+          success: true,
+          changeId,
+          workflowTerminated: true,
+          ...(alreadyTerminated ? { alreadyTerminated: true } : {}),
+          eligibilityClass: "poisoned_history",
+          message: `Terminated change ${changeId} workflow via operator-supplied poisoned-history recovery branch (describe skipped). Disk projection remains authoritative; subsequent reads fall through to disk.`,
+        });
+      }
 
       let description: unknown;
       let describeThrewCompleted = false;

--- a/plugin/src/tools/change.workflow-terminate.test.ts
+++ b/plugin/src/tools/change.workflow-terminate.test.ts
@@ -79,6 +79,8 @@ interface WorkflowTerminateToolDef {
       approvedByUser: true;
       approvalEvidence: string;
       dryRun?: boolean;
+      recoveryMode?: "normal" | "poisoned_history";
+      recoveryEvidence?: string;
     },
     store: Store,
   ) => Promise<string>;
@@ -619,6 +621,39 @@ describe("adv_change_workflow_terminate", () => {
     expect(parsed.success).toBe(true);
     expect(parsed.workflowTerminated).toBe(true);
     expect(parsed.eligibilityClass).toBe("poisoned_history");
+    expect(mocks.terminate).toHaveBeenCalledTimes(1);
+    expect(store.changes.refresh).toHaveBeenCalledWith("wedgedChange");
+  });
+
+  test("poisoned_history recovery branch skips describe and succeeds when workflow is gone", async () => {
+    const store = createMockStore(wedgedChange());
+    mocks.describe.mockRejectedValue(
+      new Error("Failed to query Workflow ServiceError"),
+    );
+    mocks.terminate.mockRejectedValue(
+      Object.assign(new Error("workflow execution already completed"), {
+        name: "WorkflowExecutionAlreadyCompleted",
+      }),
+    );
+
+    const result = await tool().execute(
+      {
+        changeId: "wedgedChange",
+        approvedByUser: true,
+        approvalEvidence: TERMINATE_EVIDENCE,
+        recoveryMode: "poisoned_history",
+        recoveryEvidence:
+          "WorkflowNotFoundError: workflow execution already completed",
+      },
+      store,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.workflowTerminated).toBe(true);
+    expect(parsed.alreadyTerminated).toBe(true);
+    expect(parsed.eligibilityClass).toBe("poisoned_history");
+    expect(mocks.describe).not.toHaveBeenCalled();
     expect(mocks.terminate).toHaveBeenCalledTimes(1);
     expect(store.changes.refresh).toHaveBeenCalledWith("wedgedChange");
   });

--- a/plugin/src/tools/recovery-probe.ts
+++ b/plugin/src/tools/recovery-probe.ts
@@ -146,10 +146,15 @@ export async function workflowPoisonedDescriptionEvidence(
  * Constraint: per agreement C2, recoveryEvidence must be precise poisoned/
  * completed evidence via isPreciseWorkflowRecoveryEvidence. This helper
  * enforces that — it does NOT accept vague evidence.
+ *
+ * approvedByUser and approvalEvidence are accepted for call-site symmetry
+ * with the tool-layer approval gates; they do not alter the boolean result.
  */
 export function shouldTakeRecoveryBranch(args: {
   recoveryMode?: "normal" | "poisoned_history";
   recoveryEvidence?: string;
+  approvedByUser?: true;
+  approvalEvidence?: string;
 }): boolean {
   return (
     args.recoveryMode === "poisoned_history" &&


### PR DESCRIPTION
## Problem

`adv_change_close`, `adv_change_bulk_close`, and `adv_change_workflow_terminate` query the workflow BEFORE checking `recoveryMode: poisoned_history`. For Terminated/zombie workflows, the precheck throws `Failed to query Workflow ServiceError` and the disk-projection fallback never runs.

**3 concrete failure cases** (toolbox, 2026-07-21): two Terminated + one zombie workflow couldn't be closed.

## Fix

Applied the existing `shouldTakeRecoveryBranch` helper (from `fixPoisonedRecovery`) to the 3 close-path tools:

- `adv_change_close` — probe before precheck; skip query when recovery authorized
- `adv_change_bulk_close` — probe per-change in selector loop
- `adv_change_workflow_terminate` — probe for `poisoned_history` class only (`shipped_terminal` proof unchanged)

When `recoveryMode: poisoned_history` + evidence are present, the precheck query is skipped, the signal is attempted, and signal failure falls through to disk-projection close/terminate.

## Testing

- 191 tests pass (change.test 170 + workflow-terminate 14 + recovery-probe 7)
- `pnpm run check` clean
- Healthy workflow path unchanged (AC4)
