### PR TITLE
perf(temporal): adopt orphan queues in bounded batches per tick

### DIFF
--- a/plugin/src/temporal/orphan-queue-adopter.scan-resilience.test.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.scan-resilience.test.ts
@@ -441,3 +441,142 @@ describe("evaluateOrphanAdoptionHealth", () => {
     expect(health.state).toBe("failing_scans");
   });
 });
+
+describe("OrphanQueueAdopter — batched adoption", () => {
+  const many = Array.from({ length: 12 }, (_, i) => `advance-P-sess_q${i}`);
+
+  function clientWith(queues: string[]): OrphanListClient {
+    return {
+      workflow: {
+        list: () =>
+          (async function* () {
+            for (let i = 0; i < queues.length; i++) {
+              yield record(queues[i], new Date(T0.getTime() + i * 1000));
+            }
+          })(),
+      },
+    };
+  }
+
+  it("adopts up to maxAdoptionsPerTick in a single tick", async () => {
+    const worker = mockWorker();
+    const adopter = new OrphanQueueAdopter({
+      client: clientWith(many),
+      projectId: PROJECT,
+      worker: {
+        registerQueue: worker.registerQueue,
+        queues: worker.polledQueues,
+      },
+      tickTimeoutMs: TICK_MS,
+      maxAdoptionsPerTick: 4,
+    });
+
+    await adopter.adoptNextOrphan();
+
+    expect(worker.registerQueue).toHaveBeenCalledTimes(4);
+  });
+
+  it("preserves FIFO order across the batch", async () => {
+    const worker = mockWorker();
+    const adopter = new OrphanQueueAdopter({
+      client: clientWith(many),
+      projectId: PROJECT,
+      worker: {
+        registerQueue: worker.registerQueue,
+        queues: worker.polledQueues,
+      },
+      tickTimeoutMs: TICK_MS,
+      maxAdoptionsPerTick: 3,
+    });
+
+    await adopter.adoptNextOrphan();
+
+    expect(worker.registerQueue.mock.calls.map((c) => c[0])).toEqual(
+      many.slice(0, 3),
+    );
+  });
+
+  it("stops the batch early when the worker is shutting down", async () => {
+    const worker = mockWorker();
+    worker.setRegisterImpl(async () => {
+      throw new Error("worker is shutting down");
+    });
+    const adopter = new OrphanQueueAdopter({
+      client: clientWith(many),
+      projectId: PROJECT,
+      worker: {
+        registerQueue: worker.registerQueue,
+        queues: worker.polledQueues,
+      },
+      tickTimeoutMs: TICK_MS,
+      maxAdoptionsPerTick: 5,
+    });
+
+    await adopter.adoptNextOrphan();
+
+    // Every subsequent register would fail identically; hammering the shutting-
+    // down worker 5x per tick is pure noise.
+    expect(worker.registerQueue).toHaveBeenCalledTimes(1);
+    expect(adopter.getDiagnostics().suppressedShutdownCount).toBe(1);
+  });
+
+  it("stops the batch once the per-tick budget is exhausted", async () => {
+    let clock = 0;
+    const worker = mockWorker();
+    worker.setRegisterImpl(async () => {
+      clock += 1000;
+    });
+    const adopter = new OrphanQueueAdopter({
+      client: clientWith(many),
+      projectId: PROJECT,
+      worker: {
+        registerQueue: worker.registerQueue,
+        queues: worker.polledQueues,
+      },
+      tickTimeoutMs: 2_500,
+      maxAdoptionsPerTick: 10,
+      now: () => clock,
+    });
+
+    await adopter.adoptNextOrphan();
+
+    // 1000ms per register against a 2500ms budget: 3 land, then the batch
+    // yields so the tick cannot overrun the driver interval.
+    expect(worker.registerQueue).toHaveBeenCalledTimes(3);
+  });
+
+  it("skips queues still in cooldown when batching", async () => {
+    const worker = mockWorker();
+    let failing = true;
+    worker.setRegisterImpl(async (queue) => {
+      if (failing && queue === many[0]) throw new Error("boom");
+    });
+    const adopter = new OrphanQueueAdopter({
+      client: clientWith(many.slice(0, 3)),
+      projectId: PROJECT,
+      worker: {
+        registerQueue: worker.registerQueue,
+        queues: worker.polledQueues,
+      },
+      tickTimeoutMs: TICK_MS,
+      maxAdoptionsPerTick: 3,
+      maxAttempts: 1,
+      cooldownMs: 60_000,
+    });
+
+    await adopter.adoptNextOrphan();
+    const cooled = adopter
+      .getDiagnostics()
+      .trackedQueues.find((q) => q.queue === many[0]);
+    expect(cooled?.inCooldown).toBe(true);
+
+    failing = false;
+    worker.registerQueue.mockClear();
+    await adopter.adoptNextOrphan();
+
+    // The cooled queue is excluded from the next batch.
+    expect(worker.registerQueue.mock.calls.map((c) => c[0])).not.toContain(
+      many[0],
+    );
+  });
+});

