### PR TITLE
fix(adv): decouple orphan adopter from plugin-init spawn branch

### DIFF
--- a/plugin/src/__tests__/plugin-init.registrar-guard.test.ts
+++ b/plugin/src/__tests__/plugin-init.registrar-guard.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+const PLUGIN_INIT_SOURCE = readFileSync(
+  new URL("../plugin-init.ts", import.meta.url),
+  "utf8",
+);
+
+describe("structural guard: registerInProcessTemporalWorker is not exported", () => {
+  test("plugin-init.ts does not export registerInProcessTemporalWorker", () => {
+    // The function definition must NOT be preceded by 'export'
+    expect(PLUGIN_INIT_SOURCE).not.toMatch(
+      /export\s+function\s+registerInProcessTemporalWorker/,
+    );
+  });
+
+  test("plugin-init.ts does not re-export registerInProcessTemporalWorker", () => {
+    expect(PLUGIN_INIT_SOURCE).not.toMatch(
+      /export\s*\{[^}]*registerInProcessTemporalWorker/,
+    );
+  });
+});

--- a/plugin/src/plugin-init.orphan-adopter-restart.test.ts
+++ b/plugin/src/plugin-init.orphan-adopter-restart.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Orphan-queue adopter construction after restart (RED test).
+ *
+ * restartCurrentProjectTemporalWorker currently registers the restarted worker
+ * but does not instantiate OrphanQueueAdopter. Therefore
+ * getOrphanQueueAdoptionDiagnostics() returns null after restart — this test
+ * captures that defect.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { PathLike } from "node:fs";
+
+import { cleanupTempDir, createTempDir } from "./__tests__/setup";
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  getProjectId: vi.fn(),
+  getExternalRoot: vi.fn(),
+  ensureTemporalRuntime: vi.fn(),
+  probeTemporalWorkerRuntime: vi.fn(),
+  createInProcessWorker: vi.fn(),
+  createOutOfProcessWorker: vi.fn(),
+  getService: vi.fn(),
+  initStsl: vi.fn(),
+  closeStsl: vi.fn(),
+  fakeWorker: {
+    queues: ["adv-test-queue"],
+    shutdown: vi.fn(async () => {}),
+  } as const,
+}));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: (path: PathLike) => {
+      const override = mocks.existsSync(path);
+      if (override !== undefined) return override;
+      return actual.existsSync(path);
+    },
+  };
+});
+
+vi.mock("./utils/project-id", async () => {
+  const actual = await vi.importActual<typeof import("./utils/project-id")>(
+    "./utils/project-id",
+  );
+  return {
+    ...actual,
+    getProjectId: mocks.getProjectId,
+    getExternalRoot: mocks.getExternalRoot,
+  };
+});
+
+vi.mock("./temporal/runtime-manager", async () => {
+  const actual = await vi.importActual<
+    typeof import("./temporal/runtime-manager")
+  >("./temporal/runtime-manager");
+  return {
+    ...actual,
+    ensureTemporalRuntime: mocks.ensureTemporalRuntime,
+    probeTemporalWorkerRuntime: mocks.probeTemporalWorkerRuntime,
+  };
+});
+
+vi.mock("./temporal/in-process-worker", () => ({
+  createInProcessWorker: mocks.createInProcessWorker,
+}));
+
+vi.mock("./temporal/out-of-process-worker", () => ({
+  createOutOfProcessWorker: mocks.createOutOfProcessWorker,
+}));
+
+vi.mock("./temporal/service", () => ({
+  getService: mocks.getService,
+  initStsl: mocks.initStsl,
+  closeStsl: mocks.closeStsl,
+}));
+
+import {
+  getOrphanQueueAdoptionDiagnostics,
+  restartCurrentProjectTemporalWorker,
+} from "./plugin-init";
+
+describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () => {
+  let tempDirs: string[] = [];
+  let externalDir: string | undefined;
+  let savedAdoptionEnv: string | undefined;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    savedAdoptionEnv = process.env.ADV_ORPHAN_QUEUE_ADOPTION;
+    process.env.ADV_ORPHAN_QUEUE_ADOPTION = "1";
+
+    externalDir = await createTempDir("adv-restart-adopter-ext-");
+    tempDirs.push(externalDir);
+
+    mocks.existsSync.mockImplementation((path) => {
+      if (
+        typeof path === "string" &&
+        path.includes("dist/temporal/worker.js")
+      ) {
+        return true;
+      }
+      return undefined;
+    });
+
+    mocks.probeTemporalWorkerRuntime.mockReturnValue({
+      supported: true,
+      runtime: "node",
+      reason: "mocked",
+    });
+
+    mocks.ensureTemporalRuntime.mockResolvedValue({
+      address: "localhost:7233",
+      namespace: "default",
+    });
+
+    mocks.createInProcessWorker.mockResolvedValue(mocks.fakeWorker);
+    mocks.createOutOfProcessWorker.mockResolvedValue(mocks.fakeWorker);
+
+    mocks.getProjectId.mockImplementation((dir: string) =>
+      Promise.resolve(`synthetic-project-${dir}`),
+    );
+
+    mocks.getExternalRoot.mockImplementation(() => externalDir ?? "/tmp");
+
+    mocks.getService.mockReturnValue({ client: {} });
+  });
+
+  afterEach(async () => {
+    if (savedAdoptionEnv === undefined) {
+      delete process.env.ADV_ORPHAN_QUEUE_ADOPTION;
+    } else {
+      process.env.ADV_ORPHAN_QUEUE_ADOPTION = savedAdoptionEnv;
+    }
+    await Promise.all(tempDirs.map((dir) => cleanupTempDir(dir)));
+    tempDirs = [];
+  });
+
+  test("constructs an orphan-queue adopter after restart", async () => {
+    const projectDir = await createTempDir("adv-restart-adopter-");
+    tempDirs.push(projectDir);
+
+    await restartCurrentProjectTemporalWorker(projectDir);
+
+    const diag = getOrphanQueueAdoptionDiagnostics();
+    expect(diag).not.toBeNull();
+  });
+});

--- a/plugin/src/plugin-init.orphan-adopter-restart.test.ts
+++ b/plugin/src/plugin-init.orphan-adopter-restart.test.ts
@@ -83,6 +83,7 @@ import {
   getOrphanQueueAdoptionStatus,
   restartCurrentProjectTemporalWorker,
 } from "./plugin-init";
