### PR TITLE
fix(change): bypass Temporal query for poisoned recovery

### DIFF
--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -5312,6 +5312,100 @@ export const changeTools = {
         });
       }
 
+      // Operator-supplied poisoned-history recovery branch (fixWedgedWorkflowRecovery).
+      // Evaluated BEFORE any Temporal-backed store query so that a poisoned
+      // workflow that cannot answer changeStateQuery does not hang the tool.
+      // Existence and archived status are read from the authoritative disk
+      // projection only; dryRun is fully no-mutation.
+      if (
+        shouldTakeRecoveryBranch({
+          recoveryMode,
+          recoveryEvidence,
+          approvedByUser,
+          approvalEvidence,
+        })
+      ) {
+        const diskResult = await loadChange(store.paths.changes, changeId);
+        if (!diskResult.success || !diskResult.data) {
+          return formatToolOutput({
+            success: false,
+            error: `Change not found: ${changeId}`,
+            changeId,
+          });
+        }
+        if (diskResult.data.status === "archived") {
+          return formatToolOutput({
+            success: false,
+            error: `Workflow termination refused: change ${changeId} is archived.`,
+            changeId,
+            currentStatus: diskResult.data.status,
+            hint: "Use adv_archive_purge for archived changes — it is the sole archived-change workflow termination lever.",
+          });
+        }
+        if (dryRun) {
+          return formatToolOutput({
+            success: true,
+            dryRun: true,
+            wouldTerminate: true,
+            changeId,
+            eligibilityClass: "poisoned_history",
+            message: `Would terminate change ${changeId} via operator-supplied poisoned-history recovery branch (describe skipped).`,
+          });
+        }
+
+        const { getService } = await import("../temporal/service");
+        const service = getService();
+        const projectId = service ? await getProjectId(store.paths.root) : null;
+        if (!service || !projectId) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Temporal service not available — cannot terminate the change workflow",
+            changeId,
+            hint: "Restore the Temporal service (adv_doctor) and retry the termination.",
+          });
+        }
+        const { getChangeHandle } = await import("./_adapters");
+        const handle = getChangeHandle(service.client, projectId, changeId);
+        const { isWorkflowCompletedError } =
+          await import("../temporal/recovery-classification");
+
+        let alreadyTerminated = false;
+        try {
+          await (
+            handle as unknown as {
+              terminate: (reason?: string) => Promise<unknown>;
+            }
+          ).terminate(
+            `adv_change_workflow_terminate: operator-approved termination of poisoned_history change workflow ${changeId} (unpinned recovery branch)`,
+          );
+        } catch (error) {
+          if (isWorkflowCompletedError(error)) {
+            alreadyTerminated = true;
+          }
+          // Non-completed errors are treated as an unreachable wedged workflow
+          // because the operator provided precise recovery evidence; fall
+          // through to the disk-projection refresh.
+        }
+
+        try {
+          await store.changes.refresh(changeId);
+        } catch (error) {
+          logger.debug(
+            `Post-termination cache refresh failed for ${changeId}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+
+        return formatToolOutput({
+          success: true,
+          changeId,
+          workflowTerminated: true,
+          ...(alreadyTerminated ? { alreadyTerminated: true } : {}),
+          eligibilityClass: "poisoned_history",
+          message: `Terminated change ${changeId} workflow via operator-supplied poisoned-history recovery branch (describe skipped). Disk projection remains authoritative; subsequent reads fall through to disk.`,
+        });
+      }
+
       const result = await store.changes.get(changeId);
       if (!result.success) {
         return formatToolOutput({ success: false, error: result.error });
@@ -5365,60 +5459,6 @@ export const changeTools = {
       };
       const { isWorkflowCompletedError } =
         await import("../temporal/recovery-classification");
-
-      // Operator-supplied poisoned-history recovery branch
-      // (fixPoisonedClosePathPrecheck): run after approval + existence +
-      // archived check but BEFORE shipped-gate proof. An unfinished poisoned
-      // change cannot satisfy acceptance+release shipped proof, so gating this
-      // branch behind shipped proof made it unreachable. This branch is
-      // recoveryMode-gated and evidence-gated: terminate only, refresh the
-      // cache, and never write convergence/status. Shipped-terminal/normal
-      // mode still requires full shipped proof + exact run pinning below.
-      if (
-        shouldTakeRecoveryBranch({
-          recoveryMode,
-          recoveryEvidence,
-          approvedByUser,
-          approvalEvidence,
-        })
-      ) {
-        if (dryRun) {
-          return formatToolOutput({
-            success: true,
-            dryRun: true,
-            wouldTerminate: true,
-            changeId,
-            eligibilityClass: "poisoned_history",
-            message: `Would terminate change ${changeId} via operator-supplied poisoned-history recovery branch (describe skipped).`,
-          });
-        }
-        let alreadyTerminated = false;
-        try {
-          await (
-            handle as unknown as {
-              terminate: (reason?: string) => Promise<unknown>;
-            }
-          ).terminate(
-            `adv_change_workflow_terminate: operator-approved termination of poisoned_history change workflow ${changeId} (unpinned recovery branch)`,
-          );
-        } catch (error) {
-          if (isWorkflowCompletedError(error)) {
-            alreadyTerminated = true;
-          }
-          // Non-completed errors are treated as an unreachable wedged workflow
-          // because the operator provided precise recovery evidence; fall
-          // through to the disk-projection refresh.
-        }
-        await refreshProjectionCache();
-        return formatToolOutput({
-          success: true,
-          changeId,
-          workflowTerminated: true,
-          ...(alreadyTerminated ? { alreadyTerminated: true } : {}),
-          eligibilityClass: "poisoned_history",
-          message: `Terminated change ${changeId} workflow via operator-supplied poisoned-history recovery branch (describe skipped). Disk projection remains authoritative; subsequent reads fall through to disk.`,
-        });
-      }
 
       // Shipped proof: acceptance AND release gates done. This must pass
       // BEFORE idempotent completed/not-found handling in the normal path — a

--- a/plugin/src/tools/change.workflow-terminate.test.ts
+++ b/plugin/src/tools/change.workflow-terminate.test.ts
@@ -144,6 +144,34 @@ function createMockStore(change: Change | null): Store {
   } as unknown as Store;
 }
 
+async function createDiskBackedMockStore(
+  change: Change,
+  tempRoot: string,
+): Promise<Store> {
+  const changesDir = join(tempRoot, "changes");
+  const archiveDir = join(tempRoot, "archive");
+  await mkdir(changesDir, { recursive: true });
+  await mkdir(archiveDir, { recursive: true });
+  const dir = join(changesDir, change.id);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "change.json"), JSON.stringify(change, null, 2));
+  return {
+    paths: {
+      root: tempRoot,
+      changes: changesDir,
+      archive: archiveDir,
+    } as Store["paths"],
+    config: { name: "test", features: {} } as Store["config"],
+    changes: {
+      get: vi.fn(async (changeId: string) => ({
+        success: true,
+        data: change && change.id === changeId ? change : null,
+      })),
+      refresh: vi.fn(async () => undefined),
+    } as unknown as Store["changes"],
+  } as unknown as Store;
+}
+
 /** describe() payload for a RUNNING run carrying poisoned-history evidence. */
 function poisonedRunningDescription(runId = "run-123") {
   return {
@@ -288,13 +316,17 @@ describe("adv_change_workflow_terminate", () => {
   test("operator-supplied poisoned_history recovery bypasses shipped-gate proof for unshipped changes", async () => {
     // Unfinished poisoned changes (acceptance/release pending) cannot satisfy
     // the shipped-terminal proof requirement, so the explicit recovery branch
-    // must be reachable before that gate check.
+    // must be reachable before that gate check. The branch reads only the disk
+    // projection and must not touch the Temporal-backed store.changes.get query.
     const gates = shippedGates();
     (gates.acceptance as { status: string }).status = "pending";
     (gates.release as { status: string }).status = "pending";
-    const store = createMockStore(
-      wedgedChange({ gates, status: "active" }),
+    const change = wedgedChange({ gates, status: "active" });
+
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "adv-wf-terminate-poisoned-wet-"),
     );
+    const store = await createDiskBackedMockStore(change, tempRoot);
 
     const result = await tool().execute(
       {
@@ -312,9 +344,54 @@ describe("adv_change_workflow_terminate", () => {
     expect(parsed.success).toBe(true);
     expect(parsed.workflowTerminated).toBe(true);
     expect(parsed.eligibilityClass).toBe("poisoned_history");
+    expect(store.changes.get).not.toHaveBeenCalled();
     expect(mocks.describe).not.toHaveBeenCalled();
     expect(mocks.terminate).toHaveBeenCalledTimes(1);
     expect(store.changes.refresh).toHaveBeenCalledWith("wedgedChange");
+
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  test("dryRun poisoned_history recovery bypasses the Temporal store query and returns immediately", async () => {
+    const gates = shippedGates();
+    (gates.acceptance as { status: string }).status = "pending";
+    (gates.release as { status: string }).status = "pending";
+    const change = wedgedChange({ gates, status: "active" });
+
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "adv-wf-terminate-poisoned-dryrun-"),
+    );
+    const store = await createDiskBackedMockStore(change, tempRoot);
+    (store.changes.get as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error(
+        "store.changes.get must not be invoked for poisoned_history dryRun",
+      );
+    });
+
+    const result = await tool().execute(
+      {
+        changeId: "wedgedChange",
+        approvedByUser: true,
+        approvalEvidence: TERMINATE_EVIDENCE,
+        dryRun: true,
+        recoveryMode: "poisoned_history",
+        recoveryEvidence:
+          "WorkflowTaskFailedCauseNonDeterministicError: TMPRL1100 No command scheduled for event",
+      },
+      store,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.wouldTerminate).toBe(true);
+    expect(parsed.eligibilityClass).toBe("poisoned_history");
+    expect(store.changes.get).not.toHaveBeenCalled();
+    expect(mocks.describe).not.toHaveBeenCalled();
+    expect(mocks.terminate).not.toHaveBeenCalled();
+    expect(store.changes.refresh).not.toHaveBeenCalled();
+
+    await rm(tempRoot, { recursive: true, force: true });
   });
 
   test("returns structured error when Temporal service is unavailable", async () => {
@@ -658,7 +735,11 @@ describe("adv_change_workflow_terminate", () => {
   });
 
   test("poisoned_history recovery branch skips describe and succeeds when workflow is gone", async () => {
-    const store = createMockStore(wedgedChange());
+    const change = wedgedChange();
+    const tempRoot = await mkdtemp(
+      join(tmpdir(), "adv-wf-terminate-poisoned-gone-"),
+    );
+    const store = await createDiskBackedMockStore(change, tempRoot);
     mocks.describe.mockRejectedValue(
       new Error("Failed to query Workflow ServiceError"),
     );
@@ -685,9 +766,12 @@ describe("adv_change_workflow_terminate", () => {
     expect(parsed.workflowTerminated).toBe(true);
     expect(parsed.alreadyTerminated).toBe(true);
     expect(parsed.eligibilityClass).toBe("poisoned_history");
+    expect(store.changes.get).not.toHaveBeenCalled();
     expect(mocks.describe).not.toHaveBeenCalled();
     expect(mocks.terminate).toHaveBeenCalledTimes(1);
     expect(store.changes.refresh).toHaveBeenCalledWith("wedgedChange");
+
+    await rm(tempRoot, { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
## Summary
- evaluate explicit poisoned-history recovery before Temporal-backed change reads
- use typed disk projection loading for recovery-mode existence/archived checks
- retain normal shipped proof, exact run pinning, and convergence safeguards

## Verification
- 
 RUN  v4.1.8 /home/jon/.local/share/opencode/worktree-adhoc/advance/fix-poisoned-recovery-disk-read/plugin


 Test Files  1 passed (1)
      Tests  35 passed (35)
   Start at  16:05:02
   Duration  9.75s (transform 6.62s, setup 0ms, import 8.70s, tests 648ms, environment 0ms) (35 passed)
- [ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND] No package.json (or package.yaml, or package.json5) was found in "/home/jon/.local/share/opencode/worktree-adhoc/advance/fix-poisoned-recovery-disk-read".
- exact ESLint and Prettier checks for touched files