### PR TITLE
fix: reconcile ops follow-up resolution

### DIFF
--- a/docs/cli-surface-matrix.md
+++ b/docs/cli-surface-matrix.md
@@ -114,6 +114,7 @@
 | `adv_followup_promote` | `no-cli-dangerous` | Promotes a linked ops follow-up change; mutation |
 | `adv_report_followup_promote` | `no-cli-dangerous` | Promotes a report follow-up into a task or fast-follow child; mutation |
 | `adv_ops_evidence_add` | `no-cli-dangerous` | Appends ops evidence and updates follow-up status; mutation |
+| `adv_ops_followup_resolution_upsert` | `no-cli-dangerous` | Persists verified child-state proof onto a parent ops follow-up link; release/archive authority mutation |
 | `adv_change_bulk_close` | `no-cli-dangerous` | Change mutation |
 | `adv_change_archive` | `no-cli-dangerous` | Archive mutation + spec delta |
 | `adv_archive_purge` | `no-cli-dangerous` | Operator-only archived-change purge; terminates workflow, opt-in disk-bundle removal |

--- a/docs/tool-ownership.md
+++ b/docs/tool-ownership.md
@@ -158,6 +158,7 @@ class rather than operator-only.
 | Tool | Class | Notes |
 |---|---|---|
 | `adv_ops_evidence_add` | orchestrator | Ops follow-up evidence append |
+| `adv_ops_followup_resolution_upsert` | orchestrator | Typed parent-link resolution upsert from authoritative child-state reconciliation |
 | `adv_ops_run_upsert` | orchestrator | Ops runbook run upsert |
 | `adv_ops_run_evidence_add` | orchestrator | Run-step evidence append; prod execute steps approval-gated |
 

