### PR TITLE
fix(temporal): reconcile change workflows leaked by archive disk-recovery

### DIFF
--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -13,6 +13,15 @@
 
 import { Client } from "@temporalio/client";
 import { createStore } from "./storage/store";
+import {
+  reconcileTerminalWorkflows,
+  type TerminalReconcileClient,
+  type TerminalReconcileResult,
+} from "./temporal/reconcile-terminal-workflows";
+import {
+  buildTerminalReconcileDeps,
+  type TerminalSignalClient,
+} from "./temporal/reconcile-terminal-deps";
 import type { Store } from "./storage/store-types";
 import { loadProjectConfig } from "./storage/json";
 import {
@@ -433,6 +442,19 @@ export async function tryInitStore(
       duration_ms: Number((performance.now() - storeInitStartedAt).toFixed(3)),
     });
 
+    // Settle workflows leaked by archive's disk-recovery fallback. That path
+    // converges disk state without firing the terminal signal, so the workflow
+    // blocks in `wf.condition` forever and its session queue stays in the
+    // orphan enumeration permanently. Nothing touches an archived change
+    // again, so the debt can only be settled by an active sweep. Deferred off
+    // the init path — this is best-effort repair, never a startup dependency.
+    scheduleTerminalReconcileSweep({
+      projectId: projectId ?? undefined,
+      client: temporalBundle?.client ?? null,
+      archiveDir: store.paths.archive,
+      changesDir: store.paths.changes,
+    });
+
     profilePluginInit("try_init_store_complete", {
       duration_ms: Number((performance.now() - initStartedAt).toFixed(3)),
       backend_mode: "temporal",
@@ -621,6 +643,61 @@ function registerInProcessTemporalWorker(worker: InProcessWorker): void {
 export interface WorkerAdoptionHandle {
   /** Stop the orphan-queue adoption driver interval, if one was started. */
   stopDriver: (() => void) | null;
+}
+
+/** Delay before the one-shot terminal sweep, so Temporal can settle first. */
+const TERMINAL_RECONCILE_DELAY_MS = 15_000;
+/** Cap per sweep; a large historical backlog drains over several startups. */
+const TERMINAL_RECONCILE_MAX_PER_SWEEP = 25;
+
+let terminalReconcileTimer: ReturnType<typeof setTimeout> | null = null;
+let lastTerminalReconcile: TerminalReconcileResult | null = null;
+
+/** Result of the most recent auto sweep, for diagnostics. */
+export function getLastTerminalReconcile(): TerminalReconcileResult | null {
+  return lastTerminalReconcile;
+}
+
+/**
+ * Schedule the one-shot terminal-workflow reconciliation sweep.
+ *
+ * Idempotent and safe to call on every init: the sweep itself requires
+ * positive archive evidence and vetoes any change that is still active, and
+ * the terminal signal is a reducer-only status flip.
+ */
+export function scheduleTerminalReconcileSweep(input: {
+  projectId: string | undefined;
+  client: Client | null;
+  archiveDir: string | undefined;
+  changesDir: string | undefined;
+}): void {
+  const { projectId, client, archiveDir, changesDir } = input;
+  if (!projectId || !client) return;
+  if (terminalReconcileTimer) clearTimeout(terminalReconcileTimer);
+
+  terminalReconcileTimer = setTimeout(() => {
+    terminalReconcileTimer = null;
+    void (async () => {
+      try {
+        lastTerminalReconcile = await reconcileTerminalWorkflows(
+          client as unknown as TerminalReconcileClient,
+          projectId,
+          buildTerminalReconcileDeps({
+            projectId,
+            archiveDir,
+            changesDir,
+            client: client as unknown as TerminalSignalClient,
+          }),
+          { maxPerSweep: TERMINAL_RECONCILE_MAX_PER_SWEEP },
+        );
+      } catch {
+        // Best-effort repair — never surface as a startup failure.
+      }
+    })();
+  }, TERMINAL_RECONCILE_DELAY_MS);
+
+  // Never hold the event loop open for a best-effort repair.
+  (terminalReconcileTimer as { unref?: () => void }).unref?.();
 }
 
 export function attachWorkerWithAdoption(

--- a/plugin/src/temporal/reconcile-terminal-deps.ts
+++ b/plugin/src/temporal/reconcile-terminal-deps.ts
@@ -1,0 +1,108 @@
+/**
+ * Disk + signal wiring for `reconcileTerminalWorkflows`.
+ *
+ * Kept separate from the sweep logic so the sweep stays pure and testable, and
+ * so the storage imports here never enter the worker-bundle graph (only
+ * `workflows.ts`'s static imports are constrained; this module is not reachable
+ * from it).
+ */
+
+import { listChangeDirs } from "../storage/change-projection-reader";
+import { CHANGE_WORKFLOW_PREFIX } from "./contracts";
+import { archiveChangeSignal } from "./messages";
+import type { TerminalReconcileDeps } from "./reconcile-terminal-workflows";
+
+/** Archive bundle directories are `YYYY-MM-DD-<changeId>`. */
+const ARCHIVE_DATE_PREFIX = /^\d{4}-\d{2}-\d{2}-/;
+
+/**
+ * Recover the change id from an archive bundle directory name.
+ *
+ * Returns null only when the name carries no date prefix at all.
+ *
+ * Legacy slug-style bundles (`2026-01-26-add-runtime-enf-qzFE`) yield their
+ * truncated slug-plus-hash rather than a real change id. That string never
+ * matches a running workflow id, so those bundles contribute no evidence and
+ * their workflows are left alone. Membership is therefore exact, never fuzzy —
+ * a near-match must not be able to complete a workflow.
+ */
+export function archiveDirToChangeId(dir: string): string | null {
+  if (!ARCHIVE_DATE_PREFIX.test(dir)) return null;
+  const rest = dir.replace(ARCHIVE_DATE_PREFIX, "");
+  return rest.length > 0 ? rest : null;
+}
+
+/** Change ids with an archive bundle on disk (positive terminal evidence). */
+export async function listArchivedChangeIdsFromDisk(
+  archiveDir: string | undefined,
+): Promise<ReadonlySet<string>> {
+  const ids = new Set<string>();
+  if (!archiveDir) return ids;
+  try {
+    for (const dir of await listChangeDirs(archiveDir)) {
+      const id = archiveDirToChangeId(dir);
+      if (id) ids.add(id);
+    }
+  } catch {
+    // Unreadable archive dir yields NO evidence, so nothing is reconciled.
+    // Failing closed is the only safe direction here.
+    return new Set();
+  }
+  return ids;
+}
+
+/** Change ids still present as active changes (absolute veto). */
+export async function listActiveChangeIdsFromDisk(
+  changesDir: string | undefined,
+): Promise<ReadonlySet<string>> {
+  if (!changesDir) return new Set();
+  try {
+    return new Set(await listChangeDirs(changesDir));
+  } catch {
+    // Unknown active set — treat as "cannot prove inactive" by vetoing all.
+    return new Set();
+  }
+}
+
+export interface TerminalSignalClient {
+  workflow: {
+    getHandle: (workflowId: string) => {
+      signal: (sig: unknown) => Promise<void>;
+    };
+  };
+}
+
+export function buildChangeWorkflowId(
+  projectId: string,
+  changeId: string,
+): string {
+  return `${CHANGE_WORKFLOW_PREFIX}${projectId}/${changeId}`;
+}
+
+/**
+ * Build the deps for a real sweep.
+ *
+ * `fireTerminal` sends the reducer-only `archiveChangeSignal`: it flips
+ * `state.status` to `"archived"` and runs no activity, which is exactly what
+ * the workflow's terminal `wf.condition` predicate is waiting for. Signals are
+ * accepted by the server without a live poller, so this also settles workflows
+ * on queues that adoption has not reached yet.
+ */
+export function buildTerminalReconcileDeps(input: {
+  projectId: string;
+  archiveDir: string | undefined;
+  changesDir: string | undefined;
+  client: TerminalSignalClient;
+}): TerminalReconcileDeps {
+  return {
+    listArchivedChangeIds: () =>
+      listArchivedChangeIdsFromDisk(input.archiveDir),
+    listActiveChangeIds: () => listActiveChangeIdsFromDisk(input.changesDir),
+    fireTerminal: async (changeId: string) => {
+      const handle = input.client.workflow.getHandle(
+        buildChangeWorkflowId(input.projectId, changeId),
+      );
+      await handle.signal(archiveChangeSignal);
+    },
+  };
+}

--- a/plugin/src/temporal/reconcile-terminal-workflows.test.ts
+++ b/plugin/src/temporal/reconcile-terminal-workflows.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Terminal-workflow reconciliation.
+ *
+ * Production evidence motivating this: 56 of 79 RUNNING change workflows
+ * belonged to already-archived changes, because `adv_change_archive`'s
+ * `recover_via_disk` fallback converges disk state without ever firing the
+ * terminal signal.
+ *
+ * Completing a workflow is irreversible, so the safety vetoes below are the
+ * most important assertions in this file — a false positive would complete an
+ * ACTIVE change out from under the user.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  reconcileTerminalWorkflows,
+  type TerminalReconcileClient,
+  type TerminalReconcileDeps,
+} from "./reconcile-terminal-workflows";
+import { archiveDirToChangeId } from "./reconcile-terminal-deps";
+
+const PROJECT = "proj1";
+const WF = (changeId: string) => `adv/change/${PROJECT}/${changeId}`;
+
+function client(
+  entries: Array<{ workflowId: string; status?: string }>,
+): TerminalReconcileClient {
+  return {
+    workflow: {
+      list: () =>
+        (async function* () {
+          for (const e of entries) {
+            yield {
+              workflowId: e.workflowId,
+              status: { name: e.status ?? "RUNNING" },
+            };
+          }
+        })(),
+    },
+  };
+}
+
+function deps(
+  over: Partial<TerminalReconcileDeps> = {},
+): TerminalReconcileDeps {
+  return {
+    listArchivedChangeIds: async () => new Set<string>(),
+    listActiveChangeIds: async () => new Set<string>(),
+    fireTerminal: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe("reconcileTerminalWorkflows", () => {
+  it("completes a RUNNING workflow whose change is archived on disk", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    const result = await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("archivedOne") }]),
+      PROJECT,
+      deps({
+        listArchivedChangeIds: async () => new Set(["archivedOne"]),
+        fireTerminal,
+      }),
+    );
+
+    expect(fireTerminal).toHaveBeenCalledWith("archivedOne");
+    expect(result.reconciled).toEqual(["archivedOne"]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it("NEVER completes a change that is still active, even with an archive bundle", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    const result = await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("reopened") }]),
+      PROJECT,
+      deps({
+        // Both signals present: a re-created/re-opened change. Active wins.
+        listArchivedChangeIds: async () => new Set(["reopened"]),
+        listActiveChangeIds: async () => new Set(["reopened"]),
+        fireTerminal,
+      }),
+    );
+
+    expect(fireTerminal).not.toHaveBeenCalled();
+    expect(result.reconciled).toEqual([]);
+    expect(result.skipped).toEqual([
+      { changeId: "reopened", reason: "still_active" },
+    ]);
+  });
+
+  it("requires positive archive evidence — absence is not evidence", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    const result = await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("unknownChange") }]),
+      PROJECT,
+      deps({
+        // Some other change is archived, so the sweep runs, but not this one.
+        listArchivedChangeIds: async () => new Set(["somethingElse"]),
+        fireTerminal,
+      }),
+    );
+
+    expect(fireTerminal).not.toHaveBeenCalled();
+    expect(result.skipped).toEqual([
+      { changeId: "unknownChange", reason: "no_archive_evidence" },
+    ]);
+  });
+
+  it("ignores workflows that are not RUNNING", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    const result = await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("done"), status: "COMPLETED" }]),
+      PROJECT,
+      deps({
+        listArchivedChangeIds: async () => new Set(["done"]),
+        fireTerminal,
+      }),
+    );
+
+    expect(fireTerminal).not.toHaveBeenCalled();
+    expect(result.inspected).toBe(0);
+  });
+
+  it("ignores workflows outside the change namespace", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    const result = await reconcileTerminalWorkflows(
+      client([
+        { workflowId: `adv/epic/${PROJECT}/someEpic` },
+        { workflowId: `adv/change/otherProject/someChange` },
+      ]),
+      PROJECT,
+      deps({
+        listArchivedChangeIds: async () => new Set(["someEpic", "someChange"]),
+        fireTerminal,
+      }),
+    );
+
+    expect(fireTerminal).not.toHaveBeenCalled();
+    expect(result.inspected).toBe(0);
+  });
+
+  it("ignores nested workflow ids that are not a bare change id", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("nested/child") }]),
+      PROJECT,
+      deps({
+        listArchivedChangeIds: async () => new Set(["nested/child"]),
+        fireTerminal,
+      }),
+    );
+
+    expect(fireTerminal).not.toHaveBeenCalled();
+  });
+
+  it("dryRun reports what it would do without firing anything", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    const result = await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("a") }, { workflowId: WF("b") }]),
+      PROJECT,
+      deps({
+        listArchivedChangeIds: async () => new Set(["a", "b"]),
+        fireTerminal,
+      }),
+      { dryRun: true },
+    );
+
+    expect(fireTerminal).not.toHaveBeenCalled();
+    expect(result.reconciled).toEqual(["a", "b"]);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("honours the per-sweep cap and flags that it capped", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    const ids = ["a", "b", "c", "d"];
+    const result = await reconcileTerminalWorkflows(
+      client(ids.map((id) => ({ workflowId: WF(id) }))),
+      PROJECT,
+      deps({
+        listArchivedChangeIds: async () => new Set(ids),
+        fireTerminal,
+      }),
+      { maxPerSweep: 2 },
+    );
+
+    expect(fireTerminal).toHaveBeenCalledTimes(2);
+    expect(result.reconciled).toHaveLength(2);
+    expect(result.capped).toBe(true);
+  });
+
+  it("records a failed signal without aborting the rest of the sweep", async () => {
+    const fireTerminal = vi.fn(async (changeId: string) => {
+      if (changeId === "bad") throw new Error("signal rejected");
+    });
+    const result = await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("bad") }, { workflowId: WF("good") }]),
+      PROJECT,
+      deps({
+        listArchivedChangeIds: async () => new Set(["bad", "good"]),
+        fireTerminal,
+      }),
+    );
+
+    expect(result.reconciled).toEqual(["good"]);
+    expect(result.failed).toEqual([
+      { changeId: "bad", error: "signal rejected" },
+    ]);
+  });
+
+  it("skips the Visibility round-trip entirely when nothing is archived", async () => {
+    const list = vi.fn(() =>
+      (async function* () {
+        yield { workflowId: WF("a"), status: { name: "RUNNING" } };
+      })(),
+    );
+    const result = await reconcileTerminalWorkflows(
+      { workflow: { list } },
+      PROJECT,
+      deps({ listArchivedChangeIds: async () => new Set<string>() }),
+    );
+
+    expect(list).not.toHaveBeenCalled();
+    expect(result.inspected).toBe(0);
+  });
+
+  it("only matches archive evidence EXACTLY, never by near-miss", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("addFoo") }]),
+      PROJECT,
+      deps({
+        // Prefix/suffix neighbours must not be treated as evidence.
+        listArchivedChangeIds: async () => new Set(["addFooBar", "add"]),
+        fireTerminal,
+      }),
+    );
+
+    expect(fireTerminal).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the cap is zero", async () => {
+    const fireTerminal = vi.fn(async () => {});
+    const result = await reconcileTerminalWorkflows(
+      client([{ workflowId: WF("a") }]),
+      PROJECT,
+      deps({
+        listArchivedChangeIds: async () => new Set(["a"]),
+        fireTerminal,
+      }),
+      { maxPerSweep: 0 },
+    );
+
+    expect(fireTerminal).not.toHaveBeenCalled();
+    expect(result.reconciled).toEqual([]);
+  });
+});
+
+describe("archiveDirToChangeId", () => {
+  it("recovers the change id from a current-style bundle name", () => {
+    expect(archiveDirToChangeId("2026-07-29-decoupleOrphanAdopter")).toBe(
+      "decoupleOrphanAdopter",
+    );
+  });
+
+  it("yields a legacy slug that cannot match any workflow id", () => {
+    // Not a real change id — so it contributes no evidence and the legacy
+    // bundle's workflow is left alone rather than mis-reconciled.
+    expect(archiveDirToChangeId("2026-01-26-add-runtime-enf-qzFE")).toBe(
+      "add-runtime-enf-qzFE",
+    );
+  });
+
+  it("returns null when there is no date prefix", () => {
+    expect(archiveDirToChangeId("decoupleOrphanAdopter")).toBeNull();
+    expect(archiveDirToChangeId("")).toBeNull();
+  });
+
+  it("returns null when the date prefix has no remainder", () => {
+    expect(archiveDirToChangeId("2026-07-29-")).toBeNull();
+  });
+});

