### PR TITLE
fix(adv): give primary adv manifest the Tier-4 invoke-routing contract

### DIFF
--- a/.opencode/agents/adv-designer.md
+++ b/.opencode/agents/adv-designer.md
@@ -59,7 +59,7 @@ tools:
   # === BLOCKED: Orchestration, gate management, agenda, worktree ===
   # <<< ADV-GENERATED adv_* tools <<<
   task: false
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 ---
 
 You are the `adv-designer` agent: an ADV apply-phase frontend follow-up specialist. After a successful engineer or inline receipt, **fix in-scope UI/component issues, then verify** the result. You are remediation-capable, not review-only. Never initial route for `metadata.frontend == "true"`. The spawnable identifier is `adv-designer`; the `DESIGNER_REPORT.agent` field submitted to `adv_subagent_report_submit` must use that exact string.

--- a/.opencode/agents/adv-engineer.md
+++ b/.opencode/agents/adv-engineer.md
@@ -56,7 +56,7 @@ tools:
   # === BLOCKED: Orchestration, gate management, agenda, worktree ===
   # <<< ADV-GENERATED adv_* tools <<<
   task: false
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 ---
 
 You are the `adv-engineer` agent. You are a delegated ADV code-writing executor and the initial implementation owner for classified UI tasks — you implement, test, and verify within a locked scope handed to you by the ADV orchestrator. A matching-cycle `adv-designer` follow-up may validate UI quality after your successful evidence. The spawnable identifier is `adv-engineer`; the `ENGINEER_REPORT.agent` field submitted to `adv_subagent_report_submit` must use that exact string.

--- a/.opencode/agents/adv-researcher.md
+++ b/.opencode/agents/adv-researcher.md
@@ -48,7 +48,7 @@ tools:
   adv_tool_invoke: true
   # <<< ADV-GENERATED adv_* tools <<<
   # UX tools
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
   question: true
   # Disabled - research agents don't write code
   write: false

--- a/.opencode/agents/adv-reviewer.md
+++ b/.opencode/agents/adv-reviewer.md
@@ -61,7 +61,7 @@ tools:
   task: false
   # <<< ADV-GENERATED adv_* tools <<<
 ---
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 
 You are the `adv-reviewer` agent. You are a delegated ADV analyst+remediator for `/adv-review` and `/adv-harden`. You inspect, find issues, apply scoped fixes within your locked objective, run verification, and submit a structured `REVIEWER_REPORT` to durable ADV state. The spawnable identifier is `adv-reviewer`; the `REVIEWER_REPORT.agent` field must use that exact string.
 

--- a/.opencode/agents/adv-temporal-repair.md
+++ b/.opencode/agents/adv-temporal-repair.md
@@ -37,7 +37,7 @@ tools:
   morph_edit: false
   # <<< ADV-GENERATED adv_* tools <<<
 ---
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 
 You are `adv-temporal-repair`, a focused ADV repair-classifier sub-agent. You offload noisy Temporal/session-pointer diagnosis from primary ADV. You do **not** own gates, tasks, archive, cancellation, scope drift, or approval-gated repair actions.
 

--- a/.opencode/agents/adv-tron.md
+++ b/.opencode/agents/adv-tron.md
@@ -47,7 +47,7 @@ tools:
   adv_tool_invoke: true
   # <<< ADV-GENERATED adv_* tools <<<
   # Disabled - Tron does not do external research
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
   context7_*: false
   exa_*: false
   webfetch: false

--- a/.opencode/agents/adv-verifier.md
+++ b/.opencode/agents/adv-verifier.md
@@ -50,7 +50,7 @@ tools:
   adv_tool_invoke: true
   # <<< ADV-GENERATED adv_* tools <<<
 ---
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 
 You are `adv-verifier`, a local verify-only sub-agent for ADV.
 

--- a/.opencode/agents/adv-visual-review.md
+++ b/.opencode/agents/adv-visual-review.md
@@ -47,7 +47,7 @@ tools:
   adv_tool_invoke: true
   # <<< ADV-GENERATED adv_* tools <<<
 
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
   # Disabled - Visual Review does not perform external research
   context7_*: false
   exa_*: false

--- a/.opencode/agents/adv.md
+++ b/.opencode/agents/adv.md
@@ -73,6 +73,7 @@ tools:
   searchcode_*: true
   firecrawl_*: true
   webfetch: true
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 ---
 <!-- ADV_SYNC:START adv -->
 

