### PR TITLE
fix(tests): repair stale packet-defect anchors and cite 4 uncited requirements

### DIFF
--- a/plugin/src/adv-verifier-assets.test.ts
+++ b/plugin/src/adv-verifier-assets.test.ts
@@ -99,7 +99,6 @@ describe("adv-verifier agent asset", () => {
       "VERIFICATION",
       "COMMANDS",
       "Do not edit files",
-      "Do not call adv_subagent_report_submit",
       "Do not complete gates",
       "Do not spawn",
       "final acceptance",
@@ -107,6 +106,15 @@ describe("adv-verifier agent asset", () => {
     ]) {
       expect(body, `missing body anchor ${anchor}`).toContain(anchor);
     }
+
+    // Pin the POLICY, not the call syntax. `adv_subagent_report_submit` is now
+    // dispatched through the Tier-3 `adv_tool_invoke` wrapper, so a literal
+    // "Do not call adv_subagent_report_submit" anchor breaks on a routing
+    // change even though the prohibition is fully intact. Assert a prohibition
+    // that names the tool, tolerant of the wrapper.
+    expect(body, "missing report-submission prohibition").toMatch(
+      /do not call[^.\n]*adv_subagent_report_submit/i,
+    );
   });
 
   test("preserves orchestrator-submitted verification bundle result identity", () => {

--- a/plugin/src/archive/archive.ts
+++ b/plugin/src/archive/archive.ts
@@ -183,6 +183,10 @@ async function writeArchiveBundleFiles(
   }
 
   // Release notes sidecar, when the change carries release-note content.
+  // Additive by construction: absent data emits no sidecar, so every existing
+  // bundle file and release behaviour is unchanged, and the sidecar travels as
+  // an ordinary file through the existing archive-PR / git-tree flows.
+  // rq-releaseNotesSidecar01
   if (change.release_notes !== undefined) {
     await atomicWriteFile(
       join(archivePath, "release-notes.json"),

--- a/plugin/src/optimized-handoff-assets.test.ts
+++ b/plugin/src/optimized-handoff-assets.test.ts
@@ -237,9 +237,12 @@ describe("read-only lane packet-defect policy (lane-aware)", () => {
       // The new policy explicitly directs the worker to skip the typed
       // submission call when anchors are missing (rather than submit a
       // malformed persisted report).
-      expect(content).toMatch(
-        /do not call `adv_subagent_report_submit`|do NOT call `adv_subagent_report_submit`/i,
-      );
+      //
+      // Match the POLICY, not the call syntax: submission is now dispatched
+      // through the Tier-3 `adv_tool_invoke` wrapper, so pinning the
+      // pre-migration literal made this fail while the prohibition was fully
+      // present and correct.
+      expect(content).toMatch(/do not call[^.\n]*adv_subagent_report_submit/i);
     });
   }
 });

--- a/plugin/src/storage/change-projection-transaction.ts
+++ b/plugin/src/storage/change-projection-transaction.ts
@@ -406,6 +406,11 @@ export async function commitChangeProjection(
       };
     }
 
+    // Command success is only reportable once the accepted monotonic revision
+    // is committed AND verified in the durable projection: the readback must
+    // carry this exact operation identity, payload hash and state revision.
+    // Anything else downgrades to committed_unverified rather than success.
+    // rq-projectionCommandProof01
     if (
       operationId &&
       (readback.projection_commits?.[readback.projection_commits.length - 1]

--- a/plugin/src/storage/store-temporal/read-model.ts
+++ b/plugin/src/storage/store-temporal/read-model.ts
@@ -6,6 +6,12 @@ import type { ReadSnapshot } from "../store-types";
  * A full active-change projection is the authority for routine reads. This
  * module intentionally has no Temporal dependency: callers can therefore use
  * it safely when a workflow is missing, poisoned, or otherwise unreachable.
+ *
+ * This is the enforcement point for projection-first routine reads: routine
+ * reads resolve from schema-versioned durable projections here and never issue
+ * a workflow Query. Query/Visibility/Describe remain reserved for command
+ * confirmation, reconciliation, diagnostics and repair.
+ * rq-projectionReadModel02
  */
 export type ChangeReadSnapshot =
   | ReadSnapshot<Change>

--- a/plugin/src/tools/status-health-plan.ts
+++ b/plugin/src/tools/status-health-plan.ts
@@ -53,6 +53,12 @@ import {
   type PendingDeleteSummary,
 } from "./worktree/state";
 
+// One request-scoped absolute budget for `adv_status view:health`. The cutoff
+// closes provider admission early enough to reserve bounded composition time
+// (cutoff + reserve = deadline), and concurrency/candidate limits are fixed and
+// explicit rather than derived. Deadline expiry yields typed partial output;
+// late provider completion must not mutate the returned result.
+// rq-statusHealthAggregateBudget01
 export const HEALTH_RESPONSE_DEADLINE_MS = 8_000;
 export const HEALTH_EXECUTION_CUTOFF_MS = 7_500;
 export const HEALTH_COMPOSITION_RESERVE_MS = 500;


### PR DESCRIPTION
Two independent CI failures, both **pre-existing on trunk** (present at baseline `5106efa9`).

## 1. Stale literal anchors — TEST_BUG

`adv-verifier-assets.test.ts` and `optimized-handoff-assets.test.ts` asserted the literal phrase:

```
do not call `adv_subagent_report_submit`
```

Report submission is now dispatched through the Tier-3 `adv_tool_invoke` wrapper, so the agent files read:

```
do NOT call `adv_tool_invoke({name: "adv_subagent_report_submit", ...})`
```

**The prohibition is fully present and correct** in all four read-only lane agents — `adv-researcher`, `adv-tron`, `adv-visual-review`, `adv-verifier`. Only the assertion was pinned to pre-migration call syntax.

Now asserts the **policy** (a "do not call" prohibition naming the tool, tolerant of the wrapper) rather than the call syntax, so a future routing change cannot break it again while the policy itself holds.

Fixes 4 red tests.

## 2. Uncited requirements — REAL_DEFECT

`spec-citation-invariant` asserts every requirement has an enforcement path outside its own spec — *"this prevents new laws from shipping without an enforcement path."* Four had none.

Citing them arbitrarily would satisfy the test while defeating the invariant, so each is cited at its **genuine** enforcement site:

| Requirement | Site | Why there |
|---|---|---|
| `rq-releaseNotesSidecar01` | `archive/archive.ts` | at the sidecar writer, documenting the additive-when-absent contract |
| `rq-projectionReadModel02` | `storage/store-temporal/read-model.ts` | the Temporal-free routine-read authority the law mandates |
| `rq-statusHealthAggregateBudget01` | `tools/status-health-plan.ts` | on the 8000 ms budget constants (cutoff + reserve = deadline) |
| `rq-projectionCommandProof01` | `storage/change-projection-transaction.ts` | at the operation-identity readback verification that gates success |

## Verification

- 22 tests green across the three affected files
- `pnpm run check` clean

## Scope

Deliberately does **not** touch the remaining 12 failing files. Those encode the pre-read-model contract and belong to the in-flight `fixWorkerDependentResume` / `makeToolReadsWorkerFree` migration — rewriting their assertions needs the migration owner's judgment, not a drive-by.

## Context

Trunk CI (`ci.yml` → `Test (24.x)`) has been failing for 6+ commits including baseline `5106efa9`. This PR removes 3 of the 15 failing files.