### PR TITLE
fix(adv-verifier): fail soft on a defective packet instead of discarding work

### DIFF
--- a/.opencode/agents/adv-verifier.md
+++ b/.opencode/agents/adv-verifier.md
@@ -87,7 +87,13 @@ COMMANDS:
   - {exact command or orchestrator-approved intent/tier}
 ```
 
-If strict identity anchors (`WORKING DIRECTORY`, `CHANGE`, `SCOPE KEY`, `PHASE`, `ATTEMPT`) are missing, stop with `status: "inconclusive"`, `error_class: "UNKNOWN"`, and `recommended_next_action: "ask_user"`.
+If identity anchors are missing, never discard completed verification work. Anchors are orchestrator-owned, so a packet defect is an internal defect — never escalate one to the user, and never infer an anchor heuristically.
+
+- `WORKING DIRECTORY` is the only hard prerequisite. Without it there is no safe place to run commands, so stop with `status: "inconclusive"`, `error_class: "UNKNOWN"`, and `recommended_next_action: "ask_user"`.
+- If `PHASE` is absent, assume `local_verify`, because that is the only mode that can proceed without supplied check evidence.
+- If `CHANGE`, `SCOPE KEY`, or `ATTEMPT` are absent, proceed anyway. They are identity labels that do not change what must be verified.
+
+Whenever you proceed with a defective packet, still perform the verification and return the normal typed result, prefixed with a `## PACKET DEFECT` section listing the missing anchors so the orchestrator can correct the spawn pattern. Do not call `question` for packet identity values.
 
 ## Authority Boundaries
 

--- a/plugin/src/adv-verifier-assets.test.ts
+++ b/plugin/src/adv-verifier-assets.test.ts
@@ -117,6 +117,38 @@ describe("adv-verifier agent asset", () => {
     );
   });
 
+  test("fails soft on a defective packet instead of discarding the work", () => {
+    const { body } = splitFrontmatter(readFileSync(AGENT_PATH, "utf8"));
+
+    // A missing anchor previously stopped the lane outright: it returned
+    // inconclusive/ask_user having run ZERO commands, so a correctly-scoped
+    // verification was thrown away over an orchestrator-owned label. Anchors
+    // are orchestrator-owned, so a packet defect is an internal defect.
+    expect(body, "must not discard completed work").toMatch(
+      /never discard completed verification work/i,
+    );
+    expect(body, "must report the defect rather than ask the user").toContain(
+      "## PACKET DEFECT",
+    );
+    expect(body, "must not escalate orchestrator-owned identity").toMatch(
+      /do not call `question` for packet identity values/i,
+    );
+
+    // WORKING DIRECTORY is the ONLY anchor that may hard-block: without it
+    // there is nowhere safe to run commands.
+    expect(body, "WORKING DIRECTORY must remain a hard prerequisite").toMatch(
+      /`WORKING DIRECTORY` is the only hard prerequisite/i,
+    );
+    // PHASE must degrade to the mode that can run unaided, not block.
+    expect(body, "PHASE must default rather than block").toMatch(
+      /if `PHASE` is absent, assume `local_verify`/i,
+    );
+    // Pure identity labels must never block verification.
+    expect(body, "identity labels must not block").toMatch(
+      /`CHANGE`, `SCOPE KEY`, or `ATTEMPT` are absent, proceed anyway/i,
+    );
+  });
+
   test("preserves orchestrator-submitted verification bundle result identity", () => {
     const { body } = splitFrontmatter(readFileSync(AGENT_PATH, "utf8"));
 


### PR DESCRIPTION
Implements `bl-1zHDUuaX`.

## Problem

`adv-verifier` stopped outright when any identity anchor was missing:

```json
{"status":"inconclusive","error_class":"UNKNOWN","recommended_next_action":"ask_user",
 "evidence_basis":"Required packet identity anchors missing: SCOPE KEY and PHASE. No commands run."}
```

**Zero commands run.** Observed live: a correctly-scoped trunk-baseline regression comparison was discarded because the packet omitted `SCOPE KEY` and `PHASE`. Re-running with those two anchors added succeeded unchanged — the work was always viable.

Anchors are **orchestrator-owned**, so a packet defect is an *internal* defect. The old behaviour both discarded valid work and pointed the operator at something they cannot supply.

Sibling read-only lanes already require the opposite:

> *"Complete the reconnaissance anyway — your findings are still valuable to the orchestrator; never discard completed work because of a packet defect. Return findings … prefixed with a `## PACKET DEFECT` section."*

`adv-verifier` is also read-only (`edit: deny`) yet refused — inconsistent with its own lane class.

## Fix

Graded by what each anchor actually affects, rather than blanket fail-soft:

| Anchor | Behaviour |
|---|---|
| `WORKING DIRECTORY` | **hard prerequisite** — no safe place to run commands, still stops with `inconclusive`/`ask_user` |
| `PHASE` | defaults to `local_verify`, the only mode that proceeds without supplied check evidence |
| `CHANGE`, `SCOPE KEY`, `ATTEMPT` | identity labels only — verification proceeds |

When proceeding with a defective packet, the lane returns its normal typed result prefixed with `## PACKET DEFECT` listing the missing anchors, so the orchestrator can repair the spawn pattern.

## Correction to the original report

`SCOPE KEY` and `PHASE` are **legitimately required** anchors — pinned by `adv-verifier-assets.test.ts`. My initial framing in `bl-1zHDUuaX` called this documented-vs-enforced drift; that was wrong. Requiring them was never the defect. **Refusing rather than reporting** was.

## Verification

- New test pins the graded policy, so a future edit cannot silently restore blanket refusal or drop the `WORKING DIRECTORY` hard block.
- 21 tests green across `adv-verifier-assets` and `optimized-handoff-assets`; `pnpm run check` clean.