### PR TITLE
fix(temporal): bound orphan-queue Visibility scan so adoption cannot stall

### DIFF
--- a/plugin/src/temporal/list-orphan-session-queues.ts
+++ b/plugin/src/temporal/list-orphan-session-queues.ts
@@ -37,6 +37,24 @@ export interface OrphanListClient {
       status: { name: string };
     }>;
   };
+  /**
+   * Optional gRPC connection handle. `@temporalio/client` Client satisfies this
+   * structurally.
+   *
+   * This is the ONLY cancellation surface available for Visibility enumeration:
+   * `ListOptions` is `{ pageSize?, query? }` — it carries no `abortSignal` and
+   * no deadline (SDK v1.16). Cancellation is scoped at the connection via
+   * `withAbortSignal`, which cancels ongoing gRPC requests inside `fn`.
+   *
+   * Without this, a Visibility stream that stalls before yielding its first
+   * page cannot be torn down, and each driver tick leaks another stream (#327).
+   */
+  connection?: {
+    withAbortSignal?: <T>(
+      signal: AbortSignal,
+      fn: () => Promise<T>,
+    ) => Promise<T>;
+  };
 }
 
 export interface OrphanSessionQueue {
@@ -44,6 +62,26 @@ export interface OrphanSessionQueue {
   queue: string;
   /** Oldest workflow startTime on this queue (for FIFO sort). */
   oldestStartTime: Date;
+}
+
+export interface ListOrphanSessionQueuesOptions {
+  /**
+   * Cancels the underlying Visibility gRPC calls when aborted (routed through
+   * `client.connection.withAbortSignal`). Also breaks the collection loop.
+   */
+  signal?: AbortSignal;
+  /**
+   * Wall-clock bound checked between yielded records. Partial results are
+   * returned rather than thrown — a truncated orphan list is still adoptable,
+   * and the caller re-enumerates on the next tick.
+   *
+   * NB: this bound only fires between records. A stream that stalls before
+   * yielding anything is the caller's responsibility to bound (see
+   * `OrphanQueueAdopter.enumerateOrphansBounded`).
+   */
+  deadlineMs?: number;
+  /** Injectable clock for deterministic tests. */
+  now?: () => number;
 }
 
 function buildSessionQueuePrefix(projectId: string): string {
@@ -61,7 +99,11 @@ export async function listOrphanSessionQueues(
   client: OrphanListClient,
   projectId: string,
   polledQueues: readonly string[],
+  options: ListOrphanSessionQueuesOptions = {},
 ): Promise<OrphanSessionQueue[]> {
+  const { signal, deadlineMs, now = () => Date.now() } = options;
+  const startedAt = now();
+
   const safeProjectId = escapeVisibilityValue(projectId);
   const query = `AdvAffectedProjects = "${safeProjectId}"`;
 
@@ -69,43 +111,57 @@ export async function listOrphanSessionQueues(
   const sessionPrefix = buildSessionQueuePrefix(projectId);
   const polled = new Set(polledQueues);
 
-  // Collect per-queue oldest startTime
-  const queueOldestStart = new Map<string, Date>();
-  let inspected = 0;
+  const collect = async (): Promise<OrphanSessionQueue[]> => {
+    // Collect per-queue oldest startTime
+    const queueOldestStart = new Map<string, Date>();
+    let inspected = 0;
 
-  for await (const wf of client.workflow.list({ query })) {
-    if (inspected >= INSPECTION_LIMIT) break;
-    inspected++;
+    // `break` (not `return`) so the async iterator's `return()` runs and the
+    // underlying Visibility stream is released rather than left dangling.
+    for await (const wf of client.workflow.list({ query })) {
+      if (signal?.aborted) break;
+      if (deadlineMs !== undefined && now() - startedAt >= deadlineMs) break;
+      if (inspected >= INSPECTION_LIMIT) break;
+      inspected++;
 
-    // Only change workflows (exclude epics)
-    if (!wf.workflowId.startsWith(projectPrefix)) continue;
+      // Only change workflows (exclude epics)
+      if (!wf.workflowId.startsWith(projectPrefix)) continue;
 
-    // Only RUNNING workflows need a poller
-    if (wf.status.name !== "RUNNING") continue;
+      // Only RUNNING workflows need a poller
+      if (wf.status.name !== "RUNNING") continue;
 
-    // Only session-scoped queues can be orphaned
-    if (!wf.taskQueue.startsWith(sessionPrefix)) continue;
+      // Only session-scoped queues can be orphaned
+      if (!wf.taskQueue.startsWith(sessionPrefix)) continue;
 
-    // Skip queues already being polled
-    if (polled.has(wf.taskQueue)) continue;
+      // Skip queues already being polled
+      if (polled.has(wf.taskQueue)) continue;
 
-    // Keep the oldest startTime per queue (for deterministic FIFO sort)
-    const existing = queueOldestStart.get(wf.taskQueue);
-    if (!existing || wf.startTime < existing) {
-      queueOldestStart.set(wf.taskQueue, wf.startTime);
+      // Keep the oldest startTime per queue (for deterministic FIFO sort)
+      const existing = queueOldestStart.get(wf.taskQueue);
+      if (!existing || wf.startTime < existing) {
+        queueOldestStart.set(wf.taskQueue, wf.startTime);
+      }
     }
+
+    // Sort by oldest startTime ascending (FIFO — oldest orphans first)
+    const result = [...queueOldestStart.entries()].map(
+      ([queue, oldestStartTime]) => ({
+        queue,
+        oldestStartTime,
+      }),
+    );
+    result.sort(
+      (a, b) => a.oldestStartTime.getTime() - b.oldestStartTime.getTime(),
+    );
+
+    return result;
+  };
+
+  // Scope the enumeration to the caller's abort signal when the client exposes
+  // a real connection, so aborting actually cancels the in-flight gRPC call.
+  const connection = client.connection;
+  if (signal && typeof connection?.withAbortSignal === "function") {
+    return await connection.withAbortSignal(signal, collect);
   }
-
-  // Sort by oldest startTime ascending (FIFO — oldest orphans first)
-  const result = [...queueOldestStart.entries()].map(
-    ([queue, oldestStartTime]) => ({
-      queue,
-      oldestStartTime,
-    }),
-  );
-  result.sort(
-    (a, b) => a.oldestStartTime.getTime() - b.oldestStartTime.getTime(),
-  );
-
-  return result;
+  return await collect();
 }

--- a/plugin/src/temporal/orphan-queue-adopter.scan-resilience.test.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.scan-resilience.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Regression coverage for the stalled orphan-queue adoption blackout (#327).
+ *
+ * Reported fingerprint: ~17 orphan queues, `scanInFlight: true`, and ALL
+ * `attemptCount: 0` — permanently, while every liveness probe reported healthy
+ * and the last Visibility RPC showed `1 CANCELLED: context canceled`.
+ *
+ * Mechanism: `listOrphanSessionQueues` was awaited OUTSIDE the tick's only
+ * try/catch and had no bound. A Visibility stream that never yielded suspended
+ * the tick forever, so:
+ *   - the `finally` that releases single-flight never ran;
+ *   - the register race (whose timeout is DOWNSTREAM of that await) never began;
+ *   - `recordFailure` never ran, so the attempt counter never advanced.
+ *
+ * These tests pin the bound, the cancellation, and the observability.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { OrphanListClient } from "./list-orphan-session-queues";
+import { listOrphanSessionQueues } from "./list-orphan-session-queues";
+import { OrphanQueueAdopter } from "./orphan-queue-adopter";
+import { resetReadinessState } from "./session-readiness";
+
+const PROJECT = "P";
+const Q1 = "advance-P-sess_aaa";
+const Q2 = "advance-P-sess_bbb";
+const T0 = new Date("2026-07-22T00:00:00Z");
+
+/** Per-tick bound used across these tests; small enough to keep them fast. */
+const TICK_MS = 25;
+
+type VisRecord = {
+  workflowId: string;
+  taskQueue: string;
+  startTime: Date;
+  status: { name: string };
+};
+
+function record(queue: string, startTime = T0): VisRecord {
+  return {
+    workflowId: `adv/change/${PROJECT}/${queue}/wf1`,
+    taskQueue: queue,
+    startTime,
+    status: { name: "RUNNING" },
+  };
+}
+
+/** An async iterable whose first `next()` never settles. */
+function hangingIterable(): AsyncIterable<VisRecord> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => new Promise<IteratorResult<VisRecord>>(() => {}),
+      };
+    },
+  } as AsyncIterable<VisRecord>;
+}
+
+function mockWorker(initialQueues: string[] = []) {
+  const queues = new Set(initialQueues);
+  let registerImpl: (queue: string) => Promise<void> = async (queue) => {
+    queues.add(queue);
+  };
+  const registerQueue = vi.fn((queue: string) => registerImpl(queue));
+  return {
+    registerQueue,
+    setRegisterImpl(fn: (queue: string) => Promise<void>) {
+      registerImpl = fn;
+    },
+    get polledQueues() {
+      return [...queues];
+    },
+  };
+}
+
+function adopterFor(
+  client: OrphanListClient,
+  worker: ReturnType<typeof mockWorker>,
+) {
+  return new OrphanQueueAdopter({
+    client,
+    projectId: PROJECT,
+    worker: {
+      registerQueue: worker.registerQueue,
+      queues: worker.polledQueues,
+    },
+    tickTimeoutMs: TICK_MS,
+  });
+}
+
+beforeEach(() => {
+  resetReadinessState();
+});
+
+describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
+  it("releases single-flight when the Visibility stream never yields", async () => {
+    const worker = mockWorker();
+    const adopter = adopterFor({ workflow: { list: hangingIterable } }, worker);
+
+    await adopter.adoptNextOrphan();
+
+    // The precise regression: the latch must not survive a hung enumeration.
+    expect(adopter.getState().scanInFlight).toBe(false);
+    expect(worker.registerQueue).not.toHaveBeenCalled();
+  });
+
+  it("counts the stall instead of failing silently", async () => {
+    const worker = mockWorker();
+    const adopter = adopterFor({ workflow: { list: hangingIterable } }, worker);
+
+    await adopter.adoptNextOrphan();
+
+    const diag = adopter.getDiagnostics();
+    expect(diag.scanFailureCount).toBe(1);
+    expect(diag.consecutiveScanFailures).toBe(1);
+    expect(diag.lastScanError).toMatch(/timed out/i);
+  });
+
+  it("keeps advancing the failure counter across repeated hung ticks", async () => {
+    const worker = mockWorker();
+    const adopter = adopterFor({ workflow: { list: hangingIterable } }, worker);
+
+    await adopter.adoptNextOrphan();
+    await adopter.adoptNextOrphan();
+    await adopter.adoptNextOrphan();
+
+    // #327's signature was a counter frozen at 0 forever. It must advance.
+    expect(adopter.getDiagnostics().scanFailureCount).toBe(3);
+    expect(adopter.getState().scanInFlight).toBe(false);
+  });
+
+  it("aborts the in-flight Visibility RPC so streams are not leaked per tick", async () => {
+    const worker = mockWorker();
+    let captured: AbortSignal | undefined;
+    const client: OrphanListClient = {
+      workflow: { list: hangingIterable },
+      connection: {
+        withAbortSignal: async (signal, fn) => {
+          captured = signal;
+          return await fn();
+        },
+      },
+    };
+
+    await adopterFor(client, worker).adoptNextOrphan();
+
+    expect(captured).toBeDefined();
+    // ListOptions carries no abortSignal/deadline (SDK v1.16), so the
+    // connection scope is the only teardown path available.
+    expect(captured?.aborted).toBe(true);
+  });
+
+  it("records a scan failure when Visibility rejects with context canceled", async () => {
+    const worker = mockWorker();
+    const client: OrphanListClient = {
+      workflow: {
+        list: () =>
+          ({
+            [Symbol.asyncIterator]() {
+              return {
+                next: () =>
+                  Promise.reject(new Error("1 CANCELLED: context canceled")),
+              };
+            },
+          }) as AsyncIterable<VisRecord>,
+      },
+    };
+
+    const adopter = adopterFor(client, worker);
+    await adopter.adoptNextOrphan();
+
+    expect(adopter.getState().scanInFlight).toBe(false);
+    expect(adopter.getDiagnostics().scanFailureCount).toBe(1);
+    expect(adopter.getDiagnostics().lastScanError).toMatch(/context canceled/i);
+  });
+
+  it("recovers and adopts once enumeration succeeds again", async () => {
+    const worker = mockWorker();
+    let healthy = false;
+    const client: OrphanListClient = {
+      workflow: {
+        list: () =>
+          healthy
+            ? (async function* () {
+                yield record(Q1);
+              })()
+            : hangingIterable(),
+      },
+    };
+
+    const adopter = adopterFor(client, worker);
+    await adopter.adoptNextOrphan();
+    expect(adopter.getDiagnostics().consecutiveScanFailures).toBe(1);
+
+    healthy = true;
+    await adopter.adoptNextOrphan();
+
+    expect(worker.registerQueue).toHaveBeenCalledWith(Q1);
+    const diag = adopter.getDiagnostics();
+    expect(diag.consecutiveScanFailures).toBe(0);
+    expect(diag.lastScanError).toBeUndefined();
+    // Historical total is retained for operator forensics.
+    expect(diag.scanFailureCount).toBe(1);
+  });
+
+  it("counts suppressed shutdown refusals rather than dropping them", async () => {
+    const worker = mockWorker();
+    worker.setRegisterImpl(async () => {
+      throw new Error('Cannot register queue "x" — worker is shutting down');
+    });
+    const client: OrphanListClient = {
+      workflow: {
+        list: () =>
+          (async function* () {
+            yield record(Q1);
+          })(),
+      },
+    };
+
+    const adopter = adopterFor(client, worker);
+    await adopter.adoptNextOrphan();
+
+    const diag = adopter.getDiagnostics();
+    // Suppression must remain non-counting for retries (unchanged contract)...
+    expect(diag.trackedQueues).toHaveLength(0);
+    // ...but must no longer be indistinguishable from "nothing was attempted".
+    expect(diag.suppressedShutdownCount).toBe(1);
+  });
+});
+
+describe("listOrphanSessionQueues — bounded enumeration", () => {
+  it("stops at the deadline and releases the stream via iterator return()", async () => {
+    let now = 1_000;
+    const onReturn = vi.fn();
+    const items = [record(Q1), record(Q2, new Date(T0.getTime() + 5_000))];
+    let index = 0;
+
+    const client: OrphanListClient = {
+      workflow: {
+        list: () =>
+          ({
+            [Symbol.asyncIterator]() {
+              return {
+                next: async () => {
+                  if (index >= items.length) {
+                    return { value: undefined, done: true };
+                  }
+                  const value = items[index++];
+                  // Blow the deadline only from the SECOND record onward, so
+                  // the first is processed and the bound is observed between
+                  // records (not before the first one is ever seen).
+                  if (index > 1) now += 500;
+                  return { value, done: false };
+                },
+                return: async () => {
+                  onReturn();
+                  return { value: undefined, done: true };
+                },
+              };
+            },
+          }) as AsyncIterable<VisRecord>,
+      },
+    };
+
+    const result = await listOrphanSessionQueues(client, PROJECT, [], {
+      deadlineMs: 100,
+      now: () => now,
+    });
+
+    // Partial results are still adoptable; the caller re-enumerates next tick.
+    expect(result.map((r) => r.queue)).toEqual([Q1]);
+    // `break` (not `return`) is what triggers this — it is the stream teardown.
+    expect(onReturn).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await listOrphanSessionQueues(
+      {
+        workflow: {
+          list: () =>
+            (async function* () {
+              yield record(Q1);
+              yield record(Q2);
+            })(),
+        },
+      },
+      PROJECT,
+      [],
+      { signal: controller.signal },
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("routes enumeration through connection.withAbortSignal when available", async () => {
+    const withAbortSignal = vi.fn(
+      async <T>(_s: AbortSignal, fn: () => Promise<T>) => await fn(),
+    );
+    const client: OrphanListClient = {
+      workflow: {
+        list: () =>
+          (async function* () {
+            yield record(Q1);
+          })(),
+      },
+      connection: { withAbortSignal },
+    };
+
+    const result = await listOrphanSessionQueues(client, PROJECT, [], {
+      signal: new AbortController().signal,
+    });
+
+    expect(withAbortSignal).toHaveBeenCalledTimes(1);
+    expect(result.map((r) => r.queue)).toEqual([Q1]);
+  });
+
+  it("skips the connection scope when no signal is supplied (back-compat)", async () => {
+    const withAbortSignal = vi.fn(
+      async <T>(_s: AbortSignal, fn: () => Promise<T>) => await fn(),
+    );
+    const client: OrphanListClient = {
+      workflow: {
+        list: () =>
+          (async function* () {
+            yield record(Q1);
+          })(),
+      },
+      connection: { withAbortSignal },
+    };
+
+    const result = await listOrphanSessionQueues(client, PROJECT, []);
+
+    expect(withAbortSignal).not.toHaveBeenCalled();
+    expect(result.map((r) => r.queue)).toEqual([Q1]);
+  });
+});

--- a/plugin/src/temporal/orphan-queue-adopter.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.ts
@@ -17,7 +17,10 @@
  * surface. Phase B wires this into the heartbeat `onBeat` (env-gated).
  */
 import { listOrphanSessionQueues } from "./list-orphan-session-queues";
-import type { OrphanListClient } from "./list-orphan-session-queues";
+import type {
+  OrphanListClient,
+  OrphanSessionQueue,
+} from "./list-orphan-session-queues";
 import { markStale } from "./session-readiness";
 
 /** Minimal worker shape the coordinator depends on (structural). */
@@ -56,6 +59,21 @@ export interface OrphanQueueAdopterState {
 
 export interface OrphanQueueAdoptionDiagnostics {
   scanInFlight: boolean;
+  /** Total bounded-enumeration failures (timeout or reject) since start. */
+  scanFailureCount: number;
+  /** Consecutive enumeration failures; resets to 0 on any successful scan. */
+  consecutiveScanFailures: number;
+  /** Most recent enumeration failure reason. Cleared on success. */
+  lastScanError?: string;
+  /** Epoch ms the most recent enumeration attempt began. */
+  lastScanStartedAt: number;
+  /** Duration of the most recent enumeration attempt. */
+  lastScanDurationMs: number;
+  /**
+   * Count of shutdown-class register refusals suppressed without a retry bump.
+   * Surfaced so suppression cannot masquerade as "no adoption attempts made".
+   */
+  suppressedShutdownCount: number;
   trackedQueues: Array<{
     queue: string;
     attemptCount: number;
@@ -88,6 +106,38 @@ export function describeError(err: unknown): string {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A `delay` whose timer can be cleared once the race is decided, so a fast
+ * winner does not leave an 8 s timer pending on every driver tick.
+ */
+function cancellableDelay(ms: number): {
+  promise: Promise<void>;
+  cancel: () => void;
+} {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, ms);
+  });
+  return {
+    promise,
+    cancel: () => {
+      if (timer !== undefined) clearTimeout(timer);
+    },
+  };
+}
+
+/**
+ * Raised when Visibility enumeration exceeds the per-tick bound. Typed so the
+ * blackout in #327 (`scanInFlight: true` + `attemptCount: 0`, forever) is a
+ * named, counted condition rather than an invisible suspended await.
+ */
+export class OrphanScanTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`orphan enumeration timed out after ${timeoutMs}ms`);
+    this.name = "OrphanScanTimeoutError";
+  }
 }
 
 /**
@@ -125,6 +175,15 @@ export class OrphanQueueAdopter {
   private scanInFlight = false;
   private readonly perQueueState = new Map<string, PerQueueAdoptionState>();
 
+  // Enumeration-phase health (#327). Tracked separately from per-queue retry
+  // state because a failed scan has no target queue to attribute the failure to.
+  private scanFailureCount = 0;
+  private consecutiveScanFailures = 0;
+  private lastScanError: string | undefined;
+  private lastScanStartedAt = 0;
+  private lastScanDurationMs = 0;
+  private suppressedShutdownCount = 0;
+
   constructor(options: OrphanQueueAdopterOptions) {
     this.client = options.client;
     this.projectId = options.projectId;
@@ -150,11 +209,21 @@ export class OrphanQueueAdopter {
 
   private async runOneAdoptionTick(): Promise<void> {
     // D1 — enumerate + FIFO sort + idempotency against currently-polled queues.
-    const orphans = await listOrphanSessionQueues(
-      this.client,
-      this.projectId,
-      this.worker.queues,
-    );
+    //
+    // R10 (#327) — this await MUST be bounded and caught. Previously it sat
+    // outside the try block below, so a Visibility stream that never yielded
+    // suspended the tick forever: `finally` never ran (scanInFlight stuck true),
+    // the register race never started (its timeout is downstream of this await),
+    // and recordFailure never ran (attemptCount stuck at 0) — a silent blackout
+    // that every liveness probe reported as healthy.
+    let orphans: OrphanSessionQueue[];
+    try {
+      orphans = await this.enumerateOrphansBounded();
+    } catch (err) {
+      this.recordScanFailure(describeError(err));
+      return;
+    }
+    this.recordScanSuccess();
     if (orphans.length === 0) return;
 
     const now = this.now();
@@ -208,10 +277,79 @@ export class OrphanQueueAdopter {
       // (KD5 / AC4). Existing shutdown-error suppression and retry accounting
       // continue unchanged (DONT3).
       markStale(target.queue);
-      // D7 — suppress shutdown-class refusals silently (no retry bump).
-      if (isShutdownError(err)) return;
+      // D7 — suppress shutdown-class refusals (no retry bump), but COUNT them.
+      // Silent suppression is indistinguishable from "no adoption was ever
+      // attempted" in diagnostics, which is precisely the ambiguity that made
+      // #327 hard to classify.
+      if (isShutdownError(err)) {
+        this.suppressedShutdownCount += 1;
+        return;
+      }
       this.recordFailure(target.queue, now, describeError(err));
     }
+  }
+
+  /**
+   * Enumerate orphans under a hard wall-clock bound, cancelling the underlying
+   * Visibility gRPC call if the bound is exceeded.
+   *
+   * The bound is enforced twice, because one alone is insufficient:
+   *  - `deadlineMs` inside the helper breaks the collection loop between
+   *    records — handles a slow/large stream;
+   *  - the race here handles a stream that stalls BEFORE yielding anything,
+   *    which the in-loop check can never observe.
+   *
+   * On timeout the AbortController is fired so the connection cancels the
+   * in-flight request. Without that, each 10 s driver tick would strand another
+   * Visibility stream.
+   */
+  private async enumerateOrphansBounded(): Promise<OrphanSessionQueue[]> {
+    const controller = new AbortController();
+    const timeout = cancellableDelay(this.tickTimeoutMs);
+    this.lastScanStartedAt = this.now();
+
+    const scan = listOrphanSessionQueues(
+      this.client,
+      this.projectId,
+      this.worker.queues,
+      {
+        signal: controller.signal,
+        deadlineMs: this.tickTimeoutMs,
+        now: this.now,
+      },
+    );
+
+    try {
+      const outcome = await Promise.race([
+        scan.then((queues) => ({ ok: true as const, queues })),
+        timeout.promise.then(() => ({ ok: false as const })),
+      ]);
+      if (outcome.ok) return outcome.queues;
+
+      controller.abort();
+      // `Promise.race` already attached handlers to both branches, so a late
+      // rejection cannot surface as an unhandledRejection; this explicit no-op
+      // keeps that guarantee local and obvious.
+      void scan.catch(() => {});
+      throw new OrphanScanTimeoutError(this.tickTimeoutMs);
+    } finally {
+      timeout.cancel();
+    }
+  }
+
+  /** Record a failed enumeration (AC: the stall is counted, not silent). */
+  private recordScanFailure(reason: string): void {
+    this.scanFailureCount += 1;
+    this.consecutiveScanFailures += 1;
+    this.lastScanError = reason;
+    this.lastScanDurationMs = this.now() - this.lastScanStartedAt;
+  }
+
+  /** Clear enumeration failure state after a scan completes. */
+  private recordScanSuccess(): void {
+    this.consecutiveScanFailures = 0;
+    this.lastScanError = undefined;
+    this.lastScanDurationMs = this.now() - this.lastScanStartedAt;
   }
 
   /** Bump attempt count; enter cooldown once the cap is reached (D4 / DDC4-5). */
@@ -244,6 +382,12 @@ export class OrphanQueueAdopter {
     const now = this.now();
     return {
       scanInFlight: this.scanInFlight,
+      scanFailureCount: this.scanFailureCount,
+      consecutiveScanFailures: this.consecutiveScanFailures,
+      lastScanError: this.lastScanError,
+      lastScanStartedAt: this.lastScanStartedAt,
+      lastScanDurationMs: this.lastScanDurationMs,
+      suppressedShutdownCount: this.suppressedShutdownCount,
       trackedQueues: [...this.perQueueState.entries()].map(([queue, s]) => ({
         queue,
         attemptCount: s.attemptCount,


### PR DESCRIPTION
Closes #327.

## Problem

Orphan-queue adoption could suspend **permanently**, leaving every prior-session workflow unreachable while all liveness probes reported healthy.

Reported fingerprint: ~17 orphan queues, `scanInFlight: true`, and **all `attemptCount: 0`** — forever — with `1 CANCELLED: context canceled` on the wire.

## Root cause

`listOrphanSessionQueues` was awaited **outside** `runOneAdoptionTick`'s only `try`/`catch`, with no timeout:

```ts
const orphans = await listOrphanSessionQueues(...);  // L153 — unbounded, uncaught
if (orphans.length === 0) return;
try {
  const outcome = await Promise.race([registerQueue(...), delay(tickTimeoutMs)]);  // L179
```

When the Visibility stream stalled before yielding its first page, the tick never settled:

| Consequence | Why |
|---|---|
| `scanInFlight` stuck `true` | the `finally` releasing single-flight never ran |
| register race never started | its timeout is **downstream** of the hung await |
| `attemptCount` stuck at `0` | `recordFailure` was never reached |
| driver spun uselessly | each 10s tick bounced off the latch and returned |

Every observable in #327 follows from that one misplaced `await`.

## Fix

**Bound the enumeration in two places** — neither suffices alone:

- `deadlineMs` inside the helper breaks the collection loop *between records*, handling slow/large streams. Partial results are still adoptable; the caller re-enumerates next tick.
- A race in `enumerateOrphansBounded` handles a stream that stalls *before yielding anything* — which the in-loop check can never observe.

**Real cancellation, not just a race.** A bare race would release the latch but strand a Visibility stream on every 10s tick. `ListOptions` is only `{ pageSize?, query? }` in SDK v1.16 — no `abortSignal`, no deadline — so teardown routes through `Connection.withAbortSignal`, the only cancellation surface available. Loop exits use `break` (not `return`) so the async iterator's `return()` runs and releases the stream.

**Make the stall observable.** The failure was invisible to diagnostics, which is why it went unclassified:

- `scanFailureCount`, `consecutiveScanFailures`, `lastScanError`, `lastScanStartedAt`, `lastScanDurationMs`
- `suppressedShutdownCount` — shutdown-class suppression was previously indistinguishable from "no adoption was ever attempted"

Also clears the per-tick race timer instead of leaving an 8s timeout pending every tick.

## Verification

- 11 new regression tests in `orphan-queue-adopter.scan-resilience.test.ts` pinning the bound, the abort, the counter advance, recovery, and partial-result semantics.
- 66/66 green across all five related suites (adopter, helper, plugin-init restart, session-readiness).
- `pnpm run check` clean (schemas, typecheck, manifests, frontmatter, isolation, lockfile, lint, format).
- Full-suite baseline comparison against trunk `5106efa9`: **identical** 15 failing files / 56 failing tests on both. **No regression** — those failures are pre-existing and cluster in the disk-projection/read-authority surface currently being migrated by `fixWorkerDependentResume` / `makeToolReadsWorkerFree`.

## Scope

Worker-side signal reachability only. CLI read paths (`fixWorkerDependentResume`) and plugin-tool read paths (`makeToolReadsWorkerFree`) are untouched.