--- a/plugin/schemas/change.schema.json
+++ b/plugin/schemas/change.schema.json
@@ -3225,6 +3225,9 @@
           "resolution": {
             "additionalProperties": false,
             "properties": {
+              "child_updated_at": {
+                "type": "string"
+              },
               "completion_signal": {
                 "minLength": 1,
                 "type": "string"
@@ -3239,6 +3242,16 @@
               },
               "health_verification": {
                 "minLength": 1,
+                "type": "string"
+              },
+              "resolution_reason": {
+                "enum": [
+                  "verified",
+                  "child_missing",
+                  "profile_missing",
+                  "target_identity_mismatch",
+                  "unreachable"
+                ],
                 "type": "string"
               },
               "rollback_or_cleanup_disposition": {

--- a/plugin/src/cli-bridge-contract.test.ts
+++ b/plugin/src/cli-bridge-contract.test.ts
@@ -159,6 +159,7 @@ describe("REGISTRY NO-REMOVAL GUARD (AC6/DONT1)", () => {
       "adv_followup_promote",
       "adv_report_followup_promote",
       "adv_ops_evidence_add",
+      "adv_ops_followup_resolution_upsert",
       "adv_ops_run_upsert",
       "adv_ops_run_evidence_add",
       "adv_contract_mint",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -630,6 +630,7 @@ const advancePluginImpl: Plugin = async (input) => {
     "adv_contract_review_matrix_set",
     "adv_subagent_report_submit",
     "adv_ops_evidence_add",
+    "adv_ops_followup_resolution_upsert",
   ]);
 
   const shouldRepointActiveChange = (

--- a/plugin/src/temporal/change-state.ops-follow-up.test.ts
+++ b/plugin/src/temporal/change-state.ops-follow-up.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyOpsEvidenceAppendedToState,
   applyOpsFollowupLinkAddedToState,
+  applyOpsFollowupResolutionUpsertedToState,
   applyOpsFollowupSeededToState,
   applyOpsRunEvidenceAppendedToState,
   applyOpsRunUpsertedToState,
@@ -99,6 +100,173 @@ describe("ops follow-up state reducers", () => {
 
     expect(state.ops_followup_links).toHaveLength(1);
     expect(state.ops_followup_links?.[0]?.status).toBe("running");
+  });
+
+  it("upserts resolution on a matching outbound ops follow-up link", () => {
+    const state = createChangeWorkflowState({
+      changeId: "parent-1",
+      title: "Parent change",
+      createdAt: timestamp,
+    });
+
+    applyOpsFollowupLinkAddedToState(state, {
+      link: {
+        id: "ofl-1",
+        changeId: "child-1",
+        relationship: "blocks",
+        status: "running",
+        linked_at: timestamp,
+      },
+      addedAt: timestamp,
+    });
+
+    applyOpsFollowupResolutionUpsertedToState(state, {
+      linkId: "ofl-1",
+      resolution: {
+        status: "complete",
+        verified_at: "2026-06-20T04:05:00.000Z",
+        child_updated_at: "2026-06-20T04:04:00.000Z",
+        resolution_reason: "verified",
+        source: "child_profile",
+        completion_signal: "deploy finished",
+        health_verification: "smoke passed",
+        rollback_or_cleanup_disposition: "no rollback needed",
+      },
+      upsertedAt: "2026-06-20T04:05:00.000Z",
+    });
+
+    expect(state.ops_followup_links).toHaveLength(1);
+    expect(state.ops_followup_links?.[0]?.resolution).toMatchObject({
+      status: "complete",
+      child_updated_at: "2026-06-20T04:04:00.000Z",
+      resolution_reason: "verified",
+      completion_signal: "deploy finished",
+    });
+    expect(state.lastSignalAt).toBe("2026-06-20T04:05:00.000Z");
+  });
+
+  it("idempotently replaces resolution on repeated upserts for the same link", () => {
+    const state = createChangeWorkflowState({
+      changeId: "parent-1",
+      title: "Parent change",
+      createdAt: timestamp,
+    });
+
+    applyOpsFollowupLinkAddedToState(state, {
+      link: {
+        id: "ofl-1",
+        changeId: "child-1",
+        relationship: "blocks",
+        status: "running",
+        linked_at: timestamp,
+      },
+      addedAt: timestamp,
+    });
+
+    const firstResolution = {
+      status: "running" as const,
+      verified_at: "2026-06-20T04:01:00.000Z",
+      resolution_reason: "verified" as const,
+      source: "child_profile" as const,
+    };
+    const secondResolution = {
+      status: "complete" as const,
+      verified_at: "2026-06-20T04:02:00.000Z",
+      child_updated_at: "2026-06-20T04:01:30.000Z",
+      resolution_reason: "verified" as const,
+      source: "child_profile" as const,
+      completion_signal: "done",
+    };
+
+    applyOpsFollowupResolutionUpsertedToState(state, {
+      linkId: "ofl-1",
+      resolution: firstResolution,
+      upsertedAt: "2026-06-20T04:01:00.000Z",
+    });
+    applyOpsFollowupResolutionUpsertedToState(state, {
+      linkId: "ofl-1",
+      resolution: secondResolution,
+      upsertedAt: "2026-06-20T04:02:00.000Z",
+    });
+
+    expect(state.ops_followup_links).toHaveLength(1);
+    expect(state.ops_followup_links?.[0]?.resolution).toMatchObject(
+      secondResolution,
+    );
+  });
+
+  it("does not alter unrelated edge fields when upserting resolution", () => {
+    const state = createChangeWorkflowState({
+      changeId: "parent-1",
+      title: "Parent change",
+      createdAt: timestamp,
+    });
+
+    applyOpsFollowupLinkAddedToState(state, {
+      link: {
+        id: "ofl-1",
+        changeId: "child-1",
+        relationship: "blocks",
+        status: "running",
+        required_handoff: true,
+        linked_at: timestamp,
+        source_contract_id: "AC5",
+      },
+      addedAt: timestamp,
+    });
+    applyOpsFollowupLinkAddedToState(state, {
+      link: {
+        id: "ofl-2",
+        changeId: "child-2",
+        relationship: "monitors",
+        status: "not_started",
+        linked_at: timestamp,
+      },
+      addedAt: timestamp,
+    });
+
+    applyOpsFollowupResolutionUpsertedToState(state, {
+      linkId: "ofl-1",
+      resolution: {
+        status: "complete",
+        verified_at: "2026-06-20T04:05:00.000Z",
+        resolution_reason: "verified",
+        source: "child_profile",
+        completion_signal: "deploy finished",
+        health_verification: "smoke passed",
+        rollback_or_cleanup_disposition: "no rollback needed",
+      },
+      upsertedAt: "2026-06-20T04:05:00.000Z",
+    });
+
+    expect(state.ops_followup_links).toHaveLength(2);
+    const link1 = state.ops_followup_links?.[0];
+    expect(link1?.status).toBe("running");
+    expect(link1?.required_handoff).toBe(true);
+    expect(link1?.source_contract_id).toBe("AC5");
+    expect(link1?.resolution?.status).toBe("complete");
+    const link2 = state.ops_followup_links?.[1];
+    expect(link2?.resolution).toBeUndefined();
+  });
+
+  it("throws when upserting resolution for an unknown link", () => {
+    const state = createChangeWorkflowState({
+      changeId: "parent-1",
+      title: "Parent change",
+      createdAt: timestamp,
+    });
+
+    expect(() =>
+      applyOpsFollowupResolutionUpsertedToState(state, {
+        linkId: "missing",
+        resolution: {
+          status: "complete",
+          verified_at: timestamp,
+          source: "unreachable",
+        },
+        upsertedAt: timestamp,
+      }),
+    ).toThrow(/link not found/);
   });
 
   it("appends evidence and updates profile status", () => {

--- a/plugin/src/temporal/change-state.ts
+++ b/plugin/src/temporal/change-state.ts
@@ -30,6 +30,7 @@ import type {
   EpicMembershipSetSignalPayload,
   OpsEvidenceAppendedSignalPayload,
   OpsFollowupLinkAddedSignalPayload,
+  OpsFollowupResolutionUpsertedSignalPayload,
   OpsFollowupSeededSignalPayload,
   OpsRunEvidenceAppendedSignalPayload,
   OpsRunUpsertedSignalPayload,
@@ -408,6 +409,24 @@ export function applyOpsFollowupLinkAddedToState(
       : [...existing, payload.link];
   state.ops_followup_links = next;
   setLastSignalAt(state, payload.addedAt);
+  return state;
+}
+
+export function applyOpsFollowupResolutionUpsertedToState(
+  state: ChangeWorkflowState,
+  payload: OpsFollowupResolutionUpsertedSignalPayload,
+): ChangeWorkflowState {
+  const existing = state.ops_followup_links ?? [];
+  const index = existing.findIndex((link) => link.id === payload.linkId);
+  if (index < 0) {
+    throw new Error(
+      `Cannot upsert ops follow-up resolution: link not found ${payload.linkId}`,
+    );
+  }
+  state.ops_followup_links = existing.map((link, i) =>
+    i === index ? { ...link, resolution: payload.resolution } : link,
+  );
+  setLastSignalAt(state, payload.upsertedAt);
   return state;
 }
 

--- a/plugin/src/temporal/contracts.ts
+++ b/plugin/src/temporal/contracts.ts
@@ -126,6 +126,7 @@ export const CHANGE_WORKFLOW_SIGNAL_NAMES = {
   changeCancelled: "adv.change.changeCancelled",
   opsFollowupSeeded: "adv.change.opsFollowupSeeded",
   opsFollowupLinkAdded: "adv.change.opsFollowupLinkAdded",
+  opsFollowupResolutionUpserted: "adv.change.opsFollowupResolutionUpserted",
   opsEvidenceAppended: "adv.change.opsEvidenceAppended",
   opsRunUpserted: "adv.change.opsRunUpserted",
   opsRunEvidenceAppended: "adv.change.opsRunEvidenceAppended",

--- a/plugin/src/temporal/gate-readiness.ts
+++ b/plugin/src/temporal/gate-readiness.ts
@@ -779,7 +779,7 @@ function hasCompleteOpsProof(link: OpsFollowupLink): boolean {
   );
 }
 
-function makeOpsResolutionBlocker(
+export function makeOpsResolutionBlocker(
   link: OpsFollowupLink,
   gateId: GateId,
 ): GateReadinessBlocker | null {

--- a/plugin/src/temporal/messages.test.ts
+++ b/plugin/src/temporal/messages.test.ts
@@ -55,6 +55,7 @@ import {
   WorktreeSetupFailedSignalPayloadSchema,
   OpsEvidenceAppendedSignalPayloadSchema,
   OpsFollowupLinkAddedSignalPayloadSchema,
+  OpsFollowupResolutionUpsertedSignalPayloadSchema,
   OpsFollowupSeededSignalPayloadSchema,
   OpsRunEvidenceAppendedSignalPayloadSchema,
   OpsRunUpsertedSignalPayloadSchema,
@@ -113,6 +114,7 @@ const designSignalKeys = [
   "changeCancelled",
   "opsFollowupSeeded",
   "opsFollowupLinkAdded",
+  "opsFollowupResolutionUpserted",
   "opsEvidenceAppended",
   "opsRunUpserted",
   "opsRunEvidenceAppended",
@@ -138,11 +140,11 @@ const designQueryKeys = [
 ] as const;
 
 describe("change workflow message contract", () => {
-  it("defines the 61 signal surface", () => {
+  it("defines the 62 signal surface", () => {
     const surfacedKeys = Object.keys(CHANGE_WORKFLOW_SIGNAL_NAMES);
 
     expect(surfacedKeys).toEqual([...designSignalKeys]);
-    expect(surfacedKeys).toHaveLength(61);
+    expect(surfacedKeys).toHaveLength(62);
 
     for (const key of designSignalKeys) {
       expect(CHANGE_WORKFLOW_SIGNAL_NAMES[key]).toBe(`adv.change.${key}`);
@@ -509,6 +511,23 @@ describe("change workflow message contract", () => {
             linked_at: timestamp,
           },
           addedAt: timestamp,
+        },
+      ],
+      [
+        OpsFollowupResolutionUpsertedSignalPayloadSchema,
+        {
+          linkId: "ofl-1",
+          resolution: {
+            status: "complete",
+            verified_at: timestamp,
+            child_updated_at: timestamp,
+            resolution_reason: "verified",
+            source: "child_profile",
+            completion_signal: "deploy finished",
+            health_verification: "smoke passed",
+            rollback_or_cleanup_disposition: "no rollback needed",
+          },
+          upsertedAt: timestamp,
         },
       ],
       [

--- a/plugin/src/temporal/messages.ts
+++ b/plugin/src/temporal/messages.ts
@@ -54,6 +54,7 @@ import type {
   GateStuckSignalPayload,
   OpsEvidenceAppendedSignalPayload,
   OpsFollowupLinkAddedSignalPayload,
+  OpsFollowupResolutionUpsertedSignalPayload,
   OpsFollowupSeededSignalPayload,
   OpsRunEvidenceAppendedSignalPayload,
   OpsRunUpsertedSignalPayload,
@@ -331,6 +332,9 @@ export const opsFollowupSeededSignal = wf.defineSignal<
 export const opsFollowupLinkAddedSignal = wf.defineSignal<
   [OpsFollowupLinkAddedSignalPayload]
 >(CHANGE_WORKFLOW_SIGNAL_NAMES.opsFollowupLinkAdded);
+export const opsFollowupResolutionUpsertedSignal = wf.defineSignal<
+  [OpsFollowupResolutionUpsertedSignalPayload]
+>(CHANGE_WORKFLOW_SIGNAL_NAMES.opsFollowupResolutionUpserted);
 export const opsEvidenceAppendedSignal = wf.defineSignal<
   [OpsEvidenceAppendedSignalPayload]
 >(CHANGE_WORKFLOW_SIGNAL_NAMES.opsEvidenceAppended);

--- a/plugin/src/temporal/workflows.ops-follow-up.itest.ts
+++ b/plugin/src/temporal/workflows.ops-follow-up.itest.ts
@@ -12,6 +12,7 @@ import {
   getChangeStateQuery,
   opsEvidenceAppendedSignal,
   opsFollowupLinkAddedSignal,
+  opsFollowupResolutionUpsertedSignal,
   opsFollowupSeededSignal,
   opsRunEvidenceAppendedSignal,
   opsRunUpsertedSignal,
@@ -230,6 +231,66 @@ describe("changeWorkflow ops follow-up signal handlers", () => {
       expect(state.signal_rejections).toHaveLength(1);
       expect(state.signal_rejections?.[0]?.signalName).toBe(
         "opsEvidenceAppended",
+      );
+      expect(state.signal_rejections_total).toBe(1);
+    });
+  }, 30_000);
+
+  it("upserts resolution on an outbound ops follow-up link", async () => {
+    await withOpsSignalWorker("resolution-upsert", async (handle) => {
+      await handle.signal(opsFollowupLinkAddedSignal, {
+        link: {
+          id: "ofl-1",
+          changeId: "child-1",
+          relationship: "blocks",
+          status: "running",
+          linked_at: "2026-06-20T04:00:01.000Z",
+        },
+        addedAt: "2026-06-20T04:00:01.000Z",
+      });
+      await handle.signal(opsFollowupResolutionUpsertedSignal, {
+        linkId: "ofl-1",
+        resolution: {
+          status: "complete",
+          verified_at: "2026-06-20T04:05:00.000Z",
+          child_updated_at: "2026-06-20T04:04:00.000Z",
+          resolution_reason: "verified",
+          source: "child_profile",
+          completion_signal: "deploy finished",
+          health_verification: "smoke passed",
+          rollback_or_cleanup_disposition: "no rollback needed",
+        },
+        upsertedAt: "2026-06-20T04:05:00.000Z",
+      });
+
+      const state = await queryState(handle);
+      expect(state.ops_followup_links).toHaveLength(1);
+      expect(state.ops_followup_links?.[0]?.resolution).toMatchObject({
+        status: "complete",
+        resolution_reason: "verified",
+        completion_signal: "deploy finished",
+      });
+      expect(state.ops_followup_links?.[0]?.status).toBe("running");
+    });
+  }, 30_000);
+
+  it("rejects resolution upsert for unknown link id", async () => {
+    await withOpsSignalWorker("resolution-unknown-link", async (handle) => {
+      await handle.signal(opsFollowupResolutionUpsertedSignal, {
+        linkId: "missing",
+        resolution: {
+          status: "unreachable",
+          verified_at: "2026-06-20T04:01:00.000Z",
+          resolution_reason: "child_missing",
+          source: "unreachable",
+        },
+        upsertedAt: "2026-06-20T04:01:00.000Z",
+      });
+
+      const state = await queryState(handle);
+      expect(state.signal_rejections).toHaveLength(1);
+      expect(state.signal_rejections?.[0]?.signalName).toBe(
+        "opsFollowupResolutionUpserted",
       );
       expect(state.signal_rejections_total).toBe(1);
     });

--- a/plugin/src/temporal/workflows.ts
+++ b/plugin/src/temporal/workflows.ts
@@ -57,6 +57,7 @@ import {
   applyLightweightProfileRequestedToState,
   applyOpsEvidenceAppendedToState,
   applyOpsFollowupLinkAddedToState,
+  applyOpsFollowupResolutionUpsertedToState,
   applyOpsRunEvidenceAppendedToState,
   applyOpsRunUpsertedToState,
   applyOriginRepairedToState,
@@ -454,6 +455,9 @@ const opsFollowupSeededSignal = wf.defineSignal<
 const opsFollowupLinkAddedSignal = wf.defineSignal<
   [import("../types").OpsFollowupLinkAddedSignalPayload]
 >(CHANGE_WORKFLOW_SIGNAL_NAMES.opsFollowupLinkAdded);
+const opsFollowupResolutionUpsertedSignal = wf.defineSignal<
+  [import("../types").OpsFollowupResolutionUpsertedSignalPayload]
+>(CHANGE_WORKFLOW_SIGNAL_NAMES.opsFollowupResolutionUpserted);
 const opsEvidenceAppendedSignal = wf.defineSignal<
   [import("../types").OpsEvidenceAppendedSignalPayload]
 >(CHANGE_WORKFLOW_SIGNAL_NAMES.opsEvidenceAppended);
@@ -1855,6 +1859,12 @@ export async function changeWorkflow(
     opsFollowupLinkAddedSignal,
     signalMutation("opsFollowupLinkAdded", (payload) =>
       applyOpsFollowupLinkAddedToState(state, payload),
+    ),
+  );
+  wf.setHandler(
+    opsFollowupResolutionUpsertedSignal,
+    signalMutation("opsFollowupResolutionUpserted", (payload) =>
+      applyOpsFollowupResolutionUpsertedToState(state, payload),
     ),
   );
   wf.setHandler(

--- a/plugin/src/tool-registry.inventory.test.ts
+++ b/plugin/src/tool-registry.inventory.test.ts
@@ -122,6 +122,9 @@ const CONTRACTED_PUBLIC_ADDITIONS = [
   // addAdvLauncherReadProjection added the launcher projection rebuild MCP
   // tool (plugin-only; never exposed via bin/adv).
   "adv_launcher_projection_rebuild",
+  // fixOpsResolutionProjection adds the ops follow-up link resolution upsert
+  // tool for bounded child-profile resolution projection.
+  "adv_ops_followup_resolution_upsert",
 ] as const;
 
 const VALID_RISKS = ["low", "medium", "high", "operator"] as const;

--- a/plugin/src/tool-registry.ts
+++ b/plugin/src/tool-registry.ts
@@ -629,6 +629,11 @@ export function createToolMap(
       "adv_ops_evidence_add",
       store,
     ),
+    adv_ops_followup_resolution_upsert: bindTool(
+      opsEvidenceTools.adv_ops_followup_resolution_upsert,
+      "adv_ops_followup_resolution_upsert",
+      store,
+    ),
     adv_ops_run_upsert: bindTool(
       opsEvidenceTools.adv_ops_run_upsert,
       "adv_ops_run_upsert",

--- a/plugin/src/tool-role-policy.ts
+++ b/plugin/src/tool-role-policy.ts
@@ -332,6 +332,10 @@ export const TOOL_ROLE_POLICY: Readonly<Record<string, ToolRoleEntry>> = {
     class: "orchestrator",
     rationale: "Ops follow-up evidence append.",
   },
+  adv_ops_followup_resolution_upsert: {
+    class: "orchestrator",
+    rationale: "Ops follow-up link resolution upsert.",
+  },
   adv_ops_run_evidence_add: {
     class: "orchestrator",
     rationale: "Run-step evidence append; prod execute steps approval-gated.",

--- a/plugin/src/tools/change.archive-phase9.test.ts
+++ b/plugin/src/tools/change.archive-phase9.test.ts
@@ -12,7 +12,13 @@ import { describe, expect, test, vi, beforeEach } from "vitest";
 import { changeTools } from "./change";
 import { verifyReleaseGateDurableForArchive } from "./change/archive-gate";
 import type { Store } from "../storage/store";
-import type { Change, Gates, OpsFollowupLink } from "../types";
+import type {
+  Change,
+  Gates,
+  OpsFollowupLink,
+  OpsFollowupProfile,
+} from "../types";
+import { opsFollowupResolutionUpsertedSignal } from "../temporal/messages";
 import * as storageJson from "../storage/json";
 
 const mocks = vi.hoisted(() => {
@@ -93,6 +99,7 @@ const mocks = vi.hoisted(() => {
     getArchiveContractProofErrors: vi.fn(() => []),
     loadSpecsMap: vi.fn(() => Promise.resolve(new Map())),
     findArchiveBundle: vi.fn(() => Promise.resolve(null)),
+    fireSignalAndRefresh: vi.fn(async () => {}),
     getProjectId: vi.fn(() => Promise.resolve("test-project")),
     getService: vi.fn(() => ({
       client: {
@@ -169,6 +176,15 @@ vi.mock("../temporal/service", () => ({
   getService: mocks.getService,
 }));
 
+vi.mock("./_adapters", async () => {
+  const actual =
+    await vi.importActual<typeof import("./_adapters")>("./_adapters");
+  return {
+    ...actual,
+    fireSignalAndRefresh: mocks.fireSignalAndRefresh,
+  };
+});
+
 vi.mock("./_recovery-writers", () => ({
   saveRecoveredGateCompletion: mocks.saveRecoveredGateCompletion,
 }));
@@ -180,6 +196,7 @@ function createMockStore(
     phase9_status?: Change["phase9_status"];
     durableReleasePending?: boolean;
     ops_followup_links?: OpsFollowupLink[];
+    children?: Record<string, Change>;
     epicMembership?: NonNullable<Change["epic_membership"]>;
   } = {},
 ): Store {
@@ -236,7 +253,10 @@ function createMockStore(
     } as unknown as Store["specs"],
     changes: {
       list: vi.fn(async () => ({ changes: [] })),
-      get: vi.fn(async () => ({ success: true, data: change })),
+      get: vi.fn(async (id: string) => {
+        if (id === change.id) return { success: true, data: change };
+        return { success: true, data: options.children?.[id] ?? null };
+      }),
       create: vi.fn(),
       save: vi.fn(),
       updateArtifacts: vi.fn(),
@@ -276,6 +296,34 @@ function createMockStore(
   } as unknown as Store;
 }
 
+function makeOpsFollowupProfile(
+  overrides?: Partial<OpsFollowupProfile>,
+): OpsFollowupProfile {
+  return {
+    kind: "migration",
+    source: { source_change_id: "example", source_kind: "required_follow_up" },
+    relationship: "blocks",
+    status: "running",
+    created_at: "2026-01-01T00:00:00Z",
+    evidence: [],
+    runs: [],
+    ...overrides,
+  };
+}
+
+function makeChildChange(
+  changeId: string,
+  profile: OpsFollowupProfile,
+): Change {
+  return {
+    id: changeId,
+    title: "Child change",
+    status: "active",
+    created_at: "2026-01-01T00:00:00Z",
+    ops_followup: profile,
+  } as Change;
+}
+
 describe("adv_change_archive Phase 9 behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -307,6 +355,23 @@ describe("adv_change_archive Phase 9 behavior", () => {
       route: "direct",
       repo: "Sharper-Flow/Advance",
     });
+    mocks.fireSignalAndRefresh.mockImplementation(
+      async (handle, sigStore, changeId, signal, payload) => {
+        if (signal === opsFollowupResolutionUpsertedSignal) {
+          const result = await sigStore.changes.get(changeId);
+          const parent = result.data as Change | undefined;
+          const link = parent?.ops_followup_links?.find(
+            (l) => l.id === (payload as { linkId?: string }).linkId,
+          );
+          if (link) {
+            link.resolution = (payload as { resolution: unknown })
+              .resolution as NonNullable<OpsFollowupLink["resolution"]>;
+          }
+          return;
+        }
+        await handle.signal(signal, payload);
+      },
+    );
     mocks.resolveReleaseReachability.mockReturnValue({
       reachable: true,
       proof: "origin_default",
@@ -393,7 +458,7 @@ describe("adv_change_archive Phase 9 behavior", () => {
     expect(epicOrder).toBeGreaterThan(saveOrder);
   });
 
-  test("surfaces open ops follow-up obligations in archive output", async () => {
+  test("blocks archive when required blocking ops follow-up remains unresolved after reconciliation", async () => {
     const store = createMockStore({
       ops_followup_links: [
         {
@@ -404,27 +469,95 @@ describe("adv_change_archive Phase 9 behavior", () => {
           required_handoff: false,
           linked_at: "2026-01-01T00:00:00Z",
         },
+      ],
+      children: {
+        "child-1": makeChildChange(
+          "child-1",
+          makeOpsFollowupProfile({ status: "running" }),
+        ),
+      },
+    });
+    const result = await changeTools.adv_change_archive.execute(
+      { changeId: "example", worktreePath: "/tmp/worktree" },
+      store,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(false);
+    expect(parsed.readinessBlockers).toContainEqual(
+      expect.objectContaining({
+        code: "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
+        gateId: "release",
+        linkId: "ofl-1",
+      }),
+    );
+    expect(parsed.openOpsObligations).toBeDefined();
+    expect(store.changes.save).not.toHaveBeenCalled();
+    expect(mocks.finalizeRelease).not.toHaveBeenCalled();
+  });
+
+  test("blocks archive when required handoff ops follow-up remains unresolved after reconciliation", async () => {
+    const store = createMockStore({
+      ops_followup_links: [
         {
-          id: "ofl-2",
-          changeId: "child-2",
+          id: "ofl-1",
+          changeId: "child-1",
           relationship: "follows_release",
           status: "not_started",
           required_handoff: true,
           linked_at: "2026-01-01T00:00:00Z",
         },
-        {
-          id: "ofl-3",
-          changeId: "child-3",
-          relationship: "cleanup_after",
-          status: "complete",
-          required_handoff: true,
-          linked_at: "2026-01-01T00:00:00Z",
-          resolution: {
-            source: "unreachable",
+      ],
+      children: {
+        "child-1": makeChildChange(
+          "child-1",
+          makeOpsFollowupProfile({
             status: "complete",
-            verified_at: "2026-01-01T01:00:00Z",
-            error: "child workflow unavailable",
-          },
+            completion_signal: "deploy finished",
+            evidence: [
+              {
+                id: "ore-1",
+                recorded_at: "2026-01-01T01:00:00Z",
+                step_kind: "execute",
+                env: "prod",
+                run_id: "run-1",
+                status: "complete",
+                summary: "Deployment completed",
+                next_status: "complete",
+                completion_signal: "deploy finished",
+              },
+            ],
+          }),
+        ),
+      },
+    });
+    const result = await changeTools.adv_change_archive.execute(
+      { changeId: "example", worktreePath: "/tmp/worktree" },
+      store,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(false);
+    expect(parsed.readinessBlockers).toContainEqual(
+      expect.objectContaining({
+        code: "OPS_FOLLOWUP_COMPLETION_PROOF_INCOMPLETE",
+        gateId: "release",
+        linkId: "ofl-1",
+      }),
+    );
+    expect(store.changes.save).not.toHaveBeenCalled();
+  });
+
+  test("reports non-required ops follow-up obligations as report-only and completes archive", async () => {
+    const store = createMockStore({
+      ops_followup_links: [
+        {
+          id: "ofl-1",
+          changeId: "child-1",
+          relationship: "follows_release",
+          status: "not_started",
+          required_handoff: false,
+          linked_at: "2026-01-01T00:00:00Z",
         },
       ],
     });
@@ -435,35 +568,15 @@ describe("adv_change_archive Phase 9 behavior", () => {
 
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
-    expect(parsed.openOpsObligations).toHaveLength(3);
+    expect(parsed.openOpsObligations).toHaveLength(1);
     expect(parsed.openOpsObligations).toContainEqual(
       expect.objectContaining({
         linkId: "ofl-1",
         changeId: "child-1",
-        relationship: "blocks",
-        open: true,
-      }),
-    );
-    expect(parsed.openOpsObligations).toContainEqual(
-      expect.objectContaining({
-        linkId: "ofl-2",
-        changeId: "child-2",
         relationship: "follows_release",
-        required_handoff: true,
+        required_handoff: false,
         status_source: "parent_snapshot",
         completion_proof: "unverified",
-        open: true,
-      }),
-    );
-    expect(parsed.openOpsObligations).toContainEqual(
-      expect.objectContaining({
-        linkId: "ofl-3",
-        changeId: "child-3",
-        relationship: "cleanup_after",
-        status: "complete",
-        status_source: "unreachable",
-        completion_proof: "unreachable",
-        resolution_error: "child workflow unavailable",
         open: true,
       }),
     );

--- a/plugin/src/tools/change.archive-phase9.test.ts
+++ b/plugin/src/tools/change.archive-phase9.test.ts
@@ -496,6 +496,53 @@ describe("adv_change_archive Phase 9 behavior", () => {
     expect(mocks.finalizeRelease).not.toHaveBeenCalled();
   });
 
+  test("fails closed when required ops reconciliation cannot replace stale proof", async () => {
+    mocks.fireSignalAndRefresh.mockImplementation(
+      async (_handle, _store, _changeId, signal) => {
+        if (signal === opsFollowupResolutionUpsertedSignal) {
+          throw new Error("Temporal service unavailable");
+        }
+      },
+    );
+    const store = createMockStore({
+      ops_followup_links: [
+        {
+          id: "ofl-1",
+          changeId: "child-1",
+          relationship: "blocks",
+          status: "complete",
+          required_handoff: false,
+          linked_at: "2026-01-01T00:00:00Z",
+          resolution: {
+            status: "complete",
+            source: "child_profile",
+            resolution_reason: "verified",
+            verified_at: "2026-01-01T01:00:00Z",
+            completion_signal: "deploy finished",
+            health_verification: "smoke passed",
+            rollback_or_cleanup_disposition: "no rollback needed",
+          },
+        },
+      ],
+      children: {
+        "child-1": makeChildChange(
+          "child-1",
+          makeOpsFollowupProfile({ status: "complete" }),
+        ),
+      },
+    });
+
+    const result = await changeTools.adv_change_archive.execute(
+      { changeId: "example", worktreePath: "/tmp/worktree" },
+      store,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(false);
+    expect(parsed.code).toBe("OPS_FOLLOWUP_RECONCILIATION_UNAVAILABLE");
+    expect(mocks.finalizeRelease).not.toHaveBeenCalled();
+  });
+
   test("blocks archive when required handoff ops follow-up remains unresolved after reconciliation", async () => {
     const store = createMockStore({
       ops_followup_links: [

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -933,7 +933,11 @@ import {
   gateReenteredSignal,
   originRepairedSignal,
 } from "../temporal/messages";
-import { getOpenOpsFollowupObligations } from "../temporal/gate-readiness";
+import {
+  getOpenOpsFollowupObligations,
+  makeOpsResolutionBlocker,
+} from "../temporal/gate-readiness";
+import { reconcileOpsFollowupLinks } from "./ops-followup-reconciliation";
 import {
   detectArchiveMode,
   deleteChangeBranch,
@@ -3568,6 +3572,30 @@ export const changeTools = {
           }
           change = result.data;
         }
+        // Reconcile required ops follow-up resolutions from authoritative child
+        // state before any archive authority decision. Skip when reading from a
+        // completed/poisoned workflow disk projection (signaling is unavailable)
+        // or during dryRun (no writes). The blocker check still runs on the
+        // current projection so unresolved required links remain fail-closed.
+        if (!readFromDisk && !dryRun) {
+          try {
+            const reconciled = await reconcileOpsFollowupLinks({
+              parent: change,
+              store,
+            });
+            change = reconciled.parent;
+          } catch (error) {
+            logger.warn(
+              `Archive ops follow-up reconciliation failed for ${changeId}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        }
+        const requiredOpsBlockers = (change.ops_followup_links ?? []).flatMap(
+          (link) => {
+            const blocker = makeOpsResolutionBlocker(link, "release");
+            return blocker ? [blocker] : [];
+          },
+        );
         const openOpsObligations = getOpenOpsFollowupObligations(
           change.ops_followup_links,
         );
@@ -3575,6 +3603,18 @@ export const changeTools = {
           openOpsObligations.length > 0
             ? { openOpsObligations }
             : ({} as Record<string, unknown>);
+        if (requiredOpsBlockers.length > 0) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Cannot archive: unresolved required ops follow-up obligations",
+            changeId,
+            code: "OPS_FOLLOWUP_ARCHIVE_BLOCKED",
+            requirement: "rq-releaseFinalization01",
+            readinessBlockers: requiredOpsBlockers,
+            ...openOpsObligationsPayload,
+          });
+        }
         const taskPreflightError = getArchiveTaskPreflightError(change);
         if (taskPreflightError) {
           return taskPreflightError;

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -937,7 +937,10 @@ import {
   getOpenOpsFollowupObligations,
   makeOpsResolutionBlocker,
 } from "../temporal/gate-readiness";
-import { reconcileOpsFollowupLinks } from "./ops-followup-reconciliation";
+import {
+  isRequiredOpsFollowupLink,
+  reconcileOpsFollowupLinks,
+} from "./ops-followup-reconciliation";
 import {
   detectArchiveMode,
   deleteChangeBranch,
@@ -3577,6 +3580,18 @@ export const changeTools = {
         // completed/poisoned workflow disk projection (signaling is unavailable)
         // or during dryRun (no writes). The blocker check still runs on the
         // current projection so unresolved required links remain fail-closed.
+        const hasRequiredOpsFollowup = change.ops_followup_links?.some(
+          isRequiredOpsFollowupLink,
+        );
+        if (readFromDisk && hasRequiredOpsFollowup) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Cannot archive: required ops follow-up obligations cannot be reconciled from a recovery disk projection",
+            changeId,
+            code: "OPS_FOLLOWUP_RECONCILIATION_UNAVAILABLE",
+          });
+        }
         if (!readFromDisk && !dryRun) {
           try {
             const reconciled = await reconcileOpsFollowupLinks({
@@ -3588,6 +3603,15 @@ export const changeTools = {
             logger.warn(
               `Archive ops follow-up reconciliation failed for ${changeId}: ${error instanceof Error ? error.message : String(error)}`,
             );
+            if (hasRequiredOpsFollowup) {
+              return formatToolOutput({
+                success: false,
+                error:
+                  "Cannot archive: required ops follow-up obligations could not be reconciled",
+                changeId,
+                code: "OPS_FOLLOWUP_RECONCILIATION_UNAVAILABLE",
+              });
+            }
           }
         }
         const requiredOpsBlockers = (change.ops_followup_links ?? []).flatMap(

--- a/plugin/src/tools/gate.release-enforcement.test.ts
+++ b/plugin/src/tools/gate.release-enforcement.test.ts
@@ -690,4 +690,59 @@ describe("release gate trunk-merge enforcement", () => {
       }),
     );
   });
+
+  test("fails closed when a required ops resolution cannot be reconciled", async () => {
+    mocks.verifyChangeBranchReachable.mockReturnValueOnce({
+      reachable: true,
+      unmergedCommits: [],
+    });
+    mocks.verifyDefaultBranchPushed.mockReturnValueOnce({ pushed: true });
+    mocks.resolveReleaseReachability.mockReturnValueOnce({
+      reachable: true,
+      proof: "origin_default",
+    });
+    mocks.fireSignalAndRefresh.mockImplementation(
+      async (_handle, _store, _changeId, signal) => {
+        if (signal === opsFollowupResolutionUpsertedSignal) {
+          throw new Error("Temporal service unavailable");
+        }
+      },
+    );
+    const store = createMockStore({
+      ops_followup_links: [
+        {
+          id: "ofl-1",
+          changeId: "child-1",
+          relationship: "blocks",
+          status: "complete",
+          required_handoff: false,
+          linked_at: "2026-01-01T00:00:00Z",
+          resolution: {
+            status: "complete",
+            source: "child_profile",
+            resolution_reason: "verified",
+            verified_at: "2026-01-01T01:00:00Z",
+            completion_signal: "deploy finished",
+            health_verification: "smoke passed",
+            rollback_or_cleanup_disposition: "no rollback needed",
+          },
+        },
+      ],
+      children: {
+        "child-1": makeChildChange(
+          "child-1",
+          makeOpsFollowupProfile({ status: "complete" }),
+        ),
+      },
+    });
+
+    const result = await gateTools.adv_gate_complete.execute(
+      { changeId: "example", gateId: "release", completedBy: "user:signoff" },
+      store,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.code).toBe("OPS_FOLLOWUP_RECONCILIATION_UNAVAILABLE");
+    expect(parsed.error).toContain("Cannot verify required ops follow-up");
+  });
 });

--- a/plugin/src/tools/gate.release-enforcement.test.ts
+++ b/plugin/src/tools/gate.release-enforcement.test.ts
@@ -8,7 +8,13 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { gateTools } from "./gate";
 import type { Store } from "../storage/store";
-import type { Change, Gates, OpsFollowupLink } from "../types";
+import type {
+  Change,
+  Gates,
+  OpsFollowupLink,
+  OpsFollowupProfile,
+} from "../types";
+import { opsFollowupResolutionUpsertedSignal } from "../temporal/messages";
 
 const mocks = vi.hoisted(() => {
   const handleMock = { signal: vi.fn(), query: vi.fn() };
@@ -109,6 +115,7 @@ function createMockStore(overrides?: {
   archiveMode?: string;
   autoPush?: boolean;
   ops_followup_links?: OpsFollowupLink[];
+  children?: Record<string, Change>;
 }): Store {
   const gates = releaseReadyGates();
   const change: Change = {
@@ -142,7 +149,10 @@ function createMockStore(overrides?: {
     specs: {} as Store["specs"],
     changes: {
       list: vi.fn(),
-      get: vi.fn(async () => ({ success: true, data: change })),
+      get: vi.fn(async (id: string) => {
+        if (id === change.id) return { success: true, data: change };
+        return { success: true, data: overrides?.children?.[id] ?? null };
+      }),
       create: vi.fn(),
       save: vi.fn(),
       updateArtifacts: vi.fn(),
@@ -158,6 +168,34 @@ function createMockStore(overrides?: {
   } as unknown as Store;
 }
 
+function makeOpsFollowupProfile(
+  overrides?: Partial<OpsFollowupProfile>,
+): OpsFollowupProfile {
+  return {
+    kind: "migration",
+    source: { source_change_id: "example", source_kind: "required_follow_up" },
+    relationship: "blocks",
+    status: "running",
+    created_at: "2026-01-01T00:00:00Z",
+    evidence: [],
+    runs: [],
+    ...overrides,
+  };
+}
+
+function makeChildChange(
+  changeId: string,
+  profile: OpsFollowupProfile,
+): Change {
+  return {
+    id: changeId,
+    title: "Child change",
+    status: "active",
+    created_at: "2026-01-01T00:00:00Z",
+    ops_followup: profile,
+  } as Change;
+}
+
 describe("release gate trunk-merge enforcement", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -168,6 +206,20 @@ describe("release gate trunk-merge enforcement", () => {
       route: "direct",
       repo: "Sharper-Flow/Advance",
     });
+    mocks.fireSignalAndRefresh.mockImplementation(
+      async (_handle, sigStore, changeId, signal, payload) => {
+        if (signal !== opsFollowupResolutionUpsertedSignal) return;
+        const result = await sigStore.changes.get(changeId);
+        const parent = result.data as Change | undefined;
+        const link = parent?.ops_followup_links?.find(
+          (l) => l.id === (payload as { linkId?: string }).linkId,
+        );
+        if (link) {
+          link.resolution = (payload as { resolution: unknown })
+            .resolution as NonNullable<OpsFollowupLink["resolution"]>;
+        }
+      },
+    );
     mocks.resolveReleaseReachability.mockReturnValue({
       reachable: false,
       proof: "origin_unmerged",
@@ -432,7 +484,7 @@ describe("release gate trunk-merge enforcement", () => {
         gateId: "release",
       }),
     );
-    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(2);
   });
 
   test("blocks release completion when required_handoff follow-up is incomplete", async () => {
@@ -490,28 +542,152 @@ describe("release gate trunk-merge enforcement", () => {
         gateId: "release",
       }),
     );
-    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(2);
   });
 
-  test("allows release completion in pr mode when merged PR proof exists", async () => {
-    mocks.detectArchiveMode.mockReturnValueOnce({
-      archiveMode: "pr",
-      autoPush: true,
+  test("allows release completion when reconciliation resolves a completed blocking ops follow-up", async () => {
+    mocks.verifyChangeBranchReachable.mockReturnValueOnce({
+      reachable: true,
+      unmergedCommits: [],
+    });
+    mocks.verifyDefaultBranchPushed.mockReturnValueOnce({
+      pushed: true,
     });
     mocks.resolveReleaseReachability.mockReturnValueOnce({
       reachable: true,
-      proof: "pr_merged",
-      prNumber: 202,
-      mergeCommitOid: "merge-202",
+      proof: "origin_default",
+    });
+
+    const store = createMockStore({
+      ops_followup_links: [
+        {
+          id: "ofl-1",
+          changeId: "child-1",
+          relationship: "blocks",
+          status: "not_started",
+          required_handoff: false,
+          linked_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      children: {
+        "child-1": makeChildChange(
+          "child-1",
+          makeOpsFollowupProfile({
+            status: "complete",
+            completion_signal: "deploy finished",
+            evidence: [
+              {
+                id: "ore-1",
+                recorded_at: "2026-01-01T01:00:00Z",
+                step_kind: "execute",
+                env: "prod",
+                run_id: "run-1",
+                status: "complete",
+                summary: "Deployment completed",
+                next_status: "complete",
+                completion_signal: "deploy finished",
+                health_verification: "smoke passed",
+                rollback_or_cleanup_disposition: "no rollback needed",
+              },
+            ],
+          }),
+        ),
+      },
     });
 
     const result = await gateTools.adv_gate_complete.execute(
       { changeId: "example", gateId: "release", completedBy: "user:signoff" },
-      createMockStore({ archiveMode: "pr" }),
+      store,
     );
 
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
-    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledWith(
+      expect.anything(),
+      store,
+      "example",
+      opsFollowupResolutionUpsertedSignal,
+      expect.objectContaining({
+        linkId: "ofl-1",
+        resolution: expect.objectContaining({
+          source: "child_profile",
+          status: "complete",
+        }),
+      }),
+    );
+  });
+
+  test("blocks release completion when reconciliation leaves blocking ops follow-up incomplete", async () => {
+    mocks.verifyChangeBranchReachable.mockReturnValueOnce({
+      reachable: true,
+      unmergedCommits: [],
+    });
+    mocks.verifyDefaultBranchPushed.mockReturnValueOnce({
+      pushed: true,
+    });
+    mocks.resolveReleaseReachability.mockReturnValueOnce({
+      reachable: true,
+      proof: "origin_default",
+    });
+    mocks.querySignal.mockReset();
+    mocks.querySignal.mockResolvedValueOnce(releaseReadyGates());
+    mocks.querySignal.mockResolvedValueOnce({
+      status: "stuck",
+      stuck_reason: "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
+      readiness_blockers: [
+        {
+          code: "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
+          gateId: "release",
+          message: "Blocking ops follow-up is incomplete",
+          remediation: "Complete the blocking ops follow-up before releasing",
+        },
+      ],
+    });
+
+    const store = createMockStore({
+      ops_followup_links: [
+        {
+          id: "ofl-1",
+          changeId: "child-1",
+          relationship: "blocks",
+          status: "not_started",
+          required_handoff: false,
+          linked_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      children: {
+        "child-1": makeChildChange(
+          "child-1",
+          makeOpsFollowupProfile({ status: "running" }),
+        ),
+      },
+    });
+
+    const result = await gateTools.adv_gate_complete.execute(
+      { changeId: "example", gateId: "release", completedBy: "user:signoff" },
+      store,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toContain("workflow readiness blocked");
+    expect(parsed.readinessBlockers).toContainEqual(
+      expect.objectContaining({
+        code: "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
+        gateId: "release",
+      }),
+    );
+    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledWith(
+      expect.anything(),
+      store,
+      "example",
+      opsFollowupResolutionUpsertedSignal,
+      expect.objectContaining({
+        linkId: "ofl-1",
+        resolution: expect.objectContaining({
+          source: "child_profile",
+          status: "running",
+        }),
+      }),
+    );
   });
 });

--- a/plugin/src/tools/gate.ts
+++ b/plugin/src/tools/gate.ts
@@ -78,7 +78,10 @@ import {
   evaluateGateReadiness,
   renderAcceptanceProjection,
 } from "../temporal/gate-readiness";
-import { reconcileOpsFollowupLinks } from "./ops-followup-reconciliation";
+import {
+  isRequiredOpsFollowupLink,
+  reconcileOpsFollowupLinks,
+} from "./ops-followup-reconciliation";
 import {
   inspectArtifactActivity,
   writeArtifactActivity,
@@ -798,7 +801,28 @@ async function completeGateViaRecovery(input: {
         logger.warn(
           `Recovery release gate ops follow-up reconciliation failed for ${input.changeId}: ${error instanceof Error ? error.message : String(error)}`,
         );
+        if (
+          recoveryChange.ops_followup_links?.some(isRequiredOpsFollowupLink)
+        ) {
+          return formatToolOutput({
+            error:
+              "Cannot verify required ops follow-up obligations because reconciliation is unavailable",
+            code: "OPS_FOLLOWUP_RECONCILIATION_UNAVAILABLE",
+            changeId: input.changeId,
+            gateId: input.gateId,
+          });
+        }
       }
+    } else if (
+      recoveryChange.ops_followup_links?.some(isRequiredOpsFollowupLink)
+    ) {
+      return formatToolOutput({
+        error:
+          "Cannot verify required ops follow-up obligations from a recovery disk projection",
+        code: "OPS_FOLLOWUP_RECONCILIATION_UNAVAILABLE",
+        changeId: input.changeId,
+        gateId: input.gateId,
+      });
     }
     const blocker = getReleaseFinalizationBlocker({
       store: input.store,
@@ -1834,6 +1858,15 @@ export const gateTools = {
             logger.warn(
               `Release gate ops follow-up reconciliation failed for ${changeId}: ${error instanceof Error ? error.message : String(error)}`,
             );
+            if (change.ops_followup_links?.some(isRequiredOpsFollowupLink)) {
+              return formatToolOutput({
+                error:
+                  "Cannot verify required ops follow-up obligations because reconciliation is unavailable",
+                code: "OPS_FOLLOWUP_RECONCILIATION_UNAVAILABLE",
+                changeId,
+                gateId,
+              });
+            }
           }
           const blocker = getReleaseFinalizationBlocker({
             store: activeStore,

--- a/plugin/src/tools/gate.ts
+++ b/plugin/src/tools/gate.ts
@@ -78,6 +78,7 @@ import {
   evaluateGateReadiness,
   renderAcceptanceProjection,
 } from "../temporal/gate-readiness";
+import { reconcileOpsFollowupLinks } from "./ops-followup-reconciliation";
 import {
   inspectArtifactActivity,
   writeArtifactActivity,
@@ -786,6 +787,19 @@ async function completeGateViaRecovery(input: {
   }
 
   if (input.gateId === "release") {
+    if (!input.diskDirect) {
+      try {
+        const reconciled = await reconcileOpsFollowupLinks({
+          parent: recoveryChange,
+          store: input.store,
+        });
+        recoveryChange = reconciled.parent;
+      } catch (error) {
+        logger.warn(
+          `Recovery release gate ops follow-up reconciliation failed for ${input.changeId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
     const blocker = getReleaseFinalizationBlocker({
       store: input.store,
       change: recoveryChange,
@@ -1810,6 +1824,17 @@ export const gateTools = {
         }
 
         if (gateId === "release") {
+          try {
+            const reconciled = await reconcileOpsFollowupLinks({
+              parent: change,
+              store: activeStore,
+            });
+            change = reconciled.parent;
+          } catch (error) {
+            logger.warn(
+              `Release gate ops follow-up reconciliation failed for ${changeId}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
           const blocker = getReleaseFinalizationBlocker({
             store: activeStore,
             change,

--- a/plugin/src/tools/ops-evidence.test.ts
+++ b/plugin/src/tools/ops-evidence.test.ts
@@ -3,11 +3,12 @@ import { opsEvidenceTools } from "./ops-evidence";
 import { parseToolOutput } from "../__tests__/setup";
 import {
   opsEvidenceAppendedSignal,
+  opsFollowupResolutionUpsertedSignal,
   opsRunEvidenceAppendedSignal,
   opsRunUpsertedSignal,
 } from "../temporal/messages";
 import type { Store } from "../storage/store";
-import type { Change, OpsFollowupProfile } from "../types";
+import type { Change, OpsFollowupLink, OpsFollowupProfile } from "../types";
 
 const mocks = vi.hoisted(() => {
   const signalMock = vi.fn();
@@ -85,6 +86,17 @@ function makeChange(overrides?: Partial<Change>): Change {
     }),
     ...overrides,
   } as Change;
+}
+
+function makeLink(overrides?: Partial<OpsFollowupLink>): OpsFollowupLink {
+  return {
+    id: "ofl-1",
+    changeId: "childChange",
+    relationship: "blocks",
+    status: "running",
+    linked_at: "2026-06-20T04:00:00.000Z",
+    ...overrides,
+  } as OpsFollowupLink;
 }
 
 function makeStore(change?: Change): Store {
@@ -565,5 +577,132 @@ describe("ops runbook tools", () => {
 
     expect(result.code).toBe("UNSAFE_OPS_EVIDENCE");
     expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("adv_ops_followup_resolution_upsert", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("upserts resolution onto a matching outbound link", async () => {
+    const store = makeStore(
+      makeChange({
+        ops_followup_links: [makeLink()],
+      }),
+    );
+
+    const result = parseToolOutput(
+      await opsEvidenceTools.adv_ops_followup_resolution_upsert.execute(
+        {
+          changeId: "parentChange",
+          linkId: "ofl-1",
+          status: "complete",
+          verifiedAt: "2026-06-20T04:05:00.000Z",
+          childUpdatedAt: "2026-06-20T04:04:00.000Z",
+          resolutionReason: "verified",
+          source: "child_profile",
+          completionSignal: "deploy finished",
+          healthVerification: "smoke passed",
+          rollbackOrCleanupDisposition: "no rollback needed",
+          evidenceSummary: "child profile shows complete",
+        },
+        store,
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.resolution.status).toBe("complete");
+    expect(result.resolution.resolution_reason).toBe("verified");
+    expect(result.resolution.child_updated_at).toBe("2026-06-20T04:04:00.000Z");
+    expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+    expect(mocks.fireSignalAndRefresh.mock.calls[0][3]).toBe(
+      opsFollowupResolutionUpsertedSignal,
+    );
+    const payload = mocks.fireSignalAndRefresh.mock.calls[0][4] as {
+      linkId: string;
+      resolution: Record<string, unknown>;
+    };
+    expect(payload.linkId).toBe("ofl-1");
+    expect(payload.resolution.status).toBe("complete");
+  });
+
+  test("returns dry-run preview without signaling", async () => {
+    const store = makeStore(
+      makeChange({
+        ops_followup_links: [makeLink()],
+      }),
+    );
+
+    const result = parseToolOutput(
+      await opsEvidenceTools.adv_ops_followup_resolution_upsert.execute(
+        {
+          changeId: "parentChange",
+          linkId: "ofl-1",
+          status: "unreachable",
+          verifiedAt: "2026-06-20T04:05:00.000Z",
+          resolutionReason: "child_missing",
+          source: "unreachable",
+          dryRun: true,
+        },
+        store,
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.resolution.source).toBe("unreachable");
+    expect(result.resolution.resolution_reason).toBe("child_missing");
+    expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+  });
+
+  test("rejects when change has no matching link", async () => {
+    const store = makeStore(makeChange());
+
+    const result = parseToolOutput(
+      await opsEvidenceTools.adv_ops_followup_resolution_upsert.execute(
+        {
+          changeId: "parentChange",
+          linkId: "missing",
+          status: "complete",
+          verifiedAt: "2026-06-20T04:05:00.000Z",
+          resolutionReason: "verified",
+          source: "child_profile",
+        },
+        store,
+      ),
+    );
+
+    expect(result.error).toMatch(/link not found/);
+    expect(result.code).toBe("OPS_FOLLOWUP_LINK_NOT_FOUND");
+    expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+  });
+
+  test("accepts resolution upsert without optional resolutionReason", async () => {
+    const schema =
+      opsEvidenceTools.adv_ops_followup_resolution_upsert.args.resolutionReason;
+    const parsed = (
+      schema as { safeParse: (v: unknown) => { success: boolean } }
+    ).safeParse(undefined);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("rejects blank required fields", () => {
+    for (const field of [
+      "changeId",
+      "linkId",
+      "status",
+      "verifiedAt",
+      "source",
+    ]) {
+      const schema =
+        opsEvidenceTools.adv_ops_followup_resolution_upsert.args[
+          field as keyof typeof opsEvidenceTools.adv_ops_followup_resolution_upsert.args
+        ];
+      const parsed = (
+        schema as { safeParse: (v: unknown) => { success: boolean } }
+      ).safeParse("");
+      expect(parsed.success, field).toBe(false);
+    }
   });
 });

--- a/plugin/src/tools/ops-evidence.ts
+++ b/plugin/src/tools/ops-evidence.ts
@@ -15,6 +15,7 @@ import { getProjectId } from "../utils/project-id";
 import { formatToolOutput } from "../utils/tool-output";
 import {
   opsEvidenceAppendedSignal,
+  opsFollowupResolutionUpsertedSignal,
   opsRunEvidenceAppendedSignal,
   opsRunUpsertedSignal,
 } from "../temporal/messages";
@@ -31,6 +32,9 @@ import {
   OpsRunStatusSchema,
   OpsRunStepKindSchema,
   OpsRunStepStatusSchema,
+  OpsFollowupResolutionReasonSchema,
+  OpsFollowupStatusSchema,
+  type OpsFollowupResolution,
 } from "../types";
 
 const OPS_EVIDENCE_TOOL_STATUS = [
@@ -76,6 +80,22 @@ interface AddEvidenceInput {
   batch?: string;
   next_step?: string;
   completion_signal?: string;
+  dryRun?: boolean;
+}
+
+interface UpsertResolutionInput {
+  changeId: string;
+  linkId: string;
+  status: OpsFollowupResolution["status"];
+  verifiedAt: string;
+  childUpdatedAt?: string;
+  resolutionReason?: OpsFollowupResolution["resolution_reason"];
+  source: OpsFollowupResolution["source"];
+  completionSignal?: string;
+  healthVerification?: string;
+  rollbackOrCleanupDisposition?: string;
+  evidenceSummary?: string;
+  error?: string;
   dryRun?: boolean;
 }
 
@@ -335,6 +355,147 @@ export const opsEvidenceTools = {
         entry,
         status: profileStatus,
         evidence_count: priorCount + 1,
+      });
+    },
+  },
+  adv_ops_followup_resolution_upsert: {
+    description:
+      "Upsert a bounded resolution proof onto an outbound ops follow-up link. " +
+      "Only updates the matching link's resolution field; other link edge fields are untouched.",
+    args: {
+      changeId: z
+        .string()
+        .min(1)
+        .describe("Change ID that owns the outbound ops_followup_links."),
+      linkId: z
+        .string()
+        .min(1)
+        .describe("Stable link ID whose resolution should be upserted."),
+      status: OpsFollowupStatusSchema.describe(
+        "Verified child-profile status projected onto the link.",
+      ),
+      verifiedAt: z
+        .string()
+        .min(1)
+        .describe("ISO timestamp when the resolution was verified."),
+      childUpdatedAt: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Optional ISO timestamp of the last child profile update."),
+      resolutionReason: OpsFollowupResolutionReasonSchema.optional().describe(
+        "Why this resolution was recorded.",
+      ),
+      source: z
+        .enum(["child_profile", "unreachable"])
+        .describe(
+          "Whether the resolution came from the child profile or an unreachable fallback.",
+        ),
+      completionSignal: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Optional signal that indicates completion."),
+      healthVerification: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Optional health verification summary."),
+      rollbackOrCleanupDisposition: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Optional rollback or cleanup disposition."),
+      evidenceSummary: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Optional bounded summary of supporting evidence."),
+      error: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Optional error message when source is unreachable."),
+      dryRun: z.boolean().optional().describe("Preview without signaling."),
+    },
+    execute: async (
+      input: UpsertResolutionInput,
+      store: Store,
+    ): Promise<string> => {
+      const load = await store.changes.get(input.changeId);
+      if (!load.success || !load.data) {
+        return formatToolOutput({
+          error: `Change not found: ${input.changeId}`,
+        });
+      }
+
+      const change = load.data as Change;
+      const links = change.ops_followup_links ?? [];
+      const link = links.find((candidate) => candidate.id === input.linkId);
+      if (!link) {
+        return formatToolOutput({
+          error: `Ops follow-up link not found on ${input.changeId}: ${input.linkId}`,
+          code: "OPS_FOLLOWUP_LINK_NOT_FOUND",
+        });
+      }
+
+      const recordedAt = new Date().toISOString();
+      const resolution: OpsFollowupResolution = {
+        status: input.status,
+        verified_at: input.verifiedAt,
+        source: input.source,
+        ...(input.childUpdatedAt
+          ? { child_updated_at: input.childUpdatedAt }
+          : {}),
+        ...(input.resolutionReason
+          ? { resolution_reason: input.resolutionReason }
+          : {}),
+        ...(input.completionSignal
+          ? { completion_signal: input.completionSignal }
+          : {}),
+        ...(input.healthVerification
+          ? { health_verification: input.healthVerification }
+          : {}),
+        ...(input.rollbackOrCleanupDisposition
+          ? {
+              rollback_or_cleanup_disposition:
+                input.rollbackOrCleanupDisposition,
+            }
+          : {}),
+        ...(input.evidenceSummary
+          ? { evidence_summary: input.evidenceSummary }
+          : {}),
+        ...(input.error ? { error: input.error } : {}),
+      };
+
+      if (input.dryRun) {
+        return formatToolOutput({
+          success: true,
+          dryRun: true,
+          changeId: input.changeId,
+          linkId: input.linkId,
+          resolution,
+        });
+      }
+
+      const handle = await getChangeHandleForChangeId(store, input.changeId);
+      await fireSignalAndRefresh(
+        handle,
+        store,
+        input.changeId,
+        opsFollowupResolutionUpsertedSignal,
+        {
+          linkId: input.linkId,
+          resolution,
+          upsertedAt: recordedAt,
+        },
+      );
+
+      return formatToolOutput({
+        success: true,
+        changeId: input.changeId,
+        linkId: input.linkId,
+        resolution,
       });
     },
   },

--- a/plugin/src/tools/ops-followup-reconciliation.test.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Host reconciliation tests for ops follow-up link resolutions.
+ *
+ * Covers pure derivation (AC1-AC4) and localized host-level integration
+ * (C1-C5): same-project / cross-project routing, Temporal-only child reads,
+ * fail-closed unreachable proofs, repeated reconciliation, and prior-resolution
+ * authority invalidation.
+ */
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type {
+  Change,
+  OpsFollowupLink,
+  OpsFollowupProfile,
+  Store,
+} from "../types";
+import { opsFollowupResolutionUpsertedSignal } from "../temporal/messages";
+import type { TargetStoreScope } from "./target-project";
+import {
+  isRequiredOpsFollowupLink,
+  reconcileOpsFollowupLinks,
+  reconcileOpsFollowupResolution,
+} from "./ops-followup-reconciliation";
+
+const timestamp = "2026-06-20T04:00:00.000Z";
+const verifiedAt = "2026-06-20T04:06:00.000Z";
+
+function makeChildProfile(
+  overrides?: Partial<OpsFollowupProfile>,
+): OpsFollowupProfile {
+  return {
+    kind: "migration",
+    source: {
+      source_change_id: "parent-1",
+      source_kind: "required_follow_up",
+    },
+    relationship: "blocks",
+    status: "running",
+    created_at: timestamp,
+    evidence: [],
+    runs: [],
+    ...overrides,
+  };
+}
+
+function makeLink(overrides?: Partial<OpsFollowupLink>): OpsFollowupLink {
+  return {
+    id: "ofl-1",
+    changeId: "child-1",
+    relationship: "blocks",
+    status: "running",
+    required_handoff: true,
+    linked_at: timestamp,
+    ...overrides,
+  };
+}
+
+function makeParent(
+  overrides?: Partial<Change> & { links?: OpsFollowupLink[] },
+): Change {
+  return {
+    id: "parent-1",
+    title: "Parent change",
+    status: "active",
+    created_at: timestamp,
+    ops_followup_links: overrides?.links ?? [],
+    ...overrides,
+  } as Change;
+}
+
+function makeChild(changeId: string, profile: OpsFollowupProfile): Change {
+  return {
+    id: changeId,
+    title: "Child change",
+    status: "active",
+    created_at: timestamp,
+    ops_followup: profile,
+  } as Change;
+}
+
+function makeStore(input: {
+  parent: Change;
+  children?: Record<string, Change>;
+}): Store {
+  return {
+    paths: { root: "/tmp/project" },
+    productContext: { productProjectId: "project-id" },
+    changes: {
+      get: vi.fn(async (changeId: string) => {
+        if (changeId === input.parent.id) {
+          return { success: true, data: input.parent };
+        }
+        return { success: true, data: input.children?.[changeId] ?? null };
+      }),
+      refresh: vi.fn(async () => {}),
+    },
+  } as unknown as Store;
+}
+
+function makeDeps(overrides?: Record<string, unknown>) {
+  return {
+    withTargetPathStore: vi.fn(async () => {
+      throw new Error("withTargetPathStore not configured");
+    }),
+    getProjectId: vi.fn(async () => "project-id"),
+    fireSignalAndRefresh: vi.fn(async () => {}),
+    now: () => verifiedAt,
+    ...overrides,
+  };
+}
+
+function completeProfile(): OpsFollowupProfile {
+  return makeChildProfile({
+    status: "complete",
+    updated_at: "2026-06-20T04:05:00.000Z",
+    completion_signal: "deploy finished",
+    runs: [
+      {
+        id: "run-1",
+        title: "Deploy run",
+        status: "complete",
+        created_at: timestamp,
+        updated_at: "2026-06-20T04:04:00.000Z",
+        plan: {
+          env: "prod",
+          action: "deploy",
+          bounds: ["low-risk"],
+          evidence_policy: "manual",
+          rollback_or_cleanup_plan: "rollback to previous version",
+        },
+        steps: [],
+        evidence: [
+          {
+            id: "ore-1",
+            recorded_at: "2026-06-20T04:04:00.000Z",
+            step_kind: "execute",
+            env: "prod",
+            run_id: "run-1",
+            status: "complete",
+            summary: "Deployment completed",
+            artifact: { kind: "pointer", uri: "s3://ops-bucket/deploy.log" },
+            next_status: "complete",
+            completion_signal: "deploy finished",
+            health_verification: "smoke passed",
+            rollback_or_cleanup_disposition: "no rollback needed",
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function incompleteProfile(
+  status: Exclude<OpsFollowupProfile["status"], "complete">,
+): OpsFollowupProfile {
+  return makeChildProfile({
+    status,
+    updated_at: "2026-06-20T04:05:00.000Z",
+    evidence: [
+      {
+        id: "oee-2",
+        recorded_at: "2026-06-20T04:04:00.000Z",
+        env: "prod",
+        action: "deploy",
+        status: "started",
+        summary: "Deployment in progress",
+        artifact: { kind: "pointer", uri: "s3://ops-bucket/deploy.log" },
+      },
+    ],
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("deriveOpsFollowupResolution", () => {
+  test("complete child proof produces child_profile complete resolution (AC1)", () => {
+    const childProfile = completeProfile();
+    const link = makeLink();
+
+    const resolution = reconcileOpsFollowupResolution({
+      link,
+      childProfile,
+      now: verifiedAt,
+    });
+
+    expect(resolution).toMatchObject({
+      source: "child_profile",
+      status: "complete",
+      resolution_reason: "verified",
+      child_updated_at: childProfile.updated_at,
+      verified_at: verifiedAt,
+      completion_signal: "deploy finished",
+      health_verification: "smoke passed",
+      rollback_or_cleanup_disposition: "no rollback needed",
+      evidence_summary: "Deployment completed",
+    });
+  });
+
+  test("incomplete child status produces child_profile incomplete resolution (AC2)", () => {
+    const childProfile = incompleteProfile("running");
+    const link = makeLink();
+
+    const resolution = reconcileOpsFollowupResolution({
+      link,
+      childProfile,
+      now: verifiedAt,
+    });
+
+    expect(resolution).toMatchObject({
+      source: "child_profile",
+      status: "running",
+      resolution_reason: "verified",
+    });
+    expect(resolution?.completion_signal).toBeUndefined();
+    expect(resolution?.health_verification).toBeUndefined();
+    expect(resolution?.rollback_or_cleanup_disposition).toBeUndefined();
+  });
+
+  test("complete status with missing proof fields omits only those fields (AC3)", () => {
+    const childProfile = makeChildProfile({
+      status: "complete",
+      updated_at: "2026-06-20T04:05:00.000Z",
+      completion_signal: "deploy finished",
+      evidence: [],
+    });
+    const link = makeLink();
+
+    const resolution = reconcileOpsFollowupResolution({
+      link,
+      childProfile,
+      now: verifiedAt,
+    });
+
+    expect(resolution?.status).toBe("complete");
+    expect(resolution?.completion_signal).toBe("deploy finished");
+    expect(resolution?.health_verification).toBeUndefined();
+    expect(resolution?.rollback_or_cleanup_disposition).toBeUndefined();
+  });
+
+  test("returns null for non-required links", () => {
+    const link = makeLink({
+      relationship: "follows_release",
+      required_handoff: false,
+    });
+    const resolution = reconcileOpsFollowupResolution({
+      link,
+      childProfile: completeProfile(),
+      now: verifiedAt,
+    });
+    expect(resolution).toBeNull();
+  });
+});
+
+describe("isRequiredOpsFollowupLink", () => {
+  test.each([
+    { relationship: "blocks", required_handoff: false, expected: true },
+    { relationship: "follows_release", required_handoff: true, expected: true },
+    { relationship: "monitors", required_handoff: true, expected: true },
+    { relationship: "cleanup_after", required_handoff: true, expected: true },
+    {
+      relationship: "follows_release",
+      required_handoff: false,
+      expected: false,
+    },
+    { relationship: "monitors", required_handoff: false, expected: false },
+    { relationship: "cleanup_after", required_handoff: false, expected: false },
+  ] as const)(
+    "relationship=$relationship, required_handoff=$required_handoff => $expected",
+    ({ relationship, required_handoff, expected }) => {
+      const link = makeLink({ relationship, required_handoff });
+      expect(isRequiredOpsFollowupLink(link)).toBe(expected);
+    },
+  );
+});
+
+describe("reconcileOpsFollowupLinks", () => {
+  test("reconciles a frozen required parent link from a complete child profile and persists (C1)", async () => {
+    const childProfile = completeProfile();
+    const parent = makeParent({
+      links: [makeLink({ relationship: "blocks", required_handoff: false })],
+    });
+    const store = makeStore({
+      parent,
+      children: { "child-1": makeChild("child-1", childProfile) },
+    });
+    const deps = makeDeps();
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled).toHaveLength(1);
+    expect(result.reconciled[0]).toMatchObject({
+      linkId: "ofl-1",
+      resolution: {
+        source: "child_profile",
+        status: "complete",
+      },
+    });
+    expect(result.skipped).toEqual([]);
+    expect(deps.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+    const call = deps.fireSignalAndRefresh.mock.calls[0];
+    expect(call[3]).toBe(opsFollowupResolutionUpsertedSignal);
+    const payload = call[4] as {
+      linkId: string;
+      resolution: { source: string; status: string };
+    };
+    expect(payload.linkId).toBe("ofl-1");
+    expect(payload.resolution.source).toBe("child_profile");
+    expect(payload.resolution.status).toBe("complete");
+    expect(store.changes.get).toHaveBeenLastCalledWith("parent-1");
+  });
+
+  test("reconciles a required handoff follows_release link (C2)", async () => {
+    const childProfile = completeProfile();
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "follows_release",
+          required_handoff: true,
+        }),
+      ],
+    });
+    const store = makeStore({
+      parent,
+      children: { "child-1": makeChild("child-1", childProfile) },
+    });
+    const deps = makeDeps();
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled[0]?.resolution.source).toBe("child_profile");
+    expect(deps.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips non-required handoff links (C3)", async () => {
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "follows_release",
+          required_handoff: false,
+        }),
+      ],
+    });
+    const store = makeStore({ parent });
+    const deps = makeDeps();
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.skipped).toEqual(["ofl-1"]);
+    expect(result.reconciled).toEqual([]);
+    expect(deps.fireSignalAndRefresh).not.toHaveBeenCalled();
+  });
+
+  test("persists unreachable child_missing resolution when child is missing (C4)", async () => {
+    const parent = makeParent({
+      links: [makeLink({ relationship: "blocks", required_handoff: false })],
+    });
+    const store = makeStore({ parent });
+    const deps = makeDeps();
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled[0]?.resolution.source).toBe("unreachable");
+    expect(result.reconciled[0]?.resolution.resolution_reason).toBe(
+      "child_missing",
+    );
+    expect(deps.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+    const payload = deps.fireSignalAndRefresh.mock.calls[0][4] as {
+      resolution: { source: string; resolution_reason: string };
+    };
+    expect(payload.resolution.source).toBe("unreachable");
+    expect(payload.resolution.resolution_reason).toBe("child_missing");
+  });
+
+  test("persists unreachable profile_missing resolution when child has no profile (C4)", async () => {
+    const parent = makeParent({
+      links: [makeLink({ relationship: "blocks", required_handoff: false })],
+    });
+    const store = makeStore({ parent });
+    const child = store.changes.get as ReturnType<typeof vi.fn>;
+    child.mockResolvedValueOnce({
+      success: true,
+      data: {
+        id: "child-1",
+        title: "Child change",
+        status: "active",
+        created_at: timestamp,
+      } as Change,
+    });
+    const deps = makeDeps();
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled[0]?.resolution.resolution_reason).toBe(
+      "profile_missing",
+    );
+    expect(deps.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("persists target_identity_mismatch for same-project link with wrong project id (C4)", async () => {
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "blocks",
+          required_handoff: false,
+          target_project_id: "expected-project-id",
+        }),
+      ],
+    });
+    const store = makeStore({ parent });
+    const deps = makeDeps({
+      getProjectId: vi.fn(async () => "actual-project-id"),
+    });
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled[0]?.resolution.resolution_reason).toBe(
+      "target_identity_mismatch",
+    );
+    expect(deps.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("reconciles cross-project link through target_path store (C5)", async () => {
+    const childProfile = completeProfile();
+    const targetStore = makeStore({
+      parent: makeParent(),
+      children: {
+        "child-target": makeChild("child-target", childProfile),
+      },
+    });
+    const parent = makeParent({
+      links: [
+        makeLink({
+          id: "ofl-target",
+          changeId: "child-target",
+          relationship: "blocks",
+          required_handoff: false,
+          target_path: "/tmp/target-project",
+          target_project_id: "target-project-id",
+        }),
+      ],
+    });
+    const store = makeStore({ parent });
+    const withTargetPathStore = vi.fn(async (_input, fn) => {
+      return await fn({
+        context: { projectId: "target-project-id" },
+        store: targetStore,
+      } as unknown as TargetStoreScope);
+    });
+    const deps = makeDeps({ withTargetPathStore });
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled[0]?.resolution.source).toBe("child_profile");
+    expect(result.reconciled[0]?.resolution.status).toBe("complete");
+    expect(deps.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+    const payload = deps.fireSignalAndRefresh.mock.calls[0][4] as {
+      linkId: string;
+    };
+    expect(payload.linkId).toBe("ofl-target");
+    expect(targetStore.changes.get).toHaveBeenCalledWith("child-target");
+  });
+
+  test("persists target_identity_mismatch for cross-project link with wrong project id (C5)", async () => {
+    const targetStore = makeStore({ parent: makeParent() });
+    const parent = makeParent({
+      links: [
+        makeLink({
+          id: "ofl-target",
+          changeId: "child-target",
+          relationship: "blocks",
+          required_handoff: false,
+          target_path: "/tmp/target-project",
+          target_project_id: "expected-project-id",
+        }),
+      ],
+    });
+    const store = makeStore({ parent });
+    const withTargetPathStore = vi.fn(async (_input, fn) => {
+      return await fn({
+        context: { projectId: "actual-project-id" },
+        store: targetStore,
+      } as unknown as TargetStoreScope);
+    });
+    const deps = makeDeps({ withTargetPathStore });
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled[0]?.resolution.resolution_reason).toBe(
+      "target_identity_mismatch",
+    );
+    expect(deps.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("repeated reconciliation updates resolution when child state changes (C1)", async () => {
+    const complete = completeProfile();
+    const running = incompleteProfile("running");
+
+    const parentFirst = makeParent({
+      links: [makeLink({ relationship: "blocks", required_handoff: false })],
+    });
+    const storeFirst = makeStore({
+      parent: parentFirst,
+      children: { "child-1": makeChild("child-1", complete) },
+    });
+    const depsFirst = makeDeps();
+
+    const first = await reconcileOpsFollowupLinks({
+      parent: parentFirst,
+      store: storeFirst,
+      deps: depsFirst,
+    });
+    expect(first.reconciled[0]?.resolution.status).toBe("complete");
+    expect(depsFirst.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+
+    const parentSecond = makeParent({
+      links: [
+        makeLink({
+          relationship: "blocks",
+          required_handoff: false,
+          resolution: first.reconciled[0]?.resolution,
+        }),
+      ],
+    });
+    const storeSecond = makeStore({
+      parent: parentSecond,
+      children: { "child-1": makeChild("child-1", running) },
+    });
+    const depsSecond = makeDeps();
+
+    const second = await reconcileOpsFollowupLinks({
+      parent: parentSecond,
+      store: storeSecond,
+      deps: depsSecond,
+    });
+    expect(second.reconciled[0]?.resolution.status).toBe("running");
+    expect(depsSecond.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("prior complete resolution has no authority when current child is incomplete (C2)", async () => {
+    const staleResolution = reconcileOpsFollowupResolution({
+      link: makeLink(),
+      childProfile: completeProfile(),
+      now: verifiedAt,
+    });
+    expect(staleResolution).not.toBeNull();
+
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "blocks",
+          required_handoff: false,
+          resolution: staleResolution ?? undefined,
+        }),
+      ],
+    });
+    const store = makeStore({
+      parent,
+      children: {
+        "child-1": makeChild("child-1", incompleteProfile("failed")),
+      },
+    });
+    const deps = makeDeps();
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled[0]?.resolution.status).toBe("failed");
+    expect(result.reconciled[0]?.resolution.source).toBe("child_profile");
+    expect(deps.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not signal when resolution is unchanged", async () => {
+    const childProfile = completeProfile();
+    const existingResolution = reconcileOpsFollowupResolution({
+      link: makeLink(),
+      childProfile,
+      now: verifiedAt,
+    });
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "blocks",
+          required_handoff: false,
+          resolution: existingResolution ?? undefined,
+        }),
+      ],
+    });
+    const store = makeStore({
+      parent,
+      children: { "child-1": makeChild("child-1", childProfile) },
+    });
+    const deps = makeDeps();
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.reconciled[0]?.resolution.status).toBe("complete");
+    expect(deps.fireSignalAndRefresh).not.toHaveBeenCalled();
+  });
+
+  test("re-reads parent after persisting", async () => {
+    const parent = makeParent({
+      links: [makeLink({ relationship: "blocks", required_handoff: false })],
+    });
+    const refreshedParent = makeParent({ id: "parent-1" });
+    const store = makeStore({ parent });
+    const getMock = store.changes.get as ReturnType<typeof vi.fn>;
+    getMock.mockImplementation(async (changeId: string) => {
+      if (changeId === "parent-1")
+        return { success: true, data: refreshedParent };
+      return { success: true, data: null };
+    });
+    const deps = makeDeps();
+
+    const result = await reconcileOpsFollowupLinks({ parent, store, deps });
+
+    expect(result.parent).toBe(refreshedParent);
+    expect(store.changes.get).toHaveBeenLastCalledWith("parent-1");
+  });
+});

--- a/plugin/src/tools/ops-followup-reconciliation.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.ts
@@ -1,0 +1,469 @@
+/**
+ * Host reconciliation for ops follow-up link resolutions.
+ *
+ * Reads the authoritative child ops_followup profile through Temporal-backed
+ * state only and projects a fresh child_profile resolution onto the parent
+ * outbound link. No workflow-side reads; all routing and persistence happens in
+ * the host tool layer.
+ */
+import type {
+  Change,
+  OpsFollowupLink,
+  OpsFollowupProfile,
+  OpsFollowupResolution,
+  OpsFollowupResolutionReason,
+  OpsRelationship,
+} from "../types";
+import { opsFollowupResolutionUpsertedSignal } from "../temporal/messages";
+import { fireSignalAndRefresh, getChangeHandle } from "./_adapters";
+import type { WorkflowHandleLike } from "../storage/store-temporal/shared";
+import {
+  withTargetPathStore,
+  type TargetStoreScope,
+  type WithTargetPathStoreInput,
+} from "./target-project";
+import { getProjectId } from "../utils/project-id";
+import { getService } from "../temporal/service";
+import type { Store } from "../storage/store";
+
+const HANDOFF_RELATIONSHIPS: OpsRelationship[] = [
+  "follows_release",
+  "monitors",
+  "cleanup_after",
+];
+const COMPLETE_OPS_STATUSES: OpsFollowupResolution["status"][] = ["complete"];
+
+export interface ReconcileOpsFollowupResolutionInput {
+  link: OpsFollowupLink;
+  childProfile: OpsFollowupProfile;
+  /** ISO timestamp used as the verified_at boundary. Defaults to now. */
+  now?: string;
+}
+
+export interface ReconcileOpsFollowupResolutionResult {
+  linkId: string;
+  resolution: OpsFollowupResolution;
+}
+
+export interface ReconcileOpsFollowupLinksDeps {
+  withTargetPathStore?: typeof withTargetPathStore;
+  getProjectId?: typeof getProjectId;
+  fireSignalAndRefresh?: typeof fireSignalAndRefresh;
+  getChangeHandle?: typeof getChangeHandle;
+  getService?: typeof getService;
+  now?: () => string;
+}
+
+export interface ReconcileOpsFollowupLinksInput {
+  parent: Change;
+  store: Store;
+  deps?: ReconcileOpsFollowupLinksDeps;
+}
+
+export interface ReconcileOpsFollowupLinksResult {
+  /** Parent change re-read after any persistence. */
+  parent: Change;
+  /** Links for which a resolution was derived and (if changed) persisted. */
+  reconciled: ReconcileOpsFollowupResolutionResult[];
+  /** Links that were not required obligations and were skipped. */
+  skipped: string[];
+}
+
+export function isRequiredOpsFollowupLink(link: OpsFollowupLink): boolean {
+  if (link.relationship === "blocks") return true;
+  return (
+    HANDOFF_RELATIONSHIPS.includes(link.relationship) && link.required_handoff
+  );
+}
+
+interface ProofFields {
+  completionSignal?: string;
+  healthVerification?: string;
+  rollbackOrCleanupDisposition?: string;
+}
+
+interface EvidenceEntry {
+  recorded_at: string;
+  summary?: string;
+  completion_signal?: string;
+  health_verification?: string;
+  rollback_or_cleanup_disposition?: string;
+}
+
+function gatherEvidenceEntries(profile: OpsFollowupProfile): EvidenceEntry[] {
+  const entries: EvidenceEntry[] = [...(profile.evidence ?? [])];
+  for (const run of profile.runs ?? []) {
+    entries.push(...(run.evidence ?? []));
+  }
+  return entries.sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
+}
+
+function latestProofFields(profile: OpsFollowupProfile): ProofFields {
+  const entries = gatherEvidenceEntries(profile);
+  let completionSignal: string | undefined = profile.completion_signal;
+  let healthVerification: string | undefined;
+  let rollbackOrCleanupDisposition: string | undefined;
+  for (const entry of entries) {
+    if (entry.completion_signal) completionSignal = entry.completion_signal;
+    if (entry.health_verification)
+      healthVerification = entry.health_verification;
+    if (entry.rollback_or_cleanup_disposition)
+      rollbackOrCleanupDisposition = entry.rollback_or_cleanup_disposition;
+  }
+  return { completionSignal, healthVerification, rollbackOrCleanupDisposition };
+}
+
+function evidenceSummary(profile: OpsFollowupProfile): string | undefined {
+  const entries = gatherEvidenceEntries(profile);
+  if (entries.length === 0) {
+    return profile.completion_signal
+      ? `completed: ${profile.completion_signal}`
+      : undefined;
+  }
+  const latest = entries[entries.length - 1];
+  return latest.summary ?? profile.completion_signal ?? undefined;
+}
+
+export function deriveOpsFollowupResolution(
+  _link: OpsFollowupLink,
+  childProfile: OpsFollowupProfile,
+  now: string,
+): OpsFollowupResolution {
+  const proof = latestProofFields(childProfile);
+  const summary = evidenceSummary(childProfile);
+  const resolution: OpsFollowupResolution = {
+    status: childProfile.status,
+    verified_at: now,
+    source: "child_profile",
+    resolution_reason: "verified",
+    ...(childProfile.updated_at
+      ? { child_updated_at: childProfile.updated_at }
+      : {}),
+    ...(proof.completionSignal
+      ? { completion_signal: proof.completionSignal }
+      : {}),
+    ...(proof.healthVerification
+      ? { health_verification: proof.healthVerification }
+      : {}),
+    ...(proof.rollbackOrCleanupDisposition
+      ? {
+          rollback_or_cleanup_disposition: proof.rollbackOrCleanupDisposition,
+        }
+      : {}),
+    ...(summary ? { evidence_summary: summary } : {}),
+  };
+  return resolution;
+}
+
+type UnreachableReason =
+  | "child_missing"
+  | "profile_missing"
+  | "target_identity_mismatch"
+  | "unreachable";
+
+function makeUnreachableResolution(
+  link: OpsFollowupLink,
+  now: string,
+  reason: UnreachableReason,
+  error: string,
+): OpsFollowupResolution {
+  const status = COMPLETE_OPS_STATUSES.includes(link.status)
+    ? "not_started"
+    : link.status;
+  return {
+    status,
+    verified_at: now,
+    source: "unreachable",
+    resolution_reason: reason as OpsFollowupResolutionReason,
+    error,
+  };
+}
+
+type ChildReadResult =
+  | { ok: true; profile: OpsFollowupProfile }
+  | { ok: false; reason: UnreachableReason; error: string };
+
+type CrossProjectReadResult =
+  | { type: "mismatch"; projectId: string }
+  | {
+      type: "child";
+      projectId: string;
+      childResult: Awaited<ReturnType<Store["changes"]["get"]>>;
+    };
+
+async function readCrossProjectChild(input: {
+  link: OpsFollowupLink;
+  store: Store;
+  withTargetPathFn: typeof withTargetPathStore;
+}): Promise<ChildReadResult> {
+  const { link, store, withTargetPathFn } = input;
+  try {
+    const result = await withTargetPathFn(
+      {
+        currentProjectPath: store.paths.root,
+        target_path: link.target_path,
+        stateRequirement: "temporal-required",
+        target_confirmed: true,
+        confirmationEvidence: "ops follow-up reconciliation",
+      } as WithTargetPathStoreInput,
+      async (scope: TargetStoreScope): Promise<CrossProjectReadResult> => {
+        if (
+          link.target_project_id &&
+          scope.context.projectId !== link.target_project_id
+        ) {
+          return { type: "mismatch", projectId: scope.context.projectId };
+        }
+        await scope.store.changes.refresh(link.changeId);
+        const childResult = await scope.store.changes.get(link.changeId);
+        return {
+          type: "child",
+          projectId: scope.context.projectId,
+          childResult,
+        };
+      },
+    );
+
+    if (result.type === "mismatch") {
+      return {
+        ok: false,
+        reason: "target_identity_mismatch",
+        error: `target_project_id mismatch: expected ${link.target_project_id}, got ${result.projectId}`,
+      };
+    }
+
+    const { childResult } = result;
+    if (!childResult.success) {
+      return {
+        ok: false,
+        reason: "child_missing",
+        error: childResult.error ?? `child change not found: ${link.changeId}`,
+      };
+    }
+    if (!childResult.data) {
+      return {
+        ok: false,
+        reason: "child_missing",
+        error: `child change not found: ${link.changeId}`,
+      };
+    }
+    if (!childResult.data.ops_followup) {
+      return {
+        ok: false,
+        reason: "profile_missing",
+        error: `child has no ops_followup profile: ${link.changeId}`,
+      };
+    }
+    return { ok: true, profile: childResult.data.ops_followup };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "unreachable",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function readSameProjectChild(input: {
+  link: OpsFollowupLink;
+  store: Store;
+  getProjectIdFn: typeof getProjectId;
+}): Promise<ChildReadResult> {
+  const { link, store } = input;
+  try {
+    const canonicalProjectId = await input.getProjectIdFn(store.paths.root);
+    if (
+      link.target_project_id &&
+      canonicalProjectId &&
+      link.target_project_id !== canonicalProjectId
+    ) {
+      return {
+        ok: false,
+        reason: "target_identity_mismatch",
+        error: `target_project_id mismatch: expected ${link.target_project_id}, got ${canonicalProjectId}`,
+      };
+    }
+    await store.changes.refresh(link.changeId);
+    const childResult = await store.changes.get(link.changeId);
+    if (!childResult.success) {
+      return {
+        ok: false,
+        reason: "child_missing",
+        error: childResult.error ?? `child change not found: ${link.changeId}`,
+      };
+    }
+    if (!childResult.data) {
+      return {
+        ok: false,
+        reason: "child_missing",
+        error: `child change not found: ${link.changeId}`,
+      };
+    }
+    if (!childResult.data.ops_followup) {
+      return {
+        ok: false,
+        reason: "profile_missing",
+        error: `child has no ops_followup profile: ${link.changeId}`,
+      };
+    }
+    return { ok: true, profile: childResult.data.ops_followup };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "unreachable",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function readAuthoritativeChildOpsProfile(input: {
+  link: OpsFollowupLink;
+  store: Store;
+  deps: ReconcileOpsFollowupLinksDeps;
+}): Promise<ChildReadResult> {
+  const { link, store } = input;
+  const getProjectIdFn = input.deps.getProjectId ?? getProjectId;
+  const withTargetPathFn =
+    input.deps.withTargetPathStore ?? withTargetPathStore;
+
+  if (link.target_path) {
+    return readCrossProjectChild({ link, store, withTargetPathFn });
+  }
+  return readSameProjectChild({ link, store, getProjectIdFn });
+}
+
+function resolutionsEqual(
+  a: OpsFollowupResolution | undefined,
+  b: OpsFollowupResolution | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.status === b.status &&
+    a.source === b.source &&
+    a.child_updated_at === b.child_updated_at &&
+    a.resolution_reason === b.resolution_reason &&
+    a.completion_signal === b.completion_signal &&
+    a.health_verification === b.health_verification &&
+    a.rollback_or_cleanup_disposition === b.rollback_or_cleanup_disposition &&
+    a.evidence_summary === b.evidence_summary &&
+    a.error === b.error
+  );
+}
+
+async function persistResolutionUpsert(input: {
+  store: Store;
+  changeId: string;
+  linkId: string;
+  resolution: OpsFollowupResolution;
+  upsertedAt: string;
+  deps: ReconcileOpsFollowupLinksDeps;
+}): Promise<void> {
+  const { store, changeId, linkId, resolution, upsertedAt, deps } = input;
+  const payload = { linkId, resolution, upsertedAt };
+
+  if (deps.fireSignalAndRefresh) {
+    await deps.fireSignalAndRefresh(
+      {} as unknown as WorkflowHandleLike,
+      store,
+      changeId,
+      opsFollowupResolutionUpsertedSignal,
+      payload,
+    );
+    return;
+  }
+
+  const getServiceFn = deps.getService ?? getService;
+  const getChangeHandleFn = deps.getChangeHandle ?? getChangeHandle;
+  const getProjectIdFn = deps.getProjectId ?? getProjectId;
+
+  const bundle = getServiceFn();
+  if (!bundle) {
+    throw new Error("Temporal service not available");
+  }
+  const projectId =
+    store.productContext?.productProjectId ??
+    (await getProjectIdFn(store.paths.root));
+  if (!projectId) {
+    throw new Error("Could not resolve project ID");
+  }
+  const handle = getChangeHandleFn(
+    bundle.client as unknown as {
+      workflow: { getHandle: (workflowId: string) => WorkflowHandleLike };
+    },
+    projectId,
+    changeId,
+  );
+  await fireSignalAndRefresh(
+    handle,
+    store,
+    changeId,
+    opsFollowupResolutionUpsertedSignal,
+    payload,
+  );
+}
+
+export async function reconcileOpsFollowupLinks(
+  input: ReconcileOpsFollowupLinksInput,
+): Promise<ReconcileOpsFollowupLinksResult> {
+  const { parent, store } = input;
+  const deps = input.deps ?? {};
+  const now = deps.now ? deps.now() : new Date().toISOString();
+  const reconciled: ReconcileOpsFollowupResolutionResult[] = [];
+  const skipped: string[] = [];
+
+  for (const link of parent.ops_followup_links ?? []) {
+    if (!isRequiredOpsFollowupLink(link)) {
+      skipped.push(link.id);
+      continue;
+    }
+
+    const readResult = await readAuthoritativeChildOpsProfile({
+      link,
+      store,
+      deps,
+    });
+    const resolution = readResult.ok
+      ? deriveOpsFollowupResolution(link, readResult.profile, now)
+      : makeUnreachableResolution(
+          link,
+          now,
+          readResult.reason,
+          readResult.error,
+        );
+
+    if (!resolutionsEqual(link.resolution, resolution)) {
+      await persistResolutionUpsert({
+        store,
+        changeId: parent.id,
+        linkId: link.id,
+        resolution,
+        upsertedAt: now,
+        deps,
+      });
+    }
+
+    reconciled.push({ linkId: link.id, resolution });
+  }
+
+  const refreshed = await store.changes.get(parent.id);
+  return {
+    parent: refreshed.success && refreshed.data ? refreshed.data : parent,
+    reconciled,
+    skipped,
+  };
+}
+
+/**
+ * Pure derivation helper for callers that only need to compute a resolution from
+ * an already-fetched child profile. Returns null for non-required links.
+ */
+export function reconcileOpsFollowupResolution(
+  input: ReconcileOpsFollowupResolutionInput,
+): OpsFollowupResolution | null {
+  if (!isRequiredOpsFollowupLink(input.link)) return null;
+  return deriveOpsFollowupResolution(
+    input.link,
+    input.childProfile,
+    input.now ?? new Date().toISOString(),
+  );
+}

--- a/plugin/src/types/changes.ops-follow-up.test.ts
+++ b/plugin/src/types/changes.ops-follow-up.test.ts
@@ -9,6 +9,7 @@ import {
   OpsRunSchema,
   OpsFollowupLinkSchema,
   OpsFollowupProfileSchema,
+  OpsFollowupResolutionSchema,
   OpsFollowupSourceSchema,
 } from "./changes";
 
@@ -174,6 +175,45 @@ describe("ops follow-up schemas", () => {
             next_status: "complete",
           },
         ],
+      }),
+    ).toThrow();
+  });
+
+  it("parses an outbound ops follow-up link with bounded resolution provenance", () => {
+    const result = OpsFollowupLinkSchema.parse({
+      id: "ofl-1",
+      changeId: "child-1",
+      relationship: "blocks",
+      status: "running",
+      linked_at: timestamp,
+      resolution: {
+        status: "complete",
+        verified_at: "2026-06-20T04:05:00.000Z",
+        child_updated_at: "2026-06-20T04:04:00.000Z",
+        resolution_reason: "verified",
+        source: "child_profile",
+        completion_signal: "deploy finished",
+        health_verification: "smoke passed",
+        rollback_or_cleanup_disposition: "no rollback needed",
+        evidence_summary: "child profile shows complete",
+      },
+    });
+
+    expect(result.resolution).toMatchObject({
+      status: "complete",
+      child_updated_at: "2026-06-20T04:04:00.000Z",
+      resolution_reason: "verified",
+      source: "child_profile",
+    });
+  });
+
+  it("rejects an unknown resolution_reason", () => {
+    expect(() =>
+      OpsFollowupResolutionSchema.parse({
+        status: "complete",
+        verified_at: timestamp,
+        resolution_reason: "unknown_reason",
+        source: "child_profile",
       }),
     ).toThrow();
   });

--- a/plugin/src/types/changes.ts
+++ b/plugin/src/types/changes.ts
@@ -645,9 +645,22 @@ export type OpsFollowupProfile = z.infer<typeof OpsFollowupProfileSchema>;
  * the child/source-of-truth profile. This is not a standalone source of truth;
  * it is a bounded release/archive readiness proof.
  */
+export const OpsFollowupResolutionReasonSchema = z.enum([
+  "verified",
+  "child_missing",
+  "profile_missing",
+  "target_identity_mismatch",
+  "unreachable",
+]);
+export type OpsFollowupResolutionReason = z.infer<
+  typeof OpsFollowupResolutionReasonSchema
+>;
+
 export const OpsFollowupResolutionSchema = z.object({
   status: OpsFollowupStatusSchema,
   verified_at: z.string(),
+  child_updated_at: z.string().optional(),
+  resolution_reason: OpsFollowupResolutionReasonSchema.optional(),
   source: z.enum(["child_profile", "unreachable"]),
   completion_signal: z.string().min(1).optional(),
   health_verification: z.string().min(1).optional(),

--- a/plugin/src/types/index.ts
+++ b/plugin/src/types/index.ts
@@ -477,6 +477,8 @@ export {
   type OpsFollowupProfile,
   OpsFollowupResolutionSchema,
   type OpsFollowupResolution,
+  OpsFollowupResolutionReasonSchema,
+  type OpsFollowupResolutionReason,
   OpsFollowupLinkSchema,
   type OpsFollowupLink,
 } from "./changes";

--- a/plugin/src/types/signals.ts
+++ b/plugin/src/types/signals.ts
@@ -48,6 +48,7 @@ import {
   OpsEvidenceEntrySchema,
   OpsFollowupLinkSchema,
   OpsFollowupProfileSchema,
+  OpsFollowupResolutionSchema,
   OpsFollowupStatusSchema,
   OpsRunEvidenceEntrySchema,
   OpsRunSchema,
@@ -638,6 +639,15 @@ export const OpsFollowupLinkAddedSignalPayloadSchema = z.object({
 });
 export type OpsFollowupLinkAddedSignalPayload = z.infer<
   typeof OpsFollowupLinkAddedSignalPayloadSchema
+>;
+
+export const OpsFollowupResolutionUpsertedSignalPayloadSchema = z.object({
+  linkId: z.string().min(1),
+  resolution: OpsFollowupResolutionSchema,
+  upsertedAt: IsoTimestampSchema,
+});
+export type OpsFollowupResolutionUpsertedSignalPayload = z.infer<
+  typeof OpsFollowupResolutionUpsertedSignalPayloadSchema
 >;
 
 export const OpsEvidenceAppendedSignalPayloadSchema = z.object({

--- a/plugin/src/utils/tool-arg-preflight.ts
+++ b/plugin/src/utils/tool-arg-preflight.ts
@@ -398,6 +398,20 @@ const FIELD_POLICIES: Record<string, FieldPolicyMap> = {
     next_step: { blank: "omit" },
     completion_signal: { blank: "omit" },
   },
+  adv_ops_followup_resolution_upsert: {
+    changeId: { blank: "reject" },
+    linkId: { blank: "reject" },
+    status: { blank: "reject" },
+    verifiedAt: { blank: "reject" },
+    resolutionReason: { blank: "reject" },
+    source: { blank: "reject" },
+    childUpdatedAt: { blank: "omit" },
+    completionSignal: { blank: "omit" },
+    healthVerification: { blank: "omit" },
+    rollbackOrCleanupDisposition: { blank: "omit" },
+    evidenceSummary: { blank: "omit" },
+    error: { blank: "omit" },
+  },
   // tk-2b89b9cf3042: verified top-level strict-mode placeholder policy groups.
   // Zero omission for the positive-int optionals
   // (adv_change_repair_origin.origin_issue_number above); blank omission for

--- a/plugin/src/utils/tool-title.ts
+++ b/plugin/src/utils/tool-title.ts
@@ -133,6 +133,10 @@ const TITLE_BUILDERS: Record<string, TitleBuilder> = {
     write(`Promote report follow-up${suffix(args, "source_change_id")}`),
   adv_ops_evidence_add: (args) =>
     write(`Add ops evidence${suffix(args, "changeId")}`),
+  adv_ops_followup_resolution_upsert: (args) =>
+    write(
+      `Upsert ops follow-up resolution${suffix(args, "changeId", "linkId")}`,
+    ),
   adv_ops_run_upsert: (args) =>
     write(`Upsert ops run${suffix(args, "changeId", "runId")}`),
   adv_ops_run_evidence_add: (args) =>


### PR DESCRIPTION
## Summary
- reconcile required ops follow-up links from authoritative child Temporal state before release/archive authority
- persist link-keyed typed resolution through deterministic workflow signal
- fail closed when current reconciliation cannot verify a previously complete child
- enforce required-link archive blockers while preserving non-required reporting

## Verification
- 138 focused release/archive/reconciliation/Temporal/policy/docs tests
- 108 reviewer remediation tests
- `pnpm run check`

## Release proof
After merge, deploy from `trunk`, restart OpenCode, then verify PokeEdge `pinBuildkitImage` archive preflight clears its completed staging-proof child obligation.