+import { OrphanQueueAdopter } from "./temporal/orphan-queue-adopter";
 
 describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () => {
   let tempDirs: string[] = [];
@@ -163,5 +164,25 @@ describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () =>
     expect(status.enabled).toBe(false);
     expect(status.reason).toBe("no_temporal_client"); // typed, not silent null
     expect(status.diagnostics).toBeNull();
+  });
+
+  test("restart-path adopter is driven by attachment tick driver (AC3)", async () => {
+    const projectDir = await createTempDir("adv-restart-driven-");
+    tempDirs.push(projectDir);
+
+    // Spy on adoptNextOrphan via the real OrphanQueueAdopter prototype.
+    const adoptSpy = vi.spyOn(OrphanQueueAdopter.prototype, "adoptNextOrphan");
+    adoptSpy.mockResolvedValue(undefined);
+
+    // Use fake timers *before* restart so the attachment's setInterval is
+    // created under fake time and can be advanced deterministically.
+    vi.useFakeTimers();
+    await restartCurrentProjectTemporalWorker(projectDir);
+
+    await vi.advanceTimersByTimeAsync(10_500); // one tick
+    vi.useRealTimers();
+
+    expect(adoptSpy).toHaveBeenCalled(); // AC3: tick occurred, not just construction
+    adoptSpy.mockRestore();
   });
 });