--- a/plugin/src/temporal/orphan-queue-adopter.test.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.test.ts
@@ -69,7 +69,7 @@ beforeEach(() => {
 });
 
 describe("OrphanQueueAdopter", () => {
-  it("adopts the first (oldest) orphan via registerQueue", async () => {
+  it("adopts orphans oldest-first via registerQueue", async () => {
     const worker = mockWorker();
     const client = mockClient([
       { queue: Q(2, ""), oldestStartTime: new Date(T0.getTime() + 2000) },
@@ -85,8 +85,12 @@ describe("OrphanQueueAdopter", () => {
       },
     });
     await adopter.adoptNextOrphan();
-    expect(worker.registerQueue).toHaveBeenCalledWith(Q(1, ""));
-    expect(worker.registerQueue).toHaveBeenCalledTimes(1);
+    // FIFO is the invariant that matters: the oldest orphan is registered
+    // FIRST. Both land in one tick now that adoption batches (it was
+    // one-per-tick, which cost ~10s of unreachability per orphan).
+    expect(worker.registerQueue).toHaveBeenNthCalledWith(1, Q(1, ""));
+    expect(worker.registerQueue).toHaveBeenNthCalledWith(2, Q(2, ""));
+    expect(worker.registerQueue).toHaveBeenCalledTimes(2);
   });
 
   it("skips a queue already in worker.queues (idempotent)", async () => {

--- a/plugin/src/temporal/orphan-queue-adopter.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.ts
@@ -40,6 +40,12 @@ export interface OrphanQueueAdopterOptions {
   maxAttempts?: number;
   /** Cooldown duration after the cap (DDC5; default 5 min). */
   cooldownMs?: number;
+  /**
+   * Maximum queues adopted per tick (default 5). Registers run sequentially
+   * and the batch is additionally bounded by `tickTimeoutMs`, so raising this
+   * shortens post-restart recovery without increasing peak worker churn.
+   */
+  maxAdoptionsPerTick?: number;
   /** Injectable clock for deterministic tests. */
   now?: () => number;
 }
@@ -154,6 +160,13 @@ export function evaluateOrphanAdoptionHealth(
 const DEFAULT_TICK_TIMEOUT_MS = 8_000;
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_COOLDOWN_MS = 5 * 60_000;
+/**
+ * Queues adopted per tick. At one-per-tick a restart with 34 orphans left
+ * prior-session workflows unreachable for ~6 minutes; at 5 that drops to
+ * roughly 70 seconds. Registers remain sequential and the batch is bounded by
+ * `tickTimeoutMs`, so peak worker churn is unchanged.
+ */
+const DEFAULT_MAX_ADOPTIONS_PER_TICK = 5;
 
 /** Error string fragment marking a worker-shutdown refusal (worker-multi.ts). */
 const SHUTDOWN_MARKER = "shutting down";
@@ -170,13 +183,9 @@ export function describeError(err: unknown): string {
   return msg.length > 200 ? `${msg.slice(0, 197)}...` : msg;
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 /**
- * A `delay` whose timer can be cleared once the race is decided, so a fast
- * winner does not leave an 8 s timer pending on every driver tick.
+ * A delay whose timer can be cleared once the race is decided, so a fast
+ * winner does not leave an 8 s timeout pending on every driver tick.
  */
 function cancellableDelay(ms: number): {
   promise: Promise<void>;
@@ -236,6 +245,7 @@ export class OrphanQueueAdopter {
   private readonly tickTimeoutMs: number;
   private readonly maxAttempts: number;
   private readonly cooldownMs: number;
+  private readonly maxAdoptionsPerTick: number;
   private readonly now: () => number;
 
   private scanInFlight = false;
@@ -257,10 +267,15 @@ export class OrphanQueueAdopter {
     this.tickTimeoutMs = options.tickTimeoutMs ?? DEFAULT_TICK_TIMEOUT_MS;
     this.maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
     this.cooldownMs = options.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+    this.maxAdoptionsPerTick =
+      options.maxAdoptionsPerTick ?? DEFAULT_MAX_ADOPTIONS_PER_TICK;
     this.now = options.now ?? (() => Date.now());
   }
 
-  /** Adopt at most one orphan queue. Safe to call every heartbeat tick. */
+  /**
+   * Adopt up to `maxAdoptionsPerTick` orphan queues. Safe to call every
+   * heartbeat tick; overlapping ticks skip via single-flight.
+   */
   async adoptNextOrphan(): Promise<void> {
     // DDC7 — single-flight: overlapping ticks skip.
     if (this.scanInFlight) return;
@@ -292,15 +307,42 @@ export class OrphanQueueAdopter {
     this.recordScanSuccess();
     if (orphans.length === 0) return;
 
-    const now = this.now();
+    const tickStartedAt = this.now();
 
-    // D3 — pick the oldest orphan not currently in cooldown.
-    const target = orphans.find((o) => {
+    // D3 — FIFO order is already established by the helper's sort; keep only
+    // queues that are not in cooldown.
+    const eligible = orphans.filter((o) => {
       const state = this.perQueueState.get(o.queue);
-      return !state || state.cooldownUntil <= now;
+      return !state || state.cooldownUntil <= tickStartedAt;
     });
-    if (!target) return;
+    if (eligible.length === 0) return;
 
+    // Adopt a bounded BATCH per tick rather than exactly one.
+    //
+    // One-per-tick meant a restart with N orphans left prior-session workflows
+    // unreachable for N * driverInterval — measured at ~6 minutes for 34 queues,
+    // during which gate/task/archive signals cannot land. Registers stay
+    // SEQUENTIAL so per-register worker churn is unchanged; only the count per
+    // tick grows. The whole batch stays inside the per-tick budget so a slow
+    // register can never push the tick past the driver interval.
+    let adopted = 0;
+    for (const target of eligible) {
+      if (adopted >= this.maxAdoptionsPerTick) break;
+      if (this.now() - tickStartedAt >= this.tickTimeoutMs) break;
+      const keepGoing = await this.adoptOneQueue(target.queue);
+      adopted++;
+      if (!keepGoing) break;
+    }
+  }
+
+  /**
+   * Attempt a single registration.
+   *
+   * @returns `false` when the batch should stop early — the worker is shutting
+   * down, so every subsequent register in this tick would fail identically.
+   */
+  private async adoptOneQueue(queue: string): Promise<boolean> {
+    const now = this.now();
     try {
       // DDC2 — race the register against the hard per-tick timeout. A LATE
       // settlement of registerQueue (after the timeout wins) is handled by the
@@ -311,47 +353,52 @@ export class OrphanQueueAdopter {
       // (self-healing). During planned shutdown the worker may never reply; the
       // timeout then records a best-effort failure, but the heartbeat is torn
       // down concurrently so impact is bounded (documented limitation, D7).
-      const outcome = await Promise.race([
-        this.worker
-          .registerQueue(target.queue)
-          .then(() => ({ ok: true as const })),
-        delay(this.tickTimeoutMs).then(() => ({ ok: false as const })),
-      ]);
-      if (outcome.ok) {
-        // Success clears retry/cooldown state (and lastError) for this queue.
-        this.perQueueState.set(target.queue, {
-          attemptCount: 0,
-          lastAttemptAt: now,
-          cooldownUntil: 0,
-          lastError: undefined,
-        });
-      } else {
+      const timeout = cancellableDelay(this.tickTimeoutMs);
+      try {
+        const outcome = await Promise.race([
+          this.worker.registerQueue(queue).then(() => ({ ok: true as const })),
+          timeout.promise.then(() => ({ ok: false as const })),
+        ]);
+        if (outcome.ok) {
+          // Success clears retry/cooldown state (and lastError) for this queue.
+          this.perQueueState.set(queue, {
+            attemptCount: 0,
+            lastAttemptAt: now,
+            cooldownUntil: 0,
+            lastError: undefined,
+          });
+          return true;
+        }
         // Worker observed dead/unresponsive during the adoption heartbeat:
         // mark the target queue stale so the readiness barrier re-probes before
         // the next mutation (KD5 / AC4). Existing retry/cooldown accounting
         // continues unchanged (DONT3).
-        markStale(target.queue);
+        markStale(queue);
         this.recordFailure(
-          target.queue,
+          queue,
           now,
           `registerQueue timed out after ${this.tickTimeoutMs}ms`,
         );
+        return true;
+      } finally {
+        timeout.cancel();
       }
     } catch (err) {
       // Worker observed dead during the adoption heartbeat: mark the target
       // queue stale so the readiness barrier re-probes before the next mutation
       // (KD5 / AC4). Existing shutdown-error suppression and retry accounting
       // continue unchanged (DONT3).
-      markStale(target.queue);
+      markStale(queue);
       // D7 — suppress shutdown-class refusals (no retry bump), but COUNT them.
       // Silent suppression is indistinguishable from "no adoption was ever
       // attempted" in diagnostics, which is precisely the ambiguity that made
       // #327 hard to classify.
       if (isShutdownError(err)) {
         this.suppressedShutdownCount += 1;
-        return;
+        return false;
       }
-      this.recordFailure(target.queue, now, describeError(err));
+      this.recordFailure(queue, now, describeError(err));
+      return true;
     }
   }
 


### PR DESCRIPTION
Follow-up to #338 / #339. Refs #327.

## Problem

Adoption processed **exactly one** orphan queue per 10s driver tick.

Measured live after the #338 deploy: adopted queues went 7 → 11 over 44 seconds — one every 10s, exactly the driver interval. With ~34 orphans that is **~6 minutes** during which prior-session workflows are unreachable and gate/task/archive signals cannot land.

Recovery time after a deploy bounce was dominated by this drain rate, not by the bounce.

## Fix

Adopt up to `maxAdoptionsPerTick` (default **5**) per tick.

Deliberately conservative:

- **Registers stay sequential.** Peak worker churn per register is unchanged; only the count per tick grows. No parallel `Worker.create` storm.
- **Bounded by `tickTimeoutMs`.** A slow register can never push a tick past the driver interval — under load the batch degrades gracefully back toward one-per-tick.
- **Stops early on shutdown-class refusal.** Every subsequent register in that tick would fail identically, so hammering a shutting-down worker 5× per tick is pure noise.
- **FIFO preserved.** Oldest orphan registers first; cooldown queues stay excluded.

Expected effect: 34 orphans drain in ~70s instead of ~340s.

## Also

Removes the now-unused `delay` helper. The register race uses `cancellableDelay`, so a fast register no longer leaves an 8s timer pending on every driver tick.

## Verification

- 5 new batch tests: cap, FIFO order across the batch, early stop on shutdown, budget exhaustion (injected clock: 1000ms/register against a 2500ms budget → exactly 3 land), cooldown exclusion.
- 108/108 green across seven related suites; `pnpm run check` clean.
- One existing test updated deliberately: `adopts the first (oldest) orphan` encoded the old one-per-tick contract. Its real intent — FIFO — is preserved and **strengthened** to assert call *order* via `toHaveBeenNthCalledWith`, rather than merely asserting a call count of 1.

## Scope note

This PR does **not** implement the proposal's "typed UNREACHABLE vs not_found" item. Investigation found that distinction largely already exists — `readiness-types.ts` (`NO_POLLER_CLASS`, `isNoPoller`), `diagnostics.ts` (`class: "no_poller"`), `change-mutation-coordinator.ts` (`workflow_unresponsive`), and `session-readiness.ts` (`describe_task_queue_no_pollers`). Routine reads are already disk-only and never conflate the two. The remaining sliver is `monotonic-recovery.ts:185`, where a non-exact-name describe failure falls through to `proceed_with_signal` — which is plausibly *correct*, since Temporal servers accept signals without a poller and the mutation queues rather than being lost. Changing that without a reproducing test risks regressing archive/terminate for no proven gain.