--- a/.opencode/agents/build.md
+++ b/.opencode/agents/build.md
@@ -60,7 +60,7 @@ tools:
   # === BLOCKED: Orchestration and gate management ===
   # <<< ADV-GENERATED adv_* tools <<<
 ---
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 <!-- ADV_SYNC:START build -->
 
 ## ADV Overlay

--- a/.opencode/agents/plan.md
+++ b/.opencode/agents/plan.md
@@ -34,7 +34,7 @@ tools:
   adv_tool_invoke: true
   # <<< ADV-GENERATED adv_* tools <<<
   # Local code intelligence
-> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads also via `tools.adv.*`.
+> **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
   lgrep_search_semantic: true
   lgrep_index_semantic: true
   lgrep_search_symbols: true

--- a/plugin/scripts/generate-agent-manifests.ts
+++ b/plugin/scripts/generate-agent-manifests.ts
@@ -28,7 +28,8 @@ export const ADV_TOOLS_BLOCK_END = "  # <<< ADV-GENERATED adv_* tools <<<";
  * reachable through Code Mode as `tools.adv.*` even when the host-plugin
  * manifest denies `adv_*`.
  */
-const TIER_4_INVOKE_ROUTING_NOTE = " Tier-4 reads also via `tools.adv.*`.";
+const TIER_4_INVOKE_ROUTING_NOTE =
+  " Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.";
 
 const ADV_TOOL_ENTRY_RE = /^\s+(adv_[A-Za-z0-9_*]+):\s*(true|false)\s*$/;
 

--- a/plugin/src/tier4-manifest-awareness.test.ts
+++ b/plugin/src/tier4-manifest-awareness.test.ts
@@ -6,8 +6,13 @@ import { SPAWNABLE_SUBAGENT_ROSTER } from "./tool-role-policy.js";
 const REPO_ROOT = resolve(__dirname, "../..");
 const AGENTS_DIR = resolve(REPO_ROOT, ".opencode/agents");
 
+// Primary `adv` is not spawnable so it isn't in SPAWNABLE_SUBAGENT_ROSTER,
+// but its manifest carries the same invoke-routing contract and must stay
+// in sync with the Tier-4 Code Mode surface.
+const AGENTS_WITH_INVOKE_ROUTING = [...SPAWNABLE_SUBAGENT_ROSTER, "adv"];
+
 describe("Tier-4 MCP surface in agent manifests", () => {
-  for (const agent of SPAWNABLE_SUBAGENT_ROSTER) {
+  for (const agent of AGENTS_WITH_INVOKE_ROUTING) {
     const source = readFileSync(resolve(AGENTS_DIR, `${agent}.md`), "utf8");
     if (!source.includes("> **Invoke routing:**")) {
       continue;


### PR DESCRIPTION
## Problem

The primary `adv.md` manifest lacked the `> **Invoke routing:**` paragraph that every sub-agent carries. So the orchestrator had **no manifest-embedded Code Mode routing guidance** — only the global `adv-tools.md` instruction. This led an agent to mis-attribute a host-only call (`adv_change_list`) to a *missing Code Mode namespace*, when the real reason is structural: `change_list` is not one of the 13 Tier-4 catalog tools (by design — it's a Tier-2 host tool).

`tier4-manifest-awareness.test.ts` only iterated `SPAWNABLE_SUBAGENT_ROSTER`, so the primary agent's manifest was never regression-checked for the routing contract.

## Fix

- **`.opencode/agents/adv.md`** — add the `> **Invoke routing:` paragraph (the hand-owned anchor). The generator (`injectTier4InvokeRoutingNote`) now injects the Tier-4 note on regen, same as sub-agents.
- **`plugin/scripts/generate-agent-manifests.ts`** — reword `TIER_4_INVOKE_ROUTING_NOTE` to state the closed set **positively** (not a suppression nag): *"Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only."* Applies uniformly to every agent manifest.
- **`plugin/src/tier4-manifest-awareness.test.ts`** — extend the loop to `[...SPAWNABLE_SUBAGENT_ROSTER, "adv"]` so the primary agent is regression-covered.

All 11 manifests regenerated via `pnpm run generate:manifests`.

## Verification

- `generate:manifests:check` ✓ ("All agent manifests match generated output")
- 24 tests pass (`tier4-manifest-awareness` + `generate-agent-manifests`)
- `typecheck` ✓, `lint` clean, `format:check` (src/) ✓
- Generator diff scoped to the one constant (pre-existing `scripts/` format baseline untouched — not in CI `format:check`)