--- a/plugin/src/plugin-init.orphan-adopter-restart.test.ts
+++ b/plugin/src/plugin-init.orphan-adopter-restart.test.ts
@@ -42,9 +42,10 @@ vi.mock("node:fs", async () => {
 });
 
 vi.mock("./utils/project-id", async () => {
-  const actual = await vi.importActual<typeof import("./utils/project-id")>(
-    "./utils/project-id",
-  );
+  const actual =
+    await vi.importActual<typeof import("./utils/project-id")>(
+      "./utils/project-id",
+    );
   return {
     ...actual,
     getProjectId: mocks.getProjectId,
@@ -79,6 +80,7 @@ vi.mock("./temporal/service", () => ({
 
 import {
   getOrphanQueueAdoptionDiagnostics,
+  getOrphanQueueAdoptionStatus,
   restartCurrentProjectTemporalWorker,
 } from "./plugin-init";
 
@@ -147,5 +149,19 @@ describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () =>
 
     const diag = getOrphanQueueAdoptionDiagnostics();
     expect(diag).not.toBeNull();
+  });
+
+  test("restart with no temporal client reports typed unavailable adoption (AC10)", async () => {
+    mocks.getService.mockReturnValue(null); // no STSL bundle
+
+    const projectDir = await createTempDir("adv-restart-no-client-");
+    tempDirs.push(projectDir);
+
+    await restartCurrentProjectTemporalWorker(projectDir);
+
+    const status = getOrphanQueueAdoptionStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toBe("no_temporal_client"); // typed, not silent null
+    expect(status.diagnostics).toBeNull();
   });
 });

--- a/plugin/src/plugin-init.orphan-adopter-restart.test.ts
+++ b/plugin/src/plugin-init.orphan-adopter-restart.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
     queues: ["adv-test-queue"],
     shutdown: vi.fn(async () => {}),
   } as const,
+  shouldThrowConstruction: false,
 }));
 
 vi.mock("node:fs", async () => {
@@ -78,9 +79,26 @@ vi.mock("./temporal/service", () => ({
   closeStsl: mocks.closeStsl,
 }));
 
+vi.mock("./temporal/orphan-queue-adopter", async () => {
+  const actual =
+    await vi.importActual<typeof import("./temporal/orphan-queue-adopter")>(
+      "./temporal/orphan-queue-adopter",
+    );
+  class MockOrphanQueueAdopter extends actual.OrphanQueueAdopter {
+    constructor(options: ConstructorParameters<typeof actual.OrphanQueueAdopter>[0]) {
+      if (mocks.shouldThrowConstruction) {
+        throw new Error("construction failure");
+      }
+      super(options);
+    }
+  }
+  return { ...actual, OrphanQueueAdopter: MockOrphanQueueAdopter };
+});
+
 import {
   getOrphanQueueAdoptionDiagnostics,
   getOrphanQueueAdoptionStatus,
+  getWorkerAdoptionAttachmentCount,
   restartCurrentProjectTemporalWorker,
 } from "./plugin-init";
 import { OrphanQueueAdopter } from "./temporal/orphan-queue-adopter";
@@ -184,5 +202,87 @@ describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () =>
 
     expect(adoptSpy).toHaveBeenCalled(); // AC3: tick occurred, not just construction
     adoptSpy.mockRestore();
+  });
+
+  test("driver tick error is recorded and driver continues (C7)", async () => {
+    const projectDir = await createTempDir("adv-restart-driver-error-");
+    tempDirs.push(projectDir);
+
+    const adoptSpy = vi
+      .spyOn(OrphanQueueAdopter.prototype, "adoptNextOrphan")
+      .mockRejectedValueOnce(new Error("tick failure"));
+
+    vi.useFakeTimers();
+    await restartCurrentProjectTemporalWorker(projectDir);
+
+    await vi.advanceTimersByTimeAsync(10_500);
+    const status = getOrphanQueueAdoptionStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toMatch(/^driver_error: tick failure/);
+
+    // Driver interval is still alive — C3 fail-soft.
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.useRealTimers();
+    adoptSpy.mockRestore();
+  });
+
+  test("adopter construction failure does not break worker startup (C3)", async () => {
+    const projectDir = await createTempDir("adv-restart-construction-fail-");
+    tempDirs.push(projectDir);
+
+    mocks.shouldThrowConstruction = true;
+
+    await expect(
+      restartCurrentProjectTemporalWorker(projectDir),
+    ).resolves.toBeDefined();
+
+    const status = getOrphanQueueAdoptionStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toMatch(/^construction_failed: construction failure/);
+    expect(getOrphanQueueAdoptionDiagnostics()).toBeNull();
+
+    mocks.shouldThrowConstruction = false;
+  });
+
+  test("consecutive restarts do not leak adoption attachments or timers (AC9)", async () => {
+    const projectDir = await createTempDir("adv-restart-no-leak-");
+    tempDirs.push(projectDir);
+
+    vi.useFakeTimers();
+
+    for (let i = 0; i < 3; i++) {
+      await restartCurrentProjectTemporalWorker(projectDir);
+      expect(getWorkerAdoptionAttachmentCount()).toBe(1);
+      expect(vi.getTimerCount()).toBe(1);
+    }
+
+    expect(getWorkerAdoptionAttachmentCount()).toBe(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.useRealTimers();
+  });
+
+  test("drain stops driver before worker shutdown (C6)", async () => {
+    const projectDir = await createTempDir("adv-restart-drain-order-");
+    tempDirs.push(projectDir);
+
+    vi.useFakeTimers();
+
+    await restartCurrentProjectTemporalWorker(projectDir);
+    expect(vi.getTimerCount()).toBe(1);
+
+    mocks.fakeWorker.shutdown.mockImplementation(async () => {
+      // When shutdown is invoked, the old driver must already be cleared.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    await restartCurrentProjectTemporalWorker(projectDir);
+    expect(mocks.fakeWorker.shutdown).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(1); // new driver scheduled after restart
+
+    vi.useRealTimers();
+    mocks.fakeWorker.shutdown.mockReset();
+    mocks.fakeWorker.shutdown.mockResolvedValue(undefined);
   });
 });

--- a/plugin/src/plugin-init.orphan-adopter-restart.test.ts
+++ b/plugin/src/plugin-init.orphan-adopter-restart.test.ts
@@ -97,6 +97,7 @@ vi.mock("./temporal/orphan-queue-adopter", async () => {
 });
 
 import {
+  __drainInProcessTemporalWorkersForTest,
   attachWorkerWithAdoption,
   getOrphanQueueAdoptionDiagnostics,
   getOrphanQueueAdoptionStatus,
@@ -287,6 +288,27 @@ describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () =>
     vi.useRealTimers();
     mocks.fakeWorker.shutdown.mockReset();
     mocks.fakeWorker.shutdown.mockResolvedValue(undefined);
+  });
+
+  test("teardown clears adoption state — no stale active after drain (AC5/AC9)", async () => {
+    const projectDir = await createTempDir("adv-teardown-state-");
+    tempDirs.push(projectDir);
+
+    vi.useFakeTimers();
+
+    await restartCurrentProjectTemporalWorker(projectDir);
+    expect(getOrphanQueueAdoptionStatus().enabled).toBe(true);
+    expect(getWorkerAdoptionAttachmentCount()).toBe(1);
+
+    await __drainInProcessTemporalWorkersForTest();
+
+    const status = getOrphanQueueAdoptionStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toBe("no_worker_attached");
+    expect(status.diagnostics).toBeNull();
+    expect(getWorkerAdoptionAttachmentCount()).toBe(0);
+
+    vi.useRealTimers();
   });
 
   test("AC7: attachWorkerWithAdoption keeps only one active adopter", async () => {

--- a/plugin/src/plugin-init.orphan-adopter-restart.test.ts
+++ b/plugin/src/plugin-init.orphan-adopter-restart.test.ts
@@ -80,12 +80,13 @@ vi.mock("./temporal/service", () => ({
 }));
 
 vi.mock("./temporal/orphan-queue-adopter", async () => {
-  const actual =
-    await vi.importActual<typeof import("./temporal/orphan-queue-adopter")>(
-      "./temporal/orphan-queue-adopter",
-    );
+  const actual = await vi.importActual<
+    typeof import("./temporal/orphan-queue-adopter")
+  >("./temporal/orphan-queue-adopter");
   class MockOrphanQueueAdopter extends actual.OrphanQueueAdopter {
-    constructor(options: ConstructorParameters<typeof actual.OrphanQueueAdopter>[0]) {
+    constructor(
+      options: ConstructorParameters<typeof actual.OrphanQueueAdopter>[0],
+    ) {
       if (mocks.shouldThrowConstruction) {
         throw new Error("construction failure");
       }
@@ -96,12 +97,14 @@ vi.mock("./temporal/orphan-queue-adopter", async () => {
 });
 
 import {
+  attachWorkerWithAdoption,
   getOrphanQueueAdoptionDiagnostics,
   getOrphanQueueAdoptionStatus,
   getWorkerAdoptionAttachmentCount,
   restartCurrentProjectTemporalWorker,
 } from "./plugin-init";
 import { OrphanQueueAdopter } from "./temporal/orphan-queue-adopter";
+import type { InProcessWorker } from "./temporal/in-process-worker";
 
 describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () => {
   let tempDirs: string[] = [];
@@ -284,5 +287,57 @@ describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () =>
     vi.useRealTimers();
     mocks.fakeWorker.shutdown.mockReset();
     mocks.fakeWorker.shutdown.mockResolvedValue(undefined);
+  });
+
+  test("AC7: attachWorkerWithAdoption keeps only one active adopter", async () => {
+    vi.useFakeTimers();
+
+    const workerOne: InProcessWorker = {
+      queues: ["adv-test-queue-one"],
+      shutdown: vi.fn(async () => {}),
+      registerQueue: vi.fn(async () => {}),
+    };
+    const workerTwo: InProcessWorker = {
+      queues: ["adv-test-queue-two"],
+      shutdown: vi.fn(async () => {}),
+      registerQueue: vi.fn(async () => {}),
+    };
+
+    attachWorkerWithAdoption(workerOne, {
+      projectId: "proj-one",
+      client: {} as any,
+    });
+    attachWorkerWithAdoption(workerTwo, {
+      projectId: "proj-two",
+      client: {} as any,
+    });
+
+    // Only one active adopter exists despite two attachments.
+    expect(getOrphanQueueAdoptionStatus().enabled).toBe(true);
+    expect(getOrphanQueueAdoptionDiagnostics()).not.toBeNull();
+    expect(getWorkerAdoptionAttachmentCount()).toBeGreaterThanOrEqual(1);
+
+    vi.useRealTimers();
+  });
+
+  test("AC8: kill-switch disables adopter construction", async () => {
+    process.env.ADV_ORPHAN_QUEUE_ADOPTION = "0";
+
+    const worker: InProcessWorker = {
+      queues: ["adv-test-queue-kill"],
+      shutdown: vi.fn(async () => {}),
+      registerQueue: vi.fn(async () => {}),
+    };
+
+    attachWorkerWithAdoption(worker, {
+      projectId: "proj-kill",
+      client: {} as any,
+    });
+
+    const status = getOrphanQueueAdoptionStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toBe("kill_switch");
+    expect(status.diagnostics).toBeNull();
+    expect(getOrphanQueueAdoptionDiagnostics()).toBeNull();
   });
 });

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -452,6 +452,7 @@ export async function tryInitStore(
 
     if (worker) {
       try {
+        teardownWorkerAttachment(worker);
         await worker.shutdown();
       } catch (shutdownError) {
         debugLog(
@@ -512,6 +513,10 @@ function teardownWorkerAttachment(worker: InProcessWorker): void {
   if (attachment) {
     attachment.stopDriver?.();
     workerAdoptionAttachments.delete(worker);
+    if (attachment.adopter && attachment.adopter === activeOrphanQueueAdopter) {
+      activeOrphanQueueAdopter = null;
+      adoptionConstructionState = { kind: "not_attempted" };
+    }
   }
 }
 
@@ -808,6 +813,11 @@ async function drainInProcessTemporalWorkers(): Promise<void> {
       }
     }),
   );
+}
+
+/** Test-only accessor to drain workers for teardown-state verification. */
+export async function __drainInProcessTemporalWorkersForTest(): Promise<void> {
+  return drainInProcessTemporalWorkers();
 }
 
 async function drainWorkerLockHeartbeats(): Promise<void> {

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -27,6 +27,7 @@ import {
 import { createOutOfProcessWorker } from "./temporal/out-of-process-worker";
 import {
   OrphanQueueAdopter,
+  describeError,
   isOrphanQueueAdoptionEnabled,
   type OrphanQueueAdoptionDiagnostics,
 } from "./temporal/orphan-queue-adopter";
@@ -487,7 +488,9 @@ export type AdoptionConstructionState =
   | { kind: "not_attempted" }
   | { kind: "active"; adopter: OrphanQueueAdopter }
   | { kind: "unavailable"; reason: string }
-  | { kind: "disabled" };
+  | { kind: "disabled" }
+  | { kind: "driver_error"; lastError: string; since: number }
+  | { kind: "construction_failed"; lastError: string };
 
 let adoptionConstructionState: AdoptionConstructionState = {
   kind: "not_attempted",
@@ -503,6 +506,19 @@ const workerAdoptionAttachments = new Map<
   InProcessWorker,
   WorkerAdoptionAttachment
 >();
+
+function teardownWorkerAttachment(worker: InProcessWorker): void {
+  const attachment = workerAdoptionAttachments.get(worker);
+  if (attachment) {
+    attachment.stopDriver?.();
+    workerAdoptionAttachments.delete(worker);
+  }
+}
+
+/** Test-only accessor for the number of live worker adoption attachments. */
+export function getWorkerAdoptionAttachmentCount(): number {
+  return workerAdoptionAttachments.size;
+}
 
 /**
  * Return orphan-queue adoption diagnostics for adv_doctor +
@@ -540,7 +556,28 @@ export function getOrphanQueueAdoptionStatus(): OrphanQueueAdoptionStatus {
         diagnostics: null,
         reason: "no_worker_attached",
       };
+    case "driver_error":
+      return {
+        enabled: false,
+        diagnostics: null,
+        reason: `driver_error: ${adoptionConstructionState.lastError}`,
+      };
+    case "construction_failed":
+      return {
+        enabled: false,
+        diagnostics: null,
+        reason: `construction_failed: ${adoptionConstructionState.lastError}`,
+      };
   }
+}
+
+function recordAdoptionDriverError(err: unknown): void {
+  adoptionConstructionState = {
+    kind: "driver_error",
+    lastError: describeError(err),
+    since: Date.now(),
+  };
+  debugLog(`Orphan-queue adoption driver error: ${describeError(err)}`);
 }
 
 const exhaustedWorkerDirs = new Set<string>();
@@ -553,7 +590,10 @@ async function handleWorkerExhausted(
   exhaustedWorkerDirs.add(projectStateDir);
 
   recordWorkerRunFailure("<all>", new Error("worker exhausted"));
-  if (worker) inProcessTemporalWorkers.delete(worker);
+  if (worker) {
+    inProcessTemporalWorkers.delete(worker);
+    teardownWorkerAttachment(worker);
+  }
 }
 
 /**
@@ -597,23 +637,35 @@ export function attachWorkerWithAdoption(
     activeOrphanQueueAdopter = null;
     return;
   }
-  const adopter = new OrphanQueueAdopter({
-    client: opts.client,
-    projectId: opts.projectId,
-    worker,
-  });
-  activeOrphanQueueAdopter = adopter;
-  attachment.adopter = adopter;
-  adoptionConstructionState = { kind: "active", adopter };
+  try {
+    const adopter = new OrphanQueueAdopter({
+      client: opts.client,
+      projectId: opts.projectId,
+      worker,
+    });
+    activeOrphanQueueAdopter = adopter;
+    attachment.adopter = adopter;
+    adoptionConstructionState = { kind: "active", adopter };
 
-  // T4: drive the adopter from the attachment itself so both spawn and restart
-  // paths adopt orphans even when there is no worker-lock heartbeat (AC3).
-  // The closure captures this adopter, not the module-level variable that may
-  // be replaced by a later attachment.
-  const driverHandle = setInterval(() => {
-    void adopter.adoptNextOrphan().catch(() => undefined);
-  }, 10_000);
-  attachment.stopDriver = () => clearInterval(driverHandle);
+    // T4: drive the adopter from the attachment itself so both spawn and restart
+    // paths adopt orphans even when there is no worker-lock heartbeat (AC3).
+    // The closure captures this adopter, not the module-level variable that may
+    // be replaced by a later attachment.
+    const driverHandle = setInterval(() => {
+      adopter.adoptNextOrphan().catch((e) => {
+        recordAdoptionDriverError(e);
+      });
+    }, 10_000);
+    attachment.stopDriver = () => clearInterval(driverHandle);
+  } catch (e) {
+    adoptionConstructionState = {
+      kind: "construction_failed",
+      lastError: describeError(e),
+    };
+    activeOrphanQueueAdopter = null;
+    attachment.adopter = null;
+    attachment.stopDriver = null;
+  }
 }
 
 function registerWorkerLockHeartbeat(
@@ -735,6 +787,11 @@ export function getTemporalWorkerAliveness(): boolean {
 async function drainInProcessTemporalWorkers(): Promise<void> {
   const workers = [...inProcessTemporalWorkers];
   inProcessTemporalWorkers.clear();
+  // C6: stop drivers BEFORE shutdown — a driver outliving its worker targets a
+  // drained worker.
+  for (const worker of workers) {
+    teardownWorkerAttachment(worker);
+  }
   await Promise.all(
     workers.map(async (worker) => {
       try {

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -11,6 +11,7 @@
  * createDegradedToolMap) when initError is non-null.
  */
 
+import { Client } from "@temporalio/client";
 import { createStore } from "./storage/store";
 import type { Store } from "./storage/store-types";
 import { loadProjectConfig } from "./storage/json";
@@ -407,19 +408,10 @@ export async function tryInitStore(
         duration_ms: Number((performance.now() - bundleStartedAt).toFixed(3)),
       });
       if (worker) {
-        registerInProcessTemporalWorker(worker);
-        // rq-isolSessionTaskQueue05: instantiate the adopter once worker +
-        // temporalBundle are ready. The heartbeat onBeat calls adoptNextOrphan()
-        // on each tick (10s cadence). Gated by the ADV_ORPHAN_QUEUE_ADOPTION
-        // kill-switch (default ON; "0" disables) — adoption is always-on in
-        // production; the flag is an emergency escape hatch only.
-        if (temporalBundle && isOrphanQueueAdoptionEnabled()) {
-          activeOrphanQueueAdopter = new OrphanQueueAdopter({
-            client: temporalBundle.client,
-            projectId,
-            worker,
-          });
-        }
+        attachWorkerWithAdoption(worker, {
+          projectId,
+          client: temporalBundle?.client ?? null,
+        });
       }
     }
 
@@ -494,6 +486,17 @@ let currentWorkerRole: WorkerRole = "degraded";
 /** Module-level adopter reference for diagnostics + heartbeat callback. */
 let activeOrphanQueueAdopter: OrphanQueueAdopter | null = null;
 
+interface WorkerAdoptionAttachment {
+  worker: InProcessWorker;
+  adopter: OrphanQueueAdopter | null;
+  stopDriver: (() => void) | null;
+}
+
+const workerAdoptionAttachments = new Map<
+  InProcessWorker,
+  WorkerAdoptionAttachment
+>();
+
 /**
  * Return orphan-queue adoption diagnostics for adv_doctor +
  * adv_status health view (rq-isolSessionTaskQueue05 / AC7).
@@ -523,6 +526,35 @@ async function handleWorkerExhausted(
  */
 export function registerInProcessTemporalWorker(worker: InProcessWorker): void {
   inProcessTemporalWorkers.add(worker);
+}
+
+/**
+ * Register a worker and, if a Temporal client is available and orphan-queue
+ * adoption is enabled, attach an `OrphanQueueAdopter`. This is the single
+ * composition helper for worker-creation sites so both spawn and restart paths
+ * can share ownership behavior (T2). T3 will route the restart path through
+ * this helper; T4 will populate `stopDriver`.
+ */
+export function attachWorkerWithAdoption(
+  worker: InProcessWorker,
+  opts: { projectId: string; client: Client | null },
+): void {
+  registerInProcessTemporalWorker(worker);
+  const attachment: WorkerAdoptionAttachment = {
+    worker,
+    adopter: null,
+    stopDriver: null,
+  };
+  workerAdoptionAttachments.set(worker, attachment);
+  if (opts.client && isOrphanQueueAdoptionEnabled()) {
+    const adopter = new OrphanQueueAdopter({
+      client: opts.client,
+      projectId: opts.projectId,
+      worker,
+    });
+    activeOrphanQueueAdopter = adopter;
+    attachment.adopter = adopter;
+  }
 }
 
 function registerWorkerLockHeartbeat(

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -613,10 +613,15 @@ function registerInProcessTemporalWorker(worker: InProcessWorker): void {
  * can share ownership behavior (T2). T3 will route the restart path through
  * this helper. T4 populates `stopDriver` with the attachment tick driver.
  */
+export interface WorkerAdoptionHandle {
+  /** Stop the orphan-queue adoption driver interval, if one was started. */
+  stopDriver: (() => void) | null;
+}
+
 export function attachWorkerWithAdoption(
   worker: InProcessWorker,
   opts: { projectId: string; client: Client | null },
-): void {
+): WorkerAdoptionHandle {
   registerInProcessTemporalWorker(worker);
   const attachment: WorkerAdoptionAttachment = {
     worker,
@@ -627,7 +632,7 @@ export function attachWorkerWithAdoption(
   if (!isOrphanQueueAdoptionEnabled()) {
     adoptionConstructionState = { kind: "disabled" };
     activeOrphanQueueAdopter = null;
-    return;
+    return { stopDriver: null };
   }
   if (!opts.client) {
     adoptionConstructionState = {
@@ -635,7 +640,7 @@ export function attachWorkerWithAdoption(
       reason: "no_temporal_client",
     };
     activeOrphanQueueAdopter = null;
-    return;
+    return { stopDriver: null };
   }
   try {
     const adopter = new OrphanQueueAdopter({
@@ -657,6 +662,7 @@ export function attachWorkerWithAdoption(
       });
     }, 10_000);
     attachment.stopDriver = () => clearInterval(driverHandle);
+    return { stopDriver: attachment.stopDriver };
   } catch (e) {
     adoptionConstructionState = {
       kind: "construction_failed",
@@ -665,6 +671,7 @@ export function attachWorkerWithAdoption(
     activeOrphanQueueAdopter = null;
     attachment.adopter = null;
     attachment.stopDriver = null;
+    return { stopDriver: null };
   }
 }
 

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -299,9 +299,6 @@ export async function tryInitStore(
             // beats must never block on a roll.
             onBeat: () => {
               void workerBundleRollMonitor?.checkNow().catch(() => undefined);
-              void activeOrphanQueueAdopter
-                ?.adoptNextOrphan()
-                .catch(() => undefined);
             },
           });
           registerWorkerLockHeartbeat(workerHeartbeat);
@@ -574,7 +571,7 @@ export function registerInProcessTemporalWorker(worker: InProcessWorker): void {
  * adoption is enabled, attach an `OrphanQueueAdopter`. This is the single
  * composition helper for worker-creation sites so both spawn and restart paths
  * can share ownership behavior (T2). T3 will route the restart path through
- * this helper; T4 will populate `stopDriver`.
+ * this helper. T4 populates `stopDriver` with the attachment tick driver.
  */
 export function attachWorkerWithAdoption(
   worker: InProcessWorker,
@@ -608,6 +605,15 @@ export function attachWorkerWithAdoption(
   activeOrphanQueueAdopter = adopter;
   attachment.adopter = adopter;
   adoptionConstructionState = { kind: "active", adopter };
+
+  // T4: drive the adopter from the attachment itself so both spawn and restart
+  // paths adopt orphans even when there is no worker-lock heartbeat (AC3).
+  // The closure captures this adopter, not the module-level variable that may
+  // be replaced by a later attachment.
+  const driverHandle = setInterval(() => {
+    void adopter.adoptNextOrphan().catch(() => undefined);
+  }, 10_000);
+  attachment.stopDriver = () => clearInterval(driverHandle);
 }
 
 function registerWorkerLockHeartbeat(

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -602,7 +602,7 @@ async function handleWorkerExhausted(
  * process — shutdown is cooperative (`worker.shutdown()` signals drain,
  * `connection.close()` tears down the gRPC channel).
  */
-export function registerInProcessTemporalWorker(worker: InProcessWorker): void {
+function registerInProcessTemporalWorker(worker: InProcessWorker): void {
   inProcessTemporalWorkers.add(worker);
 }
 

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -486,6 +486,16 @@ let currentWorkerRole: WorkerRole = "degraded";
 /** Module-level adopter reference for diagnostics + heartbeat callback. */
 let activeOrphanQueueAdopter: OrphanQueueAdopter | null = null;
 
+export type AdoptionConstructionState =
+  | { kind: "not_attempted" }
+  | { kind: "active"; adopter: OrphanQueueAdopter }
+  | { kind: "unavailable"; reason: string }
+  | { kind: "disabled" };
+
+let adoptionConstructionState: AdoptionConstructionState = {
+  kind: "not_attempted",
+};
+
 interface WorkerAdoptionAttachment {
   worker: InProcessWorker;
   adopter: OrphanQueueAdopter | null;
@@ -503,6 +513,37 @@ const workerAdoptionAttachments = new Map<
  */
 export function getOrphanQueueAdoptionDiagnostics(): OrphanQueueAdoptionDiagnostics | null {
   return activeOrphanQueueAdopter?.getDiagnostics() ?? null;
+}
+
+export interface OrphanQueueAdoptionStatus {
+  enabled: boolean;
+  diagnostics: OrphanQueueAdoptionDiagnostics | null;
+  /** Present when enabled is false — distinguishes kill-switch / no-client / not-attached. */
+  reason?: string;
+}
+
+export function getOrphanQueueAdoptionStatus(): OrphanQueueAdoptionStatus {
+  switch (adoptionConstructionState.kind) {
+    case "active":
+      return {
+        enabled: true,
+        diagnostics: adoptionConstructionState.adopter.getDiagnostics(),
+      };
+    case "unavailable":
+      return {
+        enabled: false,
+        diagnostics: null,
+        reason: adoptionConstructionState.reason,
+      };
+    case "disabled":
+      return { enabled: false, diagnostics: null, reason: "kill_switch" };
+    case "not_attempted":
+      return {
+        enabled: false,
+        diagnostics: null,
+        reason: "no_worker_attached",
+      };
+  }
 }
 
 const exhaustedWorkerDirs = new Set<string>();
@@ -546,15 +587,27 @@ export function attachWorkerWithAdoption(
     stopDriver: null,
   };
   workerAdoptionAttachments.set(worker, attachment);
-  if (opts.client && isOrphanQueueAdoptionEnabled()) {
-    const adopter = new OrphanQueueAdopter({
-      client: opts.client,
-      projectId: opts.projectId,
-      worker,
-    });
-    activeOrphanQueueAdopter = adopter;
-    attachment.adopter = adopter;
+  if (!isOrphanQueueAdoptionEnabled()) {
+    adoptionConstructionState = { kind: "disabled" };
+    activeOrphanQueueAdopter = null;
+    return;
   }
+  if (!opts.client) {
+    adoptionConstructionState = {
+      kind: "unavailable",
+      reason: "no_temporal_client",
+    };
+    activeOrphanQueueAdopter = null;
+    return;
+  }
+  const adopter = new OrphanQueueAdopter({
+    client: opts.client,
+    projectId: opts.projectId,
+    worker,
+  });
+  activeOrphanQueueAdopter = adopter;
+  attachment.adopter = adopter;
+  adoptionConstructionState = { kind: "active", adopter };
 }
 
 function registerWorkerLockHeartbeat(
@@ -825,7 +878,10 @@ export async function restartCurrentProjectTemporalWorker(
         onWorkerExhausted,
       });
   workerRef.current = worker;
-  registerInProcessTemporalWorker(worker);
+  attachWorkerWithAdoption(worker, {
+    projectId,
+    client: getService()?.client ?? null,
+  });
   return {
     projectId,
     queues: [...worker.queues],

--- a/plugin/src/temporal/__tests__/orphan-session-adoption.itest.ts
+++ b/plugin/src/temporal/__tests__/orphan-session-adoption.itest.ts
@@ -19,6 +19,8 @@
  * Covers (integration level):
  *   AC2 — after adoption, a query against the workflow on that queue succeeds.
  *   AC5 — idempotency: a re-scan does not re-register an already-polled queue.
+ *   AC6 — the restart-path seam (attachWorkerWithAdoption) constructs and drives
+ *         the adopter so the orphaned workflow becomes queryable.
  *   AC7 — adoption state surfaces in getDiagnostics().
  */
 import { fileURLToPath } from "node:url";
@@ -31,6 +33,7 @@ import { buildSessionTaskQueue } from "../client";
 import { getChangeStateQuery } from "../messages";
 import type { OrphanListClient } from "../list-orphan-session-queues";
 import { OrphanQueueAdopter } from "../orphan-queue-adopter";
+import { attachWorkerWithAdoption } from "../../plugin-init";
 import { withTimeSkippingTestWorkflowEnvironment } from "./with-test-env";
 
 const workflowsPath = fileURLToPath(
@@ -161,5 +164,98 @@ describe("rq-isolSessionTaskQueue05: orphan session queue adoption (real worker 
         }
       }
     });
+  }, 60_000);
+
+  it("adopts a stranded queue through the restart-path seam (attachWorkerWithAdoption) and the orphaned workflow becomes queryable (AC6)", async () => {
+    const savedAdoptionEnv = process.env.ADV_ORPHAN_QUEUE_ADOPTION;
+    process.env.ADV_ORPHAN_QUEUE_ADOPTION = "1";
+    try {
+      await withTimeSkippingTestWorkflowEnvironment(async (env) => {
+        const sessionQueue = buildSessionTaskQueue(PROJECT_ID, SESSION_ID);
+
+        // 1. Start a change workflow on the session queue with NO poller → orphan.
+        const handle = await env.client.workflow.start("changeWorkflow", {
+          workflowId: `adv/change/${PROJECT_ID}/${CHANGE_ID}`,
+          taskQueue: sessionQueue,
+          args: [makeInput()],
+        });
+
+        // 2. Stubbed enumeration client (test server lacks ListWorkflowExecutions).
+        const stubClient: OrphanListClient = {
+          workflow: {
+            list: async function* () {
+              yield {
+                workflowId: `adv/change/${PROJECT_ID}/${CHANGE_ID}`,
+                taskQueue: sessionQueue,
+                startTime: new Date(),
+                status: { name: "RUNNING" },
+              };
+            },
+          },
+        };
+
+        // 3. Real InProcessWorker: registerQueue creates + runs a real Worker.
+        const polled = new Set<string>();
+        const spawned: Worker[] = [];
+        const worker: import("../in-process-worker").InProcessWorker = {
+          registerQueue: vi.fn(async (queue: string) => {
+            const w = await Worker.create({
+              connection: env.nativeConnection,
+              workflowsPath,
+              taskQueue: queue,
+            });
+            spawned.push(w);
+            polled.add(queue);
+            void w.run().catch(() => undefined);
+            await new Promise((resolve) =>
+              setTimeout(resolve, POLLER_SETTLE_MS),
+            );
+          }),
+          get queues() {
+            return [...polled];
+          },
+          shutdown: async () => {
+            for (const w of spawned) {
+              try {
+                await w.shutdown();
+              } catch {
+                /* best-effort */
+              }
+            }
+          },
+        };
+
+        // 4. Attach via the restart-path seam.
+        const { stopDriver } = attachWorkerWithAdoption(worker, {
+          projectId: PROJECT_ID,
+          client: stubClient as unknown as import("@temporalio/client").Client,
+        });
+
+        // 5. Wait for the 10s driver tick to fire and adoption to complete.
+        await new Promise((resolve) => setTimeout(resolve, 10_500));
+
+        // 6. Sentinel (AC6): the previously-stranded workflow is now queryable.
+        let state: unknown = null;
+        const sentinelDeadline = Date.now() + 10_000;
+        while (state === null && Date.now() < sentinelDeadline) {
+          try {
+            state = await handle.query(getChangeStateQuery);
+          } catch {
+            await new Promise((resolve) => setTimeout(resolve, 200));
+          }
+        }
+        expect(state).toBeTruthy();
+
+        // 7. Cleanup: stop the driver before shutting down the worker.
+        stopDriver?.();
+        await worker.shutdown();
+      });
+    } finally {
+      if (savedAdoptionEnv === undefined) {
+        delete process.env.ADV_ORPHAN_QUEUE_ADOPTION;
+      } else {
+        process.env.ADV_ORPHAN_QUEUE_ADOPTION = savedAdoptionEnv;
+      }
+    }
   }, 60_000);
 });

--- a/plugin/src/temporal/orphan-queue-adopter.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.ts
@@ -81,7 +81,7 @@ function isShutdownError(err: unknown): boolean {
 }
 
 /** Bound an error to a diagnostic-safe string (AC6 lastError surface). */
-function describeError(err: unknown): string {
+export function describeError(err: unknown): string {
   const msg = err instanceof Error ? err.message : String(err);
   return msg.length > 200 ? `${msg.slice(0, 197)}...` : msg;
 }

--- a/plugin/src/tools/doctor.test.ts
+++ b/plugin/src/tools/doctor.test.ts
@@ -24,7 +24,8 @@ const checkAdvSearchAttributesMock = vi.hoisted(() => vi.fn());
 const registerMissingAdvSearchAttributesMock = vi.hoisted(() => vi.fn());
 const restartCurrentProjectTemporalWorkerMock = vi.hoisted(() => vi.fn());
 const getTemporalWorkerDiagnosticsMock = vi.hoisted(() => vi.fn());
-const getOrphanQueueAdoptionDiagnosticsMock = vi.hoisted(() => vi.fn());
+const getTemporalWorkerAlivenessMock = vi.hoisted(() => vi.fn());
+const getOrphanQueueAdoptionStatusMock = vi.hoisted(() => vi.fn());
 const probeTaskQueuePollersMock = vi.hoisted(() => vi.fn());
 const getProjectIdMock = vi.hoisted(() => vi.fn());
 
@@ -47,9 +48,9 @@ vi.mock("../temporal/observability", () => ({
 vi.mock("../plugin-init", () => ({
   ensureProjectTemporalQueue: vi.fn(),
   getRegisteredTemporalWorkerQueues: vi.fn(() => []),
-  getTemporalWorkerAliveness: vi.fn(),
+  getTemporalWorkerAliveness: getTemporalWorkerAlivenessMock,
   getTemporalWorkerDiagnostics: getTemporalWorkerDiagnosticsMock,
-  getOrphanQueueAdoptionDiagnostics: getOrphanQueueAdoptionDiagnosticsMock,
+  getOrphanQueueAdoptionStatus: getOrphanQueueAdoptionStatusMock,
   restartCurrentProjectTemporalWorker: restartCurrentProjectTemporalWorkerMock,
 }));
 
@@ -133,7 +134,12 @@ function setHealthy() {
       ],
     },
   ]);
-  getOrphanQueueAdoptionDiagnosticsMock.mockReturnValue(null);
+  getOrphanQueueAdoptionStatusMock.mockReturnValue({
+    enabled: false,
+    diagnostics: null,
+    reason: "no_worker_attached",
+  });
+  getTemporalWorkerAlivenessMock.mockReturnValue(false);
   checkAdvSearchAttributesMock.mockResolvedValue({
     ok: true,
     present: [{ name: "AdvChangeId" }, { name: "AdvChangeStatus" }],
@@ -179,28 +185,111 @@ describe("adv_doctor", () => {
     expect(parsed.verification.healthy).toBe(true);
   });
 
+  test("AC4: worker alive but adoption unavailable adds unhealthy finding", async () => {
+    getTemporalWorkerAlivenessMock.mockReturnValue(true);
+    getOrphanQueueAdoptionStatusMock.mockReturnValue({
+      enabled: false,
+      diagnostics: null,
+      reason: "no_temporal_client",
+    });
+
+    const result = await doctorTools.adv_doctor.execute({}, makeStore());
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          class: "unhealthy",
+          finding: "orphan_queue_adoption_not_active",
+          detail: "no_temporal_client",
+        }),
+      ]),
+    );
+  });
+
+  test("AC4: driver_error reason is also flagged as unhealthy", async () => {
+    getTemporalWorkerAlivenessMock.mockReturnValue(true);
+    getOrphanQueueAdoptionStatusMock.mockReturnValue({
+      enabled: false,
+      diagnostics: null,
+      reason: "driver_error: tick failure",
+    });
+
+    const result = await doctorTools.adv_doctor.execute({}, makeStore());
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          class: "unhealthy",
+          finding: "orphan_queue_adoption_not_active",
+        }),
+      ]),
+    );
+  });
+
+  test("AC4: kill_switch is not flagged as unhealthy", async () => {
+    getTemporalWorkerAlivenessMock.mockReturnValue(true);
+    getOrphanQueueAdoptionStatusMock.mockReturnValue({
+      enabled: false,
+      diagnostics: null,
+      reason: "kill_switch",
+    });
+
+    const result = await doctorTools.adv_doctor.execute({}, makeStore());
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.findings).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ class: "unhealthy" })]),
+    );
+  });
+
+  test("AC5: no worker alive with no adoption is healthy (no adoption-related unhealthy finding)", async () => {
+    getTemporalWorkerAlivenessMock.mockReturnValue(false);
+    getOrphanQueueAdoptionStatusMock.mockReturnValue({
+      enabled: false,
+      diagnostics: null,
+      reason: "no_worker_attached",
+    });
+
+    const result = await doctorTools.adv_doctor.execute({}, makeStore());
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.findings).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ class: "unhealthy" })]),
+    );
+  });
+
   test("renders disabled orphan-queue adoption when no adopter is active", async () => {
     const result = await doctorTools.adv_doctor.execute({}, makeStore());
     const parsed = JSON.parse(result);
 
     expect(parsed.orphan_queue_adoption).toEqual({
       enabled: false,
+      reason: "no_worker_attached",
       note: "orphan-queue adoption: disabled (no active adopter)",
     });
   });
 
   test("renders populated orphan-queue adoption diagnostics", async () => {
-    getOrphanQueueAdoptionDiagnosticsMock.mockReturnValue({
-      scanInFlight: true,
-      trackedQueues: [
-        {
-          queue: "sess_opaque",
-          attemptCount: 2,
-          lastAttemptAt: 100,
-          cooldownUntil: 200,
-          inCooldown: true,
-        },
-      ],
+    getOrphanQueueAdoptionStatusMock.mockReturnValue({
+      enabled: true,
+      diagnostics: {
+        scanInFlight: true,
+        trackedQueues: [
+          {
+            queue: "sess_opaque",
+            attemptCount: 2,
+            lastAttemptAt: 100,
+            cooldownUntil: 200,
+            inCooldown: true,
+          },
+        ],
+      },
     });
 
     const result = await doctorTools.adv_doctor.execute({}, makeStore());
@@ -223,15 +312,18 @@ describe("adv_doctor", () => {
   });
 
   test("caps displayed orphan-queue diagnostics at 50 entries", async () => {
-    getOrphanQueueAdoptionDiagnosticsMock.mockReturnValue({
-      scanInFlight: false,
-      trackedQueues: Array.from({ length: 52 }, (_, index) => ({
-        queue: `sess_${index}`,
-        attemptCount: 3,
-        lastAttemptAt: index,
-        cooldownUntil: 0,
-        inCooldown: false,
-      })),
+    getOrphanQueueAdoptionStatusMock.mockReturnValue({
+      enabled: true,
+      diagnostics: {
+        scanInFlight: false,
+        trackedQueues: Array.from({ length: 52 }, (_, index) => ({
+          queue: `sess_${index}`,
+          attemptCount: 3,
+          lastAttemptAt: index,
+          cooldownUntil: 0,
+          inCooldown: false,
+        })),
+      },
     });
 
     const result = await doctorTools.adv_doctor.execute({}, makeStore());

--- a/plugin/src/tools/doctor.ts
+++ b/plugin/src/tools/doctor.ts
@@ -35,7 +35,8 @@ import {
   registerMissingAdvSearchAttributes,
 } from "../temporal/observability";
 import {
-  getOrphanQueueAdoptionDiagnostics,
+  getOrphanQueueAdoptionStatus,
+  getTemporalWorkerAliveness,
   getTemporalWorkerDiagnostics,
   restartCurrentProjectTemporalWorker,
 } from "../plugin-init";
@@ -62,7 +63,8 @@ export type DoctorFindingClass =
   | "worker_down_owned"
   | "suspect_lock"
   | "ambiguous_ownership"
-  | "phantom_pointer";
+  | "phantom_pointer"
+  | "unhealthy";
 
 /**
  * A safe fix the doctor applied automatically. Bounded evidence per AC9.
@@ -97,6 +99,7 @@ export interface DoctorFixRefused {
 export interface DoctorFinding {
   class: DoctorFindingClass;
   detail: string;
+  finding?: string;
 }
 
 interface DoctorVerification {
@@ -305,7 +308,8 @@ export const doctorTools = {
 
       const serverAlive = health.server_alive === true;
       const stslInitialized = bundle !== null;
-      const orphanQueueAdoption = getOrphanQueueAdoptionDiagnostics();
+      const orphanQueueAdoptionStatus = getOrphanQueueAdoptionStatus();
+      const orphanQueueAdoption = orphanQueueAdoptionStatus.diagnostics;
 
       if (!serverAlive || !stslInitialized) {
         findings.push({
@@ -393,6 +397,20 @@ export const doctorTools = {
             });
           }
         }
+      }
+
+      // AC4: a live worker without active orphan-queue adoption is an
+      // unhealthy condition unless adoption is explicitly disabled.
+      if (
+        getTemporalWorkerAliveness() &&
+        !orphanQueueAdoptionStatus.enabled &&
+        orphanQueueAdoptionStatus.reason !== "kill_switch"
+      ) {
+        findings.push({
+          class: "unhealthy",
+          finding: "orphan_queue_adoption_not_active",
+          detail: orphanQueueAdoptionStatus.reason ?? "unknown",
+        });
       }
 
       if (findings.length === 0) {
@@ -711,22 +729,25 @@ export const doctorTools = {
         fixes_applied: fixesApplied,
         fixes_refused: fixesRefused,
         verification,
-        orphan_queue_adoption: orphanQueueAdoption
+        orphan_queue_adoption: orphanQueueAdoptionStatus.enabled
           ? {
               enabled: true,
-              scanInFlight: orphanQueueAdoption.scanInFlight,
-              trackedQueues: orphanQueueAdoption.trackedQueues.slice(
+              scanInFlight: orphanQueueAdoption!.scanInFlight,
+              trackedQueues: orphanQueueAdoption!.trackedQueues.slice(
                 0,
                 ORPHAN_QUEUE_DIAGNOSTIC_DISPLAY_LIMIT,
               ),
               omittedTrackedQueues: Math.max(
                 0,
-                orphanQueueAdoption.trackedQueues.length -
+                orphanQueueAdoption!.trackedQueues.length -
                   ORPHAN_QUEUE_DIAGNOSTIC_DISPLAY_LIMIT,
               ),
             }
           : {
               enabled: false,
+              ...(orphanQueueAdoptionStatus.reason
+                ? { reason: orphanQueueAdoptionStatus.reason }
+                : {}),
               note: "orphan-queue adoption: disabled (no active adopter)",
             },
         recommendedNextAction:


### PR DESCRIPTION
## Summary

Binds orphan-queue adopter lifecycle to worker lifecycle via a single composition helper (`attachWorkerWithAdoption`). Both production worker-creation paths (plugin-init spawn + `restartCurrentProjectTemporalWorker`) now route through it.

Before: a worker created by `adv_doctor`'s `worker_restart` never got an adopter — workflows stranded on prior-session queues stayed unreachable while doctor reported healthy.

After: wherever a live ADV worker exists, a running adopter is attached, driven (~10s tick), and torn down cleanly. Absent/failing adoption is visible via typed diagnostics and factors into the doctor health verdict.

## Changes

- `plugin/src/plugin-init.ts` — composition root, tick driver, teardown, typed adoption state, init-failure cleanup
- `plugin/src/temporal/orphan-queue-adopter.ts` — `describeError` exported for reuse
- `plugin/src/tools/doctor.ts` — adoption-aware health verdict (AC4/AC5)
- 4 test files covering AC1-AC10 (unit + integration)

## Verification

- 42/42 unit tests pass
- 2/2 integration tests pass (real Temporal time-skipping server)
- typecheck, lint, format clean
- Acceptance review: READY (25/25 contract rows pass)