### PR TITLE
fix(doctor): assert orphan-adoption progress instead of mere presence

### DIFF
--- a/plugin/src/temporal/orphan-queue-adopter.scan-resilience.test.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.scan-resilience.test.ts
@@ -17,7 +17,13 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { OrphanListClient } from "./list-orphan-session-queues";
 import { listOrphanSessionQueues } from "./list-orphan-session-queues";
-import { OrphanQueueAdopter } from "./orphan-queue-adopter";
+import {
+  ORPHAN_MAX_CONSECUTIVE_SCAN_FAILURES,
+  ORPHAN_STUCK_SCAN_MS,
+  OrphanQueueAdopter,
+  evaluateOrphanAdoptionHealth,
+  type OrphanQueueAdoptionDiagnostics,
+} from "./orphan-queue-adopter";
 import { resetReadinessState } from "./session-readiness";
 
 const PROJECT = "P";
@@ -334,5 +340,104 @@ describe("listOrphanSessionQueues — bounded enumeration", () => {
 
     expect(withAbortSignal).not.toHaveBeenCalled();
     expect(result.map((r) => r.queue)).toEqual([Q1]);
+  });
+});
+
+describe("evaluateOrphanAdoptionHealth", () => {
+  const NOW = 1_000_000;
+
+  function diag(
+    over: Partial<OrphanQueueAdoptionDiagnostics> = {},
+  ): OrphanQueueAdoptionDiagnostics {
+    return {
+      scanInFlight: false,
+      scanFailureCount: 0,
+      consecutiveScanFailures: 0,
+      lastScanStartedAt: NOW,
+      lastScanDurationMs: 5,
+      suppressedShutdownCount: 0,
+      trackedQueues: [],
+      ...over,
+    };
+  }
+
+  it("reports ok for a healthy snapshot", () => {
+    expect(evaluateOrphanAdoptionHealth(diag(), NOW)).toEqual({ state: "ok" });
+  });
+
+  it("reports ok while a scan is in flight but still within bounds", () => {
+    const health = evaluateOrphanAdoptionHealth(
+      diag({ scanInFlight: true, lastScanStartedAt: NOW - 1_000 }),
+      NOW,
+    );
+    expect(health.state).toBe("ok");
+  });
+
+  it("reports stuck_scan once the latch is held past the bound", () => {
+    const health = evaluateOrphanAdoptionHealth(
+      diag({
+        scanInFlight: true,
+        lastScanStartedAt: NOW - ORPHAN_STUCK_SCAN_MS - 1,
+      }),
+      NOW,
+    );
+    expect(health).toMatchObject({ state: "stuck_scan" });
+    if (health.state === "stuck_scan") {
+      expect(health.stuckForMs).toBeGreaterThanOrEqual(ORPHAN_STUCK_SCAN_MS);
+    }
+  });
+
+  it("does not report stuck_scan when no scan has ever started", () => {
+    const health = evaluateOrphanAdoptionHealth(
+      diag({ scanInFlight: true, lastScanStartedAt: 0 }),
+      NOW,
+    );
+    expect(health.state).toBe("ok");
+  });
+
+  it("reports failing_scans at the consecutive-failure threshold", () => {
+    const health = evaluateOrphanAdoptionHealth(
+      diag({
+        consecutiveScanFailures: ORPHAN_MAX_CONSECUTIVE_SCAN_FAILURES,
+        lastScanError: "1 CANCELLED: context canceled",
+      }),
+      NOW,
+    );
+    expect(health).toMatchObject({
+      state: "failing_scans",
+      lastScanError: "1 CANCELLED: context canceled",
+    });
+  });
+
+  it("stays ok below the consecutive-failure threshold", () => {
+    const health = evaluateOrphanAdoptionHealth(
+      diag({
+        consecutiveScanFailures: ORPHAN_MAX_CONSECUTIVE_SCAN_FAILURES - 1,
+      }),
+      NOW,
+    );
+    expect(health.state).toBe("ok");
+  });
+
+  it("prefers stuck_scan over failing_scans when both hold", () => {
+    const health = evaluateOrphanAdoptionHealth(
+      diag({
+        scanInFlight: true,
+        lastScanStartedAt: NOW - ORPHAN_STUCK_SCAN_MS - 1,
+        consecutiveScanFailures: 99,
+      }),
+      NOW,
+    );
+    // A held latch is the more actionable signal: nothing else can progress.
+    expect(health.state).toBe("stuck_scan");
+  });
+
+  it("honours injected thresholds", () => {
+    const health = evaluateOrphanAdoptionHealth(
+      diag({ consecutiveScanFailures: 1 }),
+      NOW,
+      { maxConsecutiveScanFailures: 1 },
+    );
+    expect(health.state).toBe("failing_scans");
   });
 });

