### PR TITLE
fix(test): give vitest projects distinct sequence.groupOrder

### DIFF
--- a/plugin/vitest.config.ts
+++ b/plugin/vitest.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
           name: "unit",
           include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
           globalSetup: ["./src/__tests__/global-setup.ts"],
+          // Vitest refuses to group projects whose effective worker counts
+          // differ unless each declares its own order. `temporal` pins a single
+          // worker via fileParallelism:false, so both projects must be explicit.
+          sequence: { groupOrder: 0 },
           env: {
             ADV_TEST_PROJECT: "unit",
             ADV_TEST_FILE_PARALLELISM: "true",
@@ -23,6 +27,8 @@ export default defineConfig({
           name: "temporal",
           include: ["src/**/*.itest.ts"],
           fileParallelism: false,
+          // Runs after the unit project; see the groupOrder note above.
+          sequence: { groupOrder: 1 },
           // Files already run sequentially. Disabling module isolation lets the
           // module-level shared workflow-bundle cache in with-test-env.ts persist
           // across files, so the 188 KB workflow graph is webpack-bundled ONCE per


### PR DESCRIPTION
## Problem

Every `vitest` invocation in `plugin/` aborts before running anything:

```
Error: Projects "temporal" and "unit" have different 'maxWorkers' but same 'sequence.groupOrder'.
Provide unique 'sequence.groupOrder' for them.

 Test Files  no tests
      Tests  no tests
```

The `temporal` project sets `fileParallelism: false`, which pins it to one worker. `unit` uses the default. Vitest 4.1.8 refuses to group projects whose effective worker counts differ unless each declares its own `sequence.groupOrder`.

Surfaced while reconciling a diverged local `trunk` — the project split landed without the accompanying group order, so the whole suite was unrunnable locally.

## Fix

Declare the order explicitly: `unit` = 0, `temporal` = 1. Matches the existing intent (integration tests run sequentially after unit tests).

## Verification

- Before: `pnpm vitest run <any path>` → `no tests`, 1 error.
- After: `pnpm vitest run src/types/tasks.test.ts src/storage/store-temporal/bounded-read-deadline.test.ts` → 2 files, 54 tests passed.
- `prettier --check` clean.