### PR TITLE
fix(adv): classify ADV-layer 'workflow not found' as completed-workflow evidence

### DIFF
--- a/plugin/src/temporal/recovery-classification.ts
+++ b/plugin/src/temporal/recovery-classification.ts
@@ -12,7 +12,7 @@ const POISONED_HISTORY_EVIDENCE_RE =
   /TMPRL1100|Nondeterminism|NonDeterministic|No command scheduled|WorkflowExecutionUpdateAccepted/i;
 
 const COMPLETED_WORKFLOW_EVIDENCE_RE =
-  /WorkflowNotFoundError|WorkflowExecutionAlreadyCompleted|workflow execution already completed|already completed|workflow is not running|cannot signal a completed/i;
+  /WorkflowNotFoundError|WorkflowExecutionAlreadyCompleted|workflow execution already completed|already completed|workflow is not running|cannot signal a completed|workflow not found|workflow execution not found/i;
 
 export const RECOVERY_RECONCILIATION_WARNING =
   "Poisoned-history recovery wrote the disk projection only; the Temporal workflow is not healed and stale workflow state may diverge if it becomes queryable later. Complete recovery in this session and archive or close promptly.";


### PR DESCRIPTION
## Problem

When a poisoned workflow (TMPRL1100) is terminated and deleted at the Temporal level, ADV tools receive `"workflow not found for ID: ..."` from the tool layer. The `COMPLETED_WORKFLOW_EVIDENCE_RE` regex only recognized Temporal SDK error names (`WorkflowNotFoundError`, `WorkflowExecutionAlreadyCompleted`) but not the ADV-layer wrapper, so the recovery classifier could not match it. Tools errored out instead of falling through to disk-projection recovery.

## Fix

Add `workflow not found` and `workflow execution not found` to `COMPLETED_WORKFLOW_EVIDENCE_RE` in `plugin/src/temporal/recovery-classification.ts`.

## Context

Recovery hotfix during `fixOpsResolutionProjection` — a 12-hour-old workflow lived across 5 worker builds, producing nondeterministic history. After Temporal-level termination + deletion, ADV tools could not self-recover.

## Verification

- `pnpm run build` passes
- Deployed locally; classifier fix verified by recovery flow