--- a/plugin/src/temporal/orphan-queue-adopter.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.ts
@@ -85,6 +85,72 @@ export interface OrphanQueueAdoptionDiagnostics {
   }>;
 }
 
+/**
+ * Typed adoption health verdict.
+ *
+ * Adoption being *constructed* is not the same as adoption *working*. In #327
+ * the adopter was enabled, live, and completely broken, yet every probe
+ * reported healthy because nothing asserted forward progress. These states
+ * exist so health surfaces can assert progress, not just presence.
+ */
+export type OrphanAdoptionHealth =
+  | { state: "ok" }
+  | { state: "stuck_scan"; stuckForMs: number; lastScanError?: string }
+  | {
+      state: "failing_scans";
+      consecutiveScanFailures: number;
+      lastScanError?: string;
+    };
+
+/**
+ * A scan in flight longer than this is stuck, not merely slow: enumeration and
+ * register are each independently bounded by `tickTimeoutMs` (8 s default), so
+ * roughly three driver ticks without settling means the latch is held.
+ */
+export const ORPHAN_STUCK_SCAN_MS = 30_000;
+
+/** Consecutive failed enumerations before adoption is declared unhealthy. */
+export const ORPHAN_MAX_CONSECUTIVE_SCAN_FAILURES = 3;
+
+/**
+ * Pure predicate over a diagnostics snapshot. Single source of truth so
+ * `adv_doctor` and `adv_status view:health` cannot drift apart.
+ */
+export function evaluateOrphanAdoptionHealth(
+  diagnostics: OrphanQueueAdoptionDiagnostics,
+  now: number,
+  opts: { stuckScanMs?: number; maxConsecutiveScanFailures?: number } = {},
+): OrphanAdoptionHealth {
+  const stuckScanMs = opts.stuckScanMs ?? ORPHAN_STUCK_SCAN_MS;
+  const maxFailures =
+    opts.maxConsecutiveScanFailures ?? ORPHAN_MAX_CONSECUTIVE_SCAN_FAILURES;
+
+  if (diagnostics.scanInFlight && diagnostics.lastScanStartedAt > 0) {
+    const stuckForMs = now - diagnostics.lastScanStartedAt;
+    if (stuckForMs >= stuckScanMs) {
+      return {
+        state: "stuck_scan",
+        stuckForMs,
+        ...(diagnostics.lastScanError
+          ? { lastScanError: diagnostics.lastScanError }
+          : {}),
+      };
+    }
+  }
+
+  if (diagnostics.consecutiveScanFailures >= maxFailures) {
+    return {
+      state: "failing_scans",
+      consecutiveScanFailures: diagnostics.consecutiveScanFailures,
+      ...(diagnostics.lastScanError
+        ? { lastScanError: diagnostics.lastScanError }
+        : {}),
+    };
+  }
+
+  return { state: "ok" };
+}
+
 const DEFAULT_TICK_TIMEOUT_MS = 8_000;
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_COOLDOWN_MS = 5 * 60_000;

