### PR TITLE
fix: resolve ops links in archive dry-run

### DIFF
--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -15,7 +15,13 @@ import {
   closeLinkedIssue,
 } from "./change";
 import type { Store } from "../storage/store";
-import type { Change, Spec } from "../types";
+import type {
+  Change,
+  OpsFollowupLink,
+  OpsFollowupProfile,
+  OpsFollowupResolution,
+  Spec,
+} from "../types";
 import { derivePhasePlanSafe, parsePhasePlan } from "../utils/phase-plan";
 import {
   PARITY_ROWS,
@@ -26,6 +32,7 @@ import { cleanupTempDir, createTempDir } from "../__tests__/setup";
 import * as gitFinalize from "./archive-helpers/git-finalize";
 import * as worktree from "./worktree";
 import { gateTools } from "./gate";
+import { overlayOpsResolutionsForRead } from "./ops-followup-reconciliation";
 
 const mocks = vi.hoisted(() => {
   const signalMock = vi.fn();
@@ -4435,6 +4442,672 @@ describe("change tools — signal-driven lifecycle", () => {
           mutation: false,
         }),
         expect.any(Function),
+      );
+    });
+
+    test("dryRun derives fresh child resolution and clears stale parent obligation without signals or persistence", async () => {
+      const childProfile: OpsFollowupProfile = {
+        kind: "migration",
+        source: {
+          source_change_id: "test-change",
+          source_kind: "required_follow_up",
+        },
+        relationship: "blocks",
+        status: "complete",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:01:00Z",
+        completion_signal: "deploy finished",
+        evidence: [],
+        runs: [
+          {
+            id: "run-1",
+            title: "Deploy run",
+            status: "complete",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:01:00Z",
+            plan: {
+              env: "prod",
+              action: "deploy",
+              bounds: ["low-risk"],
+              evidence_policy: "manual",
+              rollback_or_cleanup_plan: "rollback to previous version",
+            },
+            steps: [],
+            evidence: [
+              {
+                id: "ore-1",
+                recorded_at: "2026-01-01T00:01:00Z",
+                step_kind: "execute",
+                env: "prod",
+                status: "complete",
+                summary: "Deployment completed",
+                artifact: {
+                  kind: "pointer",
+                  uri: "s3://ops-bucket/deploy.log",
+                },
+                next_status: "complete",
+                completion_signal: "deploy finished",
+                health_verification: "smoke passed",
+                rollback_or_cleanup_disposition: "no rollback needed",
+              },
+            ],
+          },
+        ],
+      };
+      const childChange: Change = {
+        id: "child-1",
+        title: "Child ops change",
+        status: "active",
+        created_at: "2026-01-01T00:00:00Z",
+        created_by: "test",
+        tasks: [],
+        deltas: {},
+        wisdom: [],
+        ops_followup: childProfile,
+      };
+      const link: OpsFollowupLink = {
+        id: "ofl-1",
+        changeId: "child-1",
+        relationship: "blocks",
+        status: "not_started",
+        required_handoff: false,
+        linked_at: "2026-01-01T00:00:00Z",
+      };
+      const parent: Change = {
+        id: "test-change",
+        title: "Test Change",
+        status: "active",
+        created_at: "2026-01-01T00:00:00Z",
+        created_by: "test",
+        tasks: [],
+        deltas: {},
+        wisdom: [],
+        gates: allDoneGates,
+        ops_followup_links: [link],
+      };
+      const store = createMockStore(parent);
+      const getMock = store.changes.get as ReturnType<typeof vi.fn>;
+      getMock.mockImplementation(async (id: string) => {
+        if (id === "test-change") return { success: true, data: parent };
+        if (id === "child-1") return { success: true, data: childChange };
+        return { success: true, data: null };
+      });
+      mocks.queryMock.mockResolvedValueOnce(allDoneGates);
+
+      const result = await changeTools.adv_change_archive.execute(
+        { changeId: "test-change", dryRun: true },
+        store,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error ?? "").not.toContain("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(parsed.error ?? "").not.toContain(
+        "unresolved required ops follow-up obligations",
+      );
+      expect(parsed.openOpsObligations ?? []).toEqual([]);
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+    });
+
+    function makeCompleteOpsProfile(): OpsFollowupProfile {
+      return {
+        kind: "migration",
+        source: {
+          source_change_id: "test-change",
+          source_kind: "required_follow_up",
+        },
+        relationship: "blocks",
+        status: "complete",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:01:00Z",
+        completion_signal: "deploy finished",
+        evidence: [],
+        runs: [
+          {
+            id: "run-1",
+            title: "Deploy run",
+            status: "complete",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:01:00Z",
+            plan: {
+              env: "prod",
+              action: "deploy",
+              bounds: ["low-risk"],
+              evidence_policy: "manual",
+              rollback_or_cleanup_plan: "rollback to previous version",
+            },
+            steps: [],
+            evidence: [
+              {
+                id: "ore-1",
+                recorded_at: "2026-01-01T00:01:00Z",
+                step_kind: "execute",
+                env: "prod",
+                run_id: "run-1",
+                status: "complete",
+                summary: "Deployment completed",
+                artifact: {
+                  kind: "pointer",
+                  uri: "s3://ops-bucket/deploy.log",
+                },
+                next_status: "complete",
+                completion_signal: "deploy finished",
+                health_verification: "smoke passed",
+                rollback_or_cleanup_disposition: "no rollback needed",
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    function makeIncompleteOpsProfile(
+      status: OpsFollowupProfile["status"] = "running",
+    ): OpsFollowupProfile {
+      return {
+        kind: "migration",
+        source: {
+          source_change_id: "test-change",
+          source_kind: "required_follow_up",
+        },
+        relationship: "blocks",
+        status,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:01:00Z",
+        evidence: [],
+        runs: [],
+      };
+    }
+
+    function makeCompleteButProofMissingProfile(): OpsFollowupProfile {
+      return {
+        ...makeCompleteOpsProfile(),
+        runs: [],
+      };
+    }
+
+    function makeOpsChild(
+      changeId: string,
+      profile?: OpsFollowupProfile,
+    ): Change {
+      return {
+        id: changeId,
+        title: "Ops child",
+        status: "active",
+        created_at: "2026-01-01T00:00:00Z",
+        created_by: "test",
+        tasks: [],
+        deltas: {},
+        wisdom: [],
+        ...(profile ? { ops_followup: profile } : {}),
+      };
+    }
+
+    function makeParentWithOpsLink(
+      linkOverrides: Partial<OpsFollowupLink> = {},
+    ): Change {
+      return {
+        id: "test-change",
+        title: "Test Change",
+        status: "active",
+        created_at: "2026-01-01T00:00:00Z",
+        created_by: "test",
+        tasks: [],
+        deltas: {},
+        wisdom: [],
+        gates: allDoneGates,
+        ops_followup_links: [
+          {
+            id: "ofl-1",
+            changeId: "child-1",
+            relationship: "blocks",
+            status: "not_started",
+            required_handoff: false,
+            linked_at: "2026-01-01T00:00:00Z",
+            ...linkOverrides,
+          },
+        ],
+      };
+    }
+
+    function configureStore(
+      parent: Change,
+      child: Change | null | "unreachable",
+    ): Store {
+      const store = createMockStore(parent);
+      const getMock = store.changes.get as ReturnType<typeof vi.fn>;
+      getMock.mockImplementation(async (id: string) => {
+        if (id === "test-change") return { success: true, data: parent };
+        if (id === "child-1") {
+          if (child === "unreachable") {
+            throw new Error("child workflow unreachable");
+          }
+          return { success: true, data: child };
+        }
+        return { success: true, data: null };
+      });
+      return store;
+    }
+
+    async function runArchive(changeId: string, dryRun: boolean, store: Store) {
+      const result = await changeTools.adv_change_archive.execute(
+        { changeId, dryRun },
+        store,
+      );
+      return JSON.parse(result);
+    }
+
+    function installSignalMutation(parent: Change) {
+      vi.mocked(mocks.fireSignalAndRefresh).mockImplementation(
+        async (_handle, _store, _changeId, _signal, payload) => {
+          const p = payload as {
+            linkId: string;
+            resolution: OpsFollowupResolution;
+          };
+          const link = parent.ops_followup_links?.find(
+            (l) => l.id === p.linkId,
+          );
+          if (link) {
+            link.resolution = p.resolution;
+          }
+        },
+      );
+    }
+
+    function expectParentSnapshot(
+      parent: Change,
+      beforeParent: string,
+      beforeLink: string,
+      originalLink: OpsFollowupLink,
+      originalResolution: OpsFollowupResolution | undefined,
+    ) {
+      expect(JSON.stringify(parent)).toBe(beforeParent);
+      expect(parent.ops_followup_links![0]).toBe(originalLink);
+      expect(JSON.stringify(parent.ops_followup_links![0])).toBe(beforeLink);
+      if (originalResolution === undefined) {
+        expect(parent.ops_followup_links![0].resolution).toBeUndefined();
+      } else {
+        expect(parent.ops_followup_links![0].resolution).toBe(
+          originalResolution,
+        );
+      }
+    }
+
+    test("AC2/AC4 same-project: incomplete child status blocks with the same code in dry and wet", async () => {
+      const parent = makeParentWithOpsLink();
+      const child = makeOpsChild(
+        "child-1",
+        makeIncompleteOpsProfile("running"),
+      );
+      const store = configureStore(parent, child);
+      const beforeParent = JSON.stringify(parent);
+      const beforeLink = JSON.stringify(parent.ops_followup_links![0]);
+      const originalLink = parent.ops_followup_links![0];
+      const originalResolution = originalLink.resolution;
+
+      const dry = await runArchive("test-change", true, store);
+      expect(dry.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
+      );
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+      expectParentSnapshot(
+        parent,
+        beforeParent,
+        beforeLink,
+        originalLink,
+        originalResolution,
+      );
+
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+      expect(wet.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(wet.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
+      );
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalled();
+    });
+
+    test("AC2: complete child missing required proof fields blocks with the same code in dry and wet", async () => {
+      const parent = makeParentWithOpsLink();
+      const child = makeOpsChild(
+        "child-1",
+        makeCompleteButProofMissingProfile(),
+      );
+      const store = configureStore(parent, child);
+      const beforeParent = JSON.stringify(parent);
+      const beforeLink = JSON.stringify(parent.ops_followup_links![0]);
+      const originalLink = parent.ops_followup_links![0];
+      const originalResolution = originalLink.resolution;
+
+      const dry = await runArchive("test-change", true, store);
+      expect(dry.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_COMPLETION_PROOF_INCOMPLETE",
+      );
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+      expectParentSnapshot(
+        parent,
+        beforeParent,
+        beforeLink,
+        originalLink,
+        originalResolution,
+      );
+
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+      expect(wet.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(wet.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_COMPLETION_PROOF_INCOMPLETE",
+      );
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalled();
+    });
+
+    test("AC2: missing child change blocks with the same code in dry and wet", async () => {
+      const parent = makeParentWithOpsLink();
+      const store = configureStore(parent, null);
+      const beforeParent = JSON.stringify(parent);
+      const beforeLink = JSON.stringify(parent.ops_followup_links![0]);
+      const originalLink = parent.ops_followup_links![0];
+      const originalResolution = originalLink.resolution;
+
+      const dry = await runArchive("test-change", true, store);
+      expect(dry.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+      expectParentSnapshot(
+        parent,
+        beforeParent,
+        beforeLink,
+        originalLink,
+        originalResolution,
+      );
+
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+      expect(wet.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(wet.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalled();
+    });
+
+    test("AC2: missing child profile blocks with the same code in dry and wet", async () => {
+      const parent = makeParentWithOpsLink();
+      const child = makeOpsChild("child-1");
+      const store = configureStore(parent, child);
+      const beforeParent = JSON.stringify(parent);
+      const beforeLink = JSON.stringify(parent.ops_followup_links![0]);
+      const originalLink = parent.ops_followup_links![0];
+      const originalResolution = originalLink.resolution;
+
+      const dry = await runArchive("test-change", true, store);
+      expect(dry.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+      expectParentSnapshot(
+        parent,
+        beforeParent,
+        beforeLink,
+        originalLink,
+        originalResolution,
+      );
+
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+      expect(wet.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(wet.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalled();
+    });
+
+    test("AC2: unreachable child change blocks with the same code in dry and wet", async () => {
+      const parent = makeParentWithOpsLink();
+      const store = configureStore(parent, "unreachable");
+      const beforeParent = JSON.stringify(parent);
+      const beforeLink = JSON.stringify(parent.ops_followup_links![0]);
+      const originalLink = parent.ops_followup_links![0];
+      const originalResolution = originalLink.resolution;
+
+      const dry = await runArchive("test-change", true, store);
+      expect(dry.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+      expectParentSnapshot(
+        parent,
+        beforeParent,
+        beforeLink,
+        originalLink,
+        originalResolution,
+      );
+
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+      expect(wet.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(wet.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalled();
+    });
+
+    test("AC2/AC4 same-project: target identity mismatch blocks with the same code in dry and wet", async () => {
+      const parent = makeParentWithOpsLink({
+        target_project_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      });
+      const child = makeOpsChild("child-1", makeCompleteOpsProfile());
+      const store = configureStore(parent, child);
+      const beforeParent = JSON.stringify(parent);
+      const beforeLink = JSON.stringify(parent.ops_followup_links![0]);
+      const originalLink = parent.ops_followup_links![0];
+      const originalResolution = originalLink.resolution;
+
+      const dry = await runArchive("test-change", true, store);
+      expect(dry.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+      expectParentSnapshot(
+        parent,
+        beforeParent,
+        beforeLink,
+        originalLink,
+        originalResolution,
+      );
+
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+      expect(wet.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(wet.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalled();
+    });
+
+    test("AC2: stale-complete/current-unreachable blocks with OPS_FOLLOWUP_STATUS_UNVERIFIED", async () => {
+      const parent = makeParentWithOpsLink({
+        status: "complete",
+        resolution: {
+          status: "complete",
+          verified_at: "2026-01-01T00:00:00Z",
+          source: "child_profile",
+          resolution_reason: "verified",
+          completion_signal: "deploy finished",
+          health_verification: "smoke passed",
+          rollback_or_cleanup_disposition: "no rollback needed",
+          evidence_summary: "done",
+        },
+      });
+      const store = configureStore(parent, null);
+      const beforeParent = JSON.stringify(parent);
+      const beforeLink = JSON.stringify(parent.ops_followup_links![0]);
+      const originalLink = parent.ops_followup_links![0];
+      const originalResolution = originalLink.resolution;
+
+      const dry = await runArchive("test-change", true, store);
+      expect(dry.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+      expectParentSnapshot(
+        parent,
+        beforeParent,
+        beforeLink,
+        originalLink,
+        originalResolution,
+      );
+
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+      expect(wet.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(wet.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_STATUS_UNVERIFIED",
+      );
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalled();
+    });
+
+    test("AC4 cross-project: complete child clears stale parent obligation in dry-run", async () => {
+      const child = makeOpsChild("child-target", makeCompleteOpsProfile());
+      vi.mocked(mocks.targetStore.changes.get).mockResolvedValue({
+        success: true,
+        data: child,
+      });
+      const parent = makeParentWithOpsLink({
+        id: "ofl-target",
+        changeId: "child-target",
+        target_path: "/tmp/target",
+        target_project_id: "target-project-id",
+      });
+      const store = createMockStore(parent);
+      const getMock = store.changes.get as ReturnType<typeof vi.fn>;
+      getMock.mockImplementation(async (id: string) => {
+        if (id === "test-change") return { success: true, data: parent };
+        return { success: true, data: null };
+      });
+
+      mocks.queryMock.mockResolvedValueOnce(allDoneGates);
+
+      const result = await runArchive("test-change", true, store);
+      expect(result.error ?? "").not.toContain("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(result.error ?? "").not.toContain(
+        "unresolved required ops follow-up obligations",
+      );
+      expect(result.openOpsObligations ?? []).toEqual([]);
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+    });
+
+    test("AC4 cross-project: incomplete child blocks with the same code in dry and wet", async () => {
+      const child = makeOpsChild(
+        "child-target",
+        makeIncompleteOpsProfile("running"),
+      );
+      vi.mocked(mocks.targetStore.changes.get).mockResolvedValue({
+        success: true,
+        data: child,
+      });
+      const parent = makeParentWithOpsLink({
+        id: "ofl-target",
+        changeId: "child-target",
+        target_path: "/tmp/target",
+        target_project_id: "target-project-id",
+      });
+      const store = createMockStore(parent);
+      const getMock = store.changes.get as ReturnType<typeof vi.fn>;
+      getMock.mockImplementation(async (id: string) => {
+        if (id === "test-change") return { success: true, data: parent };
+        return { success: true, data: null };
+      });
+      const beforeParent = JSON.stringify(parent);
+      const beforeLink = JSON.stringify(parent.ops_followup_links![0]);
+      const originalLink = parent.ops_followup_links![0];
+      const originalResolution = originalLink.resolution;
+
+      const dry = await runArchive("test-change", true, store);
+      expect(dry.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
+      );
+      expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
+      expect(store.changes.save).not.toHaveBeenCalled();
+      expectParentSnapshot(
+        parent,
+        beforeParent,
+        beforeLink,
+        originalLink,
+        originalResolution,
+      );
+
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+      expect(wet.code).toBe("OPS_FOLLOWUP_ARCHIVE_BLOCKED");
+      expect(wet.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
+      );
+      expect(mocks.fireSignalAndRefresh).toHaveBeenCalled();
+    });
+
+    test("AC3/C2: dry-run overlay is non-aliasing and mutating the returned change does not affect the input parent", () => {
+      const parent = makeParentWithOpsLink();
+      const resolution: OpsFollowupResolution = {
+        status: "complete",
+        verified_at: "2026-01-01T00:02:00Z",
+        source: "child_profile",
+        resolution_reason: "verified",
+        completion_signal: "deploy finished",
+        health_verification: "smoke passed",
+        rollback_or_cleanup_disposition: "no rollback needed",
+        evidence_summary: "done",
+      };
+      const resolutionByLinkId = new Map([["ofl-1", resolution]]);
+
+      const overlaid = overlayOpsResolutionsForRead(parent, resolutionByLinkId);
+
+      expect(overlaid).not.toBe(parent);
+      expect(overlaid.ops_followup_links).not.toBe(parent.ops_followup_links);
+      expect(overlaid.ops_followup_links![0]).not.toBe(
+        parent.ops_followup_links![0],
+      );
+      expect(overlaid.ops_followup_links![0].resolution).toEqual(resolution);
+
+      overlaid.ops_followup_links![0].status = "complete";
+      overlaid.ops_followup_links![0].resolution!.status = "failed";
+
+      expect(parent.ops_followup_links![0].status).toBe("not_started");
+      expect(parent.ops_followup_links![0].resolution).toBeUndefined();
+    });
+
+    test("parity: dry and wet produce identical blocker codes for the same incomplete fixture", async () => {
+      const parent = makeParentWithOpsLink();
+      const child = makeOpsChild(
+        "child-1",
+        makeIncompleteOpsProfile("running"),
+      );
+      const store = configureStore(parent, child);
+
+      const dry = await runArchive("test-change", true, store);
+      installSignalMutation(parent);
+      const wet = await runArchive("test-change", false, store);
+
+      expect(dry.code).toBe(wet.code);
+      expect(dry.readinessBlockers[0].code).toBe(wet.readinessBlockers[0].code);
+      expect(dry.readinessBlockers[0].code).toBe(
+        "OPS_FOLLOWUP_BLOCKS_INCOMPLETE",
       );
     });
 

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -940,7 +940,9 @@ import {
 } from "../temporal/gate-readiness";
 import {
   isRequiredOpsFollowupLink,
+  overlayOpsResolutionsForRead,
   reconcileOpsFollowupLinks,
+  resolveRequiredOpsLinks,
 } from "./ops-followup-reconciliation";
 import {
   detectArchiveMode,
@@ -3578,9 +3580,11 @@ export const changeTools = {
         }
         // Reconcile required ops follow-up resolutions from authoritative child
         // state before any archive authority decision. Skip when reading from a
-        // completed/poisoned workflow disk projection (signaling is unavailable)
-        // or during dryRun (no writes). The blocker check still runs on the
-        // current projection so unresolved required links remain fail-closed.
+        // completed/poisoned workflow disk projection (signaling is unavailable);
+        // otherwise dryRun derives an ephemeral non-aliasing overlay so the
+        // blocker/obligation check uses fresh child proof, while wet runs signal
+        // the resolution and re-read the parent. Unresolved required links
+        // remain fail-closed in both modes.
         const hasRequiredOpsFollowup = change.ops_followup_links?.some(
           isRequiredOpsFollowupLink,
         );
@@ -3593,13 +3597,21 @@ export const changeTools = {
             code: "OPS_FOLLOWUP_RECONCILIATION_UNAVAILABLE",
           });
         }
-        if (!readFromDisk && !dryRun) {
+        if (!readFromDisk && hasRequiredOpsFollowup) {
           try {
-            const reconciled = await reconcileOpsFollowupLinks({
-              parent: change,
-              store,
-            });
-            change = reconciled.parent;
+            if (dryRun) {
+              const { resolutionByLinkId } = await resolveRequiredOpsLinks({
+                parent: change,
+                store,
+              });
+              change = overlayOpsResolutionsForRead(change, resolutionByLinkId);
+            } else {
+              const reconciled = await reconcileOpsFollowupLinks({
+                parent: change,
+                store,
+              });
+              change = reconciled.parent;
+            }
           } catch (error) {
             logger.warn(
               `Archive ops follow-up reconciliation failed for ${changeId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugin/src/tools/ops-followup-reconciliation.test.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.test.ts
@@ -17,8 +17,10 @@ import { opsFollowupResolutionUpsertedSignal } from "../temporal/messages";
 import type { TargetStoreScope } from "./target-project";
 import {
   isRequiredOpsFollowupLink,
+  overlayOpsResolutionsForRead,
   reconcileOpsFollowupLinks,
   reconcileOpsFollowupResolution,
+  resolveRequiredOpsLinks,
 } from "./ops-followup-reconciliation";
 
 const timestamp = "2026-06-20T04:00:00.000Z";
@@ -617,3 +619,193 @@ describe("reconcileOpsFollowupLinks", () => {
     expect(store.changes.get).toHaveBeenLastCalledWith("parent-1");
   });
 });
+
+describe("resolveRequiredOpsLinks", () => {
+  test("derives complete resolution from fresh child profile (AC1)", async () => {
+    const childProfile = completeProfile();
+    const parent = makeParent({
+      links: [makeLink({ relationship: "blocks", required_handoff: false })],
+    });
+    const store = makeStore({
+      parent,
+      children: { "child-1": makeChild("child-1", childProfile) },
+    });
+    const deps = makeDeps();
+
+    const result = await resolveRequiredOpsLinks({ parent, store, deps });
+
+    expect(result.skipped).toEqual([]);
+    expect(result.resolutionByLinkId.size).toBe(1);
+    expect(result.resolutionByLinkId.get("ofl-1")).toMatchObject({
+      source: "child_profile",
+      status: "complete",
+      resolution_reason: "verified",
+      completion_signal: "deploy finished",
+      health_verification: "smoke passed",
+      rollback_or_cleanup_disposition: "no rollback needed",
+    });
+  });
+
+  test("returns fail-closed unreachable resolution when child is missing (AC2)", async () => {
+    const parent = makeParent({
+      links: [makeLink({ relationship: "blocks", required_handoff: false })],
+    });
+    const store = makeStore({ parent });
+    const deps = makeDeps();
+
+    const result = await resolveRequiredOpsLinks({ parent, store, deps });
+
+    expect(result.resolutionByLinkId.get("ofl-1")).toMatchObject({
+      source: "unreachable",
+      resolution_reason: "child_missing",
+      status: "running",
+    });
+  });
+
+  test("returns stale-complete/current-unreachable as not_started unverified (AC2)", async () => {
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "blocks",
+          required_handoff: false,
+          status: "complete",
+        }),
+      ],
+    });
+    const store = makeStore({ parent });
+    const deps = makeDeps();
+
+    const result = await resolveRequiredOpsLinks({ parent, store, deps });
+
+    expect(result.resolutionByLinkId.get("ofl-1")).toMatchObject({
+      source: "unreachable",
+      resolution_reason: "child_missing",
+      status: "not_started",
+    });
+  });
+
+  test("derives cross-project resolution through target_path store (AC4)", async () => {
+    const childProfile = completeProfile();
+    const targetStore = makeStore({
+      parent: makeParent(),
+      children: {
+        "child-target": makeChild("child-target", childProfile),
+      },
+    });
+    const parent = makeParent({
+      links: [
+        makeLink({
+          id: "ofl-target",
+          changeId: "child-target",
+          relationship: "blocks",
+          required_handoff: false,
+          target_path: "/tmp/target-project",
+          target_project_id: "target-project-id",
+        }),
+      ],
+    });
+    const store = makeStore({ parent });
+    const withTargetPathStore = vi.fn(async (_input, fn) => {
+      return await fn({
+        context: { projectId: "target-project-id" },
+        store: targetStore,
+      } as unknown as TargetStoreScope);
+    });
+    const deps = makeDeps({ withTargetPathStore });
+
+    const result = await resolveRequiredOpsLinks({ parent, store, deps });
+
+    expect(result.resolutionByLinkId.get("ofl-target")).toMatchObject({
+      source: "child_profile",
+      status: "complete",
+    });
+  });
+
+  test("sends zero signals and saves zero state (AC3)", async () => {
+    const childProfile = completeProfile();
+    const parent = makeParent({
+      links: [makeLink({ relationship: "blocks", required_handoff: false })],
+    });
+    const store = makeStore({
+      parent,
+      children: { "child-1": makeChild("child-1", childProfile) },
+    });
+    const deps = makeDeps();
+
+    await resolveRequiredOpsLinks({ parent, store, deps });
+
+    expect(deps.fireSignalAndRefresh).not.toHaveBeenCalled();
+    // No Temporal signal, no parent mutation, and no disk write happened.
+    expect(parent.ops_followup_links![0].resolution).toBeUndefined();
+  });
+});
+
+describe("overlayOpsResolutionsForRead", () => {
+  test("returns non-aliasing parent and links with applied resolutions (C2)", () => {
+    const staleResolution = reconcileOpsFollowupResolution({
+      link: makeLink(),
+      childProfile: completeProfile(),
+      now: verifiedAt,
+    })!;
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "blocks",
+          required_handoff: false,
+          resolution: staleResolution,
+        }),
+      ],
+    });
+    const originalLink = parent.ops_followup_links![0];
+    const freshResolution = reconcileOpsFollowupResolution({
+      link: makeLink(),
+      childProfile: incompleteProfile("running"),
+      now: verifiedAt,
+    })!;
+    const resolutionByLinkId = new Map([["ofl-1", freshResolution]]);
+
+    const overlaid = overlayOpsResolutionsForRead(parent, resolutionByLinkId);
+
+    expect(overlaid).not.toBe(parent);
+    expect(overlaid.ops_followup_links).not.toBe(parent.ops_followup_links);
+    expect(overlaid.ops_followup_links![0]).not.toBe(originalLink);
+    expect(overlaid.ops_followup_links![0].resolution).toEqual(freshResolution);
+    expect(overlaid.ops_followup_links![0].resolution).not.toBe(
+      staleResolution,
+    );
+    expect(originalLink.resolution).toEqual(staleResolution);
+    expect(parent.ops_followup_links![0]).toBe(originalLink);
+  });
+
+  test("leaves non-targeted links unchanged", () => {
+    const parent = makeParent({
+      links: [
+        makeLink({ id: "ofl-1" }),
+        makeLink({
+          id: "ofl-2",
+          relationship: "follows_release",
+          required_handoff: false,
+        }),
+      ],
+    });
+    const resolutionByLinkId = new Map<
+      string,
+      ReturnType<typeof reconcileOpsFollowupResolution>
+    >();
+    resolutionByLinkId.set(
+      "ofl-1",
+      reconcileOpsFollowupResolution({
+        link: makeLink({ id: "ofl-1" }),
+        childProfile: completeProfile(),
+        now: verifiedAt,
+      })!,
+    );
+
+    const overlaid = overlayOpsResolutionsForRead(parent, resolutionByLinkId);
+
+    expect(overlaid.ops_followup_links![0].resolution).toBeDefined();
+    expect(overlaid.ops_followup_links![1].resolution).toBeUndefined();
+  });
+});
+
+// cross-mode parity smoke: reconcile and dry-run overlay produce the same resolution shape for the same inputs.

--- a/plugin/src/tools/ops-followup-reconciliation.test.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.test.ts
@@ -802,6 +802,36 @@ describe("overlayOpsResolutionsForRead", () => {
     expect(parent.ops_followup_links![0]).toBe(originalLink);
   });
 
+  test("overlayOpsResolutionsForRead clones replacement resolutions and does not alias the source Map", () => {
+    const mapResolution = reconcileOpsFollowupResolution({
+      link: makeLink(),
+      childProfile: completeProfile(),
+      now: verifiedAt,
+    })!;
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "blocks",
+          required_handoff: false,
+        }),
+      ],
+    });
+    const resolutionByLinkId = new Map([["ofl-1", mapResolution]]);
+
+    const overlaid = overlayOpsResolutionsForRead(parent, resolutionByLinkId);
+
+    expect(overlaid).not.toBe(parent);
+    expect(overlaid.ops_followup_links![0].resolution).toEqual(mapResolution);
+    expect(overlaid.ops_followup_links![0].resolution).not.toBe(mapResolution);
+
+    const originalMapStatus = mapResolution.status;
+    (overlaid.ops_followup_links![0].resolution as { status: string }).status =
+      "not_started";
+    expect(mapResolution.status).toBe(originalMapStatus);
+
+    expect(parent.ops_followup_links![0].resolution).toBeUndefined();
+  });
+
   test("leaves non-targeted links unchanged", () => {
     const parent = makeParent({
       links: [

--- a/plugin/src/tools/ops-followup-reconciliation.test.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.test.ts
@@ -684,6 +684,31 @@ describe("resolveRequiredOpsLinks", () => {
     });
   });
 
+  test("fails closed when a same-project target identity cannot be resolved", async () => {
+    const parent = makeParent({
+      links: [
+        makeLink({
+          relationship: "blocks",
+          required_handoff: false,
+          target_project_id: "expected-project-id",
+        }),
+      ],
+    });
+    const store = makeStore({
+      parent,
+      children: { "child-1": makeChild("child-1", completeProfile()) },
+    });
+    const deps = makeDeps({ getProjectId: vi.fn(async () => undefined) });
+
+    const result = await resolveRequiredOpsLinks({ parent, store, deps });
+
+    expect(result.resolutionByLinkId.get("ofl-1")).toMatchObject({
+      source: "unreachable",
+      resolution_reason: "target_identity_mismatch",
+    });
+    expect(store.changes.get).not.toHaveBeenCalledWith("child-1");
+  });
+
   test("derives cross-project resolution through target_path store (AC4)", async () => {
     const childProfile = completeProfile();
     const targetStore = makeStore({

--- a/plugin/src/tools/ops-followup-reconciliation.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.ts
@@ -69,11 +69,81 @@ export interface ReconcileOpsFollowupLinksResult {
   skipped: string[];
 }
 
+export interface ResolveRequiredOpsLinksInput {
+  parent: Change;
+  store: Store;
+  deps?: ReconcileOpsFollowupLinksDeps;
+}
+
+export interface ResolveRequiredOpsLinksResult {
+  /** Freshly derived authoritative resolution keyed by link id. */
+  resolutionByLinkId: Map<string, OpsFollowupResolution>;
+  /** Links that were not required obligations and were skipped. */
+  skipped: string[];
+}
+
 export function isRequiredOpsFollowupLink(link: OpsFollowupLink): boolean {
   if (link.relationship === "blocks") return true;
   return (
     HANDOFF_RELATIONSHIPS.includes(link.relationship) && link.required_handoff
   );
+}
+
+export async function resolveRequiredOpsLinks(
+  input: ResolveRequiredOpsLinksInput,
+): Promise<ResolveRequiredOpsLinksResult> {
+  const { parent, store } = input;
+  const deps = input.deps ?? {};
+  const now = deps.now ? deps.now() : new Date().toISOString();
+  const resolutionByLinkId = new Map<string, OpsFollowupResolution>();
+  const skipped: string[] = [];
+
+  for (const link of parent.ops_followup_links ?? []) {
+    if (!isRequiredOpsFollowupLink(link)) {
+      skipped.push(link.id);
+      continue;
+    }
+
+    const readResult = await readAuthoritativeChildOpsProfile({
+      link,
+      store,
+      deps,
+    });
+    const resolution = readResult.ok
+      ? deriveOpsFollowupResolution(link, readResult.profile, now)
+      : makeUnreachableResolution(
+          link,
+          now,
+          readResult.reason,
+          readResult.error,
+        );
+
+    resolutionByLinkId.set(link.id, resolution);
+  }
+
+  return { resolutionByLinkId, skipped };
+}
+
+function cloneChange(change: Change): Change {
+  return structuredClone(change);
+}
+
+export function overlayOpsResolutionsForRead(
+  parent: Change,
+  resolutionByLinkId: Map<string, OpsFollowupResolution>,
+): Change {
+  if (!parent.ops_followup_links || parent.ops_followup_links.length === 0) {
+    return cloneChange(parent);
+  }
+
+  const overlaid = cloneChange(parent);
+  for (const link of overlaid.ops_followup_links!) {
+    const resolution = resolutionByLinkId.get(link.id);
+    if (resolution !== undefined) {
+      link.resolution = resolution;
+    }
+  }
+  return overlaid;
 }
 
 interface ProofFields {
@@ -408,41 +478,26 @@ export async function reconcileOpsFollowupLinks(
   const { parent, store } = input;
   const deps = input.deps ?? {};
   const now = deps.now ? deps.now() : new Date().toISOString();
+  const { resolutionByLinkId, skipped } = await resolveRequiredOpsLinks({
+    parent,
+    store,
+    deps: { ...deps, now: () => now },
+  });
   const reconciled: ReconcileOpsFollowupResolutionResult[] = [];
-  const skipped: string[] = [];
 
-  for (const link of parent.ops_followup_links ?? []) {
-    if (!isRequiredOpsFollowupLink(link)) {
-      skipped.push(link.id);
-      continue;
-    }
-
-    const readResult = await readAuthoritativeChildOpsProfile({
-      link,
-      store,
-      deps,
-    });
-    const resolution = readResult.ok
-      ? deriveOpsFollowupResolution(link, readResult.profile, now)
-      : makeUnreachableResolution(
-          link,
-          now,
-          readResult.reason,
-          readResult.error,
-        );
-
-    if (!resolutionsEqual(link.resolution, resolution)) {
+  for (const [linkId, resolution] of resolutionByLinkId) {
+    const link = parent.ops_followup_links?.find((l) => l.id === linkId);
+    if (!resolutionsEqual(link?.resolution, resolution)) {
       await persistResolutionUpsert({
         store,
         changeId: parent.id,
-        linkId: link.id,
+        linkId,
         resolution,
         upsertedAt: now,
         deps,
       });
     }
-
-    reconciled.push({ linkId: link.id, resolution });
+    reconciled.push({ linkId, resolution });
   }
 
   const refreshed = await store.changes.get(parent.id);

--- a/plugin/src/tools/ops-followup-reconciliation.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.ts
@@ -140,7 +140,7 @@ export function overlayOpsResolutionsForRead(
   for (const link of overlaid.ops_followup_links!) {
     const resolution = resolutionByLinkId.get(link.id);
     if (resolution !== undefined) {
-      link.resolution = resolution;
+      link.resolution = structuredClone(resolution);
     }
   }
   return overlaid;

--- a/plugin/src/tools/ops-followup-reconciliation.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.ts
@@ -341,16 +341,21 @@ async function readSameProjectChild(input: {
   const { link, store } = input;
   try {
     const canonicalProjectId = await input.getProjectIdFn(store.paths.root);
-    if (
-      link.target_project_id &&
-      canonicalProjectId &&
-      link.target_project_id !== canonicalProjectId
-    ) {
-      return {
-        ok: false,
-        reason: "target_identity_mismatch",
-        error: `target_project_id mismatch: expected ${link.target_project_id}, got ${canonicalProjectId}`,
-      };
+    if (link.target_project_id) {
+      if (!canonicalProjectId) {
+        return {
+          ok: false,
+          reason: "target_identity_mismatch",
+          error: `target_project_id could not be verified: expected ${link.target_project_id}, canonical project ID unavailable`,
+        };
+      }
+      if (link.target_project_id !== canonicalProjectId) {
+        return {
+          ok: false,
+          reason: "target_identity_mismatch",
+          error: `target_project_id mismatch: expected ${link.target_project_id}, got ${canonicalProjectId}`,
+        };
+      }
     }
     await store.changes.refresh(link.changeId);
     const childResult = await store.changes.get(link.changeId);


### PR DESCRIPTION
## Summary
- derive fresh required child proof during archive dry-run
- evaluate immutable non-aliasing overlay without signals or persistence
- fail closed for unavailable target identity and stale prior proof

## Verification
- 183 focused archive/reconciliation tests
- plugin check

## Release proof
After merge, deploy from `trunk`, restart OpenCode, and run Temporal-authoritative PokeEdge archive preflight.