### PR TITLE
fix: prevent redeploy workflow poisoning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
         run: pnpm run build:worker
         working-directory: plugin
 
+      - name: Verify candidate worker bundle
+        run: pnpm run verify:worker-bundle
+        working-directory: plugin
+
       - name: Install Temporal CLI
         uses: temporalio/setup-temporal@v0
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -36,7 +36,8 @@
     "schemas:check": "tsx scripts/generate-json-schemas.ts --check",
     "generate:manifests": "tsx scripts/generate-agent-manifests.ts",
     "generate:manifests:check": "tsx scripts/generate-agent-manifests.ts --check",
-    "bench:latency": "bun --smol scripts/bench-adv-latency.ts"
+    "bench:latency": "bun --smol scripts/bench-adv-latency.ts",
+    "verify:worker-bundle": "tsx scripts/verify-candidate-worker-bundle.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -357,9 +357,8 @@ export async function tryInitStore(
             bundleDir: dirname(workerScriptPath),
             restartChild: () => outOfProcessWorker.restartChild(),
             verifyCandidateBundle: async ({ workflowsPath, historiesDir }) => {
-              const { verifyCommittedReplayFixtures } = await import(
-                "./migration/replay-verification"
-              );
+              const { verifyCommittedReplayFixtures } =
+                await import("./migration/replay-verification");
               return verifyCommittedReplayFixtures({
                 workflowsPath,
                 historiesDir,

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -356,6 +356,16 @@ export async function tryInitStore(
             projectStateDir,
             bundleDir: dirname(workerScriptPath),
             restartChild: () => outOfProcessWorker.restartChild(),
+            verifyCandidateBundle: async ({ workflowsPath, historiesDir }) => {
+              const { verifyCommittedReplayFixtures } = await import(
+                "./migration/replay-verification"
+              );
+              return verifyCommittedReplayFixtures({
+                workflowsPath,
+                historiesDir,
+                replayNamePrefix: "self-roll-gate",
+              });
+            },
             stampBundleGeneration: async (generation) => {
               await workerHeartbeat?.stampBundleGeneration(generation);
             },

--- a/plugin/src/temporal/worker-roll.test.ts
+++ b/plugin/src/temporal/worker-roll.test.ts
@@ -361,4 +361,137 @@ describe("worker bundle roll monitor", () => {
 
     await heartbeat.stop();
   });
+
+  // --- Replay-verification gate tests (preventRedeployWorkflow) ---
+
+  test("verification failure blocks the roll — restartChild NOT called", async () => {
+    const { stateDir, bundleDir } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const restartChild = vi.fn(async () => {});
+    const verifyCandidateBundle = vi.fn(async () => ({
+      passed: false,
+    }));
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+      verifyCandidateBundle,
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result.rolled).toBe(false);
+    if (!result.rolled) {
+      expect(result.reason).toBe("roll_failed");
+      expect(result.error).toMatch(/replay verification/i);
+    }
+    expect(restartChild).not.toHaveBeenCalled();
+    expect(verifyCandidateBundle).toHaveBeenCalledTimes(1);
+  });
+
+  test("verification pass allows the roll — restartChild IS called", async () => {
+    const { stateDir, bundleDir } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const restartChild = vi.fn(async () => {});
+    const verifyCandidateBundle = vi.fn(async () => ({
+      passed: true,
+    }));
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+      verifyCandidateBundle,
+      setBundleGeneration: vi.fn(),
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result.rolled).toBe(true);
+    expect(restartChild).toHaveBeenCalledTimes(1);
+    expect(verifyCandidateBundle).toHaveBeenCalledTimes(1);
+  });
+
+  test("ADV_FORCE_DEPLOY=1 skips verification and proceeds with roll", async () => {
+    const { stateDir, bundleDir } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const restartChild = vi.fn(async () => {});
+    const verifyCandidateBundle = vi.fn(async () => ({
+      passed: false,
+    }));
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+      verifyCandidateBundle,
+      setBundleGeneration: vi.fn(),
+    });
+
+    const prev = process.env.ADV_FORCE_DEPLOY;
+    process.env.ADV_FORCE_DEPLOY = "1";
+    try {
+      const result = await monitor.checkNow();
+      expect(result.rolled).toBe(true);
+      expect(restartChild).toHaveBeenCalledTimes(1);
+      // Verification callback must NOT be called when override is active
+      expect(verifyCandidateBundle).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.ADV_FORCE_DEPLOY;
+      else process.env.ADV_FORCE_DEPLOY = prev;
+    }
+  });
+
+  test("omitted verifyCandidateBundle preserves back-compat — roll proceeds", async () => {
+    const { stateDir, bundleDir } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const restartChild = vi.fn(async () => {});
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+      setBundleGeneration: vi.fn(),
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result.rolled).toBe(true);
+    expect(restartChild).toHaveBeenCalledTimes(1);
+  });
+
+  test("verification throwing blocks the roll and calls onRollError", async () => {
+    const { stateDir, bundleDir } = await setup({
+      lockGeneration: "gen-stale",
+    });
+    const restartChild = vi.fn(async () => {});
+    const verifyError = new Error("replay worker crashed");
+    const verifyCandidateBundle = vi.fn(async () => {
+      throw verifyError;
+    });
+    const onRollError = vi.fn();
+
+    const monitor = createWorkerBundleRollMonitor({
+      projectStateDir: stateDir,
+      bundleDir,
+      restartChild,
+      verifyCandidateBundle,
+      onRollError,
+    });
+
+    const result = await monitor.checkNow();
+
+    expect(result.rolled).toBe(false);
+    if (!result.rolled) {
+      expect(result.reason).toBe("roll_failed");
+      expect(result.error).toMatch(/replay worker crashed/);
+    }
+    expect(restartChild).not.toHaveBeenCalled();
+    expect(onRollError).toHaveBeenCalledWith(verifyError);
+  });
 });

