### PR TITLE
fix(cli): stop advisory resume projection from hanging adv status

### DIFF
--- a/bin/adv
+++ b/bin/adv
@@ -58,6 +58,7 @@ import {
 } from "./lib/epic-list";
 import { loadLiveResumeProjection } from "./lib/resume-projection-live";
 import { runRoadmapCommand } from "./lib/roadmap";
+import { settleWithinBudget } from "./lib/optional-enrichment";
 
 // =============================================================================
 // Constants
@@ -65,6 +66,16 @@ import { runRoadmapCommand } from "./lib/roadmap";
 
 const VERSION = "0.1.0";
 const EPIC_READ_ONLY_SUBCOMMANDS = new Set(["list"]);
+
+/**
+ * Wall-clock budget for the advisory resume projection.
+ *
+ * Deliberately independent of ADV_STATUS_TIMEOUT_MS: that governs primary
+ * reads, which must fail closed (rq-statusCliWorkerFree01.2). This governs
+ * enrichment, which must degrade instead. Coupling the two is what allowed a
+ * projection with no polling worker to gate the status table.
+ */
+const RESUME_ENRICHMENT_BUDGET_MS = 2_000;
 
 // =============================================================================
 // Subcommands
@@ -126,16 +137,15 @@ async function runStatus(noColor: boolean, json: boolean): Promise<number> {
       : QUERY_TIMEOUT_MS;
 
   try {
-    const [summaries, terminalCounts, resumeResult] = await Promise.all([
+    // The resume projection is advisory and is bounded independently. It must
+    // never gate the status table — `.catch()` alone was insufficient because
+    // it handles rejection but not a slow resolve.
+    const [summaries, terminalCounts, resumeOutcome] = await Promise.all([
       loadLiveSummaries(projectId, now, timeoutMs),
       countTerminalChanges(root),
-      loadLiveResumeProjection(projectId, timeoutMs).catch(
-        (err): Awaited<ReturnType<typeof loadLiveResumeProjection>> => ({
-          live: false,
-          error: err instanceof Error ? err.message : String(err),
-          remediation:
-            "ADV resume projection unavailable. Verify Temporal is running and the project has active changes/epics.",
-        }),
+      settleWithinBudget(
+        loadLiveResumeProjection(projectId, timeoutMs),
+        RESUME_ENRICHMENT_BUDGET_MS,
       ),
     ]);
     const visibleSummaries = filterTerminalSummaries(
@@ -147,8 +157,12 @@ async function runStatus(noColor: boolean, json: boolean): Promise<number> {
       now,
       ...terminalCounts,
     });
-    if (resumeResult.live && resumeResult.resume_projection) {
-      payload.resume_projection = resumeResult.resume_projection;
+    if (
+      resumeOutcome.settled &&
+      resumeOutcome.value.live &&
+      resumeOutcome.value.resume_projection
+    ) {
+      payload.resume_projection = resumeOutcome.value.resume_projection;
     }
 
     if (json) {
@@ -225,23 +239,21 @@ async function runEpicListCommand(json: boolean): Promise<number> {
       : QUERY_TIMEOUT_MS;
 
   try {
-    const [epics, resumeResult] = await Promise.all([
+    // Advisory enrichment, bounded independently of the epic list read.
+    const [epics, resumeOutcome] = await Promise.all([
       loadLiveEpics(projectId, timeoutMs),
-      loadLiveResumeProjection(
-        projectId,
-        timeoutMs,
-      ).catch(
-        (err): Awaited<ReturnType<typeof loadLiveResumeProjection>> => ({
-          live: false,
-          error: err instanceof Error ? err.message : String(err),
-          remediation:
-            "ADV resume projection unavailable. Verify Temporal is running and the project has active changes/epics.",
-        }),
+      settleWithinBudget(
+        loadLiveResumeProjection(projectId, timeoutMs),
+        RESUME_ENRICHMENT_BUDGET_MS,
       ),
     ]);
     const payload = buildLiveEpicListPayload(epics, { projectId, now });
-    if (resumeResult.live && resumeResult.resume_projection) {
-      payload.resume_projection = resumeResult.resume_projection;
+    if (
+      resumeOutcome.settled &&
+      resumeOutcome.value.live &&
+      resumeOutcome.value.resume_projection
+    ) {
+      payload.resume_projection = resumeOutcome.value.resume_projection;
     }
     process.stdout.write(emitJson(payload) + "\n");
     return 0;

--- a/bin/adv
+++ b/bin/adv
@@ -59,6 +59,7 @@ import {
 import { loadLiveResumeProjection } from "./lib/resume-projection-live";
 import { runRoadmapCommand } from "./lib/roadmap";
 import { settleWithinBudget } from "./lib/optional-enrichment";
+import { buildResumeProjectionState } from "./lib/resume-projection-state";
 
 // =============================================================================
 // Constants
@@ -157,6 +158,12 @@ async function runStatus(noColor: boolean, json: boolean): Promise<number> {
       now,
       ...terminalCounts,
     });
+    // Always emit the state, even on success. An absent projection must be
+    // explicable, never silently missing (DONT5).
+    payload.resume_projection_state = buildResumeProjectionState(
+      resumeOutcome,
+      now,
+    );
     if (
       resumeOutcome.settled &&
       resumeOutcome.value.live &&
@@ -248,6 +255,10 @@ async function runEpicListCommand(json: boolean): Promise<number> {
       ),
     ]);
     const payload = buildLiveEpicListPayload(epics, { projectId, now });
+    payload.resume_projection_state = buildResumeProjectionState(
+      resumeOutcome,
+      now,
+    );
     if (
       resumeOutcome.settled &&
       resumeOutcome.value.live &&

--- a/bin/lib/epic-list.ts
+++ b/bin/lib/epic-list.ts
@@ -26,6 +26,11 @@ export interface EpicListPayload {
   project_id: string | null;
   epics: EpicListEntry[];
   resume_projection?: unknown;
+  /**
+   * Always present. Explains whether `resume_projection` can be trusted as a
+   * full answer, so an absent projection is never silently ambiguous.
+   */
+  resume_projection_state?: unknown;
   error?: string;
   remediation?: string;
 }

--- a/bin/lib/optional-enrichment.test.ts
+++ b/bin/lib/optional-enrichment.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Bun tests for the bounded optional-enrichment wrapper.
+ *
+ * Regression cover for fixWorkerDependentResume: an advisory enrichment must
+ * never gate primary CLI output. Before this change, `runStatus` and
+ * `runEpicListCommand` awaited `loadLiveResumeProjection` inside a
+ * `Promise.all`, so a projection that never resolved (no worker polling the
+ * task queue) held the status table hostage for N x timeout.
+ *
+ * Run with: bun test bin/lib/optional-enrichment.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { settleWithinBudget } from "./optional-enrichment";
+
+/** A promise that never settles — models a query with zero pollers. */
+const never = () => new Promise<never>(() => {});
+
+describe("settleWithinBudget", () => {
+  test("returns unsettled within budget when the promise never resolves", async () => {
+    const start = Date.now();
+    const result = await settleWithinBudget(never(), 100);
+    const elapsed = Date.now() - start;
+
+    expect(result.settled).toBe(false);
+    if (!result.settled) {
+      expect(result.reason).toBeTruthy();
+    }
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test("passes a resolved value through unchanged", async () => {
+    const result = await settleWithinBudget(Promise.resolve("ok"), 100);
+
+    expect(result).toEqual({ settled: true, value: "ok" });
+  });
+
+  test("converts rejection into unsettled rather than throwing", async () => {
+    const result = await settleWithinBudget(
+      Promise.reject(new Error("boom")),
+      100,
+    );
+
+    expect(result.settled).toBe(false);
+    if (!result.settled) {
+      expect(result.reason).toContain("boom");
+    }
+  });
+
+  test("reports a distinct reason for timeout vs failure", async () => {
+    const timedOut = await settleWithinBudget(never(), 50);
+    const failed = await settleWithinBudget(
+      Promise.reject(new Error("boom")),
+      50,
+    );
+
+    expect(timedOut.settled).toBe(false);
+    expect(failed.settled).toBe(false);
+    if (!timedOut.settled && !failed.settled) {
+      // A consumer must be able to tell "we ran out of time" from "it broke".
+      expect(timedOut.reason).not.toEqual(failed.reason);
+    }
+  });
+
+  test("N pending enrichments do not sum their budgets (AC4)", async () => {
+    const start = Date.now();
+
+    await Promise.all(
+      Array.from({ length: 25 }, () => settleWithinBudget(never(), 100)),
+    );
+
+    const elapsed = Date.now() - start;
+
+    // Sequential behaviour would be 25 x 100ms = 2500ms. Concurrent is ~100ms.
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test("does not leave a pending timer that keeps the process alive", async () => {
+    // A settled promise must clear its timeout; otherwise `bun test` hangs on
+    // the longest budget passed anywhere in the run.
+    const start = Date.now();
+    await settleWithinBudget(Promise.resolve(1), 30_000);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/bin/lib/optional-enrichment.ts
+++ b/bin/lib/optional-enrichment.ts
@@ -1,0 +1,67 @@
+/**
+ * Bounded optional-enrichment wrapper for bin/adv read commands.
+ *
+ * Primary CLI output (the status table, the epic list) must never wait on an
+ * advisory enrichment. Awaiting an enrichment inside the same `Promise.all` as
+ * the primary read makes the slowest member gate the whole command — which is
+ * how a resume projection with zero polling workers hung `adv status` for
+ * N x timeout.
+ *
+ * This wrapper converts "enrichment might never finish" into "enrichment is
+ * either present or explicitly absent, within a fixed budget". It never throws
+ * and never resolves later than `budgetMs`.
+ *
+ * Note the asymmetry with `withTimeout`: that helper REJECTS on expiry, which
+ * is correct for a primary read that must fail closed. Enrichment must degrade
+ * instead, so this helper resolves with a typed outcome.
+ *
+ * rq-statusCliWorkerFree01 (fixWorkerDependentResume) — AC1, AC2, AC4, AC5
+ */
+
+/** Result of attempting an advisory enrichment within a fixed time budget. */
+export type EnrichmentOutcome<T> =
+  | { settled: true; value: T }
+  | { settled: false; reason: string };
+
+/** Reason prefix used when the budget expired rather than the work failing. */
+export const ENRICHMENT_TIMEOUT_REASON = "enrichment exceeded budget";
+
+/**
+ * Resolve `promise` if it settles within `budgetMs`, otherwise resolve an
+ * explicit unsettled outcome.
+ *
+ * Guarantees:
+ * - never rejects (a rejected input becomes `{ settled: false }`)
+ * - never resolves later than `budgetMs`
+ * - distinguishes timeout from failure via `reason`
+ * - clears its timer, so a fast result does not hold the process open
+ */
+export async function settleWithinBudget<T>(
+  promise: Promise<T>,
+  budgetMs: number,
+): Promise<EnrichmentOutcome<T>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const budget = new Promise<EnrichmentOutcome<T>>((resolve) => {
+    timer = setTimeout(() => {
+      resolve({
+        settled: false,
+        reason: `${ENRICHMENT_TIMEOUT_REASON} of ${budgetMs}ms`,
+      });
+    }, budgetMs);
+  });
+
+  const attempted = promise.then(
+    (value): EnrichmentOutcome<T> => ({ settled: true, value }),
+    (err): EnrichmentOutcome<T> => ({
+      settled: false,
+      reason: err instanceof Error ? err.message : String(err),
+    }),
+  );
+
+  try {
+    return await Promise.race([attempted, budget]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/bin/lib/resume-projection-live.ts
+++ b/bin/lib/resume-projection-live.ts
@@ -80,6 +80,14 @@ export interface LiveResumeProjectionResult {
   resume_projection?: ResumeProjection;
   error?: string;
   remediation?: string;
+  /** Source timestamp of the underlying data, when known. */
+  freshness?: string;
+  /**
+   * Explicit truncation signal. Set when a capped source dropped records, so
+   * the omission is reported rather than silently absorbed (DONT5).
+   */
+  truncated?: boolean;
+  truncated_count?: number;
 }
 
 export async function loadLiveResumeProjection(

--- a/bin/lib/resume-projection-state.test.ts
+++ b/bin/lib/resume-projection-state.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Bun tests for resume-projection completeness markers.
+ *
+ * AC6 / DONT5 regression cover. The original defect hid because a failed
+ * projection and an empty projection were indistinguishable in the payload:
+ * per-change timeouts were swallowed by a bare `catch {}` with the comment
+ * "Skip unreachable changes; projection is advisory", so nothing surfaced in
+ * output OR logs.
+ *
+ * Run with: bun test bin/lib/resume-projection-state.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildResumeProjectionState } from "./resume-projection-state";
+import type { LiveResumeProjectionResult } from "./resume-projection-live";
+import type { EnrichmentOutcome } from "./optional-enrichment";
+
+const NOW = new Date("2026-07-28T12:00:00.000Z");
+
+/** Minimal projection stand-in — shape is irrelevant to marker logic. */
+const projection = (nodes: unknown[]) =>
+  ({ ready: nodes, blocked: [], active: [] }) as unknown as NonNullable<
+    LiveResumeProjectionResult["resume_projection"]
+  >;
+
+const settled = (
+  value: LiveResumeProjectionResult,
+): EnrichmentOutcome<LiveResumeProjectionResult> => ({
+  settled: true,
+  value,
+});
+
+const unsettled = (
+  reason: string,
+): EnrichmentOutcome<LiveResumeProjectionResult> => ({
+  settled: false,
+  reason,
+});
+
+describe("buildResumeProjectionState", () => {
+  test("budget expiry yields unavailable with a reason", () => {
+    const state = buildResumeProjectionState(
+      unsettled("enrichment exceeded budget of 2000ms"),
+      NOW,
+    );
+
+    expect(state.completeness).toBe("unavailable");
+    expect(state.reason).toContain("budget");
+  });
+
+  test("live:false yields unavailable carrying the underlying error", () => {
+    const state = buildResumeProjectionState(
+      settled({ live: false, error: "Temporal connection refused" }),
+      NOW,
+    );
+
+    expect(state.completeness).toBe("unavailable");
+    expect(state.reason).toContain("Temporal connection refused");
+  });
+
+  test("successful projection yields complete with no reason", () => {
+    const state = buildResumeProjectionState(
+      settled({ live: true, resume_projection: projection([{ id: "a" }]) }),
+      NOW,
+    );
+
+    expect(state.completeness).toBe("complete");
+    expect(state.reason).toBeUndefined();
+  });
+
+  test("AC6 — an EMPTY projection is distinguishable from an UNAVAILABLE one", () => {
+    const empty = buildResumeProjectionState(
+      settled({ live: true, resume_projection: projection([]) }),
+      NOW,
+    );
+    const broken = buildResumeProjectionState(unsettled("timed out"), NOW);
+
+    // "nothing is blocked" vs "we could not determine what is blocked"
+    expect(empty.completeness).toBe("complete");
+    expect(broken.completeness).toBe("unavailable");
+    expect(empty.completeness).not.toBe(broken.completeness);
+  });
+
+  test("a reason is always present when completeness is not complete", () => {
+    const cases = [
+      buildResumeProjectionState(unsettled("timed out"), NOW),
+      buildResumeProjectionState(settled({ live: false }), NOW),
+    ];
+
+    for (const state of cases) {
+      expect(state.completeness).not.toBe("complete");
+      expect(state.reason).toBeTruthy();
+    }
+  });
+
+  test("state is always emitted with schema_version and generated_at", () => {
+    const cases = [
+      buildResumeProjectionState(unsettled("x"), NOW),
+      buildResumeProjectionState(settled({ live: false }), NOW),
+      buildResumeProjectionState(
+        settled({ live: true, resume_projection: projection([]) }),
+        NOW,
+      ),
+    ];
+
+    for (const state of cases) {
+      expect(state.schema_version).toBe(1);
+      expect(state.generated_at).toBe(NOW.toISOString());
+    }
+  });
+
+  test("truncation is signalled explicitly, never silent", () => {
+    const state = buildResumeProjectionState(
+      settled({
+        live: true,
+        resume_projection: projection([]),
+        truncated: true,
+        truncated_count: 52,
+      }),
+      NOW,
+    );
+
+    expect(state.truncated).toBe(true);
+    expect(state.truncated_count).toBe(52);
+    expect(state.completeness).toBe("partial");
+    expect(state.reason).toBeTruthy();
+  });
+});

--- a/bin/lib/resume-projection-state.ts
+++ b/bin/lib/resume-projection-state.ts
@@ -1,0 +1,95 @@
+/**
+ * Completeness markers for the advisory resume projection.
+ *
+ * The resume projection is allowed to be absent. It is NOT allowed to be
+ * absent silently: a consumer must be able to tell "nothing is blocked" from
+ * "we could not determine what is blocked". Those two states were previously
+ * indistinguishable, which is a large part of why a projection that never
+ * resolved went unnoticed — per-change timeouts were swallowed by a bare
+ * `catch {}` and surfaced in neither output nor logs.
+ *
+ * Marker shape follows Google AIP-157 (partial responses) and AIP-158
+ * (explicit truncation signalling). Temporal defines no standard projection
+ * freshness schema, so this is an application contract.
+ *
+ * rq-statusCliWorkerFree01 (fixWorkerDependentResume) — AC6, DONT5
+ */
+
+import type { EnrichmentOutcome } from "./optional-enrichment";
+import type { LiveResumeProjectionResult } from "./resume-projection-live";
+
+export type ResumeProjectionCompleteness =
+  | "complete"
+  | "partial"
+  | "unavailable";
+
+export interface ResumeProjectionState {
+  schema_version: 1;
+  /** Whether the projection can be trusted as a full answer. */
+  completeness: ResumeProjectionCompleteness;
+  /** When this state was computed. */
+  generated_at: string;
+  /** Required whenever completeness is not "complete". Never blank. */
+  reason?: string;
+  /** Source timestamp of the underlying data, when known. */
+  freshness?: string;
+  /** Explicit truncation signal — truncation is never silent. */
+  truncated?: boolean;
+  truncated_count?: number;
+}
+
+/**
+ * Fallback so `reason` is never empty when completeness is degraded. An
+ * unexplained absence is the exact failure mode DONT5 forbids.
+ */
+const UNREPORTED_REASON =
+  "resume projection unavailable for an unreported reason";
+
+/** Map a bounded enrichment outcome onto an explicit, always-present state. */
+export function buildResumeProjectionState(
+  outcome: EnrichmentOutcome<LiveResumeProjectionResult>,
+  now: Date,
+): ResumeProjectionState {
+  const base = {
+    schema_version: 1 as const,
+    generated_at: now.toISOString(),
+  };
+
+  // Budget expired, or the enrichment threw.
+  if (!outcome.settled) {
+    return {
+      ...base,
+      completeness: "unavailable",
+      reason: outcome.reason || UNREPORTED_REASON,
+    };
+  }
+
+  const result = outcome.value;
+
+  if (!result.live || !result.resume_projection) {
+    return {
+      ...base,
+      completeness: "unavailable",
+      reason: result.error || UNREPORTED_REASON,
+    };
+  }
+
+  if (result.truncated) {
+    return {
+      ...base,
+      completeness: "partial",
+      reason: `resume projection truncated at ${
+        result.truncated_count ?? "an unreported number of"
+      } records`,
+      truncated: true,
+      truncated_count: result.truncated_count,
+      freshness: result.freshness,
+    };
+  }
+
+  return {
+    ...base,
+    completeness: "complete",
+    freshness: result.freshness,
+  };
+}

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -211,7 +211,8 @@ export async function tryInitStore(
     // rq-advOwnedFrontmatterValid01 / DDC1: bounded runtime frontmatter
     // check. Warn-only, never throws — init resilience takes precedence.
     try {
-      const { runtimeFrontmatterCheck } = await import("./utils/manifest-frontmatter");
+      const { runtimeFrontmatterCheck } =
+        await import("./utils/manifest-frontmatter");
       runtimeFrontmatterCheck(300);
     } catch {
       // Swallow — frontmatter check is advisory at init time.

--- a/plugin/src/shared/cli-projection.ts
+++ b/plugin/src/shared/cli-projection.ts
@@ -108,6 +108,11 @@ export interface LiveStatusPayload {
   };
   changes: ChangeSummary[];
   resume_projection?: unknown;
+  /**
+   * Always present. Explains whether `resume_projection` can be trusted as a
+   * full answer, so an absent projection is never silently ambiguous.
+   */
+  resume_projection_state?: unknown;
   error?: string;
   remediation?: string;
 }

--- a/plugin/src/temporal/change-state.ts
+++ b/plugin/src/temporal/change-state.ts
@@ -988,7 +988,8 @@ function applyContentWithSizeGuard(
   // the same payload is an idempotent replay; same operation_id with a different
   // payload is a typed conflict.
   if (operation_id && command_kind) {
-    ledgerHash = options?.payload_hash ?? computeLegacyDocumentPayloadHash(text);
+    ledgerHash =
+      options?.payload_hash ?? computeLegacyDocumentPayloadHash(text);
     const existing = state.operation_ledger?.[operation_id];
     if (existing) {
       if (isOperationIdempotentReplay(existing, command_kind, ledgerHash)) {

--- a/plugin/src/utils/manifest-frontmatter.ts
+++ b/plugin/src/utils/manifest-frontmatter.ts
@@ -252,9 +252,7 @@ export function runtimeFrontmatterCheck(
         if (!result.ok) {
           failures++;
           // eslint-disable-next-line no-console
-          console.warn(
-            `[ADV] frontmatter: ${fullPath} — ${result.error}`,
-          );
+          console.warn(`[ADV] frontmatter: ${fullPath} — ${result.error}`);
         }
       }
     }


### PR DESCRIPTION
## Problem

`adv status --json` and `adv epic list --json` hung indefinitely for any ADV project with running change workflows and **no live OpenCode session**. Measured on a 12-project host: 8 of 12 failed. pokeedge produced **zero bytes after 120 seconds** and never returned.

Root cause: `loadLiveResumeProjection` issues one worker-routed `getState` query per running change, sequentially, and sits inside the same `Promise.all` as the primary status read. Task queues are session-scoped (`advance-{hash}-sess_{id}`), so a project with no live session has zero pollers and every query burns its full timeout. Cost is `O(N running changes x timeout)`.

Temporal documents this directly:
> "A Worker must be online to process the query." — TypeScript docs. Go docs specify `FAILED_PRECONDITION` with no poller.

`loadLiveSummaries` was already migrated to the Visibility API to avoid exactly this. The resume-projection enrichment was missed, and `rq-statusCliWorkerFree01.1` scopes its prohibition to "the default table" — which is the hole the enrichment slipped through.

## What this PR changes

This is the first increment of change `fixWorkerDependentResume`. It stops the enrichment from blocking primary output and makes its absence explicit. It does **not** yet remove the `getState` loops.

**1. `bin/lib/optional-enrichment.ts` — `settleWithinBudget()`**
Converts "enrichment might never finish" into "present, or explicitly absent within a fixed budget". Never rejects, never resolves later than its budget, distinguishes timeout from failure, clears its timer.

Deliberately asymmetric with the existing `withTimeout`, which *rejects* — correct for primary reads that must fail closed per `rq-statusCliWorkerFree01.2`. Enrichment must *degrade* instead. Conflating those two policies is the root shape of this bug.

`RESUME_ENRICHMENT_BUDGET_MS` is independent of `ADV_STATUS_TIMEOUT_MS`: no primary timeout was lowered.

**2. `bin/lib/resume-projection-state.ts` — completeness markers**
An always-present marker (`schema_version`, `completeness`, `generated_at`, `reason`, `freshness`, `truncated`) so a consumer can distinguish **"nothing is blocked"** from **"we could not determine what is blocked"**. Those were previously indistinguishable, which is a large part of why this went unnoticed: per-change timeouts were swallowed by a bare `catch {}` and surfaced in neither output nor logs.

Shape follows Google AIP-157 (partial responses) and AIP-158 (explicit truncation).

## Measured result

`adv status --json`, per-project XDG shard, `timeout 8`, no live sessions:

| project | before | after |
|---|---|---|
| pokeedge | rc=124, 0 bytes @ 120s | **rc=0, 52 rows, 2.32s** |
| pokeedge-web | rc=124 @ 8s | rc=0, 20 rows, 2.31s |
| pokeedge-business | rc=124 @ 8s | rc=0, 3 rows, 2.32s |
| pokeedge-admin | rc=124 @ 8s | rc=0, 3 rows, 2.32s |
| lgrep | rc=124 @ 8s | rc=0, 2.32s |
| vision | rc=124 @ 8s | rc=0, 1 row, 2.32s |
| Corded | rc=124 @ 8s | rc=0, 1 row, 2.32s |
| opencode-model-routing | rc=124 @ 8s | rc=0, 2.31s |
| toolbox | rc=0, 1.21s | rc=0, 10 rows, 1.11s |
| advance | rc=0, 3.42s | rc=0, 16 rows, 2.31s |
| collection-scripts | rc=0, 0.41s | rc=0, 0.41s |

**4 of 12 working -> 11 of 11 ADV projects working**, worst case 2.32s.

Marker behaviour:
```
toolbox   {"completeness": "complete"}
advance   {"completeness": "unavailable", "reason": "enrichment exceeded budget of 2000ms"}
pokeedge  {"completeness": "unavailable", "reason": "enrichment exceeded budget of 2000ms"}
```

`unavailable` here is truthful, not a regression: the `getState` loops still exist and still cannot answer without a worker. Removing them is the next increment.

## Tests

- `bin/lib/optional-enrichment.test.ts` — 6 tests, incl. 25 concurrent never-settling enrichments completing in <500ms rather than 25x budget
- `bin/lib/resume-projection-state.test.ts` — 7 tests, incl. an explicit assertion that an EMPTY projection is distinguishable from an UNAVAILABLE one

Full suite: **282 pass, 0 fail** across 43 files.

## Still to come on this change

`getState` loop removal (worker-free disk reader + source swap), generalized structural guard against worker-dependent CLI reads, retired-roadmap-surface deletion, dead `loadLiveStatus`/`listLiveChangeStates` removal, plugin `adv_status` product-scope bound, and three spec deltas.