### PR TITLE
fix(temporal): use change status, not directory presence, as liveness

### DIFF
--- a/plugin/src/temporal/reconcile-terminal-deps.ts
+++ b/plugin/src/temporal/reconcile-terminal-deps.ts
@@ -7,10 +7,64 @@
  * from it).
  */
 
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { listChangeDirs } from "../storage/change-projection-reader";
 import { CHANGE_WORKFLOW_PREFIX } from "./contracts";
 import { archiveChangeSignal } from "./messages";
 import type { TerminalReconcileDeps } from "./reconcile-terminal-workflows";
+
+/** Change statuses that mean the workflow SHOULD have completed. */
+const TERMINAL_STATUSES = new Set(["archived", "closed"]);
+
+/**
+ * Status of every change present in the projection directory.
+ *
+ * Directory PRESENCE is not a liveness signal: the projection retains terminal
+ * changes (measured in production: 96 draft, 28 archived, 4 closed all sitting
+ * side by side). Reading the authoritative `status` field is the only correct
+ * way to tell an active change from a terminal one — inferring it from the
+ * directory listing silently vetoes every archived change that has not been
+ * pruned yet.
+ *
+ * Unreadable or unparseable entries map to `"unknown"`, which is treated as
+ * ACTIVE downstream so the sweep fails closed.
+ */
+async function readChangeStatuses(
+  changesDir: string | undefined,
+): Promise<Map<string, string>> {
+  const statuses = new Map<string, string>();
+  if (!changesDir) return statuses;
+  let dirs: string[];
+  try {
+    dirs = await listChangeDirs(changesDir);
+  } catch {
+    return statuses;
+  }
+  await Promise.all(
+    dirs.map(async (changeId) => {
+      try {
+        const raw = await readFile(
+          join(changesDir, changeId, "change.json"),
+          "utf8",
+        );
+        const parsed = JSON.parse(raw) as { status?: unknown };
+        statuses.set(
+          changeId,
+          typeof parsed.status === "string" ? parsed.status : "unknown",
+        );
+      } catch {
+        statuses.set(changeId, "unknown");
+      }
+    }),
+  );
+  return statuses;
+}
+
+/** True when this projected status means the workflow should be completed. */
+export function isTerminalChangeStatus(status: string): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
 
 /** Archive bundle directories are `YYYY-MM-DD-<changeId>`. */
 const ARCHIVE_DATE_PREFIX = /^\d{4}-\d{2}-\d{2}-/;
@@ -51,17 +105,31 @@ export async function listArchivedChangeIdsFromDisk(
   return ids;
 }
 