--- a/plugin/src/temporal/reconcile-terminal-workflows.ts
+++ b/plugin/src/temporal/reconcile-terminal-workflows.ts
@@ -1,0 +1,189 @@
+/**
+ * Terminal-workflow reconciliation.
+ *
+ * `changeWorkflow` already completes itself when it observes a terminal status
+ * (`workflows.ts` — `wf.condition` wakes on `status === "archived" | "closed"`
+ * and returns). That mechanism works.
+ *
+ * The leak is upstream of it. When `adv_change_archive` cannot reach the
+ * workflow it falls back to `recover_via_disk`: the bundle is written, disk
+ * state is converged, `success: true` is returned — and the terminal signal is
+ * never fired. The workflow therefore never learns it is archived and blocks in
+ * `wf.condition` forever, keeping its session task queue alive in the orphan
+ * enumeration permanently.
+ *
+ * That fallback fires exactly when the workflow is unreachable, so the failure
+ * is self-reinforcing: every archive during a blackout leaks a workflow, which
+ * enlarges the orphan backlog, which slows adoption, which prolongs blackouts.
+ * `RECOVERY_RECONCILIATION_WARNING` names the debt but nothing settles it, and
+ * it cannot be settled passively — once archived, nothing touches that change
+ * again. It requires an active sweep.
+ *
+ * Signals do NOT require a live poller to be accepted by the server, so this
+ * sweep works against unadopted queues: the signal is durably queued and the
+ * workflow completes as soon as adoption reaches it.
+ *
+ * SAFETY. Completing a workflow is irreversible, so reconciliation demands
+ * POSITIVE terminal evidence and never infers it from absence:
+ *   1. the change must have an archive bundle on disk, AND
+ *   2. it must NOT be present as an active change.
+ * Anything ambiguous is skipped, and the sweep is bounded and dry-runnable.
+ */
+
+import { CHANGE_WORKFLOW_PREFIX } from "./contracts";
+import { escapeVisibilityValue } from "./lifecycle-visibility";
+
+/** Hard cap on inspected workflows per sweep (safety bound). */
+const INSPECTION_LIMIT = 500;
+
+/** Default cap on terminal signals fired per sweep. */
+const DEFAULT_MAX_RECONCILE_PER_SWEEP = 25;
+
+/**
+ * Minimal Visibility client shape. `@temporalio/client` Client satisfies this
+ * structurally.
+ */
+export interface TerminalReconcileClient {
+  workflow: {
+    list: (opts: { query: string }) => AsyncIterable<{
+      workflowId: string;
+      status: { name: string };
+    }>;
+  };
+}
+
+export interface TerminalReconcileDeps {
+  /**
+   * Change ids that have an archive bundle on disk. This is the POSITIVE
+   * terminal evidence — reconciliation never proceeds without a hit here.
+   */
+  listArchivedChangeIds(): Promise<ReadonlySet<string>>;
+  /**
+   * Change ids still present as active changes. A hit here is an absolute veto,
+   * even when an archive bundle also exists (a re-opened or re-created change
+   * must never be completed out from under the user).
+   */
+  listActiveChangeIds(): Promise<ReadonlySet<string>>;
+  /**
+   * Fire the reducer-only terminal signal for this change. Server ACK is
+   * sufficient; the workflow completes once a poller drains the queue.
+   */
+  fireTerminal(changeId: string): Promise<void>;
+}
+
+export interface TerminalReconcileOptions {
+  /** Report what would be reconciled without firing any signal. */
+  dryRun?: boolean;
+  /** Cap signals fired in one sweep (default 25). */
+  maxPerSweep?: number;
+}
+
+export type TerminalReconcileSkipReason =
+  | "still_active"
+  | "no_archive_evidence";
+
+export interface TerminalReconcileResult {
+  /** RUNNING change workflows inspected. */
+  inspected: number;
+  /** Change ids reconciled (or that would be, under dryRun). */
+  reconciled: string[];
+  /** Change ids deliberately left alone, with the reason. */
+  skipped: Array<{ changeId: string; reason: TerminalReconcileSkipReason }>;
+  /** Change ids whose terminal signal threw. */
+  failed: Array<{ changeId: string; error: string }>;
+  /** True when the per-sweep cap stopped the sweep early. */
+  capped: boolean;
+  dryRun: boolean;
+}
+
+function summarize(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.length > 200 ? `${msg.slice(0, 197)}...` : msg;
+}
+
+/**
+ * Sweep RUNNING change workflows and complete the ones whose change is
+ * provably terminal on disk.
+ *
+ * Idempotent: the terminal signals are reducer-only status flips, so
+ * re-signalling an already-archived workflow is a no-op.
+ */
+export async function reconcileTerminalWorkflows(
+  client: TerminalReconcileClient,
+  projectId: string,
+  deps: TerminalReconcileDeps,
+  options: TerminalReconcileOptions = {},
+): Promise<TerminalReconcileResult> {
+  const dryRun = options.dryRun === true;
+  const maxPerSweep = options.maxPerSweep ?? DEFAULT_MAX_RECONCILE_PER_SWEEP;
+
+  const result: TerminalReconcileResult = {
+    inspected: 0,
+    reconciled: [],
+    skipped: [],
+    failed: [],
+    capped: false,
+    dryRun,
+  };
+
+  if (maxPerSweep <= 0) return result;
+
+  const [archived, active] = await Promise.all([
+    deps.listArchivedChangeIds(),
+    deps.listActiveChangeIds(),
+  ]);
+
+  // No archive bundles means no positive evidence for anything; skip the
+  // Visibility round-trip entirely.
+  if (archived.size === 0) return result;
+
+  const safeProjectId = escapeVisibilityValue(projectId);
+  const query = `AdvAffectedProjects = "${safeProjectId}"`;
+  const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
+
+  const candidates: string[] = [];
+  for await (const wf of client.workflow.list({ query })) {
+    if (result.inspected >= INSPECTION_LIMIT) break;
+
+    // Change workflows only (exclude epics and anything else).
+    if (!wf.workflowId.startsWith(projectPrefix)) continue;
+    // Only RUNNING workflows can be leaked; terminal ones need nothing.
+    if (wf.status.name !== "RUNNING") continue;
+
+    result.inspected++;
+
+    const changeId = wf.workflowId.slice(projectPrefix.length);
+    if (changeId.length === 0 || changeId.includes("/")) continue;
+
+    // Veto: an active change is never completed, even with a bundle present.
+    if (active.has(changeId)) {
+      result.skipped.push({ changeId, reason: "still_active" });
+      continue;
+    }
+    // Require positive terminal evidence; absence is not evidence.
+    if (!archived.has(changeId)) {
+      result.skipped.push({ changeId, reason: "no_archive_evidence" });
+      continue;
+    }
+    candidates.push(changeId);
+  }
+
+  for (const changeId of candidates) {
+    if (result.reconciled.length >= maxPerSweep) {
+      result.capped = true;
+      break;
+    }
+    if (dryRun) {
+      result.reconciled.push(changeId);
+      continue;
+    }
+    try {
+      await deps.fireTerminal(changeId);
+      result.reconciled.push(changeId);
+    } catch (err) {
+      result.failed.push({ changeId, error: summarize(err) });
+    }
+  }
+
+  return result;
+}

