### PR TITLE
docs(SETUP): convert P32 YAML block to >- folded scalar

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -721,7 +721,8 @@ Add the following entry in the `rules:` map (P32 recommended):
 ```yaml
 P32:
   name: worktree-isolation
-  rule: Do not intentionally write implementation changes into a trunk/default
+  rule: >-
+    Do not intentionally write implementation changes into a trunk/default
     checkout when an isolated worktree is required or available for the work.
     Use the correct worktree/workdir, keep git operations scoped, and never
     bypass worktree isolation with manual file shuffling. Deploy, rebuild,


### PR DESCRIPTION
Campsite follow-up to #332 (addDeclarationBehavior).

## What
Convert the P32 worktree-isolation YAML block in SETUP.md from plain multiline scalar to >- folded scalar style.

## Why
The plain scalar form contains 'the inverse: run them only' (colon-space at line 728 of SETUP.md, line 179 of deployed rules.yaml). Strict YAML parsers interpret the colon-space as a mapping separator and fail with 'mapping values are not allowed here'. python3 yaml.safe_load aborts the whole file on this entry.

>- folded style (already used by P37, P38, P39 in both SETUP.md and rules.yaml) makes the colon-space harmless.

## Scope
- 1 file (SETUP.md), 1 YAML block (P32 only)
- Text content preserved verbatim including 'the inverse: run them only'
- No behavior change; documentation-only

## Companion change
Deployed ~/.config/opencode/instructions/rules.yaml was updated in the same fix (P32 plain scalar to >- folded). Backup synced to ~/toolbox/backups/dotfiles/opencode/instructions/rules.yaml. Whole-file strict parse now passes (22 rules).

## Verification
python3 yaml.safe_load on the full deployed rules.yaml: OK, 22 rules parsed clean.