--- a/plugin/src/temporal/worker-roll.ts
+++ b/plugin/src/temporal/worker-roll.ts
@@ -50,6 +50,19 @@ export interface WorkerBundleRollMonitorOptions {
    */
   restartChild: () => Promise<void>;
   /**
+   * Optional replay-verification gate. When provided, called before
+   * restartChild() on every detected drift. If it returns
+   * { passed: false }, the roll is refused. Skipped when
+   * ADV_FORCE_DEPLOY=1 is set in the environment.
+   *
+   * When omitted (tests, back-compat, in-process workers), verification
+   * is skipped — same fail-open posture as before this change.
+   */
+  verifyCandidateBundle?: (input: {
+    workflowsPath: string;
+    historiesDir: string;
+  }) => Promise<{ passed: boolean; report?: unknown }>;
+  /**
    * Sole-writer handoff: the worker.lock heartbeat controller's
    * `stampBundleGeneration`. Invoked with the generation the current child
    * is running — at spawn (via `initWorkerBundleRoll`) and after every
@@ -139,6 +152,46 @@ export function createWorkerBundleRollMonitor(
       currentGeneration ?? lock.bundle_generation ?? null;
     if (runningGeneration === manifestGeneration) {
       return { rolled: false, reason: "same_generation" };
+    }
+
+    // Replay-verification gate: verify candidate bundle before rolling.
+    // Skipped when ADV_FORCE_DEPLOY=1 or when no callback is provided
+    // (tests, back-compat, in-process workers).
+    if (process.env.ADV_FORCE_DEPLOY !== "1") {
+      if (options.verifyCandidateBundle) {
+        const workflowsPath = join(options.bundleDir, "workflows.js");
+        const historiesDir = join(
+          options.bundleDir,
+          "..",
+          "src",
+          "temporal",
+          "__tests__",
+          "replay",
+          "histories",
+        );
+        try {
+          const result = await options.verifyCandidateBundle({
+            workflowsPath,
+            historiesDir,
+          });
+          if (!result.passed) {
+            return {
+              rolled: false,
+              reason: "roll_failed",
+              error:
+                "Candidate worker bundle failed replay verification — refusing to roll. Set ADV_FORCE_DEPLOY=1 to override.",
+            };
+          }
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          options.onRollError?.(error);
+          return {
+            rolled: false,
+            reason: "roll_failed",
+            error: `Replay verification threw: ${error.message}`,
+          };
+        }
+      }
     }
 
     try {

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1421,7 +1421,7 @@ refresh_deployed_temporal_workers() {
 	# Replay-verification gate: refuse to bounce if the candidate bundle
 	# fails replay against committed histories. ADV_FORCE_DEPLOY=1 overrides.
 	if [ "${ADV_FORCE_DEPLOY:-0}" != "1" ]; then
-		if ! (cd "$ADV_SOURCE_PLUGIN_PATH" && pnpm run verify:worker-bundle >/dev/null 2>&1); then
+		if ! (cd "$ADV_SOURCE_PLUGIN_PATH" && pnpm run verify:worker-bundle); then
 			echo "    ✗  Candidate worker bundle failed replay verification — refusing to bounce"
 			echo "    Set ADV_FORCE_DEPLOY=1 to override (operator accepts poisoning risk)"
 			return 1

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1359,7 +1359,7 @@ refresh_deployed_temporal_workers() {
 	local mode="$1"
 	local runtime_plugin_path worker_script
 	local matches advisory legacy pid cmd
-	local bounce_grace_seconds=2
+	local bounce_grace_seconds=6
 
 	if runtime_plugin_path="$(cd "$ADV_RUNTIME_PLUGIN_PATH" 2>/dev/null && pwd -P)"; then
 		worker_script="$runtime_plugin_path/dist/temporal/worker.js"
@@ -1417,6 +1417,19 @@ refresh_deployed_temporal_workers() {
 		echo "    no legacy deployed Temporal workers require signaling; self-roll capable workers skipped"
 		return 0
 	fi
+
+	# Replay-verification gate: refuse to bounce if the candidate bundle
+	# fails replay against committed histories. ADV_FORCE_DEPLOY=1 overrides.
+	if [ "${ADV_FORCE_DEPLOY:-0}" != "1" ]; then
+		if ! (cd "$ADV_SOURCE_PLUGIN_PATH" && pnpm run verify:worker-bundle >/dev/null 2>&1); then
+			echo "    ✗  Candidate worker bundle failed replay verification — refusing to bounce"
+			echo "    Set ADV_FORCE_DEPLOY=1 to override (operator accepts poisoning risk)"
+			return 1
+		fi
+	else
+		echo "    [ADV:FORCE_DEPLOY] Replay verification skipped — operator accepted poisoning risk"
+	fi
+	echo "    [ADV:RESIDUAL_RISK] Fixture corpus is advance-repo-only; cross-project workflow shapes may not be represented."
 
 	echo "    bouncing legacy deployed Temporal worker(s) for: $worker_script"
 	local failures=""


### PR DESCRIPTION
## Problem

`rq-workerEvolutionSafety01` requires ADV to prevent ordinary plugin/worker deployment from replaying active workflow histories against incompatible workflow code. This was enforced on the release path but NOT on the deploy path. Both deploy surfaces (self-roll and bounce) swapped worker bundles with zero replay verification.

Two production workflows were poisoned this way on 2026-07-15/16 (`gateArtworkMatchReadiness` pokeedge, `updatePreviewContract` pokeedge-business) — one permanently lost its disk projection.

## Fix

Wires the existing `verifyCommittedReplayFixtures` verifier (shipped by `hardenWorkflowRecovery`) into two deploy surfaces:

1. **Self-roll gate** (`worker-roll.ts`) — the dominant path. Verifies replay before `restartChild()`. Blocks on failure.
2. **Bounce gate** (`deploy-local.sh`) — the legacy path. Verifies replay before SIGTERM. Blocks on failure.
3. **CI step** — runs `verify:worker-bundle` after `build:worker`.
4. **Grace reconciliation** — `bounce_grace_seconds` 2→6 (SDK drains 5s).
5. **`ADV_FORCE_DEPLOY=1`** override on both gates with logged risk.

## Constraints

- No Worker Deployments enabled (spec-forbidden by scenario .2)
- No workflow code altered (`workflows.ts` untouched)
- No release-path gate weakened
- Verification failure never degrades to silent no-op

## Test plan

- [x] 5 new unit tests (block-on-fail, pass-allows-roll, override, back-compat, throw-blocks)
- [x] 16/16 worker-roll tests pass
- [x] Typecheck clean
- [x] Bash syntax valid
- [x] `pnpm run verify:worker-bundle` exits 0 against built bundle

ADV change: `preventRedeployWorkflow`