### PR TITLE
fix(storage): detect executable saveChange calls structurally

### DIFF
--- a/plugin/src/storage/read-command-boundary.test.ts
+++ b/plugin/src/storage/read-command-boundary.test.ts
@@ -25,8 +25,11 @@ import { describe, expect, it } from "vitest";
 import ts from "typescript";
 import { readFileSync, statSync, existsSync } from "node:fs";
 import { resolve, dirname, join, relative, extname } from "node:path";
-import { execSync } from "node:child_process";
-import { isAllowedSaveChangeCaller } from "./save-change-allow-list";
+import {
+  enclosingContextNames,
+  findExecutableSaveChangeCalls,
+  isAllowedSaveChangeCaller,
+} from "./save-change-allow-list";
 
 const pluginSrc = resolve(import.meta.dirname, "..");
 
@@ -316,31 +319,6 @@ const queryContextAllowlist = new Map<string, Set<string>>([
   ],
 ]);
 
-function enclosingContextNames(node: ts.Node): string[] {
-  const names: string[] = [];
-  let current: ts.Node | undefined = node;
-  while (current) {
-    if (ts.isFunctionDeclaration(current) && current.name) {
-      names.push(current.name.text);
-    } else if (
-      (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) &&
-      current.parent
-    ) {
-      const parent = current.parent;
-      if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
-        names.push(parent.name.text);
-      } else if (
-        (ts.isPropertyAssignment(parent) || ts.isMethodDeclaration(parent)) &&
-        parent.name
-      ) {
-        names.push(parent.name.getText().replace(/["']/g, ""));
-      }
-    }
-    current = current.parent;
-  }
-  return names;
-}
-
 function workflowCallContexts(source: ts.SourceFile): string[][] {
   const calls: string[][] = [];
   function visit(node: ts.Node) {
@@ -401,58 +379,17 @@ describe("pure metadata/spec/catalog roots are isolated", () => {
 describe("writer allowlist", () => {
   it("direct saveChange call sites are confined to the allow-list", async () => {
     const repoRoot = resolve(pluginSrc, "../..");
-    const output = execSync(
-      'rg --vimgrep "saveChange\\(" plugin/src --type ts',
-      { cwd: repoRoot, encoding: "utf-8" },
-    );
+    const calls = await findExecutableSaveChangeCalls(repoRoot);
     const violations: string[] = [];
 
-    for (const line of output.split("\n").filter(Boolean)) {
-      const [file, lineNo, column, ...rest] = line.split(":");
-      const content = rest.join(":");
-      if (!file) continue;
-      if (file.endsWith(".test.ts") || file.endsWith(".itest.ts")) continue;
-
-      const absoluteFile = resolve(repoRoot, file);
-      const fileContent = readFileSync(absoluteFile, "utf-8");
-      const lines = fileContent.split("\n");
-      const idx = Number(lineNo) - 1;
-      const callLine = lines[idx];
-      const trimmed = callLine.trim();
-      if (
-        trimmed.startsWith("//") ||
-        trimmed.startsWith("*") ||
-        trimmed.startsWith("/*")
-      ) {
+    for (const call of calls) {
+      if (call.file.endsWith(".test.ts") || call.file.endsWith(".itest.ts")) {
         continue;
       }
-      if (trimmed.startsWith("export async function saveChange(")) continue;
-
-      const contexts: string[] = [];
-      for (let i = idx - 1; i >= 0 && contexts.length < 8; i--) {
-        const l = lines[i];
-        const fnMatch = l.match(
-          /(?:export\s+)?(?:async\s+)?function\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/,
+      if (!isAllowedSaveChangeCaller(call.file, call.contexts).allowed) {
+        violations.push(
+          `${call.file}:${call.line}:${call.column}: ${call.content.trim()}`,
         );
-        if (fnMatch) {
-          contexts.push(fnMatch[1]);
-          continue;
-        }
-        const methodMatch = l.match(
-          /([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*(?:async\s+)?\(/,
-        );
-        if (methodMatch) {
-          contexts.push(methodMatch[1]);
-          continue;
-        }
-        const arrowMatch = l.match(
-          /(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/,
-        );
-        if (arrowMatch) contexts.push(arrowMatch[1]);
-      }
-
-      if (!isAllowedSaveChangeCaller(file, contexts).allowed) {
-        violations.push(`${file}:${lineNo}:${column}: ${content.trim()}`);
       }
     }
 

--- a/plugin/src/storage/save-change-allow-list.test.ts
+++ b/plugin/src/storage/save-change-allow-list.test.ts
@@ -1,82 +1,59 @@
 import { describe, expect, it } from "vitest";
-import { readFile } from "node:fs/promises";
-import { execSync } from "node:child_process";
+import {
+  collectSaveChangeCallSitesFromText,
+  findExecutableSaveChangeCalls,
+  isAllowedSaveChangeCaller,
+} from "./save-change-allow-list";
 import { dirname, resolve } from "node:path";
-import { isAllowedSaveChangeCaller } from "./save-change-allow-list";
 
 const repoRoot = resolve(dirname(import.meta.filename), "../../..");
 
 /**
- * Mechanical guard: every raw `saveChange(` call site in plugin/src must be
- * listed in the save-change allow-list with a rationale. Unlisted callers
- * indicate an active-projection write that bypasses the storage-owned
+ * Mechanical guard: every executable `saveChange(...)` call site in plugin/src
+ * must be listed in the save-change allow-list with a rationale. Unlisted
+ * callers indicate an active-projection write that bypasses the storage-owned
  * conditional commit boundary.
+ *
+ * Detection uses the TypeScript AST so literals, line comments, and block
+ * comments cannot self-match.
  */
 describe("saveChange caller inventory", () => {
   it("has no unenumerated active-projection raw saveChange callers", async () => {
-    const output = execSync(
-      'rg --vimgrep "saveChange\\(" plugin/src --type ts',
-      { cwd: repoRoot, encoding: "utf-8" },
-    );
-    const lines = output.split("\n").filter(Boolean);
+    const calls = await findExecutableSaveChangeCalls(repoRoot);
     const violations: string[] = [];
 
-    for (const line of lines) {
-      const [file, lineNo, column, ...rest] = line.split(":");
-      const content = rest.join(":");
-      if (!file) continue;
-
-      const absoluteFile = resolve(repoRoot, file);
-      const fileContent = await readFile(absoluteFile, "utf-8");
-      const linesArray = fileContent.split("\n");
-      const idx = Number(lineNo) - 1;
-      const callLine = linesArray[idx];
-
-      // Skip comment-only lines and the helper definition line.
-      const trimmed = callLine.trim();
-      if (
-        trimmed.startsWith("//") ||
-        trimmed.startsWith("*") ||
-        trimmed.startsWith("/*")
-      ) {
-        continue;
-      }
-      if (trimmed.startsWith("export async function saveChange(")) {
-        continue;
-      }
-
-      // Walk up to collect containing function/method names.
-      const contexts: string[] = [];
-      for (let i = idx - 1; i >= 0 && contexts.length < 8; i--) {
-        const l = linesArray[i];
-        const fnMatch = l.match(
-          /(?:export\s+)?(?:async\s+)?function\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/,
-        );
-        if (fnMatch) {
-          contexts.push(fnMatch[1]);
-          continue;
-        }
-        const methodMatch = l.match(
-          /([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*(?:async\s+)?\(/,
-        );
-        if (methodMatch) {
-          contexts.push(methodMatch[1]);
-          continue;
-        }
-        const arrowMatch = l.match(
-          /(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/,
-        );
-        if (arrowMatch) {
-          contexts.push(arrowMatch[1]);
-        }
-      }
-
-      const { allowed } = isAllowedSaveChangeCaller(file, contexts);
+    for (const call of calls) {
+      const { allowed } = isAllowedSaveChangeCaller(call.file, call.contexts);
       if (!allowed) {
-        violations.push(`${file}:${lineNo}:${column}: ${content.trim()}`);
+        violations.push(
+          `${call.file}:${call.line}:${call.column}: ${call.content.trim()}`,
+        );
       }
     }
 
     expect(violations).toEqual([]);
+  });
+});
+
+describe("saveChange AST call detection", () => {
+  it("ignores literals and comments but flags an executable unallowlisted call", () => {
+    const source = `
+      // A line comment containing saveChange( must not be treated as a call.
+      /* A block comment containing saveChange( must also be ignored. */
+      const searchLiteral = "export async function saveChange(path, change)";
+      function suspiciousWriter() {
+        saveChange("plugin/src/storage/unknown.ts", {});
+      }
+    `;
+    const calls = collectSaveChangeCallSitesFromText(
+      source,
+      "plugin/src/storage/unknown-fixture.ts",
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].contexts).toContain("suspiciousWriter");
+    expect(
+      isAllowedSaveChangeCaller(calls[0].file, calls[0].contexts).allowed,
+    ).toBe(false);
   });
 });

--- a/plugin/src/storage/save-change-allow-list.test.ts
+++ b/plugin/src/storage/save-change-allow-list.test.ts
@@ -44,16 +44,28 @@ describe("saveChange AST call detection", () => {
       function suspiciousWriter() {
         saveChange("plugin/src/storage/unknown.ts", {});
       }
+      function spacedSuspiciousWriter() {
+        saveChange ("plugin/src/storage/unknown.ts", {});
+      }
+      class Writer {
+        suspiciousMethod() {
+          saveChange("plugin/src/storage/unknown.ts", {});
+        }
+      }
     `;
     const calls = collectSaveChangeCallSitesFromText(
       source,
       "plugin/src/storage/unknown-fixture.ts",
     );
 
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(3);
     expect(calls[0].contexts).toContain("suspiciousWriter");
-    expect(
-      isAllowedSaveChangeCaller(calls[0].file, calls[0].contexts).allowed,
-    ).toBe(false);
+    expect(calls[1].contexts).toContain("spacedSuspiciousWriter");
+    expect(calls[2].contexts).toContain("suspiciousMethod");
+    for (const call of calls) {
+      expect(isAllowedSaveChangeCaller(call.file, call.contexts).allowed).toBe(
+        false,
+      );
+    }
   });
 });

--- a/plugin/src/storage/save-change-allow-list.ts
+++ b/plugin/src/storage/save-change-allow-list.ts
@@ -18,6 +18,11 @@
  * `commitChangeProjection` / the typed mutation coordinator.
  */
 
+import { readFile } from "node:fs/promises";
+import { execSync } from "node:child_process";
+import { resolve, relative } from "node:path";
+import ts from "typescript";
+
 export interface SaveChangeAllowListEntry {
   /** Source file path relative to the repo root. */
   file: string;
@@ -120,6 +125,120 @@ export const SAVE_CHANGE_ALLOW_LIST: SaveChangeAllowListEntry[] = [
       "RED/GREEN test seeds a durable delta-add projection directly via raw saveChange to prove the disk shard is written before the workflow ledger is consulted.",
   },
 ];
+
+export interface SaveChangeCallSite {
+  /** Source file path relative to the repo root. */
+  file: string;
+  /** 1-indexed line number of the `saveChange` identifier. */
+  line: number;
+  /** 1-indexed column number of the `saveChange` identifier. */
+  column: number;
+  /** Enclosing function/method/arrow-function names for context narrowing. */
+  contexts: string[];
+  /** The full source line containing the call. */
+  content: string;
+}
+
+/**
+ * Walk ancestor nodes to collect the names of enclosing functions, methods, and
+ * arrow-function variable declarations. Used by both guard tests to preserve the
+ * existing `(file, contexts)` allow-list matching.
+ */
+export function enclosingContextNames(node: ts.Node): string[] {
+  const names: string[] = [];
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (ts.isFunctionDeclaration(current) && current.name) {
+      names.push(current.name.text);
+    } else if (
+      (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) &&
+      current.parent
+    ) {
+      const parent = current.parent;
+      if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
+        names.push(parent.name.text);
+      } else if (
+        (ts.isPropertyAssignment(parent) || ts.isMethodDeclaration(parent)) &&
+        parent.name
+      ) {
+        names.push(parent.name.getText().replace(/["']/g, ""));
+      }
+    }
+    current = current.parent;
+  }
+  return names;
+}
+
+function createSaveChangeSourceFile(
+  fileName: string,
+  text: string,
+): ts.SourceFile {
+  return ts.createSourceFile(
+    fileName,
+    text,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+export function collectSaveChangeCallSitesFromSource(
+  source: ts.SourceFile,
+  file: string,
+): SaveChangeCallSite[] {
+  const calls: SaveChangeCallSite[] = [];
+  function visit(node: ts.Node) {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      if (ts.isIdentifier(callee) && callee.text === "saveChange") {
+        const start = node.getStart(source);
+        const { line, character } = source.getLineAndCharacterOfPosition(start);
+        const lines = source.text.split("\n");
+        calls.push({
+          file,
+          line: line + 1,
+          column: character + 1,
+          contexts: enclosingContextNames(node),
+          content: lines[line] ?? "",
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  return calls;
+}
+
+export function collectSaveChangeCallSitesFromText(
+  text: string,
+  file = "fixture.ts",
+): SaveChangeCallSite[] {
+  const source = createSaveChangeSourceFile(file, text);
+  return collectSaveChangeCallSitesFromSource(source, file);
+}
+
+export async function findExecutableSaveChangeCalls(
+  repoRoot: string,
+): Promise<SaveChangeCallSite[]> {
+  const output = execSync('rg --vimgrep "saveChange\\(" plugin/src --type ts', {
+    cwd: repoRoot,
+    encoding: "utf-8",
+  });
+  const files = new Set<string>();
+  for (const line of output.split("\n").filter(Boolean)) {
+    const [file] = line.split(":");
+    if (file) files.add(resolve(repoRoot, file));
+  }
+
+  const calls: SaveChangeCallSite[] = [];
+  for (const absoluteFile of files) {
+    const text = await readFile(absoluteFile, "utf-8");
+    const source = createSaveChangeSourceFile(absoluteFile, text);
+    const relFile = relative(repoRoot, absoluteFile).replace(/\\/g, "/");
+    calls.push(...collectSaveChangeCallSitesFromSource(source, relFile));
+  }
+  return calls;
+}
 
 /**
  * Tests scan callers as `(file, contexts)` pairs. A null context in the allow

--- a/plugin/src/storage/save-change-allow-list.ts
+++ b/plugin/src/storage/save-change-allow-list.ts
@@ -150,6 +150,8 @@ export function enclosingContextNames(node: ts.Node): string[] {
   while (current) {
     if (ts.isFunctionDeclaration(current) && current.name) {
       names.push(current.name.text);
+    } else if (ts.isMethodDeclaration(current) && current.name) {
+      names.push(current.name.getText().replace(/["']/g, ""));
     } else if (
       (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) &&
       current.parent
@@ -220,7 +222,7 @@ export function collectSaveChangeCallSitesFromText(
 export async function findExecutableSaveChangeCalls(
   repoRoot: string,
 ): Promise<SaveChangeCallSite[]> {
-  const output = execSync('rg --vimgrep "saveChange\\(" plugin/src --type ts', {
+  const output = execSync("rg --files plugin/src --type ts", {
     cwd: repoRoot,
     encoding: "utf-8",
   });


### PR DESCRIPTION
## Summary
- replace raw text saveChange scanning with TypeScript call-expression detection
- ignore literals and comments while preserving unallowlisted-call detection
- add structural guard regression coverage

## Verification
- 
 RUN  v4.1.8 /home/jon/.local/share/opencode/worktree/bdf259aa162ae192af5b18899ccdc653b085528d/change/fixSaveChangeGuard/plugin


 Test Files  2 passed (2)
      Tests  18 passed (18)
   Start at  18:12:09
   Duration  3.45s (transform 280ms, setup 0ms, import 798ms, tests 5.50s, environment 0ms) (18 passing)
- All agent manifests match generated output.
frontmatter check passed: 42 file(s) scanned

/home/jon/.local/share/opencode/worktree/bdf259aa162ae192af5b18899ccdc653b085528d/change/fixSaveChangeGuard/plugin/src/utils/manifest-frontmatter.ts
  254:11  warning  Unused eslint-disable directive (no problems were reported from 'no-console')
  269:5   warning  Unused eslint-disable directive (no problems were reported from 'no-console')
  275:5   warning  Unused eslint-disable directive (no problems were reported from 'no-console')

✖ 3 problems (0 errors, 3 warnings)
  0 errors and 3 warnings potentially fixable with the `--fix` option.

Checking formatting...
All matched files use Prettier code style!

## CI note
Full suite remains red only on unrelated baseline/release-gate failures tracked by  and .