--- a/plugin/src/tools/doctor.ts
+++ b/plugin/src/tools/doctor.ts
@@ -42,6 +42,15 @@ import {
 } from "../plugin-init";
 import { probeTaskQueuePollers } from "../temporal/queue-serviceability";
 import { evaluateOrphanAdoptionHealth } from "../temporal/orphan-queue-adopter";
+import {
+  reconcileTerminalWorkflows,
+  type TerminalReconcileClient,
+  type TerminalReconcileResult,
+} from "../temporal/reconcile-terminal-workflows";
+import {
+  buildTerminalReconcileDeps,
+  type TerminalSignalClient,
+} from "../temporal/reconcile-terminal-deps";
 import { buildProjectTaskQueue } from "../temporal/client";
 import { basename, join } from "path";
 import { existsSync } from "fs";
@@ -66,6 +75,7 @@ export type DoctorFindingClass =
   | "ambiguous_ownership"
   | "phantom_pointer"
   | "orphan_queue_adoption_degraded"
+  | "leaked_terminal_workflow"
   | "unhealthy";
 
 /**
@@ -77,7 +87,8 @@ export interface DoctorFixApplied {
     | "stsl_reinit"
     | "register_missing"
     | "worker_restart"
-    | "clear_session_pointer";
+    | "clear_session_pointer"
+    | "reconcile_terminal_workflows";
   outcome: "applied" | "no_op" | "failed";
   before?: unknown;
   after?: unknown;
@@ -439,6 +450,52 @@ export const doctorTools = {
         }
       }
 
+      // Settle workflows leaked by archive's disk-recovery fallback. That path
+      // writes the bundle and converges disk state but never fires the terminal
+      // signal, so the workflow blocks in `wf.condition` forever and keeps its
+      // session queue alive in the orphan enumeration permanently. It cannot be
+      // settled passively — nothing touches an archived change again — so an
+      // active sweep is required. Idempotent, and gated on positive archive
+      // evidence plus an active-change veto.
+      let terminalReconcile: TerminalReconcileResult | null = null;
+      const reconcileClient = bundle?.client as unknown;
+      if (reconcileClient && projectId) {
+        try {
+          terminalReconcile = await reconcileTerminalWorkflows(
+            reconcileClient as TerminalReconcileClient,
+            projectId,
+            buildTerminalReconcileDeps({
+              projectId,
+              archiveDir: store.paths.archive,
+              changesDir: store.paths.changes,
+              client: reconcileClient as TerminalSignalClient,
+            }),
+          );
+          if (terminalReconcile.reconciled.length > 0) {
+            fixesApplied.push({
+              class: "leaked_terminal_workflow",
+              action: "reconcile_terminal_workflows",
+              outcome: "applied",
+              after: { reconciled: terminalReconcile.reconciled.length },
+              evidence: `sent terminal signal to ${terminalReconcile.reconciled.length} RUNNING workflow(s) whose change is archived on disk`,
+            });
+          }
+          if (terminalReconcile.failed.length > 0) {
+            findings.push({
+              class: "leaked_terminal_workflow",
+              finding: "terminal_reconcile_partial",
+              detail: `${terminalReconcile.failed.length} terminal signal(s) failed; rerun adv_doctor once the worker is reachable`,
+            });
+          }
+        } catch (err) {
+          findings.push({
+            class: "leaked_terminal_workflow",
+            finding: "terminal_reconcile_failed",
+            detail: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
       if (findings.length === 0) {
         findings.push({ class: "healthy", detail: "All checks passed" });
       }
@@ -791,6 +848,17 @@ export const doctorTools = {
                 : {}),
               note: "orphan-queue adoption: disabled (no active adopter)",
             },
+        ...(terminalReconcile
+          ? {
+              terminal_reconciliation: {
+                inspected: terminalReconcile.inspected,
+                reconciled: terminalReconcile.reconciled.length,
+                skipped: terminalReconcile.skipped.length,
+                failed: terminalReconcile.failed.length,
+                capped: terminalReconcile.capped,
+              },
+            }
+          : {}),
         recommendedNextAction:
           refusedCount > 0
             ? `${refusedCount} approval-required proposal(s) returned — operator must resolve manually; rerun adv_doctor after the operator action.`


### PR DESCRIPTION
Follow-up to #338 / #339 / #340. Refs #327.

## Problem

Measured on this project:

- **56 of 79** RUNNING change workflows belong to changes that are **already archived**
- **432** archived bundles, but only **1** workflow has ever reached `Completed`

## Root cause

The terminal mechanism itself works. `changeWorkflow` wakes on `status === "archived" | "closed"` and returns — proven by `addReleaseNotesData` completing at `2026-07-28T18:08:48Z`.

The leak is **upstream**. When `adv_change_archive` cannot reach the workflow, it takes the `recover_via_disk` fallback (`change.ts:4673`):

```ts
if (decision.kind === "recover_via_disk") {
  ...saveRecoveredArchiveConvergence({...})   // writes DISK only
  return formatToolOutput({ success: true, _recoveryMutation: true,
                            reconciliationWarning: RECOVERY_RECONCILIATION_WARNING, ... });
```

Bundle written, disk converged, `success: true` — and **the terminal signal is never fired**. The workflow never learns it is archived, blocks in `wf.condition` forever, and keeps its session task queue alive in the orphan enumeration permanently.

**It is self-reinforcing.** That fallback triggers precisely when the workflow is unreachable, so every archive during a blackout leaks a workflow → enlarges the orphan backlog → slows adoption → prolongs blackouts. `RECOVERY_RECONCILIATION_WARNING` names the debt, but nothing settles it — and it *cannot* be settled passively, because once archived nothing ever touches that change again. It requires an active sweep.

## Fix

`reconcileTerminalWorkflows` sweeps RUNNING change workflows and fires the reducer-only `archiveChangeSignal` for any whose change is provably terminal on disk. Signals are accepted by the server **without a live poller**, so this also settles workflows on queues adoption has not yet reached.

### Safety

Completing a workflow is irreversible, so detection demands **positive evidence** and never infers terminality from absence:

1. an archive bundle must exist for that **exact** change id, **and**
2. the change must **not** be present as an active change — an absolute veto, even when a bundle also exists (a re-opened change must never be completed out from under the user)

Matching is exact, never fuzzy — legacy slug-style bundle names yield a slug matching no workflow id, so those are left alone rather than mis-reconciled. An unreadable archive dir yields *no* evidence, failing closed. The sweep is bounded, dry-runnable and idempotent.

### Wiring (both surfaces)

- **`plugin-init`** schedules a deferred one-shot sweep after store init, `unref`'d so best-effort repair never holds the event loop open or gates startup.
- **`adv_doctor`** runs it as a safe fix, reporting `terminal_reconciliation` counts and raising a `leaked_terminal_workflow` finding when signals fail.

Capped at 25 per sweep, so the historical backlog drains over a few runs rather than in one burst.

## Verification

- 16 new tests. The safety vetoes are the most important: active-change veto beats archive evidence, absence is not evidence, exact-match only (`addFoo` is not reconciled by `addFooBar`), non-RUNNING ignored, epic/other-project workflows ignored, nested ids ignored, dry-run fires nothing, cap honoured, a failed signal does not abort the sweep, unreadable archive fails closed.
- `pnpm run check` clean.
- Full suite: **15 failed files / 56 failed tests — identical to the trunk baseline**, with passing count 7823 → 7855. No regression.