### PR TITLE
style: fix prettier formatting to unblock trunk CI

### DIFF
--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -211,7 +211,8 @@ export async function tryInitStore(
     // rq-advOwnedFrontmatterValid01 / DDC1: bounded runtime frontmatter
     // check. Warn-only, never throws — init resilience takes precedence.
     try {
-      const { runtimeFrontmatterCheck } = await import("./utils/manifest-frontmatter");
+      const { runtimeFrontmatterCheck } =
+        await import("./utils/manifest-frontmatter");
       runtimeFrontmatterCheck(300);
     } catch {
       // Swallow — frontmatter check is advisory at init time.

--- a/plugin/src/temporal/change-state.ts
+++ b/plugin/src/temporal/change-state.ts
@@ -988,7 +988,8 @@ function applyContentWithSizeGuard(
   // the same payload is an idempotent replay; same operation_id with a different
   // payload is a typed conflict.
   if (operation_id && command_kind) {
-    ledgerHash = options?.payload_hash ?? computeLegacyDocumentPayloadHash(text);
+    ledgerHash =
+      options?.payload_hash ?? computeLegacyDocumentPayloadHash(text);
     const existing = state.operation_ledger?.[operation_id];
     if (existing) {
       if (isOperationIdempotentReplay(existing, command_kind, ledgerHash)) {

--- a/plugin/src/utils/manifest-frontmatter.ts
+++ b/plugin/src/utils/manifest-frontmatter.ts
@@ -252,9 +252,7 @@ export function runtimeFrontmatterCheck(
         if (!result.ok) {
           failures++;
           // eslint-disable-next-line no-console
-          console.warn(
-            `[ADV] frontmatter: ${fullPath} — ${result.error}`,
-          );
+          console.warn(`[ADV] frontmatter: ${fullPath} — ${result.error}`);
         }
       }
     }


### PR DESCRIPTION
## Problem

Trunk CI is red. `13b27ff1` (current trunk HEAD) fails the **Format check** step in `Test (24.x)`, which causes the **Build** job to be skipped. Every downstream merge inherits red trunk.

The preceding merge `22f98a38` is red for the same reason.

## Cause

Trunk HEAD is `fix(change-state): use host SHA-256 payload_hash for content artifacts`, and `change-state.ts` is one of the three unformatted files — the change shipped without running Prettier.

## Fix

`prettier --write` on the three offending files. **Purely cosmetic — line wrapping only, no semantic change** (5 insertions, 5 deletions):

- `plugin/src/plugin-init.ts`
- `plugin/src/temporal/change-state.ts`
- `plugin/src/utils/manifest-frontmatter.ts`

## Verification

`pnpm run check` passes locally — 0 errors:

```
schemas:check      ok
typecheck          ok
generate:manifests ok  (all agent manifests match)
check-frontmatter  ok  (42 files scanned)
check-test-isolation / check-lockfile-policy  ok
lint               0 errors, 3 warnings (pre-existing)
format:check       All matched files use Prettier code style!
```

## Follow-up (deliberately not in this PR)

`eslint` reports 3 pre-existing warnings in `manifest-frontmatter.ts` (lines 254, 269, 275) — *Unused eslint-disable directive (no problems reported from 'no-console')*. Lines 269 and 275 are untouched by this PR, confirming they pre-date it. Left alone to keep this hotfix surgical.