--- a/plugin/src/tools/doctor.test.ts
+++ b/plugin/src/tools/doctor.test.ts
@@ -280,6 +280,11 @@ describe("adv_doctor", () => {
       enabled: true,
       diagnostics: {
         scanInFlight: true,
+        scanFailureCount: 0,
+        consecutiveScanFailures: 0,
+        lastScanStartedAt: Date.now(),
+        lastScanDurationMs: 12,
+        suppressedShutdownCount: 0,
         trackedQueues: [
           {
             queue: "sess_opaque",
@@ -298,6 +303,12 @@ describe("adv_doctor", () => {
     expect(parsed.orphan_queue_adoption).toEqual({
       enabled: true,
       scanInFlight: true,
+      health: "ok",
+      scanFailureCount: 0,
+      consecutiveScanFailures: 0,
+      lastScanStartedAt: expect.any(Number),
+      lastScanDurationMs: 12,
+      suppressedShutdownCount: 0,
       trackedQueues: [
         {
           queue: "sess_opaque",
@@ -309,6 +320,65 @@ describe("adv_doctor", () => {
       ],
       omittedTrackedQueues: 0,
     });
+  });
+
+  test("reports UNHEALTHY when adoption scans are repeatedly failing (#327)", async () => {
+    getOrphanQueueAdoptionStatusMock.mockReturnValue({
+      enabled: true,
+      diagnostics: {
+        scanInFlight: false,
+        scanFailureCount: 9,
+        consecutiveScanFailures: 4,
+        lastScanError: "1 CANCELLED: context canceled",
+        lastScanStartedAt: Date.now(),
+        lastScanDurationMs: 8000,
+        suppressedShutdownCount: 0,
+        trackedQueues: [],
+      },
+    });
+
+    const result = await doctorTools.adv_doctor.execute({}, makeStore());
+    const parsed = JSON.parse(result);
+
+    // The regression that mattered: doctor previously said "healthy" here.
+    expect(parsed.orphan_queue_adoption.health).toBe("failing_scans");
+    expect(
+      parsed.findings.some(
+        (f: { class: string }) => f.class === "orphan_queue_adoption_degraded",
+      ),
+    ).toBe(true);
+    expect(
+      parsed.findings.some((f: { class: string }) => f.class === "healthy"),
+    ).toBe(false);
+    expect(parsed.success).toBe(false);
+  });
+
+  test("reports UNHEALTHY when an adoption scan is stuck in flight (#327)", async () => {
+    getOrphanQueueAdoptionStatusMock.mockReturnValue({
+      enabled: true,
+      diagnostics: {
+        // The exact #327 fingerprint: latch held, counter frozen at zero.
+        scanInFlight: true,
+        scanFailureCount: 0,
+        consecutiveScanFailures: 0,
+        lastScanStartedAt: Date.now() - 120_000,
+        lastScanDurationMs: 0,
+        suppressedShutdownCount: 0,
+        trackedQueues: [],
+      },
+    });
+
+    const result = await doctorTools.adv_doctor.execute({}, makeStore());
+    const parsed = JSON.parse(result);
+
+    expect(parsed.orphan_queue_adoption.health).toBe("stuck_scan");
+    const degraded = parsed.findings.find(
+      (f: { class: string }) => f.class === "orphan_queue_adoption_degraded",
+    );
+    expect(degraded).toBeDefined();
+    expect(degraded.finding).toBe("stuck_scan");
+    expect(degraded.detail).toMatch(/unreachable/i);
+    expect(parsed.success).toBe(false);
   });
 
   test("caps displayed orphan-queue diagnostics at 50 entries", async () => {

--- a/plugin/src/tools/doctor.ts
+++ b/plugin/src/tools/doctor.ts
@@ -41,6 +41,7 @@ import {
   restartCurrentProjectTemporalWorker,
 } from "../plugin-init";
 import { probeTaskQueuePollers } from "../temporal/queue-serviceability";
+import { evaluateOrphanAdoptionHealth } from "../temporal/orphan-queue-adopter";
 import { buildProjectTaskQueue } from "../temporal/client";
 import { basename, join } from "path";
 import { existsSync } from "fs";
@@ -64,6 +65,7 @@ export type DoctorFindingClass =
   | "suspect_lock"
   | "ambiguous_ownership"
   | "phantom_pointer"
+  | "orphan_queue_adoption_degraded"
   | "unhealthy";
 
 /**
@@ -413,6 +415,30 @@ export const doctorTools = {
         });
       }
 
+      // A constructed adopter is not a working adopter. The AC4 check above
+      // only asks whether an adopter EXISTS; #327 ran enabled and live while
+      // every probe reported healthy, because nothing asserted that scans were
+      // completing. Assert forward progress, not just presence.
+      if (orphanQueueAdoptionStatus.enabled && orphanQueueAdoption) {
+        const adoptionHealth = evaluateOrphanAdoptionHealth(
+          orphanQueueAdoption,
+          Date.now(),
+        );
+        if (adoptionHealth.state !== "ok") {
+          const because = adoptionHealth.lastScanError
+            ? `; last error: ${adoptionHealth.lastScanError}`
+            : "";
+          findings.push({
+            class: "orphan_queue_adoption_degraded",
+            finding: adoptionHealth.state,
+            detail:
+              adoptionHealth.state === "stuck_scan"
+                ? `orphan enumeration in flight ${adoptionHealth.stuckForMs}ms without settling — prior-session workflows are unreachable${because}`
+                : `${adoptionHealth.consecutiveScanFailures} consecutive orphan enumeration failures — prior-session workflows may be unreachable${because}`,
+          });
+        }
+      }
+
       if (findings.length === 0) {
         findings.push({ class: "healthy", detail: "All checks passed" });
       }
@@ -733,6 +759,21 @@ export const doctorTools = {
           ? {
               enabled: true,
               scanInFlight: orphanQueueAdoption!.scanInFlight,
+              // Enumeration-phase health. Without these an operator cannot
+              // distinguish "adoption is working" from "adoption is silently
+              // failing" — the ambiguity that made #327 hard to classify.
+              health: evaluateOrphanAdoptionHealth(
+                orphanQueueAdoption!,
+                Date.now(),
+              ).state,
+              scanFailureCount: orphanQueueAdoption!.scanFailureCount,
+              consecutiveScanFailures:
+                orphanQueueAdoption!.consecutiveScanFailures,
+              lastScanError: orphanQueueAdoption!.lastScanError,
+              lastScanStartedAt: orphanQueueAdoption!.lastScanStartedAt,
+              lastScanDurationMs: orphanQueueAdoption!.lastScanDurationMs,
+              suppressedShutdownCount:
+                orphanQueueAdoption!.suppressedShutdownCount,
               trackedQueues: orphanQueueAdoption!.trackedQueues.slice(
                 0,
                 ORPHAN_QUEUE_DIAGNOSTIC_DISPLAY_LIMIT,

--- a/plugin/src/tools/status-health.session-queue.test.ts
+++ b/plugin/src/tools/status-health.session-queue.test.ts
@@ -161,6 +161,11 @@ describe("computeStatusQueueServiceability multi-queue (rq-isolSessionTaskQueue0
   it("summarizes orphan-queue adoption state without exposing queue identifiers", async () => {
     mockGetOrphanQueueAdoptionDiagnostics.mockReturnValue({
       scanInFlight: false,
+      scanFailureCount: 0,
+      consecutiveScanFailures: 0,
+      lastScanStartedAt: Date.now(),
+      lastScanDurationMs: 7,
+      suppressedShutdownCount: 0,
       trackedQueues: [
         { queue: "sess_a", inCooldown: true },
         { queue: "sess_b", inCooldown: false },
@@ -177,6 +182,36 @@ describe("computeStatusQueueServiceability multi-queue (rq-isolSessionTaskQueue0
       enabled: true,
       tracked: 3,
       inCooldown: 2,
+      health: "ok",
+      consecutiveScanFailures: 0,
+      lastScanError: undefined,
+    });
+    // The summary must stay identifier-free.
+    expect(JSON.stringify(result?.orphanQueueAdoption)).not.toContain("sess_");
+  });
+
+  it("surfaces degraded adoption health so a blackout is not reported as fine (#327)", async () => {
+    mockGetOrphanQueueAdoptionDiagnostics.mockReturnValue({
+      scanInFlight: false,
+      scanFailureCount: 12,
+      consecutiveScanFailures: 5,
+      lastScanError: "1 CANCELLED: context canceled",
+      lastScanStartedAt: Date.now(),
+      lastScanDurationMs: 8000,
+      suppressedShutdownCount: 0,
+      trackedQueues: [],
+    });
+
+    const result = await computeStatusQueueServiceability({
+      projectId: "proj-status-test-004b",
+      health: { ...HEALTH },
+    });
+
+    expect(result?.orphanQueueAdoption).toMatchObject({
+      enabled: true,
+      health: "failing_scans",
+      consecutiveScanFailures: 5,
+      lastScanError: "1 CANCELLED: context canceled",
     });
   });
 

--- a/plugin/src/tools/status-health.ts
+++ b/plugin/src/tools/status-health.ts
@@ -22,6 +22,7 @@ import {
   probeTaskQueuePollers,
   type QueueServiceability,
 } from "../temporal/queue-serviceability";
+import { evaluateOrphanAdoptionHealth } from "../temporal/orphan-queue-adopter";
 import { getTemporalFallbackTelemetry } from "../temporal/fallback-telemetry";
 import {
   getService,
@@ -385,6 +386,16 @@ export async function computeStatusQueueServiceability(input: {
         inCooldown: orphanQueueAdoptionDiagnostics.trackedQueues.filter(
           (queue) => queue.inCooldown,
         ).length,
+        // Presence of an adopter says nothing about whether it is making
+        // progress (#327). Carry the typed verdict so health consumers can
+        // branch on it without re-deriving thresholds.
+        health: evaluateOrphanAdoptionHealth(
+          orphanQueueAdoptionDiagnostics,
+          Date.now(),
+        ).state,
+        consecutiveScanFailures:
+          orphanQueueAdoptionDiagnostics.consecutiveScanFailures,
+        lastScanError: orphanQueueAdoptionDiagnostics.lastScanError,
       }
     : null;
   const bundle = getService();


### PR DESCRIPTION
Follow-up to #338. Refs #327.

## Problem

`adv_doctor`'s AC4 check only asked **"does an adopter exist?"** — never **"is it working?"**

In #327 the adopter was enabled, live, and completely broken. Every probe reported `healthy`, `server_alive`, `worker_alive`, `queue_serviceable`. Meanwhile no prior-session workflow was reachable. Nothing asserted forward progress.

Separately, #338 added enumeration-health counters to `OrphanQueueAdoptionDiagnostics`, but both health surfaces build their output by hand and silently dropped every one of them — the data existed and no operator could see it.

## Fix

`evaluateOrphanAdoptionHealth` — a pure predicate over a diagnostics snapshot, owned beside the adopter so `adv_doctor` and `adv_status view:health` cannot drift apart:

| State | Trigger |
|---|---|
| `stuck_scan` | latch held >30s (~3 driver ticks; enumeration and register are each bounded at 8s, so this means genuinely stuck) |
| `failing_scans` | 3+ consecutive enumeration failures |
| `ok` | otherwise |

Wired into both surfaces:

- **`adv_doctor`** emits an `orphan_queue_adoption_degraded` finding, which makes `success: false`. The doctor now **fails during a blackout** instead of reporting "All checks passed".
- **`adv_doctor` output** carries `scanFailureCount`, `consecutiveScanFailures`, `lastScanError`, `lastScanStartedAt`, `lastScanDurationMs`, `suppressedShutdownCount`.
- **`adv_status view:health`** carries the typed verdict plus failure context, still free of queue identifiers (asserted).

`stuck_scan` takes precedence over `failing_scans` — a held latch is the more actionable signal, since nothing else can progress behind it.

## Verification

- 8 new unit tests for the predicate (thresholds, precedence, injected bounds, never-scanned guard).
- 2 new `adv_doctor` tests reproducing the exact #327 fingerprint (latch held + counter frozen at zero) and asserting `success: false`.
- 1 new `adv_status view:health` degraded test.
- 83/83 green across the six related suites; `pnpm run check` clean.
- Two existing `toEqual` shape assertions updated deliberately, since the output shape intentionally grew.

## Note

The `lastError` field I previously suspected was being dropped is **not** — `trackedQueues.slice()` passes whole objects through. It was simply `undefined` because every adoption had succeeded.