-/** Change ids still present as active changes (absolute veto). */
-export async function listActiveChangeIdsFromDisk(
-  changesDir: string | undefined,
-): Promise<ReadonlySet<string>> {
-  if (!changesDir) return new Set();
-  try {
-    return new Set(await listChangeDirs(changesDir));
-  } catch {
-    // Unknown active set — treat as "cannot prove inactive" by vetoing all.
-    return new Set();
+/**
+ * Change ids that are NOT terminal, from the projection's `status` field.
+ *
+ * Anything whose status is missing, unreadable or unrecognised counts as
+ * active, so ambiguity always vetoes rather than completes a workflow.
+ */
+export function activeChangeIdsFromStatuses(
+  statuses: ReadonlyMap<string, string>,
+): ReadonlySet<string> {
+  const active = new Set<string>();
+  for (const [changeId, status] of statuses) {
+    if (!isTerminalChangeStatus(status)) active.add(changeId);
   }
+  return active;
+}
+
+/** Change ids the projection marks terminal (positive evidence). */
+export function terminalChangeIdsFromStatuses(
+  statuses: ReadonlyMap<string, string>,
+): ReadonlySet<string> {
+  const terminal = new Set<string>();
+  for (const [changeId, status] of statuses) {
+    if (isTerminalChangeStatus(status)) terminal.add(changeId);
+  }
+  return terminal;
 }
 
 export interface TerminalSignalClient {
@@ -94,10 +162,28 @@ export function buildTerminalReconcileDeps(input: {
   changesDir: string | undefined;
   client: TerminalSignalClient;
 }): TerminalReconcileDeps {
+  // One projection read per sweep, shared by both lookups.
+  let statusesPromise: Promise<Map<string, string>> | null = null;
+  const statuses = () => {
+    statusesPromise ??= readChangeStatuses(input.changesDir);
+    return statusesPromise;
+  };
+
   return {
-    listArchivedChangeIds: () =>
-      listArchivedChangeIdsFromDisk(input.archiveDir),
-    listActiveChangeIds: () => listActiveChangeIdsFromDisk(input.changesDir),
+    listArchivedChangeIds: async () => {
+      const ids = new Set(
+        await listArchivedChangeIdsFromDisk(input.archiveDir),
+      );
+      // The projection's own `status` is stronger evidence than a bundle
+      // directory name: it survives legacy bundle naming, and it is exactly
+      // what the workflow itself would have observed had the signal landed.
+      for (const id of terminalChangeIdsFromStatuses(await statuses())) {
+        ids.add(id);
+      }
+      return ids;
+    },
+    listActiveChangeIds: async () =>
+      activeChangeIdsFromStatuses(await statuses()),
     fireTerminal: async (changeId: string) => {
       const handle = input.client.workflow.getHandle(
         buildChangeWorkflowId(input.projectId, changeId),

--- a/plugin/src/temporal/reconcile-terminal-workflows.test.ts
+++ b/plugin/src/temporal/reconcile-terminal-workflows.test.ts
@@ -16,7 +16,12 @@ import {
   type TerminalReconcileClient,
   type TerminalReconcileDeps,
 } from "./reconcile-terminal-workflows";
-import { archiveDirToChangeId } from "./reconcile-terminal-deps";
+import {
+  activeChangeIdsFromStatuses,
+  archiveDirToChangeId,
+  isTerminalChangeStatus,
+  terminalChangeIdsFromStatuses,
+} from "./reconcile-terminal-deps";
 
 const PROJECT = "proj1";
 const WF = (changeId: string) => `adv/change/${PROJECT}/${changeId}`;
@@ -251,6 +256,50 @@ describe("reconcileTerminalWorkflows", () => {
 
     expect(fireTerminal).not.toHaveBeenCalled();
     expect(result.reconciled).toEqual([]);
+  });
+});
+
+describe("change-status authority (presence is not liveness)", () => {
+  // Measured in production: the projection directory held 96 draft, 28
+  // archived and 4 closed changes side by side. Treating directory PRESENCE as
+  // "active" vetoed every archived change that had not been pruned, which made
+  // reconciliation inert.
+  const projection = new Map<string, string>([
+    ["stillDrafting", "draft"],
+    ["archivedButPresent", "archived"],
+    ["closedButPresent", "closed"],
+    ["corruptEntry", "unknown"],
+  ]);
+
+  it("classifies archived and closed as terminal", () => {
+    expect(isTerminalChangeStatus("archived")).toBe(true);
+    expect(isTerminalChangeStatus("closed")).toBe(true);
+  });
+
+  it("classifies everything else as non-terminal", () => {
+    expect(isTerminalChangeStatus("draft")).toBe(false);
+    expect(isTerminalChangeStatus("unknown")).toBe(false);
+    expect(isTerminalChangeStatus("")).toBe(false);
+  });
+
+  it("treats a present-but-archived change as terminal, not active", () => {
+    expect([...terminalChangeIdsFromStatuses(projection)].sort()).toEqual([
+      "archivedButPresent",
+      "closedButPresent",
+    ]);
+    expect([...activeChangeIdsFromStatuses(projection)].sort()).toEqual([
+      "corruptEntry",
+      "stillDrafting",
+    ]);
+  });
+
+  it("fails closed: an unreadable entry counts as active and is vetoed", () => {
+    expect(activeChangeIdsFromStatuses(projection).has("corruptEntry")).toBe(
+      true,
+    );
+    expect(terminalChangeIdsFromStatuses(projection).has("corruptEntry")).toBe(
+      false,
+    );
   });
 });
 


### PR DESCRIPTION
Follow-up to #341. Refs #327. Found by post-deploy verification.

## Problem

The sweep in #341 was **safe but largely inert**. Live measurement after deploy:

```json
"terminal_reconciliation": {"inspected": 74, "reconciled": 2, "skipped": 72, "failed": 0}
```

Its active-change veto inferred *"still active"* from **presence of a directory** under the change projection root. That is not a liveness signal.

Measured on the live projection:

```
96 draft · 28 archived · 4 closed      # all side by side
```

Archived changes are **not pruned** from that directory, so the veto fired on them and the sweep skipped precisely the workflows it exists to settle. Confirmed individually: `autoAdoptOrphanSessionQueues`, `addAdvLauncherReadProjection` and `isolateAdvWorkerTaskQueues` are all archived, all still present in `changes/`, all vetoed.

## Fix

Read the authoritative `status` field from each `change.json`:

| Projected status | Verdict |
|---|---|
| `archived` / `closed` | **terminal** — positive evidence, reconcile |
| anything else | **active** — veto |
| missing / unreadable / unparseable → `"unknown"` | **active** — veto |

Ambiguity still vetoes rather than completes, preserving the fail-closed posture — completing a workflow is irreversible.

The projected status is also **stronger** evidence than an archive bundle directory name: it survives legacy bundle naming (`2026-01-26-add-runtime-enf-qzFE` carries a slug, not a change id) and it is exactly what the workflow itself would have observed had the terminal signal landed. Bundle-name evidence is retained and unioned with it, so neither source alone is required.

Both lookups now share a single memoized projection read per sweep.

## Verification

- 4 new tests pinning the distinction: archived/closed are terminal, everything else is not, a present-but-archived change classifies as terminal rather than active, and an unreadable entry fails closed into the veto.
- 53/53 green across the reconcile, doctor and plugin-init suites; `pnpm run check` clean.

## Note

This is a defect in my own change from #341, caught by verifying the deployed behaviour rather than trusting that the merge was correct. The original erred toward doing nothing, which is the right failure direction for an irreversible operation — but it meant the leak was not actually being drained.