### PR TITLE
refactor: enforce Temporal operation boundary

### DIFF
--- a/bin/lib/cli-source-boundary.test.ts
+++ b/bin/lib/cli-source-boundary.test.ts
@@ -74,6 +74,13 @@ function repoRelative(path: string): string {
   return normalize(relative(REPO_ROOT, path)).replaceAll("\\", "/");
 }
 
+function isApprovedDeepPath(file: string): boolean {
+  // The Temporal operation owner is the sole approved raw SDK holder.
+  // Its internal storage/tool imports are the owner's implementation detail,
+  // not a direct CLI boundary leak.
+  return file.startsWith(join(PLUGIN_SRC, "temporal/"));
+}
+
 function assertNoForbiddenPluginSrcPath(path: string) {
   const rel = repoRelative(path);
   for (const forbidden of FORBIDDEN_PLUGIN_SRC_PREFIXES) {
@@ -122,7 +129,7 @@ describe("root CLI plugin source boundary", () => {
       const source = readFileSync(file, "utf8");
       for (const specifier of importSpecifiers(source)) {
         const next = resolveRelativeImport(file, specifier);
-        if (next && next.startsWith(PLUGIN_SRC)) {
+        if (next && next.startsWith(PLUGIN_SRC) && !isApprovedDeepPath(file)) {
           stack.push(next);
         }
       }
@@ -144,7 +151,7 @@ describe("root CLI plugin source boundary", () => {
       const source = readFileSync(file, "utf8");
       for (const specifier of importSpecifiers(source)) {
         const next = resolveRelativeImport(file, specifier);
-        if (next && next.startsWith(PLUGIN_SRC)) {
+        if (next && next.startsWith(PLUGIN_SRC) && !isApprovedDeepPath(file)) {
           stack.push(next);
         }
       }

--- a/bin/lib/dashboard/adv.test.ts
+++ b/bin/lib/dashboard/adv.test.ts
@@ -30,7 +30,7 @@ describe("dashboard ADV project reader", () => {
   test("routine state does not call per-change ops enrichment", async () => {
     let opsCalls = 0;
     const snapshot = await readDashboardAdvProject(project, {
-      resolveProjectId: async () => "project123",
+      resolveProjectId: async () => "a".repeat(40),
       loadBaseSummaries: async () => [baseSummary],
       loadOpsChanges: async () => {
         opsCalls += 1;
@@ -68,7 +68,7 @@ describe("dashboard ADV project reader", () => {
     } satisfies ChangeRecord & { ops_followup: unknown; ops_followup_links: unknown[]; worktrees: unknown[] };
 
     const snapshot = await readDashboardAdvProject(project, {
-      resolveProjectId: async () => "project123",
+      resolveProjectId: async () => "a".repeat(40),
       loadBaseSummaries: async () => [summary],
       loadOpsChanges: async () => [opsChange],
       now: () => new Date("2026-06-25T21:05:00.000Z"),

--- a/bin/lib/epic-list.test.ts
+++ b/bin/lib/epic-list.test.ts
@@ -6,22 +6,23 @@ import {
   listEpicsFromVisibility,
 } from "./epic-list";
 
-function fakeEpicClient(
+const PROJECT_ID = "e".repeat(40);
+
+function fakeEpicOwner(
   workflowRows: Array<{ workflowId: string; startTime?: Date | null }>,
   listError?: Error,
 ) {
   const queries: string[] = [];
   return {
     queries,
-    workflow: {
-      list: (opts: { query: string }) => {
-        if (listError) throw listError;
-        queries.push(opts.query);
-        async function* iter() {
-          for (const row of workflowRows) yield row;
-        }
-        return iter();
-      },
+    list: async <T extends { workflowId: string; startTime?: Date | null }>(
+      _ctx: unknown,
+      query: string,
+      _options?: { limit?: number; nextPageToken?: string },
+    ): Promise<{ kind: "complete"; value: T[]; truncated: boolean }> => {
+      if (listError) throw listError;
+      queries.push(query);
+      return { kind: "complete", value: workflowRows as T[], truncated: false };
     },
   };
 }
@@ -42,7 +43,7 @@ describe("epic list CLI helper", () => {
         },
       ],
       {
-        projectId: "pid-abc",
+        projectId: PROJECT_ID,
         now,
       },
     );
@@ -52,7 +53,7 @@ describe("epic list CLI helper", () => {
       live: true,
       stale: false,
       generated_at: "2026-06-26T03:00:00.000Z",
-      project_id: "pid-abc",
+      project_id: PROJECT_ID,
       epics: [
         { id: "cardIdentity", startTime: "2026-06-25T10:00:00.000Z" },
         {
@@ -67,7 +68,7 @@ describe("epic list CLI helper", () => {
     const payload = buildLiveEpicListPayload(
       [{ id: "cardIdentity", startTime: null }],
       {
-        projectId: "pid-abc",
+        projectId: PROJECT_ID,
         now,
       },
     );
@@ -77,7 +78,7 @@ describe("epic list CLI helper", () => {
 
   test("builds fail-closed JSON metadata", () => {
     const payload = buildLiveEpicListFailure(
-      "pid-abc",
+      PROJECT_ID,
       new Error("Temporal unavailable"),
       now,
     );
@@ -85,16 +86,16 @@ describe("epic list CLI helper", () => {
     expect(payload.source).toBe("temporal");
     expect(payload.live).toBe(false);
     expect(payload.stale).toBe(false);
-    expect(payload.project_id).toBe("pid-abc");
+    expect(payload.project_id).toBe(PROJECT_ID);
     expect(payload.epics).toEqual([]);
     expect(payload.error).toBe("Temporal unavailable");
     expect(payload.remediation).toContain("Temporal");
   });
 
   test("lists only Epic IDs in the current project prefix", async () => {
-    const client = fakeEpicClient([
+    const client = fakeEpicOwner([
       {
-        workflowId: "adv/epic/pid-abc/cardIdentity",
+        workflowId: `adv/epic/${PROJECT_ID}/cardIdentity`,
         startTime: new Date("2026-06-25T10:00:00.000Z"),
       },
       {
@@ -102,21 +103,21 @@ describe("epic list CLI helper", () => {
         startTime: new Date("2026-06-25T10:01:00.000Z"),
       },
       {
-        workflowId: "adv/change/pid-abc/notEpic",
+        workflowId: `adv/change/${PROJECT_ID}/notEpic`,
         startTime: new Date("2026-06-25T10:02:00.000Z"),
       },
       {
-        workflowId: "adv/epic/pid-abc/",
+        workflowId: `adv/epic/${PROJECT_ID}/`,
         startTime: new Date("2026-06-25T10:03:00.000Z"),
       },
       {
-        workflowId: "adv/epic/pid-abc/addLauncherRows",
+        workflowId: `adv/epic/${PROJECT_ID}/addLauncherRows`,
         startTime: null,
       },
     ]);
 
     const epics = await listEpicsFromVisibility(client, {
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       timeoutMs: 1000,
     });
 
@@ -133,15 +134,15 @@ describe("epic list CLI helper", () => {
   });
 
   test("can request all execution statuses without ExecutionStatus filter", async () => {
-    const client = fakeEpicClient([
+    const client = fakeEpicOwner([
       {
-        workflowId: "adv/epic/pid-abc/cardIdentity",
+        workflowId: `adv/epic/${PROJECT_ID}/cardIdentity`,
         startTime: new Date("2026-06-25T10:00:00.000Z"),
       },
     ]);
 
     await listEpicsFromVisibility(client, {
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       timeoutMs: 1000,
       status: "all",
     });
@@ -150,10 +151,10 @@ describe("epic list CLI helper", () => {
   });
 
   test("fails closed by throwing when Visibility listing fails", async () => {
-    const client = fakeEpicClient([], new Error("visibility unavailable"));
+    const client = fakeEpicOwner([], new Error("visibility unavailable"));
 
     await expect(
-      listEpicsFromVisibility(client, { projectId: "pid-abc", timeoutMs: 1000 }),
+      listEpicsFromVisibility(client, { projectId: PROJECT_ID, timeoutMs: 1000 }),
     ).rejects.toThrow("visibility unavailable");
   });
 });

--- a/bin/lib/epic-list.ts
+++ b/bin/lib/epic-list.ts
@@ -6,10 +6,11 @@
  */
 
 import {
-  createTemporalClientBundle,
   listEpicWorkflows,
   type EpicWorkflowListEntry as TemporalEpicWorkflowListEntry,
-  type ListEpicClient,
+  withTemporalOperations,
+  type TemporalOperations,
+  TemporalListOutcomeError,
 } from "../../plugin/src/cli/temporal-boundary";
 import { QUERY_TIMEOUT_MS } from "./live-status";
 
@@ -33,23 +34,6 @@ export interface EpicListPayload {
   resume_projection_state?: unknown;
   error?: string;
   remediation?: string;
-}
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  label: string,
-): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
-      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
-
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeout) clearTimeout(timeout);
-  });
 }
 
 export function buildLiveEpicListPayload(
@@ -92,35 +76,34 @@ export function buildLiveEpicListFailure(
 }
 
 export async function listEpicsFromVisibility(
-  client: ListEpicClient,
+  owner: TemporalOperations,
   options: { projectId: string; timeoutMs?: number; status?: "active" | "all" },
 ): Promise<TemporalEpicWorkflowListEntry[]> {
   const timeoutMs = options.timeoutMs ?? QUERY_TIMEOUT_MS;
-  return await withTimeout(
-    listEpicWorkflows(client, {
-      projectId: options.projectId,
-      status: options.status ?? "active",
-    }),
-    timeoutMs,
-    "Temporal Epic Visibility list",
-  );
+  const outcome = await listEpicWorkflows(owner, {
+    projectId: options.projectId,
+    status: options.status ?? "active",
+    limit: 1000,
+  });
+  if (outcome.kind !== "complete") {
+    throw new TemporalListOutcomeError(outcome);
+  }
+  return outcome.value;
 }
 
 export async function loadLiveEpics(
   projectId: string,
   timeoutMs = QUERY_TIMEOUT_MS,
 ): Promise<TemporalEpicWorkflowListEntry[]> {
-  const bundle = await withTimeout(
-    createTemporalClientBundle(),
-    timeoutMs,
-    "Temporal connection",
+  return withTemporalOperations(
+    projectId,
+    (owner) =>
+      listEpicsFromVisibility(owner, {
+        projectId,
+        timeoutMs,
+        status: "active",
+      }),
+    undefined,
+    { connectTimeoutMs: timeoutMs },
   );
-  try {
-    return await listEpicsFromVisibility(
-      bundle.client as unknown as ListEpicClient,
-      { projectId, timeoutMs, status: "active" },
-    );
-  } finally {
-    await bundle.connection.close();
-  }
 }

--- a/bin/lib/live-status.test.ts
+++ b/bin/lib/live-status.test.ts
@@ -9,7 +9,9 @@ import {
   summariesFromVisibility,
 } from "./live-status";
 
-function fakeVisibilityClient(
+const PROJECT_ID = "0".repeat(40);
+
+function fakeVisibilityOwner(
   executions: Array<{
     id: string;
     attrs: Record<string, unknown[]>;
@@ -20,30 +22,30 @@ function fakeVisibilityClient(
   const queries: string[] = [];
   return {
     queries,
-    workflow: {
-      list: (opts: { query: string }) => {
-        if (listError) throw listError;
-        queries.push(opts.query);
-        async function* iter() {
-          const requiresRunning = /ExecutionStatus\s*=\s*"Running"/.test(
-            opts.query,
-          );
-          for (const exec of executions) {
-            if (
-              requiresRunning &&
-              exec.executionStatus !== undefined &&
-              exec.executionStatus !== "Running"
-            ) {
-              continue;
-            }
-            yield {
-              workflowId: `adv/change/project123/${exec.id}`,
-              searchAttributes: exec.attrs,
-            };
+    list: async <T extends { workflowId: string }>(
+      _ctx: unknown,
+      query: string,
+      _options?: { limit?: number; nextPageToken?: string },
+    ): Promise<{ kind: "complete"; value: T[]; truncated: boolean }> => {
+      if (listError) throw listError;
+      queries.push(query);
+      const requiresRunning = /ExecutionStatus\s*=\s*"Running"/.test(query);
+      const items = executions
+        .filter((exec) => {
+          if (
+            requiresRunning &&
+            exec.executionStatus !== undefined &&
+            exec.executionStatus !== "Running"
+          ) {
+            return false;
           }
-        }
-        return iter();
-      },
+          return true;
+        })
+        .map((exec) => ({
+          workflowId: `adv/change/${PROJECT_ID}/${exec.id}`,
+          searchAttributes: exec.attrs,
+        })) as T[];
+      return { kind: "complete", value: items, truncated: false };
     },
   };
 }
@@ -99,7 +101,7 @@ describe("live status reader", () => {
         },
       ],
       {
-        projectId: "project123",
+        projectId: PROJECT_ID,
         archivedCount: 2,
         closedCount: 1,
         now: new Date("2026-06-05T10:05:00.000Z"),
@@ -247,7 +249,7 @@ describe("visibility search-attribute status reader", () => {
 
   test("summariesFromVisibility maps executions, drops terminal-complete, sorts by activity desc", async () => {
     const summaries = await summariesFromVisibility(
-      fakeVisibilityClient([
+      fakeVisibilityOwner([
         {
           id: "older",
           attrs: {
@@ -276,14 +278,14 @@ describe("visibility search-attribute status reader", () => {
           },
         },
       ]),
-      { projectId: "project123", now },
+      { projectId: PROJECT_ID, now },
     );
 
     expect(summaries.map((s) => s.id)).toEqual(["newer", "older"]);
   });
 
   test("filters active rows to running executions so stale completed workflows are excluded", async () => {
-    const client = fakeVisibilityClient([
+    const client = fakeVisibilityOwner([
       {
         id: "archivedButStaleActive",
         executionStatus: "Completed",
@@ -307,12 +309,14 @@ describe("visibility search-attribute status reader", () => {
     ]);
 
     const summaries = await summariesFromVisibility(client, {
-      projectId: "project123",
+      projectId: PROJECT_ID,
       now,
     });
 
     expect(client.queries).toHaveLength(1);
-    expect(client.queries[0]).toContain('AdvAffectedProjects = "project123"');
+    expect(client.queries[0]).toContain(
+      `AdvAffectedProjects = "${PROJECT_ID}"`,
+    );
     expect(client.queries[0]).not.toContain("AdvChangeStatus");
     expect(client.queries[0]).toContain('ExecutionStatus = "Running"');
     expect(summaries.map((s) => s.id)).toEqual(["runningActive"]);
@@ -321,8 +325,8 @@ describe("visibility search-attribute status reader", () => {
   test("summariesFromVisibility fails closed when visibility listing fails", async () => {
     await expect(
       summariesFromVisibility(
-        fakeVisibilityClient([], new Error("visibility unavailable")),
-        { projectId: "project123", now },
+        fakeVisibilityOwner([], new Error("visibility unavailable")),
+        { projectId: PROJECT_ID, now },
       ),
     ).rejects.toThrow("visibility unavailable");
   });
@@ -341,7 +345,7 @@ describe("visibility search-attribute status reader", () => {
           now,
         )!,
       ],
-      { projectId: "project123", archivedCount: 3, closedCount: 0, now },
+      { projectId: PROJECT_ID, archivedCount: 3, closedCount: 0, now },
     );
 
     expect(payload.source).toBe("temporal");

--- a/bin/lib/live-status.ts
+++ b/bin/lib/live-status.ts
@@ -20,28 +20,13 @@ import type {
   LiveStatusPayload,
 } from "./types";
 import {
-  createTemporalClientBundle,
-  escapeVisibilityValue,
+  withTemporalOperations,
+  buildVisibilityQuery,
+  makeTemporalOperationContext,
+  type TemporalOperations,
 } from "../../plugin/src/cli/temporal-boundary";
 
 export const QUERY_TIMEOUT_MS = 5_000;
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  label: string,
-): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
-      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
-
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeout) clearTimeout(timeout);
-  });
-}
 
 export function summarizeLiveChanges(
   changes: ChangeRecord[],
@@ -137,12 +122,6 @@ const CHANGE_WORKFLOW_PREFIX = "adv/change/";
 export interface VisibilityExecution {
   workflowId: string;
   searchAttributes?: Record<string, unknown> | null;
-}
-
-export interface VisibilityListClient {
-  workflow: {
-    list: (opts: { query: string }) => AsyncIterable<VisibilityExecution>;
-  };
 }
 
 function firstSearchAttribute(
@@ -254,40 +233,42 @@ export function buildSummaryFromSearchAttributes(
  * or list failure so callers can fail closed.
  */
 export async function summariesFromVisibility(
-  client: VisibilityListClient,
-  options: { projectId: string; now: Date; timeoutMs?: number },
+  owner: TemporalOperations,
+  options: { projectId: string; now: Date; timeoutMs?: number; limit?: number },
 ): Promise<ChangeSummary[]> {
-  const { projectId, now } = options;
-  const timeoutMs = options.timeoutMs ?? QUERY_TIMEOUT_MS;
+  const { projectId, now, timeoutMs, limit } = options;
   const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
-  const clauses = [
-    `AdvAffectedProjects = "${escapeVisibilityValue(projectId)}"`,
-    `ExecutionStatus = "Running"`,
-  ];
-  const query = clauses.join(" AND ");
-
-  const collect = async (): Promise<ChangeSummary[]> => {
-    const summaries: ChangeSummary[] = [];
-    for await (const exec of client.workflow.list({ query })) {
-      const wfid = exec.workflowId;
-      if (!wfid.startsWith(projectPrefix)) continue;
-      const changeId = wfid.slice(projectPrefix.length);
-      if (changeId.length === 0) continue;
-      const summary = buildSummaryFromSearchAttributes(
-        changeId,
-        exec.searchAttributes,
-        now,
-      );
-      if (summary) summaries.push(summary);
-    }
-    return summaries;
-  };
-
-  const summaries = await withTimeout(
-    collect(),
-    timeoutMs,
-    "Temporal Visibility list",
+  const query = buildVisibilityQuery({
+    projectId,
+    statuses: null,
+    limit,
+    executionStatus: "Running",
+  });
+  // Visibility scan is scoped to this project's AdvAffectedProjects keyword
+  // list via buildVisibilityQuery; the attribute is registered on every
+  // change workflow start.
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    `${projectPrefix}visibility-status`,
+    "list",
+    "bin.liveStatus.summariesFromVisibility",
+    timeoutMs ?? QUERY_TIMEOUT_MS,
   );
+
+  const result = await owner.list<VisibilityExecution>(ctx, query, { limit: limit ?? 1_000_000 });
+  if (result.kind !== "complete") {
+    throw result.error;
+  }
+  const summaries: ChangeSummary[] = [];
+  for (const exec of result.value) {
+    const wfid = exec.workflowId;
+    if (!wfid.startsWith(projectPrefix)) continue;
+    const changeId = wfid.slice(projectPrefix.length);
+    if (changeId.length === 0) continue;
+    const summary = buildSummaryFromSearchAttributes(changeId, exec.searchAttributes, now);
+    if (summary) summaries.push(summary);
+    if (limit !== undefined && summaries.length >= limit) break;
+  }
   summaries.sort((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt));
   return summaries;
 }
@@ -329,19 +310,12 @@ export async function loadLiveSummaries(
   now: Date,
   timeoutMs = QUERY_TIMEOUT_MS,
 ): Promise<ChangeSummary[]> {
-  const bundle = await withTimeout(
-    createTemporalClientBundle(),
-    timeoutMs,
-    "Temporal connection",
+  return withTemporalOperations(
+    projectId,
+    (owner) => summariesFromVisibility(owner, { projectId, now, timeoutMs }),
+    undefined,
+    { connectTimeoutMs: timeoutMs },
   );
-  try {
-    return await summariesFromVisibility(
-      bundle.client as unknown as VisibilityListClient,
-      { projectId, now, timeoutMs },
-    );
-  } finally {
-    await bundle.connection.close();
-  }
 }
 
 

--- a/bin/lib/resume-projection-live.ts
+++ b/bin/lib/resume-projection-live.ts
@@ -9,8 +9,6 @@
  * rq-workGraphTypes01 (addDependencyAwareResume) — Phase F1
  */
 
-import type { Client } from "@temporalio/client";
-
 import { buildBinResumeProjection } from "./resume-projection";
 import type { ResumeProjection } from "../../plugin/src/cli/projection-boundary";
 import {
@@ -18,28 +16,14 @@ import {
   buildEpicWorkflowId,
   CHANGE_WORKFLOW_QUERY_NAMES,
   EPIC_WORKFLOW_QUERY_NAMES,
-  createTemporalClientBundle,
   listChangeWorkflowIds,
   listEpicWorkflowIds,
+  makeTemporalOperationContext,
+  withTemporalOperations,
+  type TemporalOperations,
+  TemporalReadOutcomeError,
 } from "../../plugin/src/cli/temporal-boundary";
 import { QUERY_TIMEOUT_MS } from "./live-status";
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  label: string,
-): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
-      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
-
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeout) clearTimeout(timeout);
-  });
-}
 
 interface ChangeRecord {
   id: string;
@@ -90,90 +74,108 @@ export interface LiveResumeProjectionResult {
   truncated_count?: number;
 }
 
+async function queryChangeState(
+  owner: TemporalOperations,
+  projectId: string,
+  changeId: string,
+): Promise<unknown> {
+  const workflowId = buildChangeWorkflowId(projectId, changeId);
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    workflowId,
+    "query",
+    "bin.resumeProjection.changeState",
+    QUERY_TIMEOUT_MS,
+  );
+  const handle = owner.getHandle(ctx);
+  const outcome = await owner.query(ctx, handle, CHANGE_WORKFLOW_QUERY_NAMES.getState);
+  if (outcome.kind !== "complete") {
+    throw new TemporalReadOutcomeError(outcome);
+  }
+  return outcome.value;
+}
+
+async function queryEpicState(
+  owner: TemporalOperations,
+  projectId: string,
+  epicId: string,
+): Promise<unknown> {
+  const workflowId = buildEpicWorkflowId(projectId, epicId);
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    workflowId,
+    "query",
+    "bin.resumeProjection.epicState",
+    QUERY_TIMEOUT_MS,
+  );
+  const handle = owner.getHandle(ctx);
+  const outcome = await owner.query(ctx, handle, EPIC_WORKFLOW_QUERY_NAMES.getState);
+  if (outcome.kind !== "complete") {
+    throw new TemporalReadOutcomeError(outcome);
+  }
+  return outcome.value;
+}
+
 export async function loadLiveResumeProjection(
   projectId: string,
   timeoutMs = QUERY_TIMEOUT_MS,
   epicIds?: string[],
 ): Promise<LiveResumeProjectionResult> {
-  const bundle = await withTimeout(
-    createTemporalClientBundle(),
-    timeoutMs,
-    "Temporal connection",
+  return withTemporalOperations(
+    projectId,
+    async (owner) => {
+      const [changeIdsOutcome, epicIdListOutcome] = await Promise.all([
+        listChangeWorkflowIds(owner, { projectId }),
+        listEpicWorkflowIds(owner, { projectId, status: "active" }),
+      ]);
+      if (changeIdsOutcome.kind !== "complete") {
+        throw changeIdsOutcome.error;
+      }
+      if (epicIdListOutcome.kind !== "complete") {
+        throw epicIdListOutcome.error;
+      }
+      const changeIds = changeIdsOutcome.value;
+      const epicIdList = epicIdListOutcome.value;
+
+      const changeRecords: ChangeRecord[] = [];
+      for (const id of changeIds) {
+        try {
+          const raw = await queryChangeState(owner, projectId, id);
+          changeRecords.push(normalizeChangeRecord(raw));
+        } catch (err) {
+          // Skip unreachable changes; projection is advisory.
+          void err;
+        }
+      }
+
+      const epicRecords: EpicRecord[] = [];
+      const idsToQuery = epicIds?.length ? epicIds : epicIdList;
+      for (const id of idsToQuery) {
+        try {
+          const raw = await queryEpicState(owner, projectId, id);
+          const epic = normalizeEpicRecord(raw);
+          if (epic) epicRecords.push(epic);
+        } catch (err) {
+          // Skip unreachable epics; projection is advisory.
+          void err;
+        }
+      }
+
+      const projection = buildBinResumeProjection(
+        changeRecords,
+        epicRecords,
+        projectId,
+        epicIds,
+      );
+
+      return {
+        live: true,
+        resume_projection: projection,
+      };
+    },
+    undefined,
+    { connectTimeoutMs: timeoutMs },
   );
-
-  try {
-    const client = bundle.client as Client;
-
-    const [changeIds, epicIdList] = await Promise.all([
-      withTimeout(
-        listChangeWorkflowIds(client, { projectId }),
-        timeoutMs,
-        "Temporal change list",
-      ),
-      withTimeout(
-        listEpicWorkflowIds(client, {
-          projectId,
-          status: "active",
-        }),
-        timeoutMs,
-        "Temporal epic list",
-      ),
-    ]);
-
-    const changeRecords: ChangeRecord[] = [];
-    for (const id of changeIds) {
-      try {
-        const workflowId = buildChangeWorkflowId(projectId, id);
-        const raw = (await withTimeout(
-          client.workflow.getHandle(workflowId).query(CHANGE_WORKFLOW_QUERY_NAMES.getState),
-          timeoutMs,
-          `Temporal query ${id}`,
-        )) as unknown;
-        changeRecords.push(normalizeChangeRecord(raw));
-      } catch (err) {
-        // Skip unreachable changes; projection is advisory.
-      }
-    }
-
-    const epicRecords: EpicRecord[] = [];
-    const idsToQuery = epicIds?.length ? epicIds : epicIdList.map((e) => e.id);
-    for (const id of idsToQuery) {
-      try {
-        const workflowId = buildEpicWorkflowId(projectId, id);
-        const raw = (await withTimeout(
-          client.workflow.getHandle(workflowId).query(EPIC_WORKFLOW_QUERY_NAMES.getState),
-          timeoutMs,
-          `Temporal epic query ${id}`,
-        )) as unknown;
-        const epic = normalizeEpicRecord(raw);
-        if (epic) epicRecords.push(epic);
-      } catch (err) {
-        // Skip unreachable epics; projection is advisory.
-      }
-    }
-
-    const projection = buildBinResumeProjection(
-      changeRecords,
-      epicRecords,
-      projectId,
-      epicIds,
-    );
-
-    return {
-      live: true,
-      resume_projection: projection,
-    };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      live: false,
-      error: message,
-      remediation:
-        "ADV resume projection unavailable. Verify Temporal is running and the project has active changes/epics.",
-    };
-  } finally {
-    await bundle.connection.close();
-  }
 }
 
 function normalizeChangeRecord(raw: unknown): ChangeRecord {

--- a/plugin/scripts/bench-adv-latency.ts
+++ b/plugin/scripts/bench-adv-latency.ts
@@ -154,7 +154,7 @@ async function ensureBenchmarkFixture(
 
 function temporalModeFailure(): Error {
   return new Error(
-    "[bench] --mode temporal requires a running Temporal worker and a real TemporalClientBundle. " +
+    "[bench] --mode temporal requires a running Temporal worker and a real Temporal client bundle. " +
       "Remediation: start `temporal server start-dev`, start the ADV worker, " +
       "then run an operator-owned wrapper that constructs createStore() with the live bundle. " +
       "No disk substitute was used.",

--- a/plugin/scripts/benchmark-temporal.ts
+++ b/plugin/scripts/benchmark-temporal.ts
@@ -691,7 +691,7 @@ export async function runConcurrentClients(opts: {
 
   // Close the Temporal connection unless caller manages lifecycle (tests).
   if (!skipConnectionClose) {
-    await temporal.bundle.connection.close();
+    await temporal.owner?.close?.();
   }
 
   const totalOps = records.length;
@@ -955,7 +955,7 @@ export async function runPromotePipeline(
       }));
 
       await writeJsonlAtomic(store.paths.wisdom, mapped);
-      await temporal.bundle.connection.close();
+      await temporal.owner?.close?.();
     }
   } catch (err) {
     warning = err instanceof Error ? err.message : String(err);

--- a/plugin/scripts/cutover-receipt.ts
+++ b/plugin/scripts/cutover-receipt.ts
@@ -46,7 +46,11 @@ import {
 } from "../src/migration/inventory";
 import { verifyCommittedReplayFixtures } from "../src/migration/replay-verification";
 import { validateStrictPlanSurface } from "../src/migration/strict-plan-validation";
-import { listChangeWorkflowIds } from "../src/temporal/list-change-workflows";
+import {
+  createTemporalScriptFacadeFactory,
+  TemporalScriptOutcomeError,
+  type TemporalScriptFacadeFactory,
+} from "./temporal-script-facade";
 
 interface Args {
   command: string;
@@ -99,20 +103,33 @@ function parseArgs(argv: string[]): Args {
   return args;
 }
 
-async function makeWorkflowProbe(address: string) {
-  const { Connection, Client } = await import("@temporalio/client");
-  const connection = await Connection.connect({ address });
-  const client = new Client({ connection });
+async function makeWorkflowProbe(factory: TemporalScriptFacadeFactory) {
   return async (projectId: string): Promise<number> => {
-    const ids = await listChangeWorkflowIds(client, {
-      projectId,
-      statuses: null, // count every known change workflow
-    });
-    return ids.length;
+    try {
+      const owner = await factory.get(projectId);
+      const ids = await owner.listChangeWorkflowIds();
+      return ids.length;
+    } catch (error) {
+      if (error instanceof TemporalScriptOutcomeError) {
+        console.error(
+          `workflow probe for ${projectId}: ${error.kind} — ${error.message}`,
+        );
+      } else {
+        console.error(
+          `workflow probe for ${projectId} unavailable (${error instanceof Error ? error.message : String(error)}); treating as zero`,
+        );
+      }
+      return 0;
+    }
   };
 }
 
 async function main(): Promise<void> {
+  const exitCode = await run();
+  process.exit(exitCode);
+}
+
+async function run(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
   const deployRoot = dirname(args.pluginRoot);
   const migrationRoot = args.migrationRoot ?? resolve(deployRoot, "migration");
@@ -126,148 +143,154 @@ async function main(): Promise<void> {
       reason: args.reason,
     });
     console.log(JSON.stringify(result, null, 2));
-    process.exit(result.disabled ? 0 : 1);
+    return result.disabled ? 0 : 1;
   }
 
-  // Shared proof gathering for status + activate.
-  const identity = verifyDeployedBuildIdentity(args.pluginRoot);
-  let workflowProbe: ((projectId: string) => Promise<number>) | undefined;
+  const factory = createTemporalScriptFacadeFactory({
+    address: args.temporalAddress,
+  });
   try {
-    workflowProbe = await makeWorkflowProbe(args.temporalAddress);
-  } catch (error) {
-    console.error(
-      `workflow probe unavailable (${error instanceof Error ? error.message : String(error)}); inventory will be incomplete`,
-    );
-  }
-  const inventory = await collectMachineInventory({
-    pluginRoot: args.pluginRoot,
-    deployRoot,
-    migrationRoot,
-    homeDir: args.homeDir,
-    listRunningWorkflows: workflowProbe,
-  });
-  const readiness = validateMigrationReadiness(inventory);
+    // Shared proof gathering for status + activate.
+    let workflowProbe: ((projectId: string) => Promise<number>) | undefined;
+    try {
+      workflowProbe = await makeWorkflowProbe(factory);
+    } catch (error) {
+      console.error(
+        `workflow probe unavailable (${error instanceof Error ? error.message : String(error)}); inventory will be incomplete`,
+      );
+    }
+    const inventory = await collectMachineInventory({
+      pluginRoot: args.pluginRoot,
+      deployRoot,
+      migrationRoot,
+      homeDir: args.homeDir,
+      listRunningWorkflows: workflowProbe,
+    });
+    const readiness = validateMigrationReadiness(inventory);
 
-  if (args.command === "status") {
-    const receipt = readCutoverReceipt({ migrationRoot });
-    console.log(
-      JSON.stringify(
-        {
-          receipt: receipt.receipt,
-          receiptMalformed: receipt.malformed,
-          build: inventory.build,
-          readiness,
-          inventorySummary: inventory.summary,
-        },
-        null,
-        2,
+    if (args.command === "status") {
+      const receipt = readCutoverReceipt({ migrationRoot });
+      console.log(
+        JSON.stringify(
+          {
+            receipt: receipt.receipt,
+            receiptMalformed: receipt.malformed,
+            build: inventory.build,
+            readiness,
+            inventorySummary: inventory.summary,
+          },
+          null,
+          2,
+        ),
+      );
+      return readiness.complete ? 0 : 1;
+    }
+
+    if (args.command !== "activate") {
+      throw new Error(
+        `unknown command "${args.command}" — expected status | activate | disable`,
+      );
+    }
+
+    if (!readiness.complete) {
+      console.error(
+        JSON.stringify(
+          { activated: false, blockers: readiness.blockers },
+          null,
+          2,
+        ),
+      );
+      return 1;
+    }
+    if (inventory.build.status !== "match" || !inventory.build.digest) {
+      console.error(
+        JSON.stringify(
+          {
+            activated: false,
+            error: `build identity status: ${inventory.build.status}`,
+          },
+          null,
+          2,
+        ),
+      );
+      return 1;
+    }
+
+    // Replay verification against the built workflows bundle (DDC6).
+    const replay = await verifyCommittedReplayFixtures({
+      historiesDir: resolve(
+        args.pluginRoot,
+        "src/temporal/__tests__/replay/histories",
       ),
-    );
-    process.exit(readiness.complete ? 0 : 1);
+      workflowsPath: resolve(args.pluginRoot, "dist/temporal/workflows.js"),
+    });
+    if (!replay.passed) {
+      console.error(JSON.stringify({ activated: false, replay }, null, 2));
+      return 1;
+    }
+
+    // Worker serviceability: current worker capacity must exist — a current
+    // deployed worker process or at least one live session registered on the
+    // current build digest (in-process worker hosts).
+    const currentCapacity =
+      inventory.processes.workers.filter((worker) => worker.root === "deployed")
+        .length + inventory.sessions.live.length;
+    const serviceability =
+      currentCapacity > 0
+        ? {
+            status: "serviceable" as const,
+            detail: `${currentCapacity} current worker-capacity source(s) (deployed workers + current sessions)`,
+          }
+        : {
+            status: "not_serviceable" as const,
+            detail:
+              "no current worker capacity: no deployed worker process and no live session on the current build",
+          };
+
+    const planValidation = validateStrictPlanSurface();
+    if (!planValidation.passed || serviceability.status !== "serviceable") {
+      console.error(
+        JSON.stringify(
+          { activated: false, serviceability, planValidation },
+          null,
+          2,
+        ),
+      );
+      return 1;
+    }
+
+    const proofs: CutoverProofs = {
+      buildIdentityDigest: inventory.build.digest,
+      inventoryComplete: true,
+      inventorySummary: inventory.summary,
+      replay: {
+        passed: true,
+        fixturesVerified: replay.fixtures.length,
+        verifiedAt: replay.verifiedAt,
+      },
+      workerServiceability: {
+        status: "serviceable",
+        detail: serviceability.detail,
+      },
+      strictPlanValidation: {
+        passed: true,
+        checks: planValidation.checks,
+        detail: planValidation.detail,
+      },
+    };
+
+    const result = activateCutoverReceipt({
+      migrationRoot,
+      pluginRoot: args.pluginRoot,
+      buildDigest: inventory.build.digest,
+      proofs,
+      activatedBy: process.env.USER ?? "operator",
+    });
+    console.log(JSON.stringify(result, null, 2));
+    return result.activated ? 0 : 1;
+  } finally {
+    await factory.closeAll();
   }
-
-  if (args.command !== "activate") {
-    throw new Error(
-      `unknown command "${args.command}" — expected status | activate | disable`,
-    );
-  }
-
-  if (!readiness.complete) {
-    console.error(
-      JSON.stringify(
-        { activated: false, blockers: readiness.blockers },
-        null,
-        2,
-      ),
-    );
-    process.exit(1);
-  }
-  if (inventory.build.status !== "match" || !inventory.build.digest) {
-    console.error(
-      JSON.stringify(
-        {
-          activated: false,
-          error: `build identity status: ${inventory.build.status}`,
-        },
-        null,
-        2,
-      ),
-    );
-    process.exit(1);
-  }
-
-  // Replay verification against the built workflows bundle (DDC6).
-  const replay = await verifyCommittedReplayFixtures({
-    historiesDir: resolve(
-      args.pluginRoot,
-      "src/temporal/__tests__/replay/histories",
-    ),
-    workflowsPath: resolve(args.pluginRoot, "dist/temporal/workflows.js"),
-  });
-  if (!replay.passed) {
-    console.error(JSON.stringify({ activated: false, replay }, null, 2));
-    process.exit(1);
-  }
-
-  // Worker serviceability: current worker capacity must exist — a current
-  // deployed worker process or at least one live session registered on the
-  // current build digest (in-process worker hosts).
-  const currentCapacity =
-    inventory.processes.workers.filter((worker) => worker.root === "deployed")
-      .length + inventory.sessions.live.length;
-  const serviceability =
-    currentCapacity > 0
-      ? {
-          status: "serviceable" as const,
-          detail: `${currentCapacity} current worker-capacity source(s) (deployed workers + current sessions)`,
-        }
-      : {
-          status: "not_serviceable" as const,
-          detail:
-            "no current worker capacity: no deployed worker process and no live session on the current build",
-        };
-
-  const planValidation = validateStrictPlanSurface();
-  if (!planValidation.passed || serviceability.status !== "serviceable") {
-    console.error(
-      JSON.stringify(
-        { activated: false, serviceability, planValidation },
-        null,
-        2,
-      ),
-    );
-    process.exit(1);
-  }
-
-  const proofs: CutoverProofs = {
-    buildIdentityDigest: inventory.build.digest,
-    inventoryComplete: true,
-    inventorySummary: inventory.summary,
-    replay: {
-      passed: true,
-      fixturesVerified: replay.fixtures.length,
-      verifiedAt: replay.verifiedAt,
-    },
-    workerServiceability: {
-      status: "serviceable",
-      detail: serviceability.detail,
-    },
-    strictPlanValidation: {
-      passed: true,
-      checks: planValidation.checks,
-      detail: planValidation.detail,
-    },
-  };
-
-  const result = activateCutoverReceipt({
-    migrationRoot,
-    pluginRoot: args.pluginRoot,
-    buildDigest: inventory.build.digest,
-    proofs,
-    activatedBy: process.env.USER ?? "operator",
-  });
-  console.log(JSON.stringify(result, null, 2));
-  process.exit(result.activated ? 0 : 1);
 }
 
 main().catch((error) => {

--- a/plugin/scripts/gen-replay-fixture.ts
+++ b/plugin/scripts/gen-replay-fixture.ts
@@ -39,7 +39,10 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { Connection, Client } from "@temporalio/client";
+import {
+  createTemporalScriptFacade,
+  TemporalScriptOutcomeError,
+} from "./temporal-script-facade";
 import { NativeConnection, Worker } from "@temporalio/worker";
 
 import {
@@ -56,7 +59,7 @@ import {
 
 const ADDRESS = process.env.REPLAY_FIXTURE_ADDRESS ?? "127.0.0.1:7233";
 const NAMESPACE = "default";
-const PROJECT_ID = "replay-fixture-project";
+const PROJECT_ID = "b".repeat(40);
 const PROJECTION_ROOT = "/tmp/adv-replay-fixture";
 
 const workflowsPath = fileURLToPath(
@@ -352,15 +355,19 @@ async function main(): Promise<void> {
     activeWorkflowsPath = variantPath;
   }
 
-  const connection = await Connection.connect({ address: ADDRESS });
-  const client = new Client({ connection, namespace: NAMESPACE });
+  const owner = await createTemporalScriptFacade({
+    projectId: PROJECT_ID,
+    address: ADDRESS,
+    namespace: NAMESPACE,
+  });
   const nativeConnection = await NativeConnection.connect({ address: ADDRESS });
 
   // Terminate any in-flight execution of the same workflowId for repeatability.
   try {
-    await client.workflow
-      .getHandle(workflowId)
-      .terminate("replay-fixture regeneration");
+    await owner.terminateWorkflow(
+      workflowId,
+      "replay-fixture regeneration",
+    );
   } catch {
     // No prior execution; ignore.
   }
@@ -381,13 +388,14 @@ async function main(): Promise<void> {
   let gateEvidence: unknown = null;
   try {
     await worker.runUntil(async () => {
-      const handle = await client.workflow.start("changeWorkflow", {
+      await owner.startWorkflow({
+        workflowType: "changeWorkflow",
         workflowId,
         taskQueue,
         args: [input],
       });
 
-      await handle.signal(gateCompletedSignal, {
+      await owner.signalWorkflow(workflowId, gateCompletedSignal, {
         gateId: config.gateId,
         completedBy: "replay-fixture-generator",
         completedAt: "2026-07-13T00:00:01.000Z",
@@ -395,7 +403,10 @@ async function main(): Promise<void> {
 
       const deadline = Date.now() + 30_000;
       while (Date.now() < deadline) {
-        const state = (await handle.query(getChangeStateQuery)) as {
+        const state = (await owner.queryWorkflow(
+          workflowId,
+          getChangeStateQuery,
+        )) as {
           gates: Record<string, { status: string; artifactEvidence?: unknown }>;
         };
         const gate = state.gates[config.gateId];
@@ -411,6 +422,7 @@ async function main(): Promise<void> {
     });
   } finally {
     if (variantPath) await rm(variantPath, { force: true });
+    await owner.close();
   }
 
   const exportCmd =
@@ -444,6 +456,21 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error(err);
+  if (err instanceof TemporalScriptOutcomeError) {
+    console.error(
+      JSON.stringify(
+        {
+          error: "Temporal script outcome",
+          kind: err.kind,
+          message: err.message,
+          cause: err.causeError instanceof Error ? err.causeError.message : String(err.causeError),
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.error(err);
+  }
   process.exit(1);
 });

--- a/plugin/scripts/temporal-script-facade.test.ts
+++ b/plugin/scripts/temporal-script-facade.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test, vi } from "vitest";
+import { TemporalOperationsOwner } from "../src/temporal/operations";
+import {
+  createTemporalScriptFacade,
+  createTemporalScriptFacadeFactory,
+  TemporalScriptOutcomeError,
+  type TemporalScriptFacade,
+} from "./temporal-script-facade";
+
+const PROJECT_ID = "0".repeat(40);
+const OTHER_PROJECT_ID = "a".repeat(40);
+
+function buildMockOwner(
+  projectId: string,
+): TemporalOperationsOwner {
+  const bundle = {
+    address: "127.0.0.1:7233",
+    namespace: "default",
+    connection: { close: vi.fn() } as unknown as ConstructorParameters<
+      typeof TemporalOperationsOwner
+    >[0]["connection"],
+    client: {
+      workflow: {
+        getHandle: vi.fn(() => ({
+          workflowId: "adv/change/0000000000000000000000000000000000000000/replayFixture",
+        })),
+      },
+    } as unknown as ConstructorParameters<
+      typeof TemporalOperationsOwner
+    >[0]["client"],
+  };
+  return new TemporalOperationsOwner(bundle, projectId);
+}
+
+describe("createTemporalScriptFacade", () => {
+  test("requires a non-empty projectId", async () => {
+    await expect(
+      createTemporalScriptFacade({ projectId: "" }),
+    ).rejects.toThrow(/projectId is required/);
+  });
+
+  test("startWorkflow returns the workflow id on confirmed", async () => {
+    const owner = buildMockOwner(PROJECT_ID);
+    owner.start = vi.fn().mockResolvedValue({
+      kind: "confirmed",
+      value: { workflowId: "adv/change/0000000000000000000000000000000000000000/replayFixture" },
+    });
+
+    const facade = await createTemporalScriptFacade({
+      projectId: PROJECT_ID,
+      owner,
+    });
+
+    const result = await facade.startWorkflow({
+      workflowType: "changeWorkflow",
+      workflowId: "adv/change/0000000000000000000000000000000000000000/replayFixture",
+      taskQueue: "replay-fixture",
+      args: ["input"],
+    });
+
+    expect(result.workflowId).toBe(
+      "adv/change/0000000000000000000000000000000000000000/replayFixture",
+    );
+  });
+
+  test("startWorkflow throws typed TemporalScriptOutcomeError on timeout_unavailable", async () => {
+    const owner = buildMockOwner(PROJECT_ID);
+    owner.start = vi.fn().mockResolvedValue({
+      kind: "timeout_unavailable",
+      error: new Error("deadline exceeded"),
+      diagnostic: { class: "deadline", reachable: true },
+    });
+
+    const facade = await createTemporalScriptFacade({
+      projectId: PROJECT_ID,
+      owner,
+    });
+
+    await expect(
+      facade.startWorkflow({
+        workflowType: "changeWorkflow",
+        workflowId: "adv/change/0000000000000000000000000000000000000000/replayFixture",
+        taskQueue: "replay-fixture",
+        args: ["input"],
+      }),
+    ).rejects.toBeInstanceOf(TemporalScriptOutcomeError);
+  });
+
+  test("signalWorkflow throws typed TemporalScriptOutcomeError on confirmed_failure", async () => {
+    const owner = buildMockOwner(PROJECT_ID);
+    owner.signal = vi.fn().mockResolvedValue({
+      kind: "confirmed_failure",
+      error: new Error("signal rejected"),
+      diagnostic: { class: "reachable", reachable: true },
+    });
+
+    const facade = await createTemporalScriptFacade({
+      projectId: PROJECT_ID,
+      owner,
+    });
+
+    await expect(
+      facade.signalWorkflow(
+        "adv/change/0000000000000000000000000000000000000000/replayFixture",
+        { name: "testSignal" } as any,
+        { payload: true },
+      ),
+    ).rejects.toMatchObject({
+      name: "TemporalScriptOutcomeError",
+      kind: "confirmed_failure",
+    });
+  });
+
+  test("queryWorkflow throws typed TemporalScriptOutcomeError on degraded", async () => {
+    const owner = buildMockOwner(PROJECT_ID);
+    owner.query = vi.fn().mockResolvedValue({
+      kind: "degraded",
+      error: new Error("query stalled"),
+      diagnostic: { class: "deadline", reachable: true },
+    });
+
+    const facade = await createTemporalScriptFacade({
+      projectId: PROJECT_ID,
+      owner,
+    });
+
+    await expect(
+      facade.queryWorkflow(
+        "adv/change/0000000000000000000000000000000000000000/replayFixture",
+        { name: "testQuery" } as any,
+      ),
+    ).rejects.toMatchObject({
+      name: "TemporalScriptOutcomeError",
+      kind: "degraded",
+    });
+  });
+
+  test("terminateWorkflow throws typed TemporalScriptOutcomeError on outcome_unknown", async () => {
+    const owner = buildMockOwner(PROJECT_ID);
+    owner.terminate = vi.fn().mockResolvedValue({
+      kind: "outcome_unknown",
+      error: new Error("terminate ack but readback failed"),
+      diagnostic: { class: "unknown", reachable: true },
+    });
+
+    const facade = await createTemporalScriptFacade({
+      projectId: PROJECT_ID,
+      owner,
+    });
+
+    await expect(
+      facade.terminateWorkflow(
+        "adv/change/0000000000000000000000000000000000000000/replayFixture",
+        "cleanup",
+      ),
+    ).rejects.toMatchObject({
+      name: "TemporalScriptOutcomeError",
+      kind: "outcome_unknown",
+    });
+  });
+
+  test("listChangeWorkflowIds returns change ids scoped to the owner project", async () => {
+    const owner = buildMockOwner(PROJECT_ID);
+    owner.list = vi.fn().mockResolvedValue({
+      kind: "complete",
+      value: [
+        { workflowId: "adv/change/0000000000000000000000000000000000000000/c1" },
+        { workflowId: "adv/change/0000000000000000000000000000000000000000/c2" },
+        { workflowId: "adv/change/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/c3" },
+      ],
+      truncated: false,
+    });
+
+    const facade = await createTemporalScriptFacade({
+      projectId: PROJECT_ID,
+      owner,
+    });
+
+    const ids = await facade.listChangeWorkflowIds();
+    expect(ids).toEqual(["c1", "c2"]);
+    expect(owner.list).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: PROJECT_ID }),
+      'AdvAffectedProjects = "0000000000000000000000000000000000000000"',
+      { limit: 1000 },
+    );
+  });
+
+  test("listChangeWorkflowIds throws typed TemporalScriptOutcomeError on unavailable", async () => {
+    const owner = buildMockOwner(PROJECT_ID);
+    owner.list = vi.fn().mockResolvedValue({
+      kind: "unavailable",
+      error: new Error("visibility unavailable"),
+      diagnostic: { class: "unknown", reachable: false },
+    });
+
+    const facade = await createTemporalScriptFacade({
+      projectId: PROJECT_ID,
+      owner,
+    });
+
+    await expect(facade.listChangeWorkflowIds()).rejects.toMatchObject({
+      name: "TemporalScriptOutcomeError",
+      kind: "unavailable",
+    });
+  });
+});
+
+describe("createTemporalScriptFacadeFactory", () => {
+  test("creates one facade per project id and closes all", async () => {
+    const owner1 = buildMockOwner(PROJECT_ID);
+    owner1.close = vi.fn().mockResolvedValue(undefined);
+    owner1.list = vi.fn().mockResolvedValue({
+      kind: "complete",
+      value: [],
+      truncated: false,
+    });
+
+    const owner2 = buildMockOwner(OTHER_PROJECT_ID);
+    owner2.close = vi.fn().mockResolvedValue(undefined);
+    owner2.list = vi.fn().mockResolvedValue({
+      kind: "complete",
+      value: [],
+      truncated: false,
+    });
+
+    const createFacade = vi.fn(
+      async (projectId: string): Promise<TemporalScriptFacade> => {
+        const owner =
+          projectId === PROJECT_ID
+            ? owner1
+            : projectId === OTHER_PROJECT_ID
+              ? owner2
+              : buildMockOwner(projectId);
+        return createTemporalScriptFacade({ projectId, owner });
+      },
+    );
+
+    const factory = createTemporalScriptFacadeFactory({ createFacade });
+
+    const facade1 = await factory.get(PROJECT_ID);
+    const facade2 = await factory.get(OTHER_PROJECT_ID);
+    const facade1Again = await factory.get(PROJECT_ID);
+
+    expect(facade1).toBe(facade1Again);
+    expect(facade1.projectId).toBe(PROJECT_ID);
+    expect(facade2.projectId).toBe(OTHER_PROJECT_ID);
+
+    await facade1.listChangeWorkflowIds();
+    await facade2.listChangeWorkflowIds();
+
+    await factory.closeAll();
+
+    expect(owner1.close).toHaveBeenCalled();
+    expect(owner2.close).toHaveBeenCalled();
+  });
+});

--- a/plugin/scripts/temporal-script-facade.ts
+++ b/plugin/scripts/temporal-script-facade.ts
@@ -1,0 +1,290 @@
+/**
+ * Script facade over the single Temporal client-operation owner.
+ *
+ * This module contains NO raw `@temporalio/client` imports or direct SDK
+ * methods. It delegates every Temporal client RPC to
+ * `TemporalOperationsOwner` in `../src/temporal/operations.ts` and adds only
+ * script-appropriate ergonomics (argument shaping, outcome unwrapping, and
+ * visibility query filtering).
+ *
+ * Worker construction (`NativeConnection`, `Worker`) is a separate build/runtime
+ * concern and is allowed here because it is not a client/Connection/Handle
+ * surface.
+ */
+
+import {
+  TemporalOperationsOwner,
+  makeTemporalOperationContext,
+  type TemporalOperationContext,
+  type TemporalOperations,
+  type TemporalWorkflowHandle,
+} from "../src/temporal/operations";
+import { buildChangeWorkflowId } from "../src/temporal/client";
+import type {
+  QueryDefinition,
+  SignalDefinition,
+} from "@temporalio/workflow";
+import type { TemporalWorkflowDiagnostic } from "../src/temporal/diagnostics";
+
+const SCRIPT_BUDGET_MS = 10_000;
+
+export type TemporalScriptMutationKind =
+  | "confirmed_failure"
+  | "timeout_unavailable"
+  | "outcome_unknown";
+
+export type TemporalScriptReadKind =
+  | "degraded"
+  | "timeout"
+  | "unavailable"
+  | "not_found";
+
+export type TemporalScriptOutcomeKind =
+  | TemporalScriptMutationKind
+  | TemporalScriptReadKind;
+
+/**
+ * Distinct error thrown when a script-level Temporal operation returns a
+ * non-success outcome. The `kind` and `diagnostic` fields preserve the original
+ * effect uncertainty so callers can branch instead of parsing message text.
+ */
+export class TemporalScriptOutcomeError extends Error {
+  readonly name = "TemporalScriptOutcomeError";
+  constructor(
+    readonly kind: TemporalScriptOutcomeKind,
+    readonly causeError: unknown,
+    readonly diagnostic: TemporalWorkflowDiagnostic | undefined,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface TemporalScriptFacade {
+  readonly address: string;
+  readonly namespace: string;
+  readonly projectId: string;
+  close(): Promise<void>;
+  startWorkflow(options: {
+    workflowType: string;
+    workflowId: string;
+    taskQueue: string;
+    args: unknown[];
+  }): Promise<{ workflowId: string }>;
+  signalWorkflow(
+    workflowId: string,
+    signalDef: SignalDefinition,
+    ...args: unknown[]
+  ): Promise<void>;
+  queryWorkflow<T>(
+    workflowId: string,
+    queryDef: QueryDefinition<T>,
+    ...args: unknown[]
+  ): Promise<T>;
+  terminateWorkflow(workflowId: string, reason?: string): Promise<void>;
+  listChangeWorkflowIds(): Promise<string[]>;
+}
+
+export interface CreateTemporalScriptFacadeOptions {
+  /** Canonical ADV project id. The facade will only operate in this context. */
+  projectId: string;
+  address?: string;
+  namespace?: string;
+  /**
+   * Internal test seam: inject a pre-created owner. When supplied, the
+   * facade uses the owner identity and skips creating a new connection.
+   */
+  owner?: TemporalOperationsOwner;
+}
+
+export async function createTemporalScriptFacade(
+  options: CreateTemporalScriptFacadeOptions,
+): Promise<TemporalScriptFacade> {
+  if (!options.projectId) {
+    throw new Error("projectId is required to create a TemporalScriptFacade");
+  }
+  const env = {
+    ADV_TEMPORAL_ADDRESS: options.address,
+    ADV_TEMPORAL_NAMESPACE: options.namespace,
+  } as NodeJS.ProcessEnv;
+  const owner =
+    options.owner ??
+    (await TemporalOperationsOwner.fromEnv(options.projectId, env));
+  const projectId = owner.projectId;
+  const address = owner.getAddress();
+  const namespace = owner.getNamespace();
+
+  function opCtx(
+    workflowId: string,
+    opKind: TemporalOperationContext["opKind"],
+    opType: string,
+  ): TemporalOperationContext {
+    return makeTemporalOperationContext(
+      projectId,
+      workflowId,
+      opKind,
+      opType,
+      SCRIPT_BUDGET_MS,
+    );
+  }
+
+  function getHandle(workflowId: string): TemporalWorkflowHandle {
+    return owner.getHandle(opCtx(workflowId, "query", "script.getHandle"));
+  }
+
+  return {
+    address,
+    namespace,
+    projectId,
+    close: () => owner.close(),
+    async startWorkflow(opts) {
+      const outcome = await owner.start(
+        opCtx(opts.workflowId, "start", "script.startWorkflow"),
+        opts.workflowType,
+        {
+          workflowId: opts.workflowId,
+          taskQueue: opts.taskQueue,
+          args: opts.args as [unknown],
+        },
+      );
+      if (outcome.kind !== "confirmed") {
+        throw new TemporalScriptOutcomeError(
+          outcome.kind,
+          outcome.error,
+          outcome.diagnostic,
+          `startWorkflow ${outcome.kind}`,
+        );
+      }
+      return { workflowId: outcome.value.workflowId };
+    },
+    async signalWorkflow(workflowId, signalDef, ...args) {
+      const outcome = await owner.signal(
+        opCtx(workflowId, "signal", "script.signalWorkflow"),
+        getHandle(workflowId),
+        signalDef as SignalDefinition<unknown[], string>,
+        args,
+      );
+      if (outcome.kind !== "confirmed") {
+        throw new TemporalScriptOutcomeError(
+          outcome.kind,
+          outcome.error,
+          outcome.diagnostic,
+          `signalWorkflow ${outcome.kind}`,
+        );
+      }
+    },
+    async queryWorkflow<T>(workflowId, queryDef, ...args) {
+      const outcome = await owner.query(
+        opCtx(workflowId, "query", "script.queryWorkflow"),
+        getHandle(workflowId),
+        queryDef as QueryDefinition<T, unknown[], string>,
+        ...args,
+      );
+      if (outcome.kind !== "complete") {
+        throw new TemporalScriptOutcomeError(
+          outcome.kind,
+          outcome.error,
+          outcome.diagnostic,
+          `queryWorkflow ${outcome.kind}`,
+        );
+      }
+      return outcome.value as T;
+    },
+    async terminateWorkflow(workflowId, reason) {
+      const outcome = await owner.terminate(
+        opCtx(workflowId, "terminate", "script.terminateWorkflow"),
+        getHandle(workflowId),
+        reason ?? "script termination",
+      );
+      if (outcome.kind !== "confirmed") {
+        throw new TemporalScriptOutcomeError(
+          outcome.kind,
+          outcome.error,
+          outcome.diagnostic,
+          `terminateWorkflow ${outcome.kind}`,
+        );
+      }
+    },
+    async listChangeWorkflowIds() {
+      const probeWorkflowId = buildChangeWorkflowId(projectId, "probe");
+      const query = `AdvAffectedProjects = "${escapeVisibilityValue(projectId)}"`;
+      const outcome = await owner.list(
+        opCtx(probeWorkflowId, "list", "script.listChangeWorkflowIds"),
+        query,
+        { limit: 1000 },
+      );
+      if (outcome.kind !== "complete") {
+        throw new TemporalScriptOutcomeError(
+          outcome.kind,
+          outcome.error,
+          outcome.diagnostic,
+          `listChangeWorkflowIds ${outcome.kind}`,
+        );
+      }
+      const prefix = `adv/change/${projectId}/`;
+      const ids: string[] = [];
+      for (const execution of outcome.value) {
+        const workflowId = execution.workflowId;
+        if (workflowId?.startsWith(prefix)) {
+          const changeId = workflowId.slice(prefix.length);
+          if (changeId) ids.push(changeId);
+        }
+      }
+      return ids;
+    },
+  };
+}
+
+export interface TemporalScriptFacadeFactoryOptions {
+  address?: string;
+  namespace?: string;
+  /**
+   * Optional seam for injecting a custom facade creation strategy (tests or
+   * callers that need to share a connection between projects).
+   */
+  createFacade?: (projectId: string) => Promise<TemporalScriptFacade>;
+}
+
+export interface TemporalScriptFacadeFactory {
+  get(projectId: string): Promise<TemporalScriptFacade>;
+  closeAll(): Promise<void>;
+}
+
+/**
+ * Create a project-keyed factory of script facades. Each canonical project id
+ * gets its own facade (and therefore its own owner/context), and facades are
+ * cached until `closeAll()` is called. This lets scripts that operate across
+ * many projects (e.g. cutover-receipt inventory) keep a single owner per
+ * project identity without accepting arbitrary per-call project ids.
+ */
+export function createTemporalScriptFacadeFactory(
+  options: TemporalScriptFacadeFactoryOptions,
+): TemporalScriptFacadeFactory {
+  const cache = new Map<string, TemporalScriptFacade>();
+  const createFacade =
+    options.createFacade ??
+    ((projectId) =>
+      createTemporalScriptFacade({
+        projectId,
+        address: options.address,
+        namespace: options.namespace,
+      }));
+  return {
+    async get(projectId) {
+      if (!cache.has(projectId)) {
+        cache.set(projectId, await createFacade(projectId));
+      }
+      return cache.get(projectId)!;
+    },
+    async closeAll() {
+      for (const facade of cache.values()) {
+        await facade.close();
+      }
+      cache.clear();
+    },
+  };
+}
+
+function escapeVisibilityValue(value: string): string {
+  return value.replace(/(["\\])/g, "\\$1");
+}

--- a/plugin/src/__tests__/active-change-pointer.test.ts
+++ b/plugin/src/__tests__/active-change-pointer.test.ts
@@ -54,7 +54,7 @@ vi.mock("../plugin-context", async (importOriginal) => {
     ...actual,
     resolveProjectContext: vi.fn(async (directory: string) => ({
       effectiveDir: directory,
-      projectId: "test-project-id",
+      projectId: "0e000000ec00d000000000000000000000000000",
       externalRoot: undefined,
       identityError: undefined,
     })),
@@ -87,7 +87,7 @@ vi.mock("../tools/target-project", async (importOriginal) => {
         }
         return {
           root: input.target_path,
-          projectId: "target-project-id",
+          projectId: "0a00e00000ec00d0000000000000000000000000",
           externalRoot: join(input.target_path, ".adv"),
           trusted: true,
           trustSource: "test",
@@ -611,7 +611,9 @@ describe("active-change pointer hooks (T4/T5/T7)", () => {
     beforeEach(() => {
       vi.clearAllMocks();
       process.env.ADV_WORKTREE_HOME = join(tempDir, "worktrees");
-      worktreeBase = getWorktreeBase("test-project-id");
+      worktreeBase = getWorktreeBase(
+        "0e000000ec00d000000000000000000000000000",
+      );
     });
 
     afterEach(() => {

--- a/plugin/src/__tests__/backlog-epic-bridge.test.ts
+++ b/plugin/src/__tests__/backlog-epic-bridge.test.ts
@@ -60,7 +60,7 @@ describe("backlog-epic bridge", () => {
 
   test("applyShellAddedToState preserves imported_from provenance", () => {
     const state = createEpicWorkflowState({
-      projectId: "p",
+      projectId: "0000000000000000000000000000000000000000",
       epicId: "epic",
       title: "Epic",
       narrative: "n",

--- a/plugin/src/__tests__/e2e-tool-calls.itest.ts
+++ b/plugin/src/__tests__/e2e-tool-calls.itest.ts
@@ -40,7 +40,10 @@ describe("P1.9 — E2E tool calls (real Temporal stack)", () => {
         // shared connections. Worker uses workflowsPath; client uses
         // the env's namespaceless default.
         const namespace = "default";
-        const projectId = "e2e-proj";
+        const projectId = "e2e0000000000000000000000000000000000000".padEnd(
+          40,
+          "0",
+        );
         const taskQueue = `advance-${projectId}`;
 
         const worker = await createInProcessWorker({
@@ -64,7 +67,7 @@ describe("P1.9 — E2E tool calls (real Temporal stack)", () => {
           // workflow.start fails with "search attribute is not
           // defined" on the test server (no shared state with prod).
           resetStsl(); // clear any prior test's cached bundle
-          const bundle = await initStsl({
+          const bundle = await initStsl(projectId, {
             ADV_TEMPORAL_ADDRESS: env.address ?? "127.0.0.1:7233",
             ADV_TEMPORAL_NAMESPACE: namespace,
             ADV_TEMPORAL_ALLOW_REMOTE: "true",
@@ -76,12 +79,7 @@ describe("P1.9 — E2E tool calls (real Temporal stack)", () => {
           const legacy = await createLegacyStore(tempDir);
           const store = createTemporalStoreBackend({
             legacy,
-            // bundle.client is the real @temporalio/client Client, which
-            // satisfies TemporalHandleClient at runtime but the structural
-            // signatures don't unify (Client.workflow.start has stricter
-            // overloads). Cast through unknown — the e2e test exercises
-            // the real wire shape.
-            temporal: { client: bundle.client as unknown as never },
+            temporal: bundle,
             projectId,
           });
           await store.init();

--- a/plugin/src/cli/temporal-boundary.ts
+++ b/plugin/src/cli/temporal-boundary.ts
@@ -7,11 +7,7 @@
  * rq-cliSourceBoundary01
  */
 
-export {
-  buildChangeWorkflowId,
-  buildEpicWorkflowId,
-  createTemporalClientBundle,
-} from "../temporal/client";
+export { buildChangeWorkflowId, buildEpicWorkflowId } from "../temporal/client";
 export {
   CHANGE_WORKFLOW_QUERY_NAMES,
   EPIC_WORKFLOW_QUERY_NAMES,
@@ -19,8 +15,47 @@ export {
 export { escapeVisibilityValue } from "../temporal/lifecycle-visibility";
 export { listChangeWorkflowIds } from "../temporal/list-change-workflows";
 export {
+  buildVisibilityQuery,
+  type ListChangeWorkflowIdsOptions,
+} from "../temporal/list-change-workflows";
+export {
   listEpicWorkflowIds,
   listEpicWorkflows,
   type EpicWorkflowListEntry,
-  type ListEpicClient,
 } from "../temporal/list-epic-workflows";
+export {
+  makeTemporalOperationContext,
+  type TemporalOperations,
+  type TemporalWorkflowHandle,
+  type TemporalReadOutcome,
+  type TemporalMutationServerOutcome,
+  type TemporalListOutcome,
+} from "../temporal/operations";
+export {
+  TemporalListOutcomeError,
+  TemporalReadOutcomeError,
+} from "../temporal/outcome-errors";
+import { TemporalOperationsOwner } from "../temporal/operations";
+
+/**
+ * Run a function with a fresh TemporalOperations owner for a project.
+ * The owner is created from the environment (ADV_TEMPORAL_ADDRESS /
+ * ADV_TEMPORAL_NAMESPACE) and closed after the callback settles, regardless
+ * of success or failure. This is the only approved way for root CLI code to
+ * open a live Temporal connection.
+ */
+export async function withTemporalOperations<T>(
+  projectId: string,
+  fn: (
+    owner: import("../temporal/operations").TemporalOperations,
+  ) => Promise<T>,
+  env?: NodeJS.ProcessEnv,
+  options?: { connectTimeoutMs?: number },
+): Promise<T> {
+  const owner = await TemporalOperationsOwner.fromEnv(projectId, env, options);
+  try {
+    return await fn(owner);
+  } finally {
+    await owner.close();
+  }
+}

--- a/plugin/src/mcp-server/degradation.ts
+++ b/plugin/src/mcp-server/degradation.ts
@@ -16,6 +16,8 @@
  */
 
 import type { Tier4ToolName, ToolClassification } from "./tools/index.js";
+import { TemporalOperationsOwner } from "../temporal/operations.js";
+import { makeTemporalLifecycleContext } from "../temporal/operations.js";
 
 export interface DegradationOptions {
   /** Override Temporal reachability probe. */
@@ -45,35 +47,30 @@ export const HOST_PROBE_FIELDS: readonly string[] = [
   "worktree_census",
 ];
 
+const TEMPORAL_REACHABILITY_PROBE_PROJECT_ID =
+  "0000000000000000000000000000000000000000";
+
 /**
  * Probe whether the configured Temporal server is reachable right now.
  * Returns `false` on any connection or timeout error.
  */
 export async function isTemporalReachable(): Promise<boolean> {
+  let owner: TemporalOperationsOwner | undefined;
   try {
-    const { createTemporalClientBundle } =
-      await import("../temporal/client.js");
-    const bundlePromise = createTemporalClientBundle();
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      const timer = setTimeout(() => {
-        reject(new Error("Temporal reachability timeout"));
-      }, TEMPORAL_REACHABILITY_TIMEOUT_MS);
-      // Node timers are not unref'd by default in all test runners; unref
-      // prevents this timer from keeping the process alive.
-      if (typeof timer === "number") {
-        // Node environment: setTimeout returns a number; no unref needed.
-      } else if (typeof timer === "object" && timer !== null) {
-        (timer as NodeJS.Timeout).unref?.();
-      }
-    });
-    const { connection } = await Promise.race([bundlePromise, timeoutPromise]);
-    try {
-      return true;
-    } finally {
-      await connection.close().catch(() => undefined);
-    }
+    owner = await TemporalOperationsOwner.fromEnv(
+      TEMPORAL_REACHABILITY_PROBE_PROJECT_ID,
+    );
+    return await owner.isReachable(
+      makeTemporalLifecycleContext(
+        TEMPORAL_REACHABILITY_PROBE_PROJECT_ID,
+        "isTemporalReachable",
+        TEMPORAL_REACHABILITY_TIMEOUT_MS,
+      ),
+    );
   } catch {
     return false;
+  } finally {
+    await owner?.close();
   }
 }
 

--- a/plugin/src/migration/inventory.test.ts
+++ b/plugin/src/migration/inventory.test.ts
@@ -80,7 +80,7 @@ async function makePassingSetup(prefix: string) {
   const migrationRoot = join(deployRoot, "migration");
   registerLoadedBuildSession({
     migrationRoot,
-    projectId: "a".repeat(40),
+    projectId: "a000000000000000000000000000000000000000".repeat(40),
     buildDigest: digest,
     pluginRoot,
     pid: PID_A,
@@ -305,7 +305,7 @@ describe("validateMigrationReadiness", () => {
     const setup = await makePassingSetup("adv-inv-sess-mismatch-");
     registerLoadedBuildSession({
       migrationRoot: setup.migrationRoot,
-      projectId: "a".repeat(40),
+      projectId: "a000000000000000000000000000000000000000".repeat(40),
       buildDigest: "sha256:" + "f".repeat(64),
       pluginRoot: setup.pluginRoot,
       pid: PID_B,

--- a/plugin/src/migration/session-registry.test.ts
+++ b/plugin/src/migration/session-registry.test.ts
@@ -45,7 +45,7 @@ describe("registerLoadedBuildSession", () => {
     const root = await tempDir("adv-sessreg-write-");
     const result = registerLoadedBuildSession({
       migrationRoot: root,
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       buildDigest: DIGEST,
       pluginRoot: "/deploy/Advance/plugin",
       pid: 4321,
@@ -58,7 +58,7 @@ describe("registerLoadedBuildSession", () => {
     expect(parsed).toMatchObject({
       pid: 4321,
       processStartTicks: "777",
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       buildDigest: DIGEST,
       startedAt: "2026-07-16T01:00:00.000Z",
     });
@@ -68,7 +68,7 @@ describe("registerLoadedBuildSession", () => {
     const root = await tempDir("adv-sessreg-rewrite-");
     registerLoadedBuildSession({
       migrationRoot: root,
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       buildDigest: DIGEST,
       pluginRoot: "/deploy/Advance/plugin",
       pid: 1,
@@ -76,21 +76,21 @@ describe("registerLoadedBuildSession", () => {
     });
     registerLoadedBuildSession({
       migrationRoot: root,
-      projectId: "proj-2",
+      projectId: "0000200000000000000000000000000000000000",
       buildDigest: DIGEST,
       pluginRoot: "/deploy/Advance/plugin",
       pid: 1,
       now: new Date("2026-07-16T02:00:00.000Z"),
     });
     const parsed = JSON.parse(readFileSync(sessionFile(root, 1), "utf8"));
-    expect(parsed.projectId).toBe("proj-2");
+    expect(parsed.projectId).toBe("0000200000000000000000000000000000000000");
     expect(parsed.startedAt).toBe("2026-07-16T02:00:00.000Z");
   });
 
   test("never throws on unwritable roots — reports the error", async () => {
     const result = registerLoadedBuildSession({
       migrationRoot: join("/definitely", "not", "writable-\0"),
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       buildDigest: DIGEST,
       pluginRoot: "/x",
       pid: 1,
@@ -105,14 +105,14 @@ describe("unregisterLoadedBuildSession", () => {
     const root = await tempDir("adv-sessreg-unreg-");
     registerLoadedBuildSession({
       migrationRoot: root,
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       buildDigest: DIGEST,
       pluginRoot: "/x",
       pid: 10,
     });
     registerLoadedBuildSession({
       migrationRoot: root,
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       buildDigest: DIGEST,
       pluginRoot: "/x",
       pid: 20,
@@ -134,7 +134,7 @@ describe("listLiveBuildSessions", () => {
     ] as const) {
       registerLoadedBuildSession({
         migrationRoot: root,
-        projectId: "proj-1",
+        projectId: "0000100000000000000000000000000000000000",
         buildDigest: DIGEST,
         pluginRoot: "/x",
         pid,
@@ -175,7 +175,7 @@ describe("registerPluginSession (init seam)", () => {
   test("skips registration in test mode even with an identity", async () => {
     const root = await tempDir("adv-sessreg-seam-test-");
     const result = registerPluginSession({
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       migrationRoot: root,
       identity: {
         schemaVersion: 1,
@@ -194,7 +194,7 @@ describe("registerPluginSession (init seam)", () => {
   test("skips when no build identity is available (dev/src mode)", async () => {
     const root = await tempDir("adv-sessreg-seam-noident-");
     const result = registerPluginSession({
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       migrationRoot: root,
       identity: null,
       sessionId: "sess_test123",
@@ -206,7 +206,7 @@ describe("registerPluginSession (init seam)", () => {
   test("registers when identity is present outside test mode", async () => {
     const root = await tempDir("adv-sessreg-seam-ok-");
     const result = registerPluginSession({
-      projectId: "proj-1",
+      projectId: "0000100000000000000000000000000000000000",
       migrationRoot: root,
       identity: {
         schemaVersion: 1,

--- a/plugin/src/plugin-init.orphan-adopter-restart.test.ts
+++ b/plugin/src/plugin-init.orphan-adopter-restart.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { PathLike } from "node:fs";
 
 import { cleanupTempDir, createTempDir } from "./__tests__/setup";
+import { createMockOwnerFromClient } from "./temporal/__tests__/mock-owner";
 
 const mocks = vi.hoisted(() => ({
   existsSync: vi.fn(),
@@ -151,7 +152,7 @@ describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () =>
 
     mocks.getExternalRoot.mockImplementation(() => externalDir ?? "/tmp");
 
-    mocks.getService.mockReturnValue({ client: {} });
+    mocks.getService.mockReturnValue(createMockOwnerFromClient({ client: {} }));
   });
 
   afterEach(async () => {
@@ -326,12 +327,12 @@ describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () =>
     };
 
     attachWorkerWithAdoption(workerOne, {
-      projectId: "proj-one",
-      client: {} as any,
+      projectId: "000000e000000000000000000000000000000000",
+      owner: createMockOwnerFromClient({ client: {} }),
     });
     attachWorkerWithAdoption(workerTwo, {
-      projectId: "proj-two",
-      client: {} as any,
+      projectId: "0000000000000000000000000000000000000000",
+      owner: createMockOwnerFromClient({ client: {} }),
     });
 
     // Only one active adopter exists despite two attachments.
@@ -352,8 +353,8 @@ describe("restartCurrentProjectTemporalWorker orphan-queue adopter (RED)", () =>
     };
 
     attachWorkerWithAdoption(worker, {
-      projectId: "proj-kill",
-      client: {} as any,
+      projectId: "0000000000000000000000000000000000000000",
+      owner: createMockOwnerFromClient({ client: {} }),
     });
 
     const status = getOrphanQueueAdoptionStatus();

--- a/plugin/src/plugin-init.ts
+++ b/plugin/src/plugin-init.ts
@@ -11,17 +11,13 @@
  * createDegradedToolMap) when initError is non-null.
  */
 
-import { Client } from "@temporalio/client";
 import { createStore } from "./storage/store";
 import {
   reconcileTerminalWorkflows,
-  type TerminalReconcileClient,
   type TerminalReconcileResult,
 } from "./temporal/reconcile-terminal-workflows";
-import {
-  buildTerminalReconcileDeps,
-  type TerminalSignalClient,
-} from "./temporal/reconcile-terminal-deps";
+import { buildTerminalReconcileDeps } from "./temporal/reconcile-terminal-deps";
+import type { TemporalOperations } from "./temporal/operations";
 import type { Store } from "./storage/store-types";
 import { loadProjectConfig } from "./storage/json";
 import { resolveProjectFeaturePolicy } from "./types";
@@ -400,6 +396,7 @@ export async function tryInitStore(
 
       const bundleStartedAt = performance.now();
       temporalBundle = await initStsl(
+        projectId,
         buildTemporalClientEnv({
           address: runtime.address,
           namespace: runtime.namespace,
@@ -411,7 +408,7 @@ export async function tryInitStore(
       if (worker) {
         attachWorkerWithAdoption(worker, {
           projectId,
-          client: temporalBundle?.client ?? null,
+          owner: temporalBundle ?? null,
         });
       }
     }
@@ -444,7 +441,7 @@ export async function tryInitStore(
     // the init path — this is best-effort repair, never a startup dependency.
     scheduleTerminalReconcileSweep({
       projectId: projectId ?? undefined,
-      client: temporalBundle?.client ?? null,
+      owner: temporalBundle ?? null,
       archiveDir: store.paths.archive,
       changesDir: store.paths.changes,
     });
@@ -661,12 +658,12 @@ export function getLastTerminalReconcile(): TerminalReconcileResult | null {
  */
 export function scheduleTerminalReconcileSweep(input: {
   projectId: string | undefined;
-  client: Client | null;
+  owner: TemporalOperations | null;
   archiveDir: string | undefined;
   changesDir: string | undefined;
 }): void {
-  const { projectId, client, archiveDir, changesDir } = input;
-  if (!projectId || !client) return;
+  const { projectId, owner, archiveDir, changesDir } = input;
+  if (!projectId || !owner) return;
   if (terminalReconcileTimer) clearTimeout(terminalReconcileTimer);
 
   terminalReconcileTimer = setTimeout(() => {
@@ -674,13 +671,13 @@ export function scheduleTerminalReconcileSweep(input: {
     void (async () => {
       try {
         lastTerminalReconcile = await reconcileTerminalWorkflows(
-          client as unknown as TerminalReconcileClient,
+          owner,
           projectId,
           buildTerminalReconcileDeps({
             projectId,
             archiveDir,
             changesDir,
-            client: client as unknown as TerminalSignalClient,
+            owner,
           }),
           { maxPerSweep: TERMINAL_RECONCILE_MAX_PER_SWEEP },
         );
@@ -696,7 +693,7 @@ export function scheduleTerminalReconcileSweep(input: {
 
 export function attachWorkerWithAdoption(
   worker: InProcessWorker,
-  opts: { projectId: string; client: Client | null },
+  opts: { projectId: string; owner: TemporalOperations | null },
 ): WorkerAdoptionHandle {
   registerInProcessTemporalWorker(worker);
   const attachment: WorkerAdoptionAttachment = {
@@ -710,7 +707,7 @@ export function attachWorkerWithAdoption(
     activeOrphanQueueAdopter = null;
     return { stopDriver: null };
   }
-  if (!opts.client) {
+  if (!opts.owner) {
     adoptionConstructionState = {
       kind: "unavailable",
       reason: "no_temporal_client",
@@ -720,7 +717,7 @@ export function attachWorkerWithAdoption(
   }
   try {
     const adopter = new OrphanQueueAdopter({
-      client: opts.client,
+      owner: opts.owner,
       projectId: opts.projectId,
       worker,
     });
@@ -920,7 +917,7 @@ let activeHealthMonitor: HealthMonitor | null = null;
  *    monitor's outer `probeTimeoutMs` catches it and routes to restart.
  */
 const probeWorkerHealth = composeWorkerHealthProbe({
-  getBundle: () => getService(),
+  getOwner: () => getService(),
 });
 
 /**
@@ -1031,7 +1028,7 @@ export async function restartCurrentProjectTemporalWorker(
   workerRef.current = worker;
   attachWorkerWithAdoption(worker, {
     projectId,
-    client: getService()?.client ?? null,
+    owner: getService() ?? null,
   });
   return {
     projectId,

--- a/plugin/src/storage/artifact-payload-signal-invariant.test.ts
+++ b/plugin/src/storage/artifact-payload-signal-invariant.test.ts
@@ -11,6 +11,7 @@
  * sequential-await ordering (C5) and the metadata signal pairing.
  */
 
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createChangeOps } from "./store-temporal/changes";
@@ -155,8 +156,8 @@ function buildRecordingDeps(): {
   const deps = {
     input: {
       legacy,
-      temporal: { client: workflowClient },
-      projectId: "test-project",
+      temporal: createMockOwnerFromClient({ client: workflowClient }),
+      projectId: "0e000000ec000000000000000000000000000000",
     },
     legacy,
     invalidateChange: vi.fn(),

--- a/plugin/src/storage/change-projection-quarantine-audit.ts
+++ b/plugin/src/storage/change-projection-quarantine-audit.ts
@@ -48,6 +48,8 @@ export type ChangeProjectionQuarantineOutcome = z.infer<
 export interface ChangeProjectionQuarantineAuditEntry {
   /** Unique audit entry id (cqpq-{nanoid(8)}). */
   id: string;
+  /** ADV project ID that owns the quarantined change projection. */
+  project_id: string;
   /** Change ID whose active projection was quarantined. */
   change_id: string;
   /** Diagnostic reason the projection was rejected by the bounded reader. */
@@ -79,6 +81,7 @@ export type ChangeProjectionQuarantineAuditInput = Omit<
 
 export const ChangeProjectionQuarantineAuditEntrySchema = z.object({
   id: z.string().startsWith("cqpq-").min(5),
+  project_id: z.string().min(1),
   change_id: z.string().min(1),
   reason: ChangeProjectionQuarantineReasonSchema,
   action: z.literal("quarantine"),

--- a/plugin/src/storage/change-projection-transaction.test.ts
+++ b/plugin/src/storage/change-projection-transaction.test.ts
@@ -462,7 +462,7 @@ describe("commitChangeProjection", () => {
     const base = makeChange(changeId);
     await seedChange(changesDir, base);
     const temporalState = changeToWorkflowState({
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
       change: { ...base, title: "Temporal authoritative title" },
     });
 

--- a/plugin/src/storage/launcher-projection.itest.ts
+++ b/plugin/src/storage/launcher-projection.itest.ts
@@ -19,7 +19,7 @@ function makeChangeInput(
   projectionChangesDir: string,
 ): ChangeWorkflowInput {
   return {
-    projectId: "launcher-projection-project",
+    projectId: "0a00c0e00000ec00000000ec0000000000000000",
     changeId,
     title: `Launcher projection test: ${changeId}`,
     initializedAt: "2026-07-23T10:00:00.000Z",

--- a/plugin/src/storage/read-command-boundary.test.ts
+++ b/plugin/src/storage/read-command-boundary.test.ts
@@ -289,7 +289,13 @@ const queryContextAllowlist = new Map<string, Set<string>>([
   ],
   [
     "storage/store-temporal/epics.ts",
-    new Set(["queryEpicState", "queryEpicStateRead", "getEpicHandle"]),
+    new Set([
+      "queryEpicState",
+      "queryEpicStateRead",
+      "getEpicHandle",
+      "verifyEpicStatusSearchAttribute",
+      "verifyEpicStatusSearchAttributeImpl",
+    ]),
   ],
   ["storage/store-temporal/gates.ts", new Set(["fireSignalWithMutationGuard"])],
   [

--- a/plugin/src/storage/store-temporal/__tests__/signal-integration.itest.ts
+++ b/plugin/src/storage/store-temporal/__tests__/signal-integration.itest.ts
@@ -31,7 +31,7 @@ import type {
 
 function makeChangeInput(changeId: string): ChangeWorkflowInput {
   return {
-    projectId: "proj-sig-001",
+    projectId: "0000000001000000000000000000000000000000",
     changeId,
     title: `Signal test: ${changeId}`,
     initializedAt: new Date().toISOString(),

--- a/plugin/src/storage/store-temporal/active-conflict-authority-benchmark.test.ts
+++ b/plugin/src/storage/store-temporal/active-conflict-authority-benchmark.test.ts
@@ -22,6 +22,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTempDir, cleanupTempDir } from "../../__tests__/setup";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { createDefaultGates, type Change } from "../../types";
 import { createDiskStore } from "../store-disk";
 import { createTemporalStoreBackend } from "./index";
@@ -108,7 +109,7 @@ function workflowStateFor(change: Change) {
     status: change.status,
     createdAt: change.created_at,
     initializedAt: change.created_at,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     tasks: [],
     deltas: change.deltas,
     wisdom: [],
@@ -133,7 +134,7 @@ async function writeArchiveBundle(tempDir: string, change: Change) {
 }
 
 function mockTemporalClient(ids: string[]) {
-  return {
+  return createMockOwnerFromClient({
     client: {
       workflow: {
         list: async function* () {
@@ -158,7 +159,7 @@ function mockTemporalClient(ids: string[]) {
         },
       },
     },
-  };
+  });
 }
 
 interface RunResult {
@@ -255,7 +256,7 @@ describe("active conflict authority benchmark gate", () => {
       const store = createTemporalStoreBackend({
         legacy,
         temporal,
-        projectId: "project-1",
+        projectId: "0000ec0100000000000000000000000000000000",
       });
 
       const durations: number[] = [];
@@ -264,7 +265,7 @@ describe("active conflict authority benchmark gate", () => {
         const coldStore = createTemporalStoreBackend({
           legacy,
           temporal,
-          projectId: "project-1",
+          projectId: "0000ec0100000000000000000000000000000000",
         });
         const run = await runBenchmarkAuthority(coldStore, concurrency);
         expect(run.completeness).toBe("complete");

--- a/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
+++ b/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
@@ -499,7 +499,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.listConflictAuthority!();

--- a/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
+++ b/plugin/src/storage/store-temporal/active-conflict-authority.test.ts
@@ -28,11 +28,13 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTempDir, cleanupTempDir } from "../../__tests__/setup";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { createDefaultGates, type Change } from "../../types";
 import { createDiskStore } from "../store-disk";
 import { createTemporalStoreBackend } from "./index";
 import { createTemporalReadDeadline } from "../../temporal/retry-wrapper";
 import { TEMPORAL_READ_DEADLINE_BUDGET_MS } from "./shared";
+const PROJECT_ID = "0000ec0100000000000000000000000000000000";
 
 const archiveReadCalls: { fn: string; args: unknown[] }[] = [];
 
@@ -110,7 +112,7 @@ function workflowStateFor(change: Change) {
     status: change.status,
     createdAt: change.created_at,
     initializedAt: change.created_at,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     tasks: [],
     deltas: change.deltas,
     wisdom: [],
@@ -144,13 +146,13 @@ interface MockTemporalOptions {
 }
 
 function mockTemporalClient(opts: MockTemporalOptions = {}) {
-  return {
+  return createMockOwnerFromClient({
     client: {
       workflow: {
         list: async function* () {
           if (opts.listError) throw opts.listError;
           for (const id of opts.ids ?? []) {
-            yield { workflowId: `adv/change/project-1/${id}` };
+            yield { workflowId: `adv/change/${PROJECT_ID}/${id}` };
             if (opts.listDelayAfter !== undefined) {
               await new Promise<void>((resolve) =>
                 globalThis.setTimeout(resolve, opts.listDelayAfter),
@@ -159,7 +161,7 @@ function mockTemporalClient(opts: MockTemporalOptions = {}) {
           }
         },
         getHandle: (workflowId: string) => {
-          const id = workflowId.replace(`adv/change/project-1/`, "");
+          const id = workflowId.replace(`adv/change/${PROJECT_ID}/`, "");
           return {
             query: async () => {
               if (opts.queryError) throw opts.queryError;
@@ -183,7 +185,7 @@ function mockTemporalClient(opts: MockTemporalOptions = {}) {
         },
       },
     },
-  };
+  });
 }
 
 /**
@@ -242,7 +244,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const authority = store.changes.listConflictAuthority;
@@ -280,7 +282,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.listConflictAuthority!();
@@ -300,7 +302,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.listConflictAuthority!();
@@ -321,7 +323,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const pending = store.changes.listConflictAuthority!({
@@ -352,7 +354,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const pending = store.changes.listConflictAuthority!({
@@ -384,7 +386,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const pending = store.changes.listConflictAuthority!({
@@ -411,7 +413,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.listConflictAuthority!();
@@ -434,7 +436,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.listConflictAuthority!();
@@ -461,7 +463,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.listConflictAuthority!();
@@ -523,7 +525,7 @@ describe("active conflict authority", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     // Warm the non-authoritative cache by listing the change.

--- a/plugin/src/storage/store-temporal/bounded-read-deadline.test.ts
+++ b/plugin/src/storage/store-temporal/bounded-read-deadline.test.ts
@@ -138,7 +138,7 @@ describe("projection-only change-list reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisoned.temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.list({});
@@ -168,7 +168,7 @@ describe("projection-only change-list reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisoned.temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const archived = await store.changes.list({ includeArchived: true });
@@ -183,8 +183,10 @@ describe("projection-only change-list reads", () => {
       "closedOne",
     ]);
 
-    // Terminal reads are projection-only (#353): the rows above come from
-    // durable summary shards, so no Temporal surface is touched at all.
+    // Terminal and routine list reads are projection-only (#353): even
+    // terminal reads do not enumerate Temporal Visibility. The rows above
+    // came from durable summary shards, so no Temporal client surface was
+    // touched.
     expect(poisoned.list).not.toHaveBeenCalled();
     expect(poisoned.query).not.toHaveBeenCalled();
     expect(poisoned.start).not.toHaveBeenCalled();
@@ -204,7 +206,7 @@ describe("projection-only change-list reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisoned.temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const page = await store.changes.listSummary!({ limit: 1, offset: 0 });
@@ -229,7 +231,7 @@ describe("projection-only change-list reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisonedTemporal().temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const archived = await store.changes.listSummary!({
@@ -255,7 +257,7 @@ describe("projection-only change-list reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisonedTemporal().temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const closed = await store.changes.listSummary!({ includeClosed: true });
@@ -273,7 +275,7 @@ describe("projection-only change-list reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisonedTemporal().temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.listSummary!({});
@@ -297,7 +299,7 @@ describe("projection-only change-list reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisoned.temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.list({});
@@ -311,9 +313,10 @@ describe("projection-only change-list reads", () => {
       ]),
     );
 
-    // Projection-only reads (#353) do not fall back to Visibility: an
-    // unreadable summary index degrades to an empty, typed-degraded result
-    // rather than reaching for Temporal.
+    // Projection-only reads (#353) do not fall back to Visibility: when
+    // durable sources fail, the summary index degrades to an empty,
+    // typed-degraded result rather than reaching for Temporal. The Temporal
+    // client surface stays untouched.
     expect(poisoned.list).not.toHaveBeenCalled();
     expect(poisoned.query).not.toHaveBeenCalled();
     expect(poisoned.start).not.toHaveBeenCalled();

--- a/plugin/src/storage/store-temporal/bounded-status.test.ts
+++ b/plugin/src/storage/store-temporal/bounded-status.test.ts
@@ -17,6 +17,7 @@ import { createTempDir, cleanupTempDir } from "../../__tests__/setup";
 import { createDefaultGates, type Change } from "../../types";
 import { createDiskStore } from "../store-disk";
 import { createTemporalStoreBackend } from "./index";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { rebuildSummaryIndex } from "../change-summary-shard";
 
 function activeChange(
@@ -45,7 +46,7 @@ function workflowStateFor(change: Change) {
     status: change.status,
     createdAt: change.created_at,
     initializedAt: change.created_at,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     tasks: [],
     deltas: {},
     wisdom: [],
@@ -69,7 +70,7 @@ function makeTemporal(
     createdAt?: string;
   }> = [],
 ) {
-  return {
+  return createMockOwnerFromClient({
     client: {
       workflow: {
         getHandle: (workflowId: string) => ({
@@ -97,7 +98,7 @@ function makeTemporal(
         },
       },
     },
-  };
+  });
 }
 
 describe("bounded summary status reads", () => {
@@ -129,7 +130,7 @@ describe("bounded summary status reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: makeTemporal(queried),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const status = await store.status({ recentLimit: 10 });
@@ -172,7 +173,7 @@ describe("bounded summary status reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: makeTemporal(queried),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const status = await store.status({ recentLimit: 10 });
@@ -208,7 +209,7 @@ describe("bounded summary status reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: makeTemporal(queried),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const status = await store.status();
@@ -256,7 +257,7 @@ describe("bounded summary status reads", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: makeTemporal(queried, new Map(seeded)),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const status = await store.status({ recentLimit: 2 });
@@ -301,7 +302,7 @@ describe("bounded summary status reads", () => {
         new Map(rows.map((row) => [row.id, row.createdAt])),
         [...rows].reverse(),
       ),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const status = await store.status({

--- a/plugin/src/storage/store-temporal/changes.close-storage.test.ts
+++ b/plugin/src/storage/store-temporal/changes.close-storage.test.ts
@@ -44,6 +44,38 @@ vi.mock("./shared", () => ({
   raceWithTemporalDeadline: async <T>(op: Promise<T>): Promise<T> => op,
   remainingDeadlineMs: vi.fn(),
   TemporalQueryTimeoutError: Error,
+  getTemporalOwner: () => ({
+    signal: async (
+      _ctx: unknown,
+      _handle: unknown,
+      def: unknown,
+      args: unknown[],
+    ) => {
+      await signalMock(def, ...args);
+      return { kind: "confirmed" };
+    },
+    query: async (
+      _ctx: unknown,
+      _handle: unknown,
+      def: unknown,
+      ...args: unknown[]
+    ) => {
+      const value = await queryMock(def, ...args);
+      return { kind: "complete", value };
+    },
+    getHandle: (_ctx: unknown) => ({
+      workflowId: "mock",
+      _opaque: Symbol("mock-handle"),
+    }),
+    describe: async () => ({ kind: "complete", value: {} }),
+    startChangeWorkflow: async () => ({
+      workflowId: "mock",
+      _opaque: Symbol("mock-handle"),
+    }),
+    list: async function* () {},
+    terminate: async () => ({ kind: "confirmed" }),
+    cancel: async () => ({ kind: "confirmed" }),
+  }),
   fallbackOperationId: vi.fn((kind: string) => kind),
   buildSummaryCommitProjection: vi.fn(() => vi.fn()),
   changeCommand: async (options: {
@@ -93,7 +125,7 @@ import { createHash, randomUUID } from "crypto";
 import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
 
 const CHANGE_ID = "chg-close-store";
-const PROJECT_ID = "pid-close";
+const PROJECT_ID = "0000000000000000000000000000000000000000";
 const AT = "2026-01-01T00:00:00.000Z";
 
 function draftChange(): Change {

--- a/plugin/src/storage/store-temporal/changes.test.ts
+++ b/plugin/src/storage/store-temporal/changes.test.ts
@@ -15,6 +15,9 @@ import { describe, test, expect, vi } from "vitest";
 import { createChangeOps } from "./changes";
 import { isWorkflowCompletedError } from "../../temporal/recovery-classification";
 import { ChangeSummaryMemo } from "../store-temporal-memo";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
+
+const PROJECT_ID = "0".repeat(40);
 
 const ensureChangeWorkflowStarted = vi.hoisted(() => vi.fn());
 const getCurrentSessionIdMock = vi.hoisted(() => vi.fn());
@@ -160,11 +163,12 @@ describe("createChangeOps", () => {
       },
     };
     const workflowClient = { workflow: { start: vi.fn(), getHandle: vi.fn() } };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-abc",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: vi.fn(),
@@ -191,11 +195,11 @@ describe("createChangeOps", () => {
     });
 
     expect(ensureChangeWorkflowStarted).toHaveBeenCalledWith(
-      workflowClient,
+      owner,
       expect.objectContaining({
         seedState: expect.objectContaining({ origin }),
       }),
-      { workflowQueueMode: "session" },
+      { workflowQueueMode: "session", budgetMs: 30_000 },
     );
   });
 
@@ -224,11 +228,12 @@ describe("createChangeOps", () => {
       },
     };
     const workflowClient = { workflow: { start: vi.fn(), getHandle: vi.fn() } };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-abc",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: vi.fn(),
@@ -245,11 +250,11 @@ describe("createChangeOps", () => {
     await ops.create("Session routing test", {});
 
     expect(ensureChangeWorkflowStarted).toHaveBeenCalledWith(
-      workflowClient,
+      owner,
       expect.objectContaining({
         sessionId: "sess_test_routing_id",
       }),
-      { workflowQueueMode: "session" },
+      { workflowQueueMode: "session", budgetMs: 30_000 },
     );
 
     getCurrentSessionIdMock.mockReset();
@@ -301,11 +306,12 @@ describe("createChangeOps", () => {
       },
     };
     const workflowClient = { workflow: { start: vi.fn(), getHandle: vi.fn() } };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-target",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: vi.fn(),
@@ -325,13 +331,13 @@ describe("createChangeOps", () => {
     });
 
     expect(ensureChangeWorkflowStarted).toHaveBeenCalledWith(
-      workflowClient,
+      owner,
       expect.objectContaining({
         seedState: expect.objectContaining({
           cross_project_origin: crossProjectOrigin,
         }),
       }),
-      { workflowQueueMode: "session" },
+      { workflowQueueMode: "session", budgetMs: 30_000 },
     );
   });
 
@@ -369,11 +375,12 @@ describe("createChangeOps", () => {
       },
     };
     const workflowClient = { workflow: { start: vi.fn(), getHandle: vi.fn() } };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-am",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: vi.fn(),
@@ -391,18 +398,18 @@ describe("createChangeOps", () => {
 
     // 1. Workflow seedState carries the marker so the workflow starts with it set.
     expect(ensureChangeWorkflowStarted).toHaveBeenCalledWith(
-      workflowClient,
+      owner,
       expect.objectContaining({
         seedState: expect.objectContaining({ worktree_auto_managed: true }),
       }),
-      { workflowQueueMode: "session" },
+      { workflowQueueMode: "session", budgetMs: 30_000 },
     );
 
     // 2. Disk projection save includes the marker (changeWithOwner).
     expect(saveMock).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "newAutoManagedChange",
-        adv_project_id: "pid-am",
+        adv_project_id: PROJECT_ID,
         worktree_auto_managed: true,
       }),
     );
@@ -459,11 +466,12 @@ describe("createChangeOps", () => {
       const workflowClient = {
         workflow: { start: vi.fn(), getHandle: vi.fn() },
       };
+      const owner = createMockOwnerFromClient({ client: workflowClient });
       const ops = createChangeOps({
         input: {
           legacy,
-          temporal: { client: workflowClient },
-          projectId: "pid-cr",
+          temporal: owner,
+          projectId: PROJECT_ID,
         },
         legacy,
         invalidateChange: vi.fn(),
@@ -585,11 +593,12 @@ describe("createChangeOps", () => {
       const workflowClient = {
         workflow: { start: vi.fn(), getHandle: vi.fn() },
       };
+      const owner = createMockOwnerFromClient({ client: workflowClient });
       const ops = createChangeOps({
         input: {
           legacy,
-          temporal: { client: workflowClient },
-          projectId: "pid-conflict",
+          temporal: owner,
+          projectId: PROJECT_ID,
         },
         legacy,
         invalidateChange: vi.fn(),
@@ -633,11 +642,12 @@ describe("createChangeOps", () => {
         getHandle: vi.fn(() => ({ signal: signalMock })),
       },
     };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-source",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: vi.fn(),
@@ -713,11 +723,12 @@ describe("createChangeOps", () => {
         getHandle: vi.fn(() => ({ signal: signalMock })),
       },
     };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-proof",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: vi.fn(),
@@ -789,13 +800,14 @@ describe("createChangeOps", () => {
       root: string;
     }) {
       const workflowClient = { workflow: { getHandle: vi.fn() } };
+      const owner = createMockOwnerFromClient({ client: workflowClient });
       const getTemporalChange = vi.fn();
       return {
         ops: createChangeOps({
           input: {
             legacy: { paths, changes: { get: vi.fn() } },
-            temporal: { client: workflowClient },
-            projectId: "pid-summary",
+            temporal: owner,
+            projectId: PROJECT_ID,
           },
           legacy: { paths, changes: { get: vi.fn() } },
           invalidateChange: vi.fn(),
@@ -1015,7 +1027,7 @@ describe("createChangeOps", () => {
       changes: {
         get: vi.fn().mockResolvedValue({
           success: true,
-          data: { id: "summaryChange", adv_project_id: "pid-summary" },
+          data: { id: "summaryChange", adv_project_id: PROJECT_ID },
         }),
         updateArtifacts: vi.fn().mockResolvedValue({
           success: true,
@@ -1065,11 +1077,12 @@ describe("createChangeOps", () => {
         })),
       },
     };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-summary",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: vi.fn(),
@@ -1134,7 +1147,7 @@ describe("createChangeOps", () => {
       changes: {
         get: vi.fn().mockResolvedValue({
           success: true,
-          data: { id: "cacheChange", adv_project_id: "pid-cache" },
+          data: { id: "cacheChange", adv_project_id: PROJECT_ID },
         }),
         updateArtifacts: vi.fn().mockResolvedValue({
           success: true,
@@ -1180,11 +1193,12 @@ describe("createChangeOps", () => {
         })),
       },
     };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-cache",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: invalidateChangeMock,
@@ -1226,7 +1240,7 @@ describe("createChangeOps", () => {
       changes: {
         get: vi.fn().mockResolvedValue({
           success: true,
-          data: { id: "capChange", adv_project_id: "pid-cap" },
+          data: { id: "capChange", adv_project_id: PROJECT_ID },
         }),
         updateArtifacts: vi.fn().mockResolvedValue({ success: true }),
       },
@@ -1234,11 +1248,12 @@ describe("createChangeOps", () => {
     const workflowClient = {
       workflow: { getHandle: vi.fn(() => ({ signal: signalMock })) },
     };
+    const owner = createMockOwnerFromClient({ client: workflowClient });
     const ops = createChangeOps({
       input: {
         legacy,
-        temporal: { client: workflowClient },
-        projectId: "pid-cap",
+        temporal: owner,
+        projectId: PROJECT_ID,
       },
       legacy,
       invalidateChange: vi.fn(),

--- a/plugin/src/storage/store-temporal/changes.ts
+++ b/plugin/src/storage/store-temporal/changes.ts
@@ -47,11 +47,17 @@ import {
 } from "../../temporal/messages";
 import { getMutationReceiptQuery } from "../../temporal/messages";
 import type { MutationReceipt } from "../../temporal/contracts";
+import { ensureChangeWorkflowStarted } from "../../temporal/workflow-start";
+import { makeTemporalOperationContext } from "../../temporal/operations";
 import {
   MutationApplicationUnconfirmedError,
   waitForQueryPredicate,
 } from "../../utils/query-predicate";
-import { ensureChangeWorkflowStarted } from "../../temporal/workflow-start";
+import {
+  TemporalListOutcomeError,
+  TemporalMutationOutcomeError,
+  TemporalReadOutcomeError,
+} from "../../temporal/outcome-errors";
 import { getCurrentSessionId } from "../../utils/session-id";
 import { removeChangeDir, loadProjectConfig } from "../json";
 import { resolveProjectFeaturePolicy } from "../../types";
@@ -70,6 +76,7 @@ import {
   runTemporalQuery,
   getChangeHandle,
   getGuardedChangeHandle,
+  getTemporalOwner,
   createTemporalReadDeadline,
   createTemporalReadContext,
   type TemporalReadContext,
@@ -94,7 +101,9 @@ import {
 import { createLogger } from "../../utils/debug-log";
 import { enforceMutationEligibilityForError } from "../../temporal/mutation-safety";
 import { fireSignalWithMutationGuard } from "./gates";
-import { listChangeWorkflowIds } from "../../temporal/list-change-workflows";
+import { buildVisibilityQuery } from "../../temporal/list-change-workflows";
+import { CHANGE_WORKFLOW_PREFIX } from "../../temporal/contracts";
+import { buildChangeWorkflowId } from "../../temporal/client";
 import { atomicWriteFile, acquireFileLock } from "../../utils/fs";
 import { mapWithConcurrency } from "../../utils/concurrency";
 import {
@@ -182,14 +191,28 @@ const ARTIFACT_SIGNAL_ORDER: ReadonlyArray<{
 async function fireGuardedSignal<Args extends unknown[]>(
   input: import("./shared").TemporalStoreBackendInput,
   changeId: string,
-  signalName: unknown,
+  signalName: import("@temporalio/workflow").SignalDefinition<unknown[]>,
   ...args: Args
 ): Promise<void> {
   try {
-    await runTemporal(async () => {
+    const outcome = await runTemporal(async () => {
+      const owner = getTemporalOwner(input);
       const handle = await getGuardedChangeHandle(input, changeId);
-      await handle.signal(signalName, ...(args as unknown[]));
+      const workflowId = buildChangeWorkflowId(input.projectId, changeId);
+      const ctx = makeTemporalOperationContext(
+        input.projectId,
+        workflowId,
+        "signal",
+        "fireGuardedSignal",
+        5_000,
+      );
+      return await owner.signal(ctx, handle, signalName, [
+        ...(args as unknown[]),
+      ]);
     });
+    if (outcome.kind !== "confirmed") {
+      throw new TemporalMutationOutcomeError(outcome);
+    }
   } catch (err) {
     // SC4 guard at signal-dispatch boundary.
     enforceMutationEligibilityForError(err);
@@ -250,16 +273,33 @@ async function fireContentArtifactCommands(
           payload_hash: payloadHash,
         },
       ],
-      postSignal: async (handle) => {
-        await handle.signal(updateArtifactMetadataSignal, {
-          kind,
-          metadata: {
-            updatedAt,
-            contentHash: computeContentHash(content),
-            source: "temporal",
-            readable: false,
-          },
-        });
+      postSignal: async (owner, handle) => {
+        const ctx = makeTemporalOperationContext(
+          input.projectId,
+          buildChangeWorkflowId(input.projectId, changeId),
+          "signal",
+          "updateArtifactMetadata",
+          5_000,
+        );
+        const outcome = await owner.signal(
+          ctx,
+          handle,
+          updateArtifactMetadataSignal,
+          [
+            {
+              kind,
+              metadata: {
+                updatedAt,
+                contentHash: computeContentHash(content),
+                source: "temporal",
+                readable: false,
+              },
+            },
+          ],
+        );
+        if (outcome.kind !== "confirmed") {
+          throw new TemporalMutationOutcomeError(outcome);
+        }
       },
       commitProjection: buildSummaryCommitProjection(
         legacy,
@@ -277,12 +317,30 @@ async function fireContentArtifactCommands(
     lastState = outcome.state;
 
     if (mutationReceiptId) {
+      const owner = getTemporalOwner(input);
       const handle = await getGuardedChangeHandle(input, changeId);
+      const ctx = makeTemporalOperationContext(
+        input.projectId,
+        buildChangeWorkflowId(input.projectId, changeId),
+        "query",
+        "getMutationReceipt",
+        5_000,
+      );
       const receipt = await waitForQueryPredicate(
-        () =>
-          handle.query(getMutationReceiptQuery, mutationReceiptId) as Promise<
-            MutationReceipt | undefined
-          >,
+        async () => {
+          const outcome = await owner.query(
+            ctx,
+            handle,
+            getMutationReceiptQuery,
+            mutationReceiptId,
+          );
+          if (outcome.kind !== "complete") {
+            throw (
+              outcome.error ?? new Error("mutation receipt query incomplete")
+            );
+          }
+          return outcome.value as MutationReceipt | undefined;
+        },
         (candidate) => candidate?.id === mutationReceiptId,
       );
       if (!receipt) {
@@ -406,10 +464,25 @@ function createBatchCloseCoordinationDeps(
         throw new Error(`Unknown batch close signal: ${signal}`);
       }
     },
-    queryState: async (changeId) =>
-      runTemporal(async () =>
-        (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
-      ) as Promise<ChangeWorkflowState>,
+    queryState: async (changeId) => {
+      const owner = getTemporalOwner(input);
+      const handle = await getGuardedChangeHandle(input, changeId);
+      const workflowId = buildChangeWorkflowId(input.projectId, changeId);
+      const ctx = makeTemporalOperationContext(
+        input.projectId,
+        workflowId,
+        "query",
+        "batchCloseQueryState",
+        5_000,
+      );
+      const outcome = await runTemporal(async () =>
+        owner.query(ctx, handle, changeStateQuery),
+      );
+      if (outcome.kind !== "complete") {
+        throw new TemporalReadOutcomeError(outcome);
+      }
+      return outcome.value as ChangeWorkflowState;
+    },
     now: () => new Date().toISOString(),
   };
 }
@@ -730,7 +803,7 @@ async function readProjectionChangeList(
 ): Promise<
   ChangeListResponse & { sourceRankedIds?: string[]; totalIds?: number }
 > {
-  const { input, legacy, memo, getTemporalChange } = deps;
+  const { input: _input, legacy, memo, getTemporalChange } = deps;
 
   const deadline = createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS);
   const ctx = createTemporalReadContext(deadline.budgetMs);
@@ -936,24 +1009,22 @@ async function readProjectionChangeList(
     }
 
     // Tier 3: capped workflow fallback only when durable evidence is missing.
-    if (typeof input.temporal.client?.workflow?.getHandle === "function") {
-      try {
-        const result = await getTemporalChange(id, { context: ctx });
-        if (result.success && result.data) {
-          rows.set(result.data.id, changeToListRow(result.data));
-          fromHydration++;
-          if (wantsTerminalStatuses) {
-            terminalFromWorkflow++;
-          }
-          return;
+    try {
+      const result = await getTemporalChange(id, { context: ctx });
+      if (result.success && result.data) {
+        rows.set(result.data.id, changeToListRow(result.data));
+        fromHydration++;
+        if (wantsTerminalStatuses) {
+          terminalFromWorkflow++;
         }
-      } catch (err) {
-        if (err instanceof TemporalQueryTimeoutError || expired()) {
-          deadlineOmissions.push(id);
-          return;
-        }
-        // Other workflow failures are recorded as load failures.
+        return;
       }
+    } catch (err) {
+      if (err instanceof TemporalQueryTimeoutError || expired()) {
+        deadlineOmissions.push(id);
+        return;
+      }
+      // Other workflow failures are recorded as load failures.
     }
 
     loadFailedOmissions.push(id);
@@ -1063,7 +1134,6 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
     indexTasksFromState,
     setCachedChange,
     getTemporalChange,
-    getTemporalWorkflowClient,
     dualWriteAfterMutation,
     persistStateToDiskDurable,
     readChangeSnapshot,
@@ -1153,9 +1223,8 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
       //
       // See design.md § KD-7.
       try {
-        const client = getTemporalWorkflowClient();
-        await ensureChangeWorkflowStarted(
-          client,
+        const owner = getTemporalOwner(input);
+        const startInput: import("../../temporal/contracts").ChangeWorkflowInput =
           {
             projectId: input.projectId,
             changeId: created.data.id,
@@ -1164,7 +1233,7 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
             projectionChangesDir: legacy.paths.changes,
             archiveProjects: [{ projectPath: legacy.paths.root }],
             // KD-10 / rq-isolSessionTaskQueue01: thread current session ID so
-            // ensureChangeWorkflowStarted can route to advance-{projectId}-{sess}.
+            // the start can route to advance-{projectId}-{sess}.
             // Undefined falls back to project queue (legacy / pre-init / tests).
             sessionId: getCurrentSessionId(),
             // rq-creationRequestHash01: enables the "already started" hash
@@ -1196,9 +1265,11 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
               creation_request_hash: creationRequestHash,
               ...(epicMembership ? { epic_membership: epicMembership } : {}),
             },
-          },
-          { workflowQueueMode: featurePolicy.workflowQueueMode },
-        );
+          };
+        await ensureChangeWorkflowStarted(owner, startInput, {
+          workflowQueueMode: featurePolicy.workflowQueueMode,
+          budgetMs: 30_000,
+        });
       } catch (err) {
         // rq-creationRequestHash01: a hash conflict is a deterministic,
         // caller-induced refusal — the just-written disk scaffold must be
@@ -1383,11 +1454,25 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
             `changes.save(${change.id}, archived): signal acknowledged but post-signal readback unavailable — outcome classified as outcome_unknown_readback_unavailable.`,
           );
         }
-        const result = (await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, change.id)).query(
-            changeStateQuery,
-          ),
-        )) as import("../../temporal/contracts").ChangeWorkflowState;
+        const owner = getTemporalOwner(input);
+        const handle = await getGuardedChangeHandle(input, change.id);
+        const ctx = makeTemporalOperationContext(
+          input.projectId,
+          buildChangeWorkflowId(input.projectId, change.id),
+          "query",
+          "archiveReadback",
+          5_000,
+        );
+        const queryOutcome = await runTemporal(async () =>
+          owner.query(ctx, handle, changeStateQuery),
+        );
+        if (queryOutcome.kind !== "complete") {
+          throw (
+            queryOutcome.error ?? new Error("archive readback query incomplete")
+          );
+        }
+        const result =
+          queryOutcome.value as import("../../temporal/contracts").ChangeWorkflowState;
         indexTasksFromState(result);
         updateOverlay(change.id, { status: "archived" });
         setCachedChange(result);
@@ -1763,12 +1848,24 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
           for (const changeId of canonicalIds) {
             const record = outcome.operation.per_target[changeId];
             if (record?.phase !== "committed") continue;
-            const result = await runTemporal(async () =>
-              (await getGuardedChangeHandle(input, changeId)).query(
-                changeStateQuery,
-              ),
+            const owner = getTemporalOwner(input);
+            const handle = await getGuardedChangeHandle(input, changeId);
+            const ctx = makeTemporalOperationContext(
+              input.projectId,
+              buildChangeWorkflowId(input.projectId, changeId),
+              "query",
+              "batchCloseReadback",
+              5_000,
             );
-            const state = result as ChangeWorkflowState;
+            const result = await runTemporal(async () =>
+              owner.query(ctx, handle, changeStateQuery),
+            );
+            if (result.kind !== "complete") {
+              throw (
+                result.error ?? new Error("batch close readback incomplete")
+              );
+            }
+            const state = result.value as ChangeWorkflowState;
             indexTasksFromState(state);
             updateOverlay(changeId, {
               status: "closed",
@@ -1935,30 +2032,45 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
       const startMs = Date.now();
       let visibilitySucceeded = false;
 
-      const bundle = input.temporal as {
-        client?: { workflow?: { list?: unknown } };
-      };
       let visibilityIds: string[] = [];
-      if (typeof bundle.client?.workflow?.list === "function") {
-        try {
-          visibilityIds = await raceWithTemporalDeadline(
-            listChangeWorkflowIds(
-              bundle.client as Parameters<typeof listChangeWorkflowIds>[0],
-              { projectId: input.projectId },
-            ),
-            deadline,
-          );
-          visibilitySucceeded = true;
-        } catch (err) {
-          const hitDeadline =
-            err instanceof TemporalQueryTimeoutError || expired();
-          warnings.push(
-            `Visibility active enumeration ${hitDeadline ? "exceeded the aggregate read deadline" : "failed"}: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-      } else {
+      try {
+        const owner = getTemporalOwner(input);
+        const listCtx = makeTemporalOperationContext(
+          input.projectId,
+          "conflict-authority-list",
+          "list",
+          "listConflictAuthority",
+          5_000,
+        );
+        const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${input.projectId}/`;
+        const query = buildVisibilityQuery({ projectId: input.projectId });
+        visibilityIds = await raceWithTemporalDeadline(
+          (async () => {
+            const ids: string[] = [];
+            const outcome = await owner.list<{ workflowId: string }>(
+              listCtx,
+              query,
+            );
+            if (outcome.kind !== "complete") {
+              throw new TemporalListOutcomeError(outcome);
+            }
+            for (const wf of outcome.value) {
+              const wfid = wf.workflowId;
+              if (!wfid.startsWith(projectPrefix)) continue;
+              const changeId = wfid.slice(projectPrefix.length);
+              if (changeId.length === 0) continue;
+              ids.push(changeId);
+            }
+            return ids;
+          })(),
+          deadline,
+        );
+        visibilitySucceeded = true;
+      } catch (err) {
+        const hitDeadline =
+          err instanceof TemporalQueryTimeoutError || expired();
         warnings.push(
-          "Temporal client does not expose workflow.list; active conflict authority cannot enumerate Visibility.",
+          `Visibility active enumeration ${hitDeadline ? "exceeded the aggregate read deadline" : "failed"}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
 
@@ -2065,11 +2177,26 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
             budgetMs: fallbackBudget,
             deadlineAt: Date.now() + fallbackBudget,
           };
-          const state = (await runTemporalQuery(
-            async () =>
-              getChangeHandle(input, changeId).query(changeStateQuery),
+          const owner = getTemporalOwner(input);
+          const handle = getChangeHandle(input, changeId);
+          const ctx = makeTemporalOperationContext(
+            input.projectId,
+            buildChangeWorkflowId(input.projectId, changeId),
+            "query",
+            "conflictAuthorityFallback",
+            fallbackBudget,
+          );
+          const outcome = await runTemporalQuery(
+            async () => owner.query(ctx, handle, changeStateQuery),
             { deadline: fallbackDeadline },
-          )) as ChangeWorkflowState;
+          );
+          if (outcome.kind !== "complete") {
+            throw (
+              outcome.error ??
+              new Error("conflict authority fallback query incomplete")
+            );
+          }
+          const state = outcome.value as ChangeWorkflowState;
 
           if (state.changeId !== changeId) {
             return {

--- a/plugin/src/storage/store-temporal/convergent-read-disk-authoritative.test.ts
+++ b/plugin/src/storage/store-temporal/convergent-read-disk-authoritative.test.ts
@@ -19,6 +19,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 
 import { createTempDir, cleanupTempDir } from "../../__tests__/setup";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { createDefaultGates, type Change } from "../../types";
 import { createDiskStore } from "../store-disk";
 import { createTemporalStoreBackend } from "./index";
@@ -51,7 +52,7 @@ function workflowStateFor(change: Change) {
     status: change.status,
     createdAt: change.created_at,
     initializedAt: change.created_at,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     tasks: [],
     deltas: {},
     wisdom: [],
@@ -110,7 +111,7 @@ function createHangingTemporal(_changeIds: string[]) {
   const connection = createHangingConnection();
   const queryCalls: { workflowId: string }[] = [];
   return {
-    temporal: {
+    temporal: createMockOwnerFromClient({
       connection,
       client: {
         workflow: {
@@ -125,7 +126,7 @@ function createHangingTemporal(_changeIds: string[]) {
           },
         },
       },
-    },
+    }),
     queryCalls,
   };
 }
@@ -149,7 +150,7 @@ describe("disk-authoritative change read convergence", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const start = Date.now();
@@ -172,7 +173,7 @@ describe("disk-authoritative change read convergence", () => {
     const change = activeChange("fastQueryChange");
     await legacy.changes.save(change);
 
-    const temporal = {
+    const temporal = createMockOwnerFromClient({
       client: {
         workflow: {
           getHandle: () => ({
@@ -183,12 +184,12 @@ describe("disk-authoritative change read convergence", () => {
           },
         },
       },
-    };
+    });
 
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.get("fastQueryChange");
@@ -216,7 +217,7 @@ describe("disk-authoritative change read convergence", () => {
     }
 
     let queryCalls = 0;
-    const temporal = {
+    const temporal = createMockOwnerFromClient({
       client: {
         workflow: {
           getHandle: () => ({
@@ -230,12 +231,12 @@ describe("disk-authoritative change read convergence", () => {
           },
         },
       },
-    };
+    });
 
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.list({ validationConcurrency: 1 });

--- a/plugin/src/storage/store-temporal/epics.test.ts
+++ b/plugin/src/storage/store-temporal/epics.test.ts
@@ -10,6 +10,11 @@ import { describe, expect, test, vi } from "vitest";
 import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import {
+  createMockOwnerFromClient,
+  createMockOwner,
+} from "../../temporal/__tests__/mock-owner";
+import { StartWorkflowOutcomeError } from "../../temporal/workflow-start";
 import { createEpicOps } from "./epics";
 import type { StoreDeps } from "./shared";
 import { createDiskStore } from "../store-disk";
@@ -55,7 +60,7 @@ function makeEpic(overrides?: Partial<Epic>): Epic {
 
 function makeState(epic: Epic): EpicWorkflowState {
   return {
-    projectId: "project-id",
+    projectId: "0000ec00d0000000000000000000000000000000",
     epicId: epic.id,
     title: epic.title,
     narrative: epic.narrative,
@@ -87,8 +92,8 @@ function setup() {
   const deps = {
     input: {
       legacy: {},
-      temporal: client,
-      projectId: "project-id",
+      temporal: createMockOwnerFromClient(client),
+      projectId: "0000ec00d0000000000000000000000000000000",
     },
     getTemporalWorkflowClient: () =>
       client as ReturnType<StoreDeps["getTemporalWorkflowClient"]>,
@@ -112,6 +117,7 @@ function setup() {
     describeMock,
     startMock,
     getHandleMock,
+    list: client.workflow.list,
   };
 }
 
@@ -136,6 +142,69 @@ describe("createEpicOps", () => {
     );
   });
 
+  test("create propagates confirmed_failure from startEpicWorkflow", async () => {
+    const owner = createMockOwner({
+      startEpicWorkflow: vi.fn(async () => ({
+        kind: "confirmed_failure",
+        error: new Error("epic start failed"),
+        diagnostic: { class: "reachable", reachable: true },
+      })),
+    });
+    const deps = {
+      input: {
+        legacy: {},
+        temporal: owner,
+        projectId: "0000ec00d0000000000000000000000000000000",
+      },
+    } as unknown as StoreDeps;
+
+    await expect(
+      createEpicOps(deps).create("addAuthEpic", "Add Auth", "Narr"),
+    ).rejects.toBeInstanceOf(StartWorkflowOutcomeError);
+  });
+
+  test("create wraps timeout_unavailable from startEpicWorkflow in StartWorkflowOutcomeError", async () => {
+    const owner = createMockOwner({
+      startEpicWorkflow: vi.fn(async () => ({
+        kind: "timeout_unavailable",
+        error: new Error("epic start deadline"),
+        diagnostic: { class: "deadline", reachable: true },
+      })),
+    });
+    const deps = {
+      input: {
+        legacy: {},
+        temporal: owner,
+        projectId: "0000ec00d0000000000000000000000000000000",
+      },
+    } as unknown as StoreDeps;
+
+    await expect(
+      createEpicOps(deps).create("addAuthEpic", "Add Auth", "Narr"),
+    ).rejects.toBeInstanceOf(StartWorkflowOutcomeError);
+  });
+
+  test("create wraps outcome_unknown from startEpicWorkflow in StartWorkflowOutcomeError", async () => {
+    const owner = createMockOwner({
+      startEpicWorkflow: vi.fn(async () => ({
+        kind: "outcome_unknown",
+        error: new Error("epic start ambiguous"),
+        diagnostic: { class: "unknown", reachable: true },
+      })),
+    });
+    const deps = {
+      input: {
+        legacy: {},
+        temporal: owner,
+        projectId: "0000ec00d0000000000000000000000000000000",
+      },
+    } as unknown as StoreDeps;
+
+    await expect(
+      createEpicOps(deps).create("addAuthEpic", "Add Auth", "Narr"),
+    ).rejects.toBeInstanceOf(StartWorkflowOutcomeError);
+  });
+
   test("get returns the active projection without workflow query", async () => {
     const { deps, queryMock } = setup();
     const epic = makeEpic();
@@ -157,7 +226,8 @@ describe("createEpicOps", () => {
       retired_at: new Date().toISOString(),
       retired_by: "agent",
       evidence: "projection read contract",
-      source_workflow_id: "adv/epic/project-id/projectedEpic",
+      source_workflow_id:
+        "adv/epic/0000ec00d0000000000000000000000000000000/projectedEpic",
       source_version: 0,
       projection_status: "retired",
     });
@@ -551,7 +621,9 @@ describe("createEpicOps", () => {
     function setupMissing(epicId = "missingEpic") {
       const { deps, handle, queryMock, signalMock, getHandleMock } = setup();
       queryMock.mockImplementation(async () => {
-        throw new Error(`Workflow not found: adv/epic/project-id/${epicId}`);
+        throw new Error(
+          `Workflow not found: adv/epic/0000ec00d0000000000000000000000000000000/${epicId}`,
+        );
       });
       return { deps, handle, queryMock, signalMock, getHandleMock };
     }
@@ -632,11 +704,8 @@ describe("createEpicOps", () => {
     });
 
     test("list ignores a poisoned Temporal client", async () => {
-      const { deps, queryMock } = setup();
-      const client = deps.input.temporal as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
-      client.workflow.list.mockImplementation(() => {
+      const { deps, queryMock, list } = setup();
+      list.mockImplementation(() => {
         throw new Error("Visibility must not be called by routine reads");
       });
 
@@ -650,7 +719,9 @@ describe("createEpicOps", () => {
     test("get falls back to retired projection when workflow is not found", async () => {
       const { deps, queryMock, tempDir } = await setupWithRetiredEpicsDir();
       queryMock.mockImplementation(async () => {
-        throw new Error("Workflow not found: adv/epic/project-id/retiredEpic");
+        throw new Error(
+          "Workflow not found: adv/epic/0000ec00d0000000000000000000000000000000/retiredEpic",
+        );
       });
 
       const projection = {
@@ -669,7 +740,8 @@ describe("createEpicOps", () => {
         retired_at: "2026-07-08T00:00:00.000Z",
         retired_by: "agent",
         evidence: "User approved retirement.",
-        source_workflow_id: "adv/epic/project-id/retiredEpic",
+        source_workflow_id:
+          "adv/epic/0000ec00d0000000000000000000000000000000/retiredEpic",
         source_version: 3,
         projection_status: "retired" as const,
       };
@@ -690,7 +762,9 @@ describe("createEpicOps", () => {
     test("get returns null when neither workflow nor retired projection exists", async () => {
       const { deps, queryMock, tempDir } = await setupWithRetiredEpicsDir();
       queryMock.mockImplementation(async () => {
-        throw new Error("Workflow not found: adv/epic/project-id/missingEpic");
+        throw new Error(
+          "Workflow not found: adv/epic/0000ec00d0000000000000000000000000000000/missingEpic",
+        );
       });
 
       const ops = createEpicOps(deps);
@@ -709,7 +783,8 @@ describe("createEpicOps", () => {
         retired_at: "2026-07-08T00:00:00.000Z",
         retired_by: "agent",
         evidence: "Evidence",
-        source_workflow_id: "adv/epic/project-id/persistedEpic",
+        source_workflow_id:
+          "adv/epic/0000ec00d0000000000000000000000000000000/persistedEpic",
         source_version: 1,
         projection_status: "retired" as const,
       };
@@ -778,7 +853,9 @@ describe("createEpicOps", () => {
       expect(result.source_version).toBe(1);
       expect(result.evidence).toBe("User approved retirement.");
       expect(result.retired_by).toBe("agent");
-      expect(result.source_workflow_id).toBe("adv/epic/project-id/addAuthEpic");
+      expect(result.source_workflow_id).toBe(
+        "adv/epic/0000ec00d0000000000000000000000000000000/addAuthEpic",
+      );
 
       expect(signalMock).toHaveBeenCalledWith(
         epicArchivedSignal,
@@ -923,20 +1000,18 @@ describe("createEpicOps", () => {
     }
 
     test("active mode reads only active disk projections", async () => {
-      const { deps, queryMock } = setup();
-      const temporal = deps.input.temporal as unknown as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
-      temporal.workflow.list.mockImplementation(
-        ({ query }: { query: string }) => {
-          expect(query).toBe(
-            `WorkflowType = "epicWorkflow" AND AdvEpicStatus = "active" AND ExecutionStatus = "Running"`,
-          );
-          return (async function* iter() {
-            yield { workflowId: "adv/epic/project-id/completedEpic" };
-          })();
-        },
-      );
+      const { deps, queryMock, list } = setup();
+      list.mockImplementation(({ query }: { query: string }) => {
+        expect(query).toBe(
+          `WorkflowType = "epicWorkflow" AND AdvEpicStatus = "active" AND ExecutionStatus = "Running"`,
+        );
+        return (async function* iter() {
+          yield {
+            workflowId:
+              "adv/epic/0000ec00d0000000000000000000000000000000/completedEpic",
+          };
+        })();
+      });
       queryMock.mockResolvedValue(makeState(makeCompletedEpic()));
 
       const ops = createEpicOps(deps);
@@ -947,18 +1022,16 @@ describe("createEpicOps", () => {
     });
 
     test("all mode reads active projections without workflow queries", async () => {
-      const { deps, queryMock } = setup();
-      const temporal = deps.input.temporal as unknown as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
-      temporal.workflow.list.mockImplementation(
-        ({ query }: { query: string }) => {
-          expect(query).toBe(`WorkflowType = "epicWorkflow"`);
-          return (async function* iter() {
-            yield { workflowId: "adv/epic/project-id/completedEpic" };
-          })();
-        },
-      );
+      const { deps, queryMock, list } = setup();
+      list.mockImplementation(({ query }: { query: string }) => {
+        expect(query).toBe(`WorkflowType = "epicWorkflow"`);
+        return (async function* iter() {
+          yield {
+            workflowId:
+              "adv/epic/0000ec00d0000000000000000000000000000000/completedEpic",
+          };
+        })();
+      });
       queryMock.mockResolvedValue(makeState(makeCompletedEpic()));
 
       const ops = createEpicOps(deps);
@@ -969,13 +1042,13 @@ describe("createEpicOps", () => {
     });
 
     test("active mode includes seeded active Epic projections", async () => {
-      const { deps, queryMock } = setup();
-      const temporal = deps.input.temporal as unknown as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
-      temporal.workflow.list.mockImplementation(() => {
+      const { deps, queryMock, list } = setup();
+      list.mockImplementation(() => {
         return (async function* iter() {
-          yield { workflowId: "adv/epic/project-id/activeEpic" };
+          yield {
+            workflowId:
+              "adv/epic/0000ec00d0000000000000000000000000000000/activeEpic",
+          };
         })();
       });
       queryMock.mockResolvedValue(makeState(makeEpic({ id: "activeEpic" })));
@@ -988,15 +1061,14 @@ describe("createEpicOps", () => {
     });
 
     test("list does not query unresponsive Epic workflows", async () => {
-      const { deps, queryMock } = setup();
-      const temporal = deps.input.temporal as unknown as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
+      const { deps, queryMock, list } = setup();
       // Five epic workflows, all unresponsive.
-      temporal.workflow.list.mockImplementation(() => {
+      list.mockImplementation(() => {
         return (async function* iter() {
           for (let i = 0; i < 5; i++) {
-            yield { workflowId: `adv/epic/project-id/wedgedEpic${i}` };
+            yield {
+              workflowId: `adv/epic/0000ec00d0000000000000000000000000000000/wedgedEpic${i}`,
+            };
           }
         })();
       });
@@ -1034,7 +1106,8 @@ describe("createEpicOps", () => {
         retired_at: "2026-07-24T11:00:00.000Z",
         retired_by: "agent",
         evidence: "terminal projection",
-        source_workflow_id: "adv/epic/project-id/shared",
+        source_workflow_id:
+          "adv/epic/0000ec00d0000000000000000000000000000000/shared",
         source_version: retired.version,
         projection_status: "retired",
       });
@@ -1066,14 +1139,17 @@ describe("createEpicOps", () => {
 
   describe("repairIndex", () => {
     test("dry-run reports running Epics with current progress status and no mutations", async () => {
-      const { deps, queryMock, signalMock } = setup();
-      const temporal = deps.input.temporal as unknown as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
-      temporal.workflow.list.mockImplementation(() => {
+      const { deps, queryMock, signalMock, list } = setup();
+      list.mockImplementation(() => {
         return (async function* iter() {
-          yield { workflowId: "adv/epic/project-id/activeEpic" };
-          yield { workflowId: "adv/epic/project-id/otherEpic" };
+          yield {
+            workflowId:
+              "adv/epic/0000ec00d0000000000000000000000000000000/activeEpic",
+          };
+          yield {
+            workflowId:
+              "adv/epic/0000ec00d0000000000000000000000000000000/otherEpic",
+          };
         })();
       });
       queryMock.mockResolvedValue(makeState(makeEpic({ id: "activeEpic" })));
@@ -1096,13 +1172,13 @@ describe("createEpicOps", () => {
     });
 
     test("non-dry-run confirms refreshed only after describe proof shows the current Epic status", async () => {
-      const { deps, queryMock, signalMock, describeMock } = setup();
-      const temporal = deps.input.temporal as unknown as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
-      temporal.workflow.list.mockImplementation(() => {
+      const { deps, queryMock, signalMock, describeMock, list } = setup();
+      list.mockImplementation(() => {
         return (async function* iter() {
-          yield { workflowId: "adv/epic/project-id/activeEpic" };
+          yield {
+            workflowId:
+              "adv/epic/0000ec00d0000000000000000000000000000000/activeEpic",
+          };
         })();
       });
       queryMock.mockResolvedValue(makeState(makeEpic({ id: "activeEpic" })));
@@ -1130,13 +1206,13 @@ describe("createEpicOps", () => {
     });
 
     test("non-dry-run reports unverified when signal is delivered but describe proof is missing", async () => {
-      const { deps, queryMock, describeMock } = setup();
-      const temporal = deps.input.temporal as unknown as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
-      temporal.workflow.list.mockImplementation(() => {
+      const { deps, queryMock, describeMock, list } = setup();
+      list.mockImplementation(() => {
         return (async function* iter() {
-          yield { workflowId: "adv/epic/project-id/activeEpic" };
+          yield {
+            workflowId:
+              "adv/epic/0000ec00d0000000000000000000000000000000/activeEpic",
+          };
         })();
       });
       queryMock.mockResolvedValue(makeState(makeEpic({ id: "activeEpic" })));
@@ -1164,13 +1240,13 @@ describe("createEpicOps", () => {
     });
 
     test("reports unreachable when workflow state cannot be queried", async () => {
-      const { deps, queryMock } = setup();
-      const temporal = deps.input.temporal as unknown as {
-        workflow: { list: ReturnType<typeof vi.fn> };
-      };
-      temporal.workflow.list.mockImplementation(() => {
+      const { deps, queryMock, list } = setup();
+      list.mockImplementation(() => {
         return (async function* iter() {
-          yield { workflowId: "adv/epic/project-id/missingEpic" };
+          yield {
+            workflowId:
+              "adv/epic/0000ec00d0000000000000000000000000000000/missingEpic",
+          };
         })();
       });
       queryMock.mockRejectedValue(new Error("Workflow not found"));

--- a/plugin/src/storage/store-temporal/epics.ts
+++ b/plugin/src/storage/store-temporal/epics.ts
@@ -1,6 +1,5 @@
 import type { Store } from "../store-types";
 import type { Epic, RetiredEpicProjection } from "../../types";
-import { ensureEpicWorkflowStarted } from "../../temporal/workflow-start";
 import {
   epicArchivedSignal,
   epicCreatedSignal,
@@ -22,12 +21,22 @@ import {
   runTemporal,
   runTemporalQuery,
   createTemporalReadContext,
-  runTemporalRead,
-  getTemporalConnection,
   TemporalQueryTimeoutError,
   type StoreDeps,
   type TemporalReadContext,
+  type TemporalWorkflowHandle,
+  getTemporalOwner,
 } from "./shared";
+import {
+  makeTemporalOperationContext,
+  type TemporalOperations,
+} from "../../temporal/operations";
+import { StartWorkflowOutcomeError } from "../../temporal/workflow-start";
+import {
+  TemporalMutationOutcomeError,
+  TemporalReadOutcomeError,
+} from "../../temporal/outcome-errors";
+import type { EpicWorkflowInput } from "../../temporal/contracts";
 import {
   listActiveEpicProjections,
   listRetiredEpicProjections,
@@ -40,16 +49,6 @@ import {
   saveRetiredEpicProjection,
 } from "../epic-projection";
 import { ADVANCE_TEMPORAL_SEARCH_ATTRIBUTES } from "../../temporal/contracts";
-
-interface EpicHandleLike {
-  query: (definition: unknown, ...args: unknown[]) => Promise<unknown>;
-  signal: (definition: unknown, ...args: unknown[]) => Promise<void>;
-  describe?: () => Promise<unknown>;
-}
-
-function asEpicHandle(handle: unknown): EpicHandleLike {
-  return handle as EpicHandleLike;
-}
 
 import { listEpicWorkflowIds } from "../../temporal/list-epic-workflows";
 import { buildEpicWorkflowId } from "../../temporal/client";
@@ -89,9 +88,28 @@ function extractMutationRejection(
 }
 
 async function queryEpicState(
-  handle: EpicHandleLike,
+  owner: TemporalOperations,
+  projectId: string,
+  handle: TemporalWorkflowHandle,
 ): Promise<import("../../temporal/contracts").EpicWorkflowState> {
-  const state = await runTemporalQuery(() => handle.query(getEpicStateQuery));
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    handle.workflowId,
+    "query",
+    "epicStateQuery",
+    5_000,
+  );
+  const outcome = await runTemporalQuery(() =>
+    owner.query<import("../../temporal/contracts").EpicWorkflowState>(
+      ctx,
+      handle,
+      getEpicStateQuery,
+    ),
+  );
+  if (outcome.kind !== "complete") {
+    throw new TemporalReadOutcomeError(outcome);
+  }
+  const state = outcome.value;
   if (!isEpicWorkflowState(state)) {
     throw new Error("Epic workflow state query returned malformed state");
   }
@@ -118,10 +136,12 @@ function isWorkflowNotFoundError(error: unknown): boolean {
 }
 
 async function tryQueryEpicState(
-  handle: EpicHandleLike,
+  owner: TemporalOperations,
+  projectId: string,
+  handle: TemporalWorkflowHandle,
 ): Promise<import("../../temporal/contracts").EpicWorkflowState | null> {
   try {
-    return await queryEpicState(handle);
+    return await queryEpicState(owner, projectId, handle);
   } catch (error) {
     if (isWorkflowNotFoundError(error)) return null;
     throw error;
@@ -174,25 +194,30 @@ function describedSearchAttributesContainStatus(
   return false;
 }
 
-async function verifyEpicStatusSearchAttribute(
-  handle: EpicHandleLike,
+async function verifyEpicStatusSearchAttributeImpl(
+  owner: TemporalOperations,
+  projectId: string,
+  handle: TemporalWorkflowHandle,
   status: string,
 ): Promise<{ verified: true } | { verified: false; error: string }> {
   // rq-epicSearchAttributeRepair01: repair reports distinguish confirmed
   // search-attribute proof from skipped, unreachable, or unverified delivery.
-  if (!handle.describe) {
-    return {
-      verified: false,
-      error:
-        "Search-attribute refresh signal delivered, but workflow describe is unavailable for AdvEpicStatus verification.",
-    };
-  }
   try {
-    const description = await runTemporal(() => handle.describe!(), {
+    const ctx = makeTemporalOperationContext(
+      projectId,
+      handle.workflowId,
+      "describe",
+      "describe-epic-search-attributes",
+      5_000,
+    );
+    const outcome = await runTemporal(() => owner.describe(ctx, handle), {
       opType: "describe-epic-search-attributes",
       timeoutMs: 5_000,
     });
-    if (describedSearchAttributesContainStatus(description, status)) {
+    if (outcome.kind !== "complete") {
+      throw new TemporalReadOutcomeError(outcome);
+    }
+    if (describedSearchAttributesContainStatus(outcome.value, status)) {
       return { verified: true };
     }
     return {
@@ -250,15 +275,29 @@ function codeFromRejectionMessage(message: string): EpicMutationError["code"] {
   return "signal_rejected";
 }
 
-async function fireEpicSignal(
-  handle: EpicHandleLike,
+async function fireEpicSignalImpl(
+  owner: TemporalOperations,
+  projectId: string,
+  handle: TemporalWorkflowHandle,
   signalName: string,
   rejectionSince: string,
-  signal: unknown,
+  signal: import("@temporalio/workflow").SignalDefinition<unknown[]>,
   ...args: unknown[]
 ): Promise<void> {
-  await runTemporal(() => handle.signal(signal, ...args));
-  const state = await queryEpicState(handle);
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    handle.workflowId,
+    "signal",
+    signalName,
+    5_000,
+  );
+  const outcome = await runTemporal(() =>
+    owner.signal(ctx, handle, signal, args),
+  );
+  if (outcome.kind !== "confirmed") {
+    throw new TemporalMutationOutcomeError(outcome);
+  }
+  const state = await queryEpicState(owner, projectId, handle);
   const rejection = lastRejectionFor(state, signalName, rejectionSince);
   if (rejection) {
     const error: EpicMutationError = {
@@ -279,8 +318,10 @@ async function fireEpicSignal(
  * not found" query failure as an error: a completed Epic workflow is no longer
  * queryable, which is the expected outcome of a successful archive.
  */
-async function fireEpicArchiveSignal(
-  handle: EpicHandleLike,
+async function fireEpicArchiveSignalImpl(
+  owner: TemporalOperations,
+  projectId: string,
+  handle: TemporalWorkflowHandle,
   payload: {
     archivedAt: string;
     archivedBy: string;
@@ -288,9 +329,21 @@ async function fireEpicArchiveSignal(
     idempotencyKey: string;
   },
 ): Promise<void> {
-  await runTemporal(() => handle.signal(epicArchivedSignal, payload));
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    handle.workflowId,
+    "signal",
+    "epicArchived",
+    5_000,
+  );
+  const outcome = await runTemporal(() =>
+    owner.signal(ctx, handle, epicArchivedSignal, [payload]),
+  );
+  if (outcome.kind !== "confirmed") {
+    throw new TemporalMutationOutcomeError(outcome);
+  }
   try {
-    const state = await queryEpicState(handle);
+    const state = await queryEpicState(owner, projectId, handle);
     const rejection = lastRejectionFor(
       state,
       "epicArchived",
@@ -314,55 +367,85 @@ async function fireEpicArchiveSignal(
 }
 
 export function createEpicOps(deps: StoreDeps): Store["epics"] {
-  const { input, getTemporalWorkflowClient } = deps;
+  const { input } = deps;
+  const owner = getTemporalOwner(input);
 
-  function getTemporalClient(): ReturnType<typeof getTemporalWorkflowClient> {
-    return getTemporalWorkflowClient();
-  }
-
-  function getEpicHandle(epicId: string): EpicHandleLike {
-    const client = getTemporalClient();
-    const handle = client.workflow.getHandle(
-      buildEpicWorkflowId(input.projectId, epicId),
+  function makeEpicCtx(
+    workflowId: string,
+    opKind: import("../../temporal/operations").TemporalOperationKind,
+    opType: string,
+    budgetMs = 5_000,
+  ) {
+    return makeTemporalOperationContext(
+      input.projectId,
+      workflowId,
+      opKind,
+      opType,
+      budgetMs,
     );
-    return asEpicHandle(handle);
   }
 
-  async function ensureEpicHandle(epicId: string): Promise<EpicHandleLike> {
-    const client = getTemporalClient();
-    const handle = await ensureEpicWorkflowStarted(client, {
+  function getEpicHandle(epicId: string): TemporalWorkflowHandle {
+    const workflowId = buildEpicWorkflowId(input.projectId, epicId);
+    return owner.getHandle(
+      makeEpicCtx(workflowId, "describe", "getEpicHandle"),
+    );
+  }
+
+  async function ensureEpicHandle(
+    epicId: string,
+  ): Promise<TemporalWorkflowHandle> {
+    const workflowId = buildEpicWorkflowId(input.projectId, epicId);
+    const ctx = makeEpicCtx(workflowId, "start", "ensureEpicHandle", 10_000);
+    const startInput: EpicWorkflowInput = {
       projectId: input.projectId,
       epicId,
       title: epicId,
       narrative: "",
       initializedAt: new Date().toISOString(),
-    });
-    return asEpicHandle(handle);
+    };
+    const outcome = await owner.startEpicWorkflow(ctx, startInput);
+    if (outcome.kind !== "confirmed") {
+      throw new StartWorkflowOutcomeError(
+        outcome.kind,
+        outcome.error,
+        outcome.diagnostic,
+        `startEpicWorkflow ${outcome.kind}`,
+      );
+    }
+    return outcome.value;
   }
 
   async function queryEpicStateRead(
-    handle: EpicHandleLike,
-    ctx: TemporalReadContext,
+    handle: TemporalWorkflowHandle,
+    _ctx: TemporalReadContext,
   ): Promise<import("../../temporal/contracts").EpicWorkflowState> {
-    const connection = getTemporalConnection(input);
-    const read = await runTemporalRead(
-      connection,
-      async () => handle.query(getEpicStateQuery),
-      ctx,
-      { opType: "epicStateQuery", timeoutMs: 1_500 },
+    const opCtx = makeEpicCtx(
+      handle.workflowId,
+      "query",
+      "epicStateQuery",
+      1_500,
     );
-    if (!read.complete) {
-      throw read.error ?? new TemporalQueryTimeoutError(ctx.deadline.budgetMs);
+    try {
+      const outcome = await runTemporalQuery(() =>
+        owner.query(opCtx, handle, getEpicStateQuery),
+      );
+      if (outcome.kind !== "complete") {
+        throw new TemporalReadOutcomeError(outcome);
+      }
+      const state = outcome.value;
+      if (!isEpicWorkflowState(state)) {
+        throw new Error("Epic workflow state query returned malformed state");
+      }
+      return state;
+    } catch (error) {
+      if (error instanceof TemporalQueryTimeoutError) throw error;
+      throw error;
     }
-    const state = read.data;
-    if (!isEpicWorkflowState(state)) {
-      throw new Error("Epic workflow state query returned malformed state");
-    }
-    return state;
   }
 
   async function tryQueryEpicStateRead(
-    handle: EpicHandleLike,
+    handle: TemporalWorkflowHandle,
     ctx: TemporalReadContext,
   ): Promise<
     | {
@@ -434,6 +517,48 @@ export function createEpicOps(deps: StoreDeps): Store["epics"] {
     }
     await saveActiveEpicProjection(activeEpicsDir, epic);
     return epic;
+  }
+
+  async function fireEpicSignal(
+    handle: TemporalWorkflowHandle,
+    signalName: string,
+    rejectionSince: string,
+    signal: import("@temporalio/workflow").SignalDefinition<unknown[]>,
+    ...args: unknown[]
+  ): Promise<void> {
+    return fireEpicSignalImpl(
+      owner,
+      input.projectId,
+      handle,
+      signalName,
+      rejectionSince,
+      signal,
+      ...args,
+    );
+  }
+
+  async function fireEpicArchiveSignal(
+    handle: TemporalWorkflowHandle,
+    payload: {
+      archivedAt: string;
+      archivedBy: string;
+      expectedVersion: number;
+      idempotencyKey: string;
+    },
+  ): Promise<void> {
+    return fireEpicArchiveSignalImpl(owner, input.projectId, handle, payload);
+  }
+
+  async function verifyEpicStatusSearchAttribute(
+    handle: TemporalWorkflowHandle,
+    status: string,
+  ): Promise<{ verified: true } | { verified: false; error: string }> {
+    return verifyEpicStatusSearchAttributeImpl(
+      owner,
+      input.projectId,
+      handle,
+      status,
+    );
   }
 
   return {
@@ -509,7 +634,7 @@ export function createEpicOps(deps: StoreDeps): Store["epics"] {
       { expectedVersion, evidence, retiredBy, dryRun },
     ) => {
       const handle = getEpicHandle(epicId);
-      const state = await tryQueryEpicState(handle);
+      const state = await tryQueryEpicState(owner, input.projectId, handle);
       if (!state) {
         throw Object.assign(new Error(`Epic not found: ${epicId}`), {
           code: "epic_not_found" as const,
@@ -1010,12 +1135,14 @@ export function createEpicOps(deps: StoreDeps): Store["epics"] {
     },
 
     repairIndex: async ({ evidence, dryRun }) => {
-      const client =
-        getTemporalClient() as unknown as import("../../temporal/list-epic-workflows").ListEpicClient;
-      const ids = await listEpicWorkflowIds(client, {
+      const idsOutcome = await listEpicWorkflowIds(owner, {
         projectId: input.projectId,
         status: "running",
       });
+      if (idsOutcome.kind !== "complete") {
+        throw idsOutcome.error;
+      }
+      const ids = idsOutcome.value;
 
       const refreshedAt = new Date().toISOString();
       const report: Awaited<
@@ -1030,7 +1157,7 @@ export function createEpicOps(deps: StoreDeps): Store["epics"] {
         const handle = getEpicHandle(epicId);
         let state: import("../../temporal/contracts").EpicWorkflowState | null;
         try {
-          state = await tryQueryEpicState(handle);
+          state = await tryQueryEpicState(owner, input.projectId, handle);
         } catch {
           state = null;
         }

--- a/plugin/src/storage/store-temporal/gates.durability.test.ts
+++ b/plugin/src/storage/store-temporal/gates.durability.test.ts
@@ -4,6 +4,7 @@ import { createGateOps } from "./gates";
 import { DiskProjectionPersistError } from "./disk-persist";
 import { commitChangeProjectionWithSummary } from "../change-summary-shard";
 import { CHANGE_WORKFLOW_QUERY_NAMES } from "../../temporal/contracts";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 
 // AC6 (gates are durability-critical): gate completion + re-entry must gate
 // success on a durable disk write via the changeCommand primitive and
@@ -60,6 +61,7 @@ function makeHandle() {
     return STATE;
   });
   return {
+    workflowId: `adv/change/pid-gate/${CHANGE_ID}`,
     signal: signalMock,
     query: queryMock,
   };
@@ -69,19 +71,17 @@ function makeDeps() {
   const handle = makeHandle();
   return {
     input: {
-      projectId: "pid-gate",
+      projectId: "00d0a0e000000000000000000000000000000000",
       legacy: {
         changes: {
           get: vi.fn().mockResolvedValue({ success: true, data: null }),
         },
       },
-      temporal: {
-        client: {
-          workflow: {
-            getHandle: vi.fn().mockReturnValue(handle),
-          },
+      temporal: createMockOwnerFromClient({
+        workflow: {
+          getHandle: vi.fn().mockReturnValue(handle),
         },
-      },
+      }),
     },
     legacy: {
       gates: {},

--- a/plugin/src/storage/store-temporal/gates.test.ts
+++ b/plugin/src/storage/store-temporal/gates.test.ts
@@ -38,7 +38,7 @@ function makeDeps(change: Change | null = makeChange("c1")): StoreDeps {
           },
         },
       },
-      projectId: "p",
+      projectId: "0000000000000000000000000000000000000000",
     } as unknown as StoreDeps["input"],
     legacy: {} as Store,
     changeCache: new Map(),
@@ -75,7 +75,6 @@ function makeDeps(change: Change | null = makeChange("c1")): StoreDeps {
     ),
     getTemporalChange,
     listResolvedChanges: vi.fn(),
-    reseedChangeFromDisk: vi.fn(),
   } as unknown as StoreDeps;
 }
 

--- a/plugin/src/storage/store-temporal/gates.ts
+++ b/plugin/src/storage/store-temporal/gates.ts
@@ -1,30 +1,27 @@
 import type { Store } from "../store-types";
 import type { GateId } from "../../types";
+import type { SignalDefinition } from "@temporalio/workflow";
+import { makeTemporalOperationContext } from "../../temporal/operations";
+import { buildChangeWorkflowId } from "../../temporal/client";
+import type { ChangeWorkflowState } from "../../temporal/contracts";
 import {
   gateCompletedSignal,
   gateReenteredSignal,
   changeStateQuery,
 } from "../../temporal/messages";
 import {
-  runTemporal,
   getGuardedChangeHandle,
+  getTemporalOwner,
   changeCommand,
   fallbackOperationId,
   buildSummaryCommitProjection,
   type ChangeCommandOutcome,
   type StoreDeps,
 } from "./shared";
-import {
-  composeTypedMutationResult,
-  enforceMutationEligibilityForError,
-  type TemporalMutationOutcome,
-} from "../../temporal/mutation-safety";
-import { createLogger } from "../../utils/debug-log";
+import { type TemporalMutationOutcome } from "../../temporal/mutation-safety";
 import { computeHostCommandPayloadHash } from "../../utils/command-payload-hash";
 
 export { fireSignalWithMutationGuard };
-
-const logger = createLogger("store-temporal-gates");
 
 function buildGateCommandIdentity(
   commandKind: string,
@@ -66,43 +63,52 @@ function unwrapCommandOutcome(
 async function fireSignalWithMutationGuard(
   input: import("./shared").TemporalStoreBackendInput,
   changeId: string,
-  signalName: unknown,
+  signalName: SignalDefinition<unknown[]>,
   args: readonly unknown[],
 ): Promise<TemporalMutationOutcome> {
-  let signalError: unknown;
-  try {
-    await runTemporal(async () => {
-      const handle = await getGuardedChangeHandle(input, changeId);
-      await handle.signal(signalName, ...(args as unknown[]));
-    });
-  } catch (err) {
-    signalError = err;
+  const owner = getTemporalOwner(input);
+  const workflowId = buildChangeWorkflowId(input.projectId, changeId);
+  const handle = await getGuardedChangeHandle(input, changeId);
+  const signalCtx = makeTemporalOperationContext(
+    input.projectId,
+    workflowId,
+    "signal",
+    signalName.name,
+    5_000,
+  );
+  const queryCtx = makeTemporalOperationContext(
+    input.projectId,
+    workflowId,
+    "query",
+    "changeStateQuery",
+    5_000,
+  );
+  const outcome = await owner.signal<ChangeWorkflowState>(
+    signalCtx,
+    handle,
+    signalName,
+    [...args],
+    {
+      readback: async () => {
+        const result = await owner.query(queryCtx, handle, changeStateQuery);
+        if (result.kind !== "complete") {
+          throw result.error ?? new Error("change state query incomplete");
+        }
+        return result.value;
+      },
+    },
+  );
+  switch (outcome.kind) {
+    case "confirmed":
+      return "confirmed";
+    case "confirmed_failure":
+      return "failed_before_ack";
+    case "outcome_unknown":
+    case "timeout_unavailable":
+      return "outcome_unknown_readback_unavailable";
+    default:
+      throw new Error("Unexpected signal outcome kind");
   }
-  // SC4 guard at signal-dispatch boundary.
-  if (signalError !== undefined) {
-    enforceMutationEligibilityForError(signalError);
-    // Surviving path: SC4-pass (not_found / poisoned_history).
-  }
-  // SC6: post-signal readback. Ambiguous result is reported as
-  // `outcome_unknown_readback_unavailable`; callers MUST surface this.
-  let readbackError: unknown;
-  try {
-    await runTemporal(async () =>
-      (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
-    );
-  } catch (err) {
-    readbackError = err;
-    logger.debug(
-      `SC6 post-signal readback failed for ${String(signalName)} on ${changeId}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-  const composed = composeTypedMutationResult({
-    ...(signalError !== undefined ? { signalError } : {}),
-    ...(readbackError !== undefined ? { readbackError } : {}),
-  });
-  return composed.outcome;
 }
 
 export function createGateOps(deps: StoreDeps): Store["gates"] {

--- a/plugin/src/storage/store-temporal/index.status-repair-readback.test.ts
+++ b/plugin/src/storage/store-temporal/index.status-repair-readback.test.ts
@@ -75,7 +75,7 @@ describe("status repair public read-path parity", () => {
               status: "active",
               createdAt: "2026-05-07T00:00:00.000Z",
               initializedAt: "2026-05-07T00:00:00.000Z",
-              projectId: "project-1",
+              projectId: "0000ec0100000000000000000000000000000000",
               tasks: [],
               deltas: {},
               wisdom: [],
@@ -98,7 +98,7 @@ describe("status repair public read-path parity", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     // Warm public read paths with the disk projection. At this point the

--- a/plugin/src/storage/store-temporal/index.test.ts
+++ b/plugin/src/storage/store-temporal/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -12,6 +12,7 @@ import {
   isPoisonedWorkflowForChange,
   clearPoisonedWorkflowCache,
 } from "./poisoned-workflow-cache";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { classifyTemporalReadFailure } from "./shared";
 
 function poisonedHistoryError(): Error {
@@ -115,7 +116,11 @@ function contractProof(): NonNullable<Change["contract"]> {
   };
 }
 
-async function createPoisonedPostReseedFailureStore(root: string) {
+/**
+ * Poisoned query fixture for disk-first read tests. The `start` spy is
+ * present only so tests can prove it is never invoked by a routine read.
+ */
+async function createPoisonedPostReadStore(root: string) {
   const legacy = await createDiskStore(root);
   let startArgs: unknown[] | undefined;
   const handle = {
@@ -138,7 +143,7 @@ async function createPoisonedPostReseedFailureStore(root: string) {
   const store = createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
   return { store, startArgs: () => startArgs };
 }
@@ -162,17 +167,16 @@ async function createPoisonedStore(root: string) {
   return createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
 }
 
 /**
- * rq-replayFallback01.3: query throws TMPRL1100 (poisoned), AND `start`
- * throws a non-already-started error so re-seed itself fails. Used to
- * exercise the catch block at reseedChangeFromDisk's `try/catch` around
- * `ensureChangeWorkflowStarted` (vs the post-reseed-query catch).
+ * rq-replayFallback01.3: query throws TMPRL1100 (poisoned). The read path
+ * must fall back to the durable disk projection and must never start or
+ * signal the workflow.
  */
-async function createPoisonedReseedFailureStore(root: string) {
+async function createPoisonedReadStore(root: string) {
   const legacy = await createDiskStore(root);
   let startCallCount = 0;
   const handle = {
@@ -186,9 +190,8 @@ async function createPoisonedReseedFailureStore(root: string) {
         getHandle: () => handle,
         start: async () => {
           startCallCount += 1;
-          // Non-already-started error → ensureChangeWorkflowStarted rethrows
-          // → reseedChangeFromDisk's catch at the `ensureChangeWorkflowStarted`
-          // try/catch fires.
+          // start is reachable only from mutation paths; a routine read must
+          // never call it.
           throw new Error("Temporal start failed: namespace handshake error");
         },
       },
@@ -198,7 +201,7 @@ async function createPoisonedReseedFailureStore(root: string) {
   const store = createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
   return { store, startCallCount: () => startCallCount };
 }
@@ -206,11 +209,10 @@ async function createPoisonedReseedFailureStore(root: string) {
 /**
  * Negative-case fixture: query throws WorkflowNotFoundError (matches
  * `not_found` regex → fallback class, but reason resolves to
- * `missing_workflow`, not `poisoned_history`). re-seed fails. The fix
- * MUST NOT mask this — the original WorkflowNotFoundError must still
- * surface.
+ * `missing_workflow`, not `poisoned_history`). The read path must fall back to
+ * disk and must never start or signal the workflow.
  */
-async function createMissingWorkflowReseedFailureStore(root: string) {
+async function createMissingWorkflowReadStore(root: string) {
   const legacy = await createDiskStore(root);
   const handle = {
     query: async () => {
@@ -231,11 +233,11 @@ async function createMissingWorkflowReseedFailureStore(root: string) {
   return createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
 }
 
-async function createGenericQueryPoisonedReseedFailureStore(root: string) {
+async function createGenericQueryPoisonedReadStore(root: string) {
   const legacy = await createDiskStore(root);
   let startCallCount = 0;
   const handle = {
@@ -265,7 +267,7 @@ async function createGenericQueryPoisonedReseedFailureStore(root: string) {
   const store = createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
   return { store, startCallCount: () => startCallCount };
 }
@@ -294,7 +296,7 @@ async function createGenericQueryUnprovenStore(root: string) {
   const store = createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
   return { store, startCallCount: () => startCallCount };
 }
@@ -303,8 +305,8 @@ async function createGenericQueryUnprovenStore(root: string) {
  * query_failed guard fixture: the query fails with a fallback-class error
  * that is neither poisoned nor completed/not-found ("query type not
  * registered" — the workflow exists but cannot answer). The typed
- * `query_failed` reason must never authorize re-seed mutation, even though
- * the retry-wrapper error class is `fallback`.
+ * `query_failed` reason must only produce a disk fallback; routine reads
+ * must never start or signal the workflow.
  */
 async function createUnregisteredQueryStore(root: string) {
   const legacy = await createDiskStore(root);
@@ -330,15 +332,12 @@ async function createUnregisteredQueryStore(root: string) {
   const store = createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
   return { store, startCallCount: () => startCallCount };
 }
 
-async function createMissingWorkflowSuccessfulReseedStore(
-  root: string,
-  changes: Change[],
-) {
+async function createDiskOnlyChangeStore(root: string, changes: Change[]) {
   const legacy = await createDiskStore(root);
   for (const change of changes) {
     await legacy.changes.save(change);
@@ -368,7 +367,7 @@ async function createMissingWorkflowSuccessfulReseedStore(
               queryCounts.set(changeId, (queryCounts.get(changeId) ?? 0) + 1);
               if (!started.has(changeId)) throw workflowNotFoundError();
               return changeToWorkflowState({
-                projectId: "project-1",
+                projectId: "0000ec0100000000000000000000000000000000",
                 change: byId.get(changeId)!,
               });
             },
@@ -381,7 +380,7 @@ async function createMissingWorkflowSuccessfulReseedStore(
           return {
             query: async () =>
               changeToWorkflowState({
-                projectId: "project-1",
+                projectId: "0000ec0100000000000000000000000000000000",
                 change: byId.get(input.changeId)!,
               }),
           };
@@ -393,7 +392,7 @@ async function createMissingWorkflowSuccessfulReseedStore(
   const store = createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
   return {
     store,
@@ -415,18 +414,18 @@ async function createHangingQueryStore(root: string, changeId: string) {
       });
     },
   };
-  const temporal = {
+  const temporal = createMockOwnerFromClient({
     client: {
       workflow: {
         getHandle: () => handle,
         start: async () => handle,
       },
     },
-  };
+  });
   const store = createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
   return { store, queryCount: () => queryCount };
 }
@@ -444,18 +443,18 @@ async function createPoisonedSignalStore(root: string, changeId: string) {
       throw new Error("signal should not be called");
     },
   };
-  const temporal = {
+  const temporal = createMockOwnerFromClient({
     client: {
       workflow: {
         getHandle: () => handle,
         start: async () => handle,
       },
     },
-  };
+  });
   const store = createTemporalStoreBackend({
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   });
   return { store, signalCount: () => signalCount };
 }
@@ -478,7 +477,7 @@ async function createMinimalPoisonedInput(root: string) {
   return {
     legacy,
     temporal,
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
   };
 }
 
@@ -542,17 +541,16 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     expect(gates).toEqual(change.gates);
   });
 
-  it("returns disk projection for non-terminal poisoned change without touching Temporal", async () => {
+  it("returns disk projection for non-terminal poisoned change without starting a workflow", async () => {
     tempDir = await createTempDir();
     const legacy = await createDiskStore(tempDir);
-    await legacy.changes.save(activeChange("activePoisonedReseedFail"));
+    await legacy.changes.save(activeChange("activePoisonedFallback"));
 
-    const { store, startCallCount } =
-      await createPoisonedReseedFailureStore(tempDir);
-    const result = await store.changes.get("activePoisonedReseedFail");
+    const { store, startCallCount } = await createPoisonedReadStore(tempDir);
+    const result = await store.changes.get("activePoisonedFallback");
 
     expect(result.success).toBe(true);
-    expect(result.data?.id).toBe("activePoisonedReseedFail");
+    expect(result.data?.id).toBe("activePoisonedFallback");
     // Legacy stored "active" normalizes to "draft" at the disk load path
     // (loadChange); the disk-first read returns it directly.
     expect(result.data?.status).toBe("draft");
@@ -562,27 +560,28 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     };
     expect(recovered._source).toBe("disk");
     expect(recovered._recovery).toBeUndefined();
-    // No workflow start or query is attempted for a routine read.
+    // Routine reads never start or signal workflows.
     expect(startCallCount()).toBe(0);
   });
 
-  it("returns recovered gates for non-terminal poisoned change with reseed failure", async () => {
+  it("returns recovered gates for non-terminal poisoned change from disk projection", async () => {
     tempDir = await createTempDir();
     const legacy = await createDiskStore(tempDir);
-    const change = activeChange("activePoisonedReseedFailGates");
+    const change = activeChange("activePoisonedFallbackGates");
     await legacy.changes.save(change);
 
-    const { store } = await createPoisonedReseedFailureStore(tempDir);
-    const gates = await store.gates.get("activePoisonedReseedFailGates");
+    const { store } = await createPoisonedReadStore(tempDir);
+    const gates = await store.gates.get("activePoisonedFallbackGates");
 
     expect(gates).toEqual(change.gates);
   });
 
-  it("returns an active disk-only change on direct read without re-seeding", async () => {
+  it("returns an active disk-only change on direct read without starting a workflow", async () => {
     tempDir = await createTempDir();
     const active = activeChange("activeDiskOnlyRead");
-    const { store, startInputs } =
-      await createMissingWorkflowSuccessfulReseedStore(tempDir, [active]);
+    const { store, startInputs } = await createDiskOnlyChangeStore(tempDir, [
+      active,
+    ]);
 
     const result = await store.changes.get("activeDiskOnlyRead");
 
@@ -601,12 +600,10 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     const active = activeChange("activeDiskOnlyList");
     const archived = archivedChange("archivedDiskOnlyList");
     const closed = closedChange("closedDiskOnlyList");
-    const { store, startInputs, queryCount } =
-      await createMissingWorkflowSuccessfulReseedStore(tempDir, [
-        active,
-        archived,
-        closed,
-      ]);
+    const { store, startInputs, queryCount } = await createDiskOnlyChangeStore(
+      tempDir,
+      [active, archived, closed],
+    );
 
     const list = await store.changes.list();
 
@@ -621,9 +618,8 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     );
     // bl-HiZJbUuy / disk-authoritative reads: enumeration is side-effect-free.
     // The active change is served from its durable change.json projection
-    // WITHOUT re-seeding (resurrecting) its workflow. Orphan re-seed now happens
-    // on the next mutation (getTemporalChange), never during a read — so no
-    // workflow start occurs for ANY candidate during list.
+    // without starting or signaling its workflow. Routine reads never mutate
+    // Temporal state, so no workflow start occurs for ANY candidate during list.
     expect(startInputs()).toEqual([]);
     // All candidates (active + both terminal) resolve from disk with zero
     // workflow queries, so a poisoned/terminated workflow is never touched
@@ -644,8 +640,7 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     } as Change;
     await legacy.changes.save(change);
 
-    const { store, startArgs } =
-      await createPoisonedPostReseedFailureStore(tempDir);
+    const { store, startArgs } = await createPoisonedPostReadStore(tempDir);
     const result = await store.changes.get("activePoisonedContractSeed");
 
     expect(result.success).toBe(true);
@@ -663,13 +658,13 @@ describe("createTemporalStoreBackend change projection fallback", () => {
   it("returns disk projection for an active disk-only change without querying workflow", async () => {
     tempDir = await createTempDir();
     const legacy = await createDiskStore(tempDir);
-    await legacy.changes.save(activeChange("activeMissingReseedFail"));
+    await legacy.changes.save(activeChange("activeMissingFallback"));
 
-    const store = await createMissingWorkflowReseedFailureStore(tempDir);
+    const store = await createMissingWorkflowReadStore(tempDir);
 
-    const result = await store.changes.get("activeMissingReseedFail");
+    const result = await store.changes.get("activeMissingFallback");
     expect(result.success).toBe(true);
-    expect(result.data?.id).toBe("activeMissingReseedFail");
+    expect(result.data?.id).toBe("activeMissingFallback");
     expect(result.data?.status).toBe("draft");
     expect(result.source).toBe("disk");
   });
@@ -680,7 +675,7 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     await legacy.changes.save(activeChange("genericPoisonedVisibility"));
 
     const { store, startCallCount } =
-      await createGenericQueryPoisonedReseedFailureStore(tempDir);
+      await createGenericQueryPoisonedReadStore(tempDir);
     const result = await store.changes.get("genericPoisonedVisibility");
 
     expect(result.success).toBe(true);
@@ -700,8 +695,7 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     const change = activeChange("genericPoisonedVisibilityGates");
     await legacy.changes.save(change);
 
-    const { store } =
-      await createGenericQueryPoisonedReseedFailureStore(tempDir);
+    const { store } = await createGenericQueryPoisonedReadStore(tempDir);
     const gates = await store.gates.get("genericPoisonedVisibilityGates");
 
     expect(gates).toEqual(change.gates);
@@ -719,11 +713,11 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     expect(result.success).toBe(true);
     expect(result.data?.id).toBe("genericUnproven");
     expect(result.source).toBe("disk");
-    // query_failed never authorizes re-seed mutation.
+    // query_failed never authorizes a workflow start from a routine read.
     expect(startCallCount()).toBe(0);
   });
 
-  it("returns disk projection for a fallback-class query failure without re-seeding", async () => {
+  it("returns disk projection for a fallback-class query failure without starting a workflow", async () => {
     tempDir = await createTempDir();
     const legacy = await createDiskStore(tempDir);
     await legacy.changes.save(activeChange("unregisteredQuery"));
@@ -736,180 +730,6 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     expect(result.data?.id).toBe("unregisteredQuery");
     expect(result.source).toBe("disk");
     expect(startCallCount()).toBe(0);
-  });
-});
-
-/**
- * rq-autoManageAdvWorktrees AC3 — lazy migration of legacy changes
- * on first read. When a change.json predating this field is loaded,
- * `getTemporalChange` fires `worktreeAutoManagedSignal` once with
- * `value: false, source: "migrate"`. The signal handler is sticky so
- * concurrent migrations from peer sessions are idempotent. Failure
- * to fire (e.g., Temporal unreachable) MUST NOT block the read.
- */
-describe("createTemporalStoreBackend worktree_auto_managed lazy migration", () => {
-  let tempDir: string | undefined;
-
-  afterEach(async () => {
-    if (tempDir) await cleanupTempDir(tempDir);
-    tempDir = undefined;
-  });
-
-  function legacyChangeWithoutMarker(id: string): Change {
-    return {
-      $schema: "https://advance.dev/schemas/change.v1.json",
-      id,
-      title: `Legacy ${id}`,
-      status: "active",
-      created_at: "2026-05-21T00:00:00.000Z",
-      tasks: [],
-      deltas: {},
-      gates: createDefaultGates(),
-      reentry_history: [],
-      wisdom: [],
-    };
-  }
-
-  async function createMigrationCaptureStore(
-    root: string,
-    options: {
-      markerInWorkflowState?: boolean;
-      signalShouldFail?: boolean;
-    } = {},
-  ) {
-    const legacy = await createDiskStore(root);
-    const signalCalls: Array<{
-      signal: { name?: string };
-      args: unknown;
-    }> = [];
-    let lastHandleId: string | undefined;
-    const makeHandle = (changeId: string) => ({
-      query: async () => ({
-        id: changeId,
-        changeId,
-        title: `Legacy ${changeId}`,
-        status: "active",
-        createdAt: "2026-05-21T00:00:00.000Z",
-        initializedAt: "2026-05-21T00:00:00.000Z",
-        projectId: "project-1",
-        tasks: [],
-        deltas: {},
-        wisdom: [],
-        gates: createDefaultGates(),
-        reentry_history: [],
-        artifacts: {},
-        documents: {},
-        reflections: [],
-        worktrees: {},
-        conformance: { lockedSpecs: [], overrides: [] },
-        ...(typeof options.markerInWorkflowState === "boolean"
-          ? { worktree_auto_managed: options.markerInWorkflowState }
-          : {}),
-      }),
-      signal: async (signal: { name?: string }, args: unknown) => {
-        if (options.signalShouldFail) {
-          throw new Error("Temporal signal failed: connection refused");
-        }
-        signalCalls.push({ signal, args });
-      },
-    });
-    const temporal = {
-      client: {
-        workflow: {
-          getHandle: (workflowId: string) => {
-            // Extract change-id suffix from the constructed workflow id
-            const suffix =
-              workflowId.split("/").pop() ?? workflowId.split(":").pop() ?? "";
-            lastHandleId = suffix || workflowId;
-            return makeHandle(lastHandleId);
-          },
-          start: async () => makeHandle(lastHandleId ?? "unknown"),
-        },
-      },
-    };
-    const store = createTemporalStoreBackend({
-      legacy,
-      temporal,
-      projectId: "project-1",
-    });
-    return { store, signalCalls: () => signalCalls };
-  }
-
-  it("fires worktreeAutoManagedSignal best-effort when state lacks marker", async () => {
-    tempDir = await createTempDir();
-    const legacy = await createDiskStore(tempDir);
-    await legacy.changes.save(legacyChangeWithoutMarker("legacyChangeA"));
-
-    const { store, signalCalls } = await createMigrationCaptureStore(tempDir);
-    const result = await store.changes.get("legacyChangeA");
-
-    // Read succeeds even though the marker is missing.
-    expect(result.success).toBe(true);
-
-    // Wait several event-loop ticks for the void async fire (which awaits
-    // getGuardedChangeHandle's legacy-disk-read then handle.signal) to
-    // enqueue + complete. setImmediate × 50 + sleep allows the disk read.
-    for (let i = 0; i < 50; i++) {
-      await new Promise((resolve) => setImmediate(resolve));
-    }
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    const calls = signalCalls();
-    expect(calls).toHaveLength(1);
-    expect(calls[0].args).toMatchObject({
-      value: false,
-      source: "migrate",
-    });
-    expect(typeof (calls[0].args as { recordedAt?: string }).recordedAt).toBe(
-      "string",
-    );
-  });
-
-  it("does NOT fire migration when workflow state already has marker set", async () => {
-    tempDir = await createTempDir();
-    const legacy = await createDiskStore(tempDir);
-    await legacy.changes.save(legacyChangeWithoutMarker("alreadyMigratedB"));
-
-    const { store, signalCalls } = await createMigrationCaptureStore(tempDir, {
-      markerInWorkflowState: true,
-    });
-    await store.changes.get("alreadyMigratedB");
-    for (let i = 0; i < 5; i++) {
-      await new Promise((resolve) => setImmediate(resolve));
-    }
-
-    expect(signalCalls()).toHaveLength(0);
-  });
-
-  it("does NOT fire migration when workflow state has marker explicitly false (legacy already-migrated)", async () => {
-    tempDir = await createTempDir();
-    const legacy = await createDiskStore(tempDir);
-    await legacy.changes.save(legacyChangeWithoutMarker("alreadyMigratedC"));
-
-    const { store, signalCalls } = await createMigrationCaptureStore(tempDir, {
-      markerInWorkflowState: false,
-    });
-    await store.changes.get("alreadyMigratedC");
-    for (let i = 0; i < 5; i++) {
-      await new Promise((resolve) => setImmediate(resolve));
-    }
-
-    expect(signalCalls()).toHaveLength(0);
-  });
-
-  it("read succeeds when migration signal fire fails (best-effort, non-blocking)", async () => {
-    tempDir = await createTempDir();
-    const legacy = await createDiskStore(tempDir);
-    await legacy.changes.save(legacyChangeWithoutMarker("signalFailureD"));
-
-    const { store } = await createMigrationCaptureStore(tempDir, {
-      signalShouldFail: true,
-    });
-    const result = await store.changes.get("signalFailureD");
-
-    // Failure to fire migration MUST NOT block the read.
-    expect(result.success).toBe(true);
-    expect(result.data?.id).toBe("signalFailureD");
   });
 });
 
@@ -945,7 +765,7 @@ describe("listResolvedChanges memo fast path", () => {
                   status: "active",
                   createdAt: "2026-05-07T00:00:00.000Z",
                   initializedAt: "2026-05-07T00:00:00.000Z",
-                  projectId: "project-1",
+                  projectId: "0000ec0100000000000000000000000000000000",
                   tasks: [],
                   deltas: {},
                   wisdom: [],
@@ -975,7 +795,7 @@ describe("listResolvedChanges memo fast path", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     // Warm memo for changeA
@@ -1026,7 +846,7 @@ describe("listResolvedChanges memo fast path", () => {
               status: "active",
               createdAt: "2026-05-07T00:00:00.000Z",
               initializedAt: "2026-05-07T00:00:00.000Z",
-              projectId: "project-1",
+              projectId: "0000ec0100000000000000000000000000000000",
               tasks,
               deltas: {},
               wisdom: [],
@@ -1049,7 +869,7 @@ describe("listResolvedChanges memo fast path", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     // Warm memo for taskedChange
@@ -1081,7 +901,7 @@ describe("listResolvedChanges memo fast path", () => {
               status: "active",
               createdAt: "2026-05-07T00:00:00.000Z",
               initializedAt: "2026-05-07T00:00:00.000Z",
-              projectId: "project-1",
+              projectId: "0000ec0100000000000000000000000000000000",
               tasks: [],
               deltas: {},
               wisdom: [],
@@ -1109,7 +929,7 @@ describe("listResolvedChanges memo fast path", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const getResult = await store.changes.get("staleClosedChange");
@@ -1152,7 +972,7 @@ describe("listResolvedChanges circuit breaker", () => {
     }
 
     let queryCalls = 0;
-    const temporal = {
+    const temporal = createMockOwnerFromClient({
       client: {
         workflow: {
           getHandle: () => ({
@@ -1166,12 +986,12 @@ describe("listResolvedChanges circuit breaker", () => {
           },
         },
       },
-    };
+    });
 
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const start = Date.now();
@@ -1218,7 +1038,7 @@ describe("listResolvedChanges memo busting (rq-crossSessionCacheConsistency01)",
                   status: "active",
                   createdAt: "2026-05-07T00:00:00.000Z",
                   initializedAt: "2026-05-07T00:00:00.000Z",
-                  projectId: "project-1",
+                  projectId: "0000ec0100000000000000000000000000000000",
                   tasks: [],
                   deltas: {},
                   wisdom: [],
@@ -1238,7 +1058,7 @@ describe("listResolvedChanges memo busting (rq-crossSessionCacheConsistency01)",
                 status: "archived",
                 createdAt: "2026-05-07T00:00:00.000Z",
                 initializedAt: "2026-05-07T00:00:00.000Z",
-                projectId: "project-1",
+                projectId: "0000ec0100000000000000000000000000000000",
                 tasks: [],
                 deltas: {},
                 wisdom: [],
@@ -1267,7 +1087,7 @@ describe("listResolvedChanges memo busting (rq-crossSessionCacheConsistency01)",
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     // Warm memo with disk-normalized status (active is normalized to draft).
@@ -1315,7 +1135,7 @@ describe("listResolvedChanges memo busting (rq-crossSessionCacheConsistency01)",
       status: "draft",
       createdAt: "2026-05-07T00:00:00.000Z",
       initializedAt: "2026-05-07T00:00:00.000Z",
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
       tasks: [],
       deltas: {},
       wisdom: [],
@@ -1343,7 +1163,7 @@ describe("listResolvedChanges memo busting (rq-crossSessionCacheConsistency01)",
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const initial = await store.changes.get("staleWorkflowChange");
@@ -1399,7 +1219,7 @@ describe("listResolvedChanges memo busting (rq-crossSessionCacheConsistency01)",
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     // Warm memo with archived status
@@ -1446,7 +1266,7 @@ describe("listResolvedChanges memo busting (rq-crossSessionCacheConsistency01)",
               status: "active",
               createdAt: "2026-05-07T00:00:00.000Z",
               initializedAt: "2026-05-07T00:00:00.000Z",
-              projectId: "project-1",
+              projectId: "0000ec0100000000000000000000000000000000",
               tasks: [],
               deltas: {},
               wisdom: [],
@@ -1469,7 +1289,7 @@ describe("listResolvedChanges memo busting (rq-crossSessionCacheConsistency01)",
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     // Warm memo
@@ -1525,7 +1345,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
                 status: "active",
                 createdAt: "2026-05-07T00:00:00.000Z",
                 initializedAt: "2026-05-07T00:00:00.000Z",
-                projectId: "project-1",
+                projectId: "0000ec0100000000000000000000000000000000",
                 tasks: [],
                 deltas: {},
                 wisdom: [],
@@ -1552,7 +1372,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.get("archiveDominatesGet");
@@ -1566,7 +1386,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
     // served from the disk terminal projection WITHOUT a live workflow query.
     // Previously loadDiskTerminalProjection only short-circuited `closed`, so an
     // archived-without-bundle change fell through to the live query and hit the
-    // poisoned/terminated workflow (TMPRL1100) before the catch→reseed path
+    // poisoned/terminated workflow (TMPRL1100) before the disk-fallback path
     // finally returned the same disk data — the per-candidate cost that
     // accumulated into the enumeration wedge.
     tempDir = await createTempDir();
@@ -1598,7 +1418,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.get("archivedNoBundlePoisoned");
@@ -1635,7 +1455,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
                 status: "active",
                 createdAt: "2026-05-07T00:00:00.000Z",
                 initializedAt: "2026-05-07T00:00:00.000Z",
-                projectId: "project-1",
+                projectId: "0000ec0100000000000000000000000000000000",
                 tasks: [],
                 deltas: {},
                 wisdom: [],
@@ -1662,7 +1482,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const list = await store.changes.list({ status: "archived" });
@@ -1721,7 +1541,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const list = await store.changes.list({ includeArchived: true });
@@ -1751,7 +1571,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
                 status: "active",
                 createdAt: "2026-05-07T00:00:00.000Z",
                 initializedAt: "2026-05-07T00:00:00.000Z",
-                projectId: "project-1",
+                projectId: "0000ec0100000000000000000000000000000000",
                 tasks: [],
                 deltas: {},
                 wisdom: [],
@@ -1775,7 +1595,7 @@ describe("archive-first terminal projection resolution (rq-terminalProjectionTru
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.listSummary!({});
@@ -1836,7 +1656,7 @@ describe("terminal aggregate degraded metadata (rq-terminalAggregateRead01)", ()
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.list({ includeArchived: true });
@@ -1897,7 +1717,7 @@ describe("terminal aggregate degraded metadata (rq-terminalAggregateRead01)", ()
     const store = createTemporalStoreBackend({
       legacy,
       temporal,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     const result = await store.changes.list({ status: "archived" });
@@ -1929,9 +1749,12 @@ describe("terminal aggregate degraded metadata (rq-terminalAggregateRead01)", ()
       "cacheSeedChange",
       poisonedHistoryError(),
     );
-    expect(isPoisonedWorkflowForChange("project-1", "cacheSeedChange")).toBe(
-      true,
-    );
+    expect(
+      isPoisonedWorkflowForChange(
+        "0000ec0100000000000000000000000000000000",
+        "cacheSeedChange",
+      ),
+    ).toBe(true);
   });
 
   it("returns a disk-only change with _poisoned marker and never queries Temporal", async () => {
@@ -1940,7 +1763,10 @@ describe("terminal aggregate degraded metadata (rq-terminalAggregateRead01)", ()
       tempDir,
       "poisonedShow",
     );
-    markPoisonedWorkflowForChange("project-1", "poisonedShow");
+    markPoisonedWorkflowForChange(
+      "0000ec0100000000000000000000000000000000",
+      "poisonedShow",
+    );
 
     const result = await store.changes.get("poisonedShow");
 
@@ -1956,7 +1782,10 @@ describe("terminal aggregate degraded metadata (rq-terminalAggregateRead01)", ()
       tempDir,
       "poisonedRefresh",
     );
-    markPoisonedWorkflowForChange("project-1", "poisonedRefresh");
+    markPoisonedWorkflowForChange(
+      "0000ec0100000000000000000000000000000000",
+      "poisonedRefresh",
+    );
 
     await store.changes.refresh("poisonedRefresh");
 
@@ -1969,12 +1798,49 @@ describe("terminal aggregate degraded metadata (rq-terminalAggregateRead01)", ()
       tempDir,
       "poisonedSignal",
     );
-    markPoisonedWorkflowForChange("project-1", "poisonedSignal");
+    markPoisonedWorkflowForChange(
+      "0000ec0100000000000000000000000000000000",
+      "poisonedSignal",
+    );
 
     await expect(
       store.gates.complete("poisonedSignal", "proposal"),
     ).rejects.toThrow(/known poisoned|signal skipped/);
 
     expect(signalCount()).toBe(0);
+  });
+});
+
+describe("createTemporalStoreBackend projection-only read enforcement", () => {
+  it("getTemporalChange source never starts, signals, reseeds, or writes recovery state", async () => {
+    const source = await readFile(
+      new URL("./index.ts", import.meta.url),
+      "utf8",
+    );
+    const body = source.match(
+      /const getTemporalChange = async \([\s\S]*?\n\s{2}};\n\n\s{2}const loadDiskTerminalProjection = async \(/,
+    )?.[0];
+    expect(body).toBeDefined();
+    const dangerous = [
+      "reseedChangeFromDisk",
+      "fireWorktreeAutoManagedMigrationIfNeeded",
+      "worktreeAutoManagedSignal",
+      "readAmbiguityLedger",
+      "writeAmbiguityLedger",
+      "ambiguity-ledger",
+      "ambiguityLedger",
+      "ensureChangeWorkflowStarted",
+      "startChangeWorkflow",
+      "signalChangeWorkflowGuarded",
+      "fireSignal",
+      "owner.signal",
+      "owner.start",
+      "legacy.changes.save",
+      "persistStateToDisk",
+      "persistAndRefreshDurable",
+    ];
+    for (const pattern of dangerous) {
+      expect(body).not.toMatch(new RegExp(`\\b${pattern}\\b`));
+    }
   });
 });

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -2,8 +2,7 @@ import { join } from "node:path";
 import type { Store } from "../store-types";
 import type { Change } from "../../types";
 import { createLogger } from "../../utils/debug-log";
-import { hasArchiveBundle, loadProjectConfig } from "../json";
-import { resolveProjectFeaturePolicy } from "../../types";
+import { hasArchiveBundle } from "../json";
 import {
   isSchemaError,
   listChangeDirs,
@@ -23,7 +22,8 @@ import type {
 import { SpecSchema } from "../../types";
 import { listSpecsFilesystem, readSpecFilesystem } from "../spec-filesystem";
 import type { LoadResult } from "../change-projection-reader";
-import { listChangeWorkflowIds } from "../../temporal/list-change-workflows";
+import { buildVisibilityQuery } from "../../temporal/list-change-workflows";
+import { CHANGE_WORKFLOW_PREFIX } from "../../temporal/contracts";
 import {
   listSourceRankedCandidates,
   type SourceRankedCandidate,
@@ -36,39 +36,38 @@ import {
 } from "../store-temporal-memo";
 import {
   type TemporalStoreBackendInput,
-  type WorkflowHandleLike,
+  type TemporalWorkflowHandle,
   type StoreDeps,
   mapTemporalChangeStateToChange,
   projectTemporalStateOntoLatest,
   getGuardedChangeHandle,
+  getTemporalOwner,
   classifyTemporalReadFailure,
   raceWithTemporalDeadline,
   remainingDeadlineMs,
   TemporalQueryTimeoutError,
   type TemporalReadDeadline,
   createTemporalReadContext,
-  runTemporalRead,
-  getTemporalConnection,
   type TemporalReadContext,
   isTemporalReadExpired,
   runTemporal,
   runTemporalQuery,
-  makeReconnectingHook,
+  QUERY_TIMEOUT_MS,
+  withProjectionRecovery,
 } from "./shared";
 import {
-  changeStateQuery,
-  worktreeAutoManagedSignal,
-} from "../../temporal/messages";
+  type TemporalOperations,
+  makeTemporalOperationContext,
+} from "../../temporal/operations";
+import { changeStateQuery } from "../../temporal/messages";
 import { isPoisonedWorkflowForChange } from "./poisoned-workflow-cache";
-import { ensureChangeWorkflowStarted } from "../../temporal/workflow-start";
-import { getCurrentSessionId } from "../../utils/session-id";
-import { changeSeedStateFromChange } from "../../temporal/change-state";
 import type { ChangeWorkflowState } from "../../temporal/contracts";
 import type { ProjectionRecoveryReason } from "../../temporal/recovery-classification";
+import { composeTypedMutationResult } from "../../temporal/mutation-safety";
 import {
-  enforceMutationEligibilityForError,
-  composeTypedMutationResult,
-} from "../../temporal/mutation-safety";
+  TemporalListOutcomeError,
+  TemporalReadOutcomeError,
+} from "../../temporal/outcome-errors";
 import { assertDurablePersist, type DiskPersistOutcome } from "./disk-persist";
 import { commitChangeProjection } from "../change-projection-transaction";
 
@@ -85,26 +84,6 @@ import { createSpecDeltaOps } from "./spec-deltas";
 import { createEpicOps } from "./epics";
 
 const logger = createLogger("store-temporal");
-
-type ProjectionSource = "disk" | "archive";
-
-function withProjectionRecovery(
-  change: Change,
-  source: ProjectionSource,
-  reason: ProjectionRecoveryReason,
-): Change & {
-  _source: ProjectionSource;
-  _recovery: {
-    mode: "temporal_query_fallback";
-    reason: ProjectionRecoveryReason;
-  };
-} {
-  return {
-    ...change,
-    _source: source,
-    _recovery: { mode: "temporal_query_fallback", reason },
-  };
-}
 
 export function createTemporalStoreBackend(
   input: TemporalStoreBackendInput,
@@ -255,21 +234,11 @@ export function createTemporalStoreBackend(
         status: "archived" as const,
       };
       setCachedProjection(archived);
-      fireWorktreeAutoManagedMigrationIfNeeded(
-        changeId,
-        undefined,
-        archived.worktree_auto_managed,
-      );
       return { ...archiveSnapshot, snapshot: archived };
     }
 
     if (diskSnapshot.found) {
       setCachedProjection(diskSnapshot.snapshot);
-      fireWorktreeAutoManagedMigrationIfNeeded(
-        changeId,
-        undefined,
-        diskSnapshot.snapshot.worktree_auto_managed,
-      );
       return diskSnapshot;
     }
 
@@ -281,11 +250,10 @@ export function createTemporalStoreBackend(
    * (`change.json`). Best-effort, fire-and-forget.
    *
    * Why this exists: Temporal signals mutate workflow state but never
-   * touch the disk file. If the workflow is terminated/evicted between
-   * sessions, `reseedChangeFromDisk` rebuilds workflow state from the
-   * disk snapshot — and any tasks/gates/wisdom updates persisted only
-   * in Temporal are silently lost. Dual-writing keeps disk current so
-   * reseeds preserve work.
+   * touch the disk file. The disk snapshot is the authoritative read model
+   * for routine reads; workflow re-creation is an explicit command, not a
+   * side effect of a read. Dual-writing keeps disk current so reads and
+   * explicit recovery commands see the latest state.
    *
    * Returns a typed {@link DiskPersistOutcome} (persisted | skipped:archived |
    * failed) and never throws itself. Durability-critical callers route through
@@ -389,9 +357,22 @@ export function createTemporalStoreBackend(
     let readbackError: unknown;
     let readbackValue: ChangeWorkflowState | undefined;
     try {
-      readbackValue = (await runTemporalQuery(async () =>
-        (await getGuardedChangeHandle(input, changeId)).query(changeStateQuery),
-      )) as ChangeWorkflowState;
+      const owner = getOwner();
+      const handle = await getGuardedChangeHandle(input, changeId);
+      const ctx = makeTemporalOperationContext(
+        input.projectId,
+        handle.workflowId,
+        "query",
+        "dualWriteAfterMutation",
+        QUERY_TIMEOUT_MS,
+      );
+      const outcome = await runTemporalQuery(async () =>
+        owner.query(ctx, handle, changeStateQuery),
+      );
+      if (outcome.kind !== "complete") {
+        throw new TemporalReadOutcomeError(outcome);
+      }
+      readbackValue = outcome.value as ChangeWorkflowState;
     } catch (err) {
       readbackError = err;
     }
@@ -444,70 +425,6 @@ export function createTemporalStoreBackend(
     memo.invalidate(changeId);
   };
 
-  /**
-   * rq-autoManageAdvWorktrees AC3 — lazy migration of legacy changes.
-   *
-   * On first read of a change whose workflow state lacks
-   * `worktree_auto_managed`, fire `worktreeAutoManagedSignal` best-effort
-   * with `value: false, source: "migrate"`. The signal handler is sticky
-   * (`applyWorktreeAutoManagedToState`) so concurrent migrations from
-   * peer sessions are idempotent. Failures log at `debug` and do NOT
-   * block the read — the next read retries automatically.
-   *
-   * Lazy by design (DONT3): never fires at plugin load. Only triggers
-   * when a tool actually requests a change.
-   *
-   * Pre-A3 detection: any change with the marker undefined is necessarily
-   * legacy (new changes get the marker stamped at create per A3, across
-   * workflow seedState + disk + Memo overlay simultaneously).
-   */
-  const fireWorktreeAutoManagedMigrationIfNeeded = (
-    changeId: string,
-    workflowMarker: boolean | undefined,
-    diskMarker: boolean | undefined,
-  ): void => {
-    if (
-      typeof workflowMarker === "boolean" ||
-      typeof diskMarker === "boolean"
-    ) {
-      return;
-    }
-    void (async () => {
-      if (isPoisonedWorkflowForChange(input.projectId, changeId)) {
-        logger.debug(
-          `Lazy worktree_auto_managed migration skipped for change ${changeId}: workflow is known poisoned.`,
-        );
-        return;
-      }
-      try {
-        // SC4 guard at signal-dispatch boundary: refuse the lazy migration
-        // signal when the workflow is mutation-ineligible (no-poller,
-        // unregistered-query, deadline, unknown, etc.). Migration is
-        // best-effort — an ineligible class skips silently via the catch
-        // below, identical to the existing skip-on-error semantics.
-        await runTemporal(async () =>
-          (await getGuardedChangeHandle(input, changeId)).signal(
-            worktreeAutoManagedSignal,
-            {
-              value: false,
-              source: "migrate",
-              recordedAt: new Date().toISOString(),
-            },
-          ),
-        ).catch((err) => {
-          enforceMutationEligibilityForError(err);
-          throw err;
-        });
-      } catch (err) {
-        logger.debug(
-          `Lazy worktree_auto_managed migration skipped for change ${changeId}: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      }
-    })();
-  };
-
   const updateOverlay = (changeId: string, patch: Partial<Change>): void => {
     const next = { ...(changeOverlayCache.get(changeId) ?? {}), ...patch };
     changeOverlayCache.set(changeId, next);
@@ -531,53 +448,7 @@ export function createTemporalStoreBackend(
     // No-op: projectWorkflow retired; change summaries live in workflow state.
   };
 
-  const getTemporalWorkflowClient = (): {
-    workflow: {
-      start: (...args: unknown[]) => Promise<WorkflowHandleLike>;
-      getHandle: (workflowId: string) => WorkflowHandleLike;
-      list?: (opts: { query: string }) => AsyncIterable<{
-        workflowId: string;
-        taskQueue: string;
-        status: { name: string };
-      }>;
-    };
-  } => {
-    const bundle = input.temporal as {
-      client: {
-        workflow: {
-          start?: (...args: unknown[]) => Promise<WorkflowHandleLike>;
-          getHandle: (workflowId: string) => WorkflowHandleLike;
-          list?: (opts: { query: string }) => AsyncIterable<{
-            workflowId: string;
-            taskQueue: string;
-            status: { name: string };
-          }>;
-        };
-      };
-    };
-    if (typeof bundle.client.workflow.start !== "function") {
-      throw new Error(
-        "Temporal client bundle does not expose workflow.start; cannot create change workflows in Temporal-only mode",
-      );
-    }
-    // Pass the full workflow object, NOT destructured methods.
-    // @temporalio/client's WorkflowClient methods (start, getHandle, etc.)
-    // rely on `this.getOrMakeInterceptors(...)` at call time. Destructuring
-    // loses the prototype receiver and crashes with
-    // "this.getOrMakeInterceptors is not a function". Forwarding the object
-    // keeps `this` bound on method-invocation.
-    return {
-      workflow: bundle.client.workflow as {
-        start: (...args: unknown[]) => Promise<WorkflowHandleLike>;
-        getHandle: (workflowId: string) => WorkflowHandleLike;
-        list?: (opts: { query: string }) => AsyncIterable<{
-          workflowId: string;
-          taskQueue: string;
-          status: { name: string };
-        }>;
-      },
-    };
-  };
+  const getOwner = (): TemporalOperations => getTemporalOwner(input);
 
   /**
    * Extract projection from update result, falling back to a direct query
@@ -588,15 +459,28 @@ export function createTemporalStoreBackend(
    * gets a fresh handle bound to the (possibly post-reconnect) client.
    */
   const resolveStateOrQuery = async (
-    getHandle: () => WorkflowHandleLike | Promise<WorkflowHandleLike>,
+    getHandle: () => TemporalWorkflowHandle | Promise<TemporalWorkflowHandle>,
     result: unknown,
   ): Promise<ChangeWorkflowState> => {
     if (result && typeof result === "object" && "changeId" in result) {
       return result as ChangeWorkflowState;
     }
-    return (await runTemporalQuery(async () =>
-      (await getHandle()).query(changeStateQuery),
-    )) as ChangeWorkflowState;
+    const owner = getOwner();
+    const handle = await getHandle();
+    const ctx = makeTemporalOperationContext(
+      input.projectId,
+      handle.workflowId,
+      "query",
+      "resolveStateOrQuery",
+      QUERY_TIMEOUT_MS,
+    );
+    const outcome = await runTemporalQuery(async () =>
+      owner.query(ctx, handle, changeStateQuery),
+    );
+    if (outcome.kind !== "complete") {
+      throw new TemporalReadOutcomeError(outcome);
+    }
+    return outcome.value as ChangeWorkflowState;
   };
 
   const indexTasksFromState = (state: ChangeWorkflowState): void => {
@@ -629,14 +513,12 @@ export function createTemporalStoreBackend(
   };
 
   /**
-   * Attempt to re-seed a missing change workflow from the disk snapshot.
-   * Used by `getTemporalChange` / `changes.get` when the Temporal query
-   * returns `WorkflowNotFoundError` (workflow terminated / evicted / never
-   * started) but a `change.json` snapshot still exists on disk.
+   * Load a missing change's archived projection when the active disk snapshot
+   * is absent. Used by the terminal-projection fallback so a `change.json`
+   * snapshot (archive bundle) still surfaces without a live workflow round-trip.
    *
-   * On success, the fresh ChangeWorkflow state is returned and cached so
-   * callers see the change instead of a hard error.
-   * On failure (no snapshot, re-seed itself throws), returns `null`.
+   * On success the archived projection is returned with a recovery marker.
+   * On failure (no snapshot, read itself throws), returns `null`.
    */
   const loadArchiveProjection = async (
     changeId: string,
@@ -742,158 +624,6 @@ export function createTemporalStoreBackend(
     const diskClosed = await loadDiskTerminalProjection(changeId);
     if (diskClosed) return setCachedProjection(diskClosed);
 
-    return null;
-  };
-
-  const reseedChangeFromDisk = async (
-    changeId: string,
-    reason: ProjectionRecoveryReason = "missing_workflow",
-    deadline?: TemporalReadDeadline,
-  ): Promise<Change | null> => {
-    // rq-replayFallback01: poisoned or missing workflow reads fall back to
-    // durable disk/archive projections instead of forcing manual bundle work.
-    const legacyRead = await legacy.changes.get(changeId);
-    if (isSchemaError(legacyRead)) {
-      throw new Error(legacyRead.error);
-    }
-    if (!legacyRead.success || !legacyRead.data) {
-      return loadArchiveProjection(changeId, reason, deadline);
-    }
-    const change = legacyRead.data;
-
-    // (A5 / rq-archivePurge01.1, M2b/terminatechangeworkflowonarchi)
-    // Archived AND closed changes are terminal — return the on-disk
-    // projection directly WITHOUT re-creating the workflow.
-    //   - For archived: re-seeding would re-emit a ChangeSummary signal
-    //     and undo adv_archive_purge on the very next read.
-    //   - For closed: change workflows now Complete on close (terminal-
-    //     state branch in workflows.ts). Re-seeding would create a new
-    //     run that immediately Completes — pointless churn.
-    // Mark the result so callers (and tests) can identify disk-sourced
-    // returns.
-    if (change.status === "archived" || change.status === "closed") {
-      return withProjectionRecovery(change, "disk", reason);
-    }
-    const projectConfig = await loadProjectConfig(legacy.paths.root).catch(
-      () => null,
-    );
-    const featurePolicy = resolveProjectFeaturePolicy(projectConfig?.features);
-
-    try {
-      const client = {
-        workflow: input.temporal.client.workflow as {
-          start: (...args: unknown[]) => Promise<WorkflowHandleLike>;
-          getHandle: (workflowId: string) => WorkflowHandleLike;
-          list?: (opts: { query: string }) => AsyncIterable<{
-            workflowId: string;
-            taskQueue: string;
-            status: { name: string };
-          }>;
-        },
-      };
-      // Defensively fill in fields that the workflow seed schema requires
-      // but an older / partial change.json may have omitted. Change
-      // snapshots on disk can be minimal (draft state, no gates/tasks
-      // yet); the workflow state machine still expects well-formed
-      // collections, so supply empty defaults rather than undefined.
-      await ensureChangeWorkflowStarted(
-        client,
-        {
-          projectId: input.projectId,
-          changeId: change.id,
-          title: change.title,
-          initializedAt: change.created_at,
-          projectionChangesDir: legacy.paths.changes,
-          archiveProjects: [{ projectPath: legacy.paths.root }],
-          // KD-10 / rq-isolSessionTaskQueue01: thread current session ID so
-          // the orphan-rescue re-seed lands on the same session queue the
-          // current process is polling. Undefined falls back to project queue.
-          sessionId: getCurrentSessionId(),
-          seedState: changeSeedStateFromChange(change),
-        },
-        { workflowQueueMode: featurePolicy.workflowQueueMode },
-      );
-    } catch (err) {
-      // Re-seed itself failed — surface the original not-found to callers
-      // rather than masking it with a seed error. Log so operators can
-      // distinguish "orphan could not be recovered" from "orphan does
-      // not exist on disk" without having to instrument locally.
-      logger.warn(
-        `Temporal re-seed failed for change ${changeId}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-      // rq-replayFallback01.3: when re-seed of a non-terminal change fails
-      // AND the original trigger error was a known poisoned-history class
-      // (TMPRL1100 / nondeterminism / no-command-replay), fall back to the
-      // durable disk projection. Mirrors the post-reseed-query fallback in
-      // the next try/catch. Missing-workflow re-seed failures still return
-      // null so callers see the real WorkflowNotFoundError instead of a
-      // synthetically-recovered stale projection.
-      if (reason === "poisoned_history") {
-        return withProjectionRecovery(change, "disk", reason);
-      }
-      return null;
-    }
-    let postReseedError: unknown;
-    let postReseedValue: ChangeWorkflowState | undefined;
-    try {
-      postReseedValue = (await runTemporalQuery(
-        async () =>
-          (await getGuardedChangeHandle(input, changeId)).query(
-            changeStateQuery,
-          ),
-        { deadline },
-      )) as ChangeWorkflowState;
-    } catch (err) {
-      postReseedError = err;
-    }
-    // SC6 wiring: classify the post-reseed readback outcome. An
-    // `outcome_unknown_readback_unavailable` is reported at warn level
-    // — the workflow was just reseeded but the post-reseed state could
-    // not be confirmed. Fall through to the recovery-reason path below
-    // which still decides whether to fall back to the disk projection.
-    const typed = composeTypedMutationResult({
-      ...(postReseedError !== undefined
-        ? { readbackError: postReseedError }
-        : {}),
-      ...(postReseedValue !== undefined
-        ? { readbackValue: postReseedValue }
-        : {}),
-    });
-    if (typed.outcome !== "confirmed" || !postReseedValue) {
-      logger.warn(
-        `reseedChangeFromDisk(${changeId}): post-reseed readback classified as ${typed.outcome}; surfacing original read failure for recovery classification.`,
-      );
-    }
-    if (typed.outcome === "confirmed" && postReseedValue) {
-      indexTasksFromState(postReseedValue);
-      return setCachedChange(postReseedValue);
-    }
-    const err =
-      postReseedError ??
-      new Error(
-        `Post-reseed readback returned ${typed.outcome} for change ${changeId}.`,
-      );
-    const failure = await classifyTemporalReadFailure(
-      input,
-      changeId,
-      err,
-      deadline,
-    );
-    // query_failed never authorizes projection recovery: the post-reseed
-    // workflow state is unknown, so surface the original failure instead
-    // of masking it with a stale disk projection.
-    if (
-      failure.errorClass === "fallback" &&
-      failure.recoveryReason !== "query_failed"
-    ) {
-      return withProjectionRecovery(
-        change,
-        "disk",
-        failure.recoveryReason ?? "missing_workflow",
-      );
-    }
     return null;
   };
 
@@ -1023,50 +753,34 @@ export function createTemporalStoreBackend(
     // budget. A timeout/unresponsive outcome degrades to the disk projection
     // with a typed advisory rather than throwing/hanging.
     try {
-      const read = await runTemporalRead(
-        getTemporalConnection(input),
-        async () => {
-          const state = (await (
-            await getGuardedChangeHandle(input, changeId)
-          ).query(changeStateQuery)) as ChangeWorkflowState;
-          return state;
-        },
-        ctx,
-        {
-          opType: "changeStateQuery",
-          timeoutMs: 1_500,
-          onTransientFailure: makeReconnectingHook(),
-        },
+      const owner = getOwner();
+      const handle = await getGuardedChangeHandle(input, changeId);
+      const queryCtx = makeTemporalOperationContext(
+        input.projectId,
+        handle.workflowId,
+        "query",
+        "changeStateQuery",
+        1_500,
       );
-      if (!read.complete) {
-        throw read.error;
+      const outcome = await runTemporalQuery(
+        async () => owner.query(queryCtx, handle, changeStateQuery),
+        { deadline: ctx.deadline, timeoutMs: 1_500 },
+      );
+      if (outcome.kind !== "complete") {
+        throw new TemporalReadOutcomeError(outcome);
       }
       ctx.recordResponsiveMember();
-      const state = read.data as ChangeWorkflowState;
+      const state = outcome.value as ChangeWorkflowState;
       indexTasksFromState(state);
-      // rq-autoManageAdvWorktrees AC3 — lazy migration trigger.
-      // Fires once on legacy reads; sticky handler dedupes concurrent races.
-      fireWorktreeAutoManagedMigrationIfNeeded(
-        changeId,
-        state.worktree_auto_managed,
-        undefined,
-      );
       return {
         success: true,
         data: setCachedChange(state),
         source: "workflow",
       };
     } catch (error) {
-      // P1.5 — orphan-tolerant changes.get with re-seed. When the
-      // workflow is missing but a disk snapshot exists, seed a fresh
-      // ChangeWorkflow from disk and return the hydrated state. This
-      // prevents a single orphan from blocking adv_status /
-      // adv_change_list / adv_change_show.
-      //
-      // (A5 / rq-archivePurge01.1) For archived changes specifically,
-      // reseedChangeFromDisk short-circuits and returns the on-disk
-      // projection without re-creating the workflow — re-seeding would
-      // re-emit a summary signal and undo adv_archive_purge.
+      // Routine reads are projection-only. Never start, signal, reseed, or
+      // write recovery state from the read path. Degrade to the durable disk
+      // projection when available; otherwise return a typed LoadResult.
       const failure = await classifyTemporalReadFailure(
         input,
         changeId,
@@ -1074,58 +788,38 @@ export function createTemporalStoreBackend(
         ctx.deadline,
       );
 
-      // workflow_unresponsive: record the unresponsive member for the CB and,
-      // when a disk projection exists, return it as authoritative with a typed
-      // advisory. Never re-seed — the workflow may still be running but is not
-      // queryable within budget.
       if (failure.recoveryReason === "workflow_unresponsive") {
         ctx.recordUnresponsiveMember();
-        if (diskChange) {
-          indexTasksFromChange(diskChange);
-          return {
-            success: true,
-            data: withProjectionRecovery(
-              diskChange,
-              "disk",
-              "workflow_unresponsive",
-            ),
-            source: "disk",
-          };
-        }
       }
 
-      // query_failed never authorizes mutation: re-seed may start a new
-      // workflow run, which is only safe when the workflow is known missing
-      // or its history is known poisoned.
-      if (
-        failure.errorClass === "fallback" &&
-        failure.recoveryReason !== "query_failed"
-      ) {
-        const reseeded = await reseedChangeFromDisk(
-          changeId,
-          failure.recoveryReason ?? "missing_workflow",
-          ctx.deadline,
-        );
-        if (reseeded) {
-          // rq-autoManageAdvWorktrees AC3 — lazy migration after reseed.
-          // The disk projection may lack the marker for legacy changes
-          // that pre-date this field; signal the workflow once so the
-          // marker becomes sticky in the freshly-seeded state.
-          fireWorktreeAutoManagedMigrationIfNeeded(
-            changeId,
-            undefined,
-            reseeded.worktree_auto_managed,
-          );
-          return {
-            success: true,
-            data: reseeded,
-            source:
-              (reseeded as Change & { _source?: "disk" | "archive" })._source ??
-              "disk",
-          };
-        }
+      const recoveryReason: ProjectionRecoveryReason =
+        failure.recoveryReason === "workflow_unresponsive" ||
+        failure.recoveryReason === "poisoned_history" ||
+        failure.recoveryReason === "missing_workflow"
+          ? failure.recoveryReason
+          : "missing_workflow";
+      if (diskChange) {
+        indexTasksFromChange(diskChange);
+        return {
+          success: true,
+          data: withProjectionRecovery(diskChange, "disk", recoveryReason),
+          source: "disk",
+        };
       }
-      throw error;
+
+      // No durable projection to serve. Preserve hard deadline / transient
+      // errors by rethrowing our own typed error; for fallback-classified
+      // missing/poisoned workflows, surface as not_found instead of mutating.
+      if (failure.errorClass !== "fallback") {
+        throw error;
+      }
+
+      return {
+        success: false,
+        error: `No durable projection and workflow is ${failure.recoveryReason ?? "unreachable"} for change ${changeId}`,
+        type: "not_found",
+        degraded: failure,
+      };
     }
   };
 
@@ -1157,19 +851,18 @@ export function createTemporalStoreBackend(
     // archive bundle is missing/raced, an archived change fell through to the
     // live query and could hit a poisoned/terminated workflow (TMPRL1100),
     // paying a wasteful query + describe() probe per candidate before the
-    // catch→reseedChangeFromDisk path finally returned the same disk data.
-    // Short-circuiting both terminal statuses here mirrors reseedChangeFromDisk
-    // and keeps enumeration/status reads fast even against poisoned terminal
-    // workflows.
+    // fallback finally returned the same disk data. Short-circuiting both
+    // terminal statuses here mirrors that fallback and keeps enumeration/status
+    // reads fast even against poisoned terminal workflows.
     if (
       result.success &&
       result.data &&
       (result.data.status === "closed" || result.data.status === "archived")
     ) {
       // Mark the disk source so callers report source "disk" (matching the
-      // prior catch→reseedChangeFromDisk path). This is terminal-projection
-      // dominance, NOT a temporal_query_fallback recovery, so it does not
-      // carry the _recovery reconciliation marker.
+      // prior catch→fallback path). This is terminal-projection dominance,
+      // NOT a temporal_query_fallback recovery, so it does not carry the
+      // _recovery reconciliation marker.
       return { ...result.data, _source: "disk" } as Change;
     }
     return null;
@@ -1194,8 +887,9 @@ export function createTemporalStoreBackend(
    *    truncation, manual termination) while its `change.json` snapshot
    *    survives on disk. We always union with a disk scan so orphaned-
    *    but-on-disk changes still surface. The per-change loader
-   *    (`getTemporalChange`) already re-seeds missing workflows from
-   *    disk, so listing them triggers self-healing.
+   *    (`getTemporalChange`) now returns the durable disk projection for
+   *    missing workflows instead of re-seeding them; self-healing is only
+   *    initiated by explicit mutation commands.
    *
    * The Memo cache supplies the fast path for active changes that the
    * adapter has already touched. We seed result IDs from Memo too so
@@ -1284,34 +978,43 @@ export function createTemporalStoreBackend(
     const memoAll = memo.getAll();
     const memoIds = memoAll.map((s) => s.id);
 
-    const bundle = input.temporal as {
-      client?: { workflow?: { list?: unknown } };
-    };
     let visibilityIds: string[] = [];
-    if (
-      !options?.sourceRanked &&
-      typeof bundle.client?.workflow?.list === "function"
-    ) {
+    if (!options?.sourceRanked) {
       try {
-        const visibilityRead = await runTemporalRead(
-          getTemporalConnection(input),
-          () =>
-            listChangeWorkflowIds(
-              bundle.client as Parameters<typeof listChangeWorkflowIds>[0],
-              {
-                projectId: input.projectId,
-                // Drop the status filter when caller wants archived/closed
-                // so the visibility query doesn't pre-narrow the result set.
-                statuses: wantsTerminalStatuses ? null : undefined,
-              },
-            ),
-          ctx,
-          { opType: "visibilityList", timeoutMs: 5_000 },
+        const owner = getOwner();
+        const listCtx = makeTemporalOperationContext(
+          input.projectId,
+          "visibility-list",
+          "list",
+          "visibilityList",
+          5_000,
         );
-        if (!visibilityRead.complete) {
-          throw visibilityRead.error;
-        }
-        visibilityIds = visibilityRead.data as string[];
+        const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${input.projectId}/`;
+        const query = buildVisibilityQuery({
+          projectId: input.projectId,
+          statuses: wantsTerminalStatuses ? null : undefined,
+        });
+        visibilityIds = await runTemporal(
+          async () => {
+            const ids: string[] = [];
+            const outcome = await owner.list<{ workflowId: string }>(
+              listCtx,
+              query,
+            );
+            if (outcome.kind !== "complete") {
+              throw new TemporalListOutcomeError(outcome);
+            }
+            for (const wf of outcome.value) {
+              const wfid = wf.workflowId;
+              if (!wfid.startsWith(projectPrefix)) continue;
+              const changeId = wfid.slice(projectPrefix.length);
+              if (changeId.length === 0) continue;
+              ids.push(changeId);
+            }
+            return ids;
+          },
+          { deadline: ctx.deadline, timeoutMs: 5_000 },
+        );
       } catch (err) {
         const hitDeadline =
           err instanceof TemporalQueryTimeoutError || expired();
@@ -1390,7 +1093,6 @@ export function createTemporalStoreBackend(
     if (
       options?.sourceRanked &&
       candidateLimit !== undefined &&
-      typeof bundle.client?.workflow?.list === "function" &&
       !wantsTerminalStatuses
     ) {
       const diskCandidates = await mapWithConcurrency(
@@ -1431,15 +1133,12 @@ export function createTemporalStoreBackend(
       );
       try {
         const ranked = await raceWithTemporalDeadline(
-          listSourceRankedCandidates(
-            bundle.client as Parameters<typeof listSourceRankedCandidates>[0],
-            {
-              projectId: input.projectId,
-              statuses: undefined,
-              limit: candidateLimit,
-              diskCandidates,
-            },
-          ),
+          listSourceRankedCandidates(getOwner(), {
+            projectId: input.projectId,
+            statuses: undefined,
+            limit: candidateLimit,
+            diskCandidates,
+          }),
           deadline,
         );
         hydrationIds = ranked.admitted.map((candidate) => candidate.id);
@@ -2265,14 +1964,13 @@ export function createTemporalStoreBackend(
     persistStateToDiskDurable,
     persistAndRefreshDurable,
     dualWriteAfterMutation,
-    getTemporalWorkflowClient,
+    getTemporalOwner: getOwner,
     resolveStateOrQuery,
     indexTasksFromState,
     resolveChangeId,
     readChangeSnapshot: readProjectionSnapshot,
     getTemporalChange,
     listResolvedChanges,
-    reseedChangeFromDisk,
   };
   const changeOps = createChangeOps(deps);
 

--- a/plugin/src/storage/store-temporal/mutation-safety-wiring.test.ts
+++ b/plugin/src/storage/store-temporal/mutation-safety-wiring.test.ts
@@ -12,6 +12,7 @@
  *   authorize mutation for SC4-ineligible classes, and reports
  *   `outcome_unknown_readback_unavailable` for ambiguous readback.
  */
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { describe, expect, test, vi } from "vitest";
 import {
   signalChangeWorkflowGuarded,
@@ -23,6 +24,7 @@ import {
   type TemporalMutationOutcome,
   type TemporalWorkflowDiagnostic,
 } from "../../temporal/mutation-safety";
+import { TemporalMutationOutcomeError } from "../../temporal/outcome-errors";
 
 function makeInput(
   opts: {
@@ -31,8 +33,8 @@ function makeInput(
   } = {},
 ): TemporalStoreBackendInput {
   return {
-    projectId: "test-project",
-    temporal: {
+    projectId: "0e000000ec000000000000000000000000000000",
+    temporal: createMockOwnerFromClient({
       client: {
         workflow: {
           start: vi.fn(async () => ({})),
@@ -42,7 +44,7 @@ function makeInput(
           })),
         },
       },
-    },
+    }),
     paths: { changes: "/tmp/changes", root: "/tmp" },
   } as unknown as TemporalStoreBackendInput;
 }
@@ -80,33 +82,50 @@ describe("signalChangeWorkflowGuarded (SC4 wiring)", () => {
     }
   });
 
-  test("passes through not_found diagnostic (not SC4-blocked)", async () => {
+  test("passes through not_found diagnostic (not SC4-blocked) as a typed mutation outcome error", async () => {
     const signal = vi.fn(async () => {
       throw new Error("workflow not found");
     });
     const input = makeInput({ signal });
-    // The helper passes the diagnostic guard for not_found, then re-throws
-    // the underlying signal error so the caller can decide.
+    // The helper passes the diagnostic guard for not_found, then throws a
+    // typed TemporalMutationOutcomeError preserving the non-confirmed
+    // outcome so callers can distinguish kind/cause.
+    let caught: unknown;
     await expect(
       signalChangeWorkflowGuarded(input, "change-1", "anySignal", [], {
         reachable: false,
         class: "not_found",
+      }).catch((err) => {
+        caught = err;
+        throw err;
       }),
-    ).rejects.toThrow(/workflow not found/);
+    ).rejects.toBeInstanceOf(TemporalMutationOutcomeError);
+    expect(
+      caught instanceof TemporalMutationOutcomeError &&
+        caught.outcome.kind === "confirmed_failure",
+    ).toBe(true);
     expect(signal).toHaveBeenCalled();
   });
 
-  test("passes through poisoned_history diagnostic (not SC4-blocked)", async () => {
+  test("passes through poisoned_history diagnostic (not SC4-blocked) as a typed mutation outcome error", async () => {
     const signal = vi.fn(async () => {
       throw new Error("TMPRL1100 No command scheduled for event");
     });
     const input = makeInput({ signal });
+    let caught: unknown;
     await expect(
       signalChangeWorkflowGuarded(input, "change-1", "anySignal", [], {
         reachable: false,
         class: "poisoned_history",
+      }).catch((err) => {
+        caught = err;
+        throw err;
       }),
-    ).rejects.toThrow(/TMPRL1100/);
+    ).rejects.toBeInstanceOf(TemporalMutationOutcomeError);
+    expect(
+      caught instanceof TemporalMutationOutcomeError &&
+        caught.outcome.kind === "confirmed_failure",
+    ).toBe(true);
     expect(signal).toHaveBeenCalled();
   });
 

--- a/plugin/src/storage/store-temporal/read-context.test.ts
+++ b/plugin/src/storage/store-temporal/read-context.test.ts
@@ -32,6 +32,11 @@ function abortError(): Error {
 }
 
 function createMockConnection(onAbort?: () => void): {
+  runWithDeadline: <R>(
+    deadlineAt: number,
+    signal: AbortSignal,
+    fn: () => Promise<R>,
+  ) => Promise<R>;
   connection: Connection;
   deadlineCalls: DeadlineCall[];
   abortCalls: AbortCall[];
@@ -85,7 +90,15 @@ function createMockConnection(onAbort?: () => void): {
       return fn();
     },
   } as unknown as Connection;
-  return { connection, deadlineCalls, abortCalls };
+  const runWithDeadline = async <R>(
+    deadlineAt: number,
+    signal: AbortSignal,
+    fn: () => Promise<R>,
+  ): Promise<R> =>
+    connection.withDeadline(deadlineAt, () =>
+      connection.withAbortSignal(signal, fn),
+    );
+  return { runWithDeadline, connection, deadlineCalls, abortCalls };
 }
 
 function activeChange(id: string): Change {
@@ -134,20 +147,21 @@ describe("Temporal read context", () => {
   });
 
   it("uses the same absolute deadline and abort signal across multiple read calls", async () => {
-    const { connection, deadlineCalls, abortCalls } = createMockConnection();
+    const { runWithDeadline, deadlineCalls, abortCalls } =
+      createMockConnection();
     const ctx = createTemporalReadContext(5_000);
 
     const op1 = vi.fn(async () => "first");
     const op2 = vi.fn(async () => "second");
     const op3 = vi.fn(async () => "third");
 
-    const r1 = await runTemporalRead(connection, op1, ctx, {
+    const r1 = await runTemporalRead(runWithDeadline, op1, ctx, {
       timeoutMs: 2_000,
     });
-    const r2 = await runTemporalRead(connection, op2, ctx, {
+    const r2 = await runTemporalRead(runWithDeadline, op2, ctx, {
       timeoutMs: 2_000,
     });
-    const r3 = await runTemporalRead(connection, op3, ctx, {
+    const r3 = await runTemporalRead(runWithDeadline, op3, ctx, {
       timeoutMs: 2_000,
     });
 
@@ -172,12 +186,12 @@ describe("Temporal read context", () => {
   });
 
   it("returns degraded and does not execute the op when aborted before the call", async () => {
-    const { connection, abortCalls } = createMockConnection();
+    const { runWithDeadline, abortCalls } = createMockConnection();
     const ctx = createTemporalReadContext(5_000);
     abortTemporalRead(ctx);
 
     const op = vi.fn(async () => "should not run");
-    const result = await runTemporalRead(connection, op, ctx, {
+    const result = await runTemporalRead(runWithDeadline, op, ctx, {
       timeoutMs: 2_000,
     });
 
@@ -190,11 +204,11 @@ describe("Temporal read context", () => {
   });
 
   it("returns degraded and does not retry after the aggregate deadline expires", async () => {
-    const { connection, deadlineCalls } = createMockConnection();
+    const { runWithDeadline, deadlineCalls } = createMockConnection();
     const ctx = createTemporalReadContext(1_000);
     const op = vi.fn(() => new Promise<never>(() => {}));
 
-    const promise = runTemporalRead(connection, op, ctx, {
+    const promise = runTemporalRead(runWithDeadline, op, ctx, {
       timeoutMs: 5_000,
       maxAttempts: 5,
     });
@@ -213,7 +227,7 @@ describe("Temporal read context", () => {
   it("cancels the in-flight RPC via the SDK abort signal and emits no retry", async () => {
     const ctx = createTemporalReadContext(5_000);
     let abortFired = false;
-    const { connection, abortCalls } = createMockConnection(() => {
+    const { runWithDeadline, abortCalls } = createMockConnection(() => {
       if (!abortFired) {
         abortFired = true;
         abortTemporalRead(ctx);
@@ -221,7 +235,7 @@ describe("Temporal read context", () => {
     });
 
     const op = vi.fn(async () => "should not finish");
-    const result = await runTemporalRead(connection, op, ctx, {
+    const result = await runTemporalRead(runWithDeadline, op, ctx, {
       timeoutMs: 2_000,
       maxAttempts: 5,
     });
@@ -234,11 +248,11 @@ describe("Temporal read context", () => {
   });
 
   it("returns complete metadata on a healthy RPC", async () => {
-    const { connection } = createMockConnection();
+    const { runWithDeadline } = createMockConnection();
     const ctx = createTemporalReadContext(5_000);
     const op = vi.fn(async () => ({ ok: true }));
 
-    const result = await runTemporalRead(connection, op, ctx, {
+    const result = await runTemporalRead(runWithDeadline, op, ctx, {
       timeoutMs: 2_000,
     });
 
@@ -340,7 +354,7 @@ describe("Temporal read context — routine reads avoid Temporal enrichment", ()
     const store = createTemporalStoreBackend({
       legacy,
       temporal: temporal as unknown as { client: typeof temporal.client },
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
     return { store, connection, deadlineCalls, abortCalls };
   }

--- a/plugin/src/storage/store-temporal/read-context.ts
+++ b/plugin/src/storage/store-temporal/read-context.ts
@@ -1,4 +1,3 @@
-import { Connection } from "@temporalio/client";
 import {
   classifyTemporalFailure,
   type TemporalFailureDiagnostics,
@@ -164,10 +163,10 @@ function buildResult<T>(
 /**
  * Run one authoritative Temporal read under the supplied context.
  *
- * When a real `Connection` is available, the SDK's `withDeadline` and
+ * When a `runWithDeadline` executor is provided, the SDK's `withDeadline` and
  * `withAbortSignal` become the RPC timeout authority — the underlying gRPC
  * call is cancelled on expiry or abort, and no local `Promise.race` can mask
- * a still-running RPC. When no connection is present (test fixtures, mocks,
+ * a still-running RPC. When no executor is present (test fixtures, mocks,
  * target-path snapshots), the read falls back to the existing retry wrapper's
  * bounded deadline behavior.
  *
@@ -176,7 +175,13 @@ function buildResult<T>(
  * as incomplete and must not grant it mutation authority.
  */
 export async function runTemporalRead<T>(
-  connection: Connection | undefined,
+  runWithDeadline:
+    | ((
+        deadlineAt: number,
+        abortSignal: AbortSignal,
+        fn: () => Promise<T>,
+      ) => Promise<T>)
+    | undefined,
   op: () => Promise<T>,
   ctx: TemporalReadContext,
   options?: RunTemporalReadOptions,
@@ -189,7 +194,7 @@ export async function runTemporalRead<T>(
   try {
     const result = await withTemporalRetry(op, {
       deadline: ctx.deadline,
-      connection,
+      runWithDeadline,
       abortSignal: ctx.abortController.signal,
       timeoutMs: options?.timeoutMs,
       opType: options?.opType,

--- a/plugin/src/storage/store-temporal/routine-readstore-routing.red.test.ts
+++ b/plugin/src/storage/store-temporal/routine-readstore-routing.red.test.ts
@@ -102,7 +102,7 @@ describe("routine reads route through the disk ReadStore projection (RED)", () =
       store: createTemporalStoreBackend({
         legacy,
         temporal: poisoned.temporal,
-        projectId: "routine-read-project",
+        projectId: "000000e0ead0000ec00000000000000000000000",
       }),
       ...poisoned,
     };
@@ -224,7 +224,7 @@ describe("routine reads route through the disk ReadStore projection (RED)", () =
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisoned.temporal,
-      projectId: "routine-read-project",
+      projectId: "000000e0ead0000ec00000000000000000000000",
     });
     const result = await store.changes
       .get("missing-read-model")
@@ -249,7 +249,7 @@ describe("routine reads route through the disk ReadStore projection (RED)", () =
     const store = createTemporalStoreBackend({
       legacy,
       temporal: poisoned.temporal,
-      projectId: "routine-read-project",
+      projectId: "000000e0ead0000ec00000000000000000000000",
     });
     const result = await store.changes.get(corruptId).catch((error) => error);
 

--- a/plugin/src/storage/store-temporal/schema-error-propagation.test.ts
+++ b/plugin/src/storage/store-temporal/schema-error-propagation.test.ts
@@ -91,7 +91,7 @@ function schemaValidChangeJson(id: string): string {
  * Mock Temporal client whose workflow query always throws a generic
  * "Failed to query Workflow" error (the masked error classifyTemporalReadFailure
  * cannot attribute to poisoned/missing). Used to force the fallback path
- * through reseedChangeFromDisk / loadDiskTerminalProjection.
+ * through loadDiskTerminalProjection.
  */
 function createGenericFailureTemporal() {
   const handle = {
@@ -143,7 +143,7 @@ describe("schema-error propagation (issue #258 Defect 1)", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: createGenericFailureTemporal(),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     await expect(store.changes.get("schemaInvalidChange")).rejects.toThrow(
@@ -160,7 +160,7 @@ describe("schema-error propagation (issue #258 Defect 1)", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: createGenericFailureTemporal(),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     await expect(store.changes.get("schemaInvalidChange")).rejects.not.toThrow(
@@ -174,7 +174,7 @@ describe("schema-error propagation (issue #258 Defect 1)", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: createGenericFailureTemporal(),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     await expect(store.gates.get("schemaInvalidGates")).rejects.toThrow(
@@ -190,7 +190,7 @@ describe("schema-error propagation (issue #258 Defect 1)", () => {
     const store = createTemporalStoreBackend({
       legacy,
       temporal: createGenericFailureTemporal(),
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
 
     // Pre-fix: schema_error propagates.
@@ -207,7 +207,7 @@ describe("schema-error propagation (issue #258 Defect 1)", () => {
     // Post-fix: should succeed (no schema_error, no Temporal query failure).
     // The Temporal mock still throws "Failed to query Workflow", but the
     // generic-failure-without-poisoned-evidence path returns the disk
-    // projection via reseedChangeFromDisk.
+    // projection directly as a fallback, without reseeding.
     const result = await store.changes.get("schemaRoundtrip");
     expect(result.success).toBe(true);
     expect(result.data?.id).toBe("schemaRoundtrip");

--- a/plugin/src/storage/store-temporal/shared.command-primitive.test.ts
+++ b/plugin/src/storage/store-temporal/shared.command-primitive.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { changeCommand, type StoreDeps } from "./shared";
 import { CHANGE_WORKFLOW_QUERY_NAMES } from "../../temporal/contracts";
+
+const PROJECT_ID = "0".repeat(40);
 
 const signalMock = vi.fn();
 const queryMock = vi.fn();
@@ -9,8 +12,8 @@ const commitProjectionMock = vi.fn();
 function makeDeps() {
   return {
     input: {
-      projectId: "pid-cmd",
-      temporal: {
+      projectId: PROJECT_ID,
+      temporal: createMockOwnerFromClient({
         client: {
           workflow: {
             getHandle: vi.fn(() => ({
@@ -19,7 +22,7 @@ function makeDeps() {
             })),
           },
         },
-      },
+      }),
     },
     legacy: {
       paths: {

--- a/plugin/src/storage/store-temporal/shared.test.ts
+++ b/plugin/src/storage/store-temporal/shared.test.ts
@@ -15,8 +15,12 @@ import {
   createTemporalReadDeadline,
   TemporalQueryTimeoutError,
 } from "../../temporal/retry-wrapper";
+import { createMockOwner } from "../../temporal/__tests__/mock-owner";
 import { reinitStsl } from "../../temporal/service";
 import { createChangeWorkflowState } from "../../temporal/change-state";
+
+const PROJECT_ID_A = "0000ec0a00000000000000000000000000000000";
+const PROJECT_ID_B = "0000ec0b00000000000000000000000000000000";
 
 vi.mock("../../temporal/service", () => ({
   reinitStsl: vi.fn(async () => undefined),
@@ -79,19 +83,13 @@ function createInput(args: {
   return {
     getHandle,
     input: {
-      projectId: args.projectId ?? "project-a",
+      projectId: args.projectId ?? PROJECT_ID_A,
       legacy: {
         changes: {
           get: args.changesGet,
         },
       } as unknown as Store,
-      temporal: {
-        client: {
-          workflow: {
-            getHandle,
-          },
-        },
-      },
+      temporal: createMockOwner({ getHandle }),
     },
   };
 }
@@ -100,7 +98,7 @@ describe("getGuardedChangeHandle owner guard cache", () => {
   test("caches successful owner-bearing validation while returning fresh handles", async () => {
     const changesGet = vi.fn(async () => ({
       success: true,
-      data: { adv_project_id: "project-a" },
+      data: { adv_project_id: PROJECT_ID_A },
     }));
     const { input, getHandle } = createInput({ changesGet });
 
@@ -125,7 +123,7 @@ describe("getGuardedChangeHandle owner guard cache", () => {
   test("does not cache owner mismatches", async () => {
     const changesGet = vi.fn(async () => ({
       success: true,
-      data: { adv_project_id: "other-project" },
+      data: { adv_project_id: PROJECT_ID_B },
     }));
     const { input, getHandle } = createInput({ changesGet });
 
@@ -143,18 +141,18 @@ describe("getGuardedChangeHandle owner guard cache", () => {
   test("isolates cache entries per Temporal store input", async () => {
     const changesGetA = vi.fn(async () => ({
       success: true,
-      data: { adv_project_id: "project-a" },
+      data: { adv_project_id: PROJECT_ID_A },
     }));
     const changesGetB = vi.fn(async () => ({
       success: true,
-      data: { adv_project_id: "project-a" },
+      data: { adv_project_id: PROJECT_ID_A },
     }));
     const { input: inputA } = createInput({
-      projectId: "project-a",
+      projectId: PROJECT_ID_A,
       changesGet: changesGetA,
     });
     const { input: inputB } = createInput({
-      projectId: "project-b",
+      projectId: PROJECT_ID_B,
       changesGet: changesGetB,
     });
 
@@ -378,17 +376,19 @@ describe("classifyTemporalReadFailure", () => {
       ...(args.describe ? { describe: args.describe } : {}),
     };
     return {
-      projectId: "project-a",
+      projectId: PROJECT_ID_A,
       legacy: {
         changes: { get: vi.fn() },
       } as unknown as Store,
-      temporal: {
-        client: {
-          workflow: {
-            getHandle: () => handle,
-          },
-        },
-      },
+      temporal: createMockOwner({
+        getHandle: vi.fn(() => handle),
+        describe: vi.fn(async (_ctx, _handle) => {
+          return {
+            kind: "complete" as const,
+            value: args.describe ? await args.describe() : undefined,
+          };
+        }),
+      }),
     };
   }
 
@@ -473,7 +473,7 @@ describe("classifyTemporalReadFailure", () => {
 
   test("fallback-class but neither poisoned nor missing → query_failed (never mutation-authorizing)", async () => {
     // "not registered" matches the retry-wrapper fallback family, but the
-    // workflow exists and cannot answer the query — re-seed mutation must
+    // workflow exists and cannot answer the query — a start/signal mutation must
     // NOT be authorized for it.
     const input = createClassifyInput({});
     const failure = await classifyTemporalReadFailure(

--- a/plugin/src/storage/store-temporal/shared.ts
+++ b/plugin/src/storage/store-temporal/shared.ts
@@ -1,4 +1,3 @@
-import type { Connection } from "@temporalio/client";
 import {
   normalizePersistedSubagentReportState,
   type Change,
@@ -24,11 +23,16 @@ import {
   markPoisonedWorkflowForChange,
   isPoisonedWorkflowForChange,
 } from "./poisoned-workflow-cache";
+import {
+  TemporalMutationOutcomeError,
+  TemporalReadOutcomeError,
+} from "../../temporal/outcome-errors";
 import { reinitStsl } from "../../temporal/service";
 import { createLogger } from "../../utils/debug-log";
 import type { ChangeSummaryMemo, ChangeSummary } from "../store-temporal-memo";
 import type { Store } from "../store-types";
-import type { TemporalClientBundle } from "../../temporal/client";
+import type { TemporalOperations } from "../../temporal/operations";
+import { makeTemporalOperationContext } from "../../temporal/operations";
 import {
   classifyMutationOutcome,
   requireMutationEligible,
@@ -69,29 +73,17 @@ function getOwnerGuardCache(
   return cache;
 }
 
-export interface WorkflowHandleLike {
-  query: (definition: unknown, ...args: unknown[]) => Promise<unknown>;
-  describe?: () => Promise<unknown>;
-  executeUpdate: (
-    definition: unknown,
-    options: { args?: unknown[] },
-  ) => Promise<unknown>;
-  signal: (definition: unknown, ...args: unknown[]) => Promise<void>;
-}
-
-export interface TemporalHandleClient {
-  workflow: {
-    getHandle: (workflowId: string) => WorkflowHandleLike;
-    start?: (...args: unknown[]) => Promise<WorkflowHandleLike>;
-  };
-}
-
 export interface TemporalStoreBackendInput {
   legacy: Store;
-  temporal: { client: TemporalHandleClient } | TemporalClientBundle;
+  temporal: TemporalOperations;
   projectId: string;
 }
 
+export function getTemporalOwner(
+  input: TemporalStoreBackendInput,
+): TemporalOperations {
+  return input.temporal;
+}
 export function mapTemporalChangeStateToChange(
   state: ChangeWorkflowState,
 ): Change {
@@ -131,6 +123,9 @@ export function mapTemporalChangeStateToChange(
     release_notes: safeState.release_notes,
   };
 }
+
+export type TemporalWorkflowHandle =
+  import("../../temporal/operations").TemporalWorkflowHandle;
 
 /**
  * Fields whose values are owned by a healthy ChangeWorkflow. Disk-only
@@ -191,10 +186,17 @@ export function projectTemporalStateOntoLatest(
 export function getChangeHandle(
   input: TemporalStoreBackendInput,
   changeId: string,
-): WorkflowHandleLike {
+): TemporalWorkflowHandle {
   const workflowId = buildChangeWorkflowId(input.projectId, changeId);
-  const bundle = input.temporal as { client: TemporalHandleClient };
-  return bundle.client.workflow.getHandle(workflowId);
+  return getTemporalOwner(input).getHandle(
+    makeTemporalOperationContext(
+      input.projectId,
+      workflowId,
+      "describe",
+      "getChangeHandle",
+      5_000,
+    ),
+  );
 }
 
 /**
@@ -208,16 +210,29 @@ export function getChangeHandle(
 export async function signalChangeWorkflowGuarded(
   input: TemporalStoreBackendInput,
   changeId: string,
-  signal: unknown,
+  signalDef: import("@temporalio/workflow").SignalDefinition<unknown[]>,
   args: unknown[],
   eligibility?: import("../../temporal/mutation-safety").TemporalWorkflowDiagnostic,
 ): Promise<void> {
   if (eligibility) {
     requireMutationEligible(eligibility);
   }
-  await runTemporal(async () =>
-    (await getGuardedChangeHandle(input, changeId)).signal(signal, ...args),
+  const owner = getTemporalOwner(input);
+  const handle = await getGuardedChangeHandle(input, changeId);
+  const workflowId = buildChangeWorkflowId(input.projectId, changeId);
+  const ctx = makeTemporalOperationContext(
+    input.projectId,
+    workflowId,
+    "signal",
+    "signalChangeWorkflowGuarded",
+    10_000,
   );
+  const outcome = await runTemporal(async () =>
+    owner.signal(ctx, handle, signalDef, args),
+  );
+  if (outcome.kind !== "confirmed") {
+    throw new TemporalMutationOutcomeError(outcome);
+  }
 }
 
 /**
@@ -258,18 +273,6 @@ export async function queryChangeWorkflowReadback<T>(
 }
 
 /**
- * Extract the underlying Temporal Connection from the store input when one
- * is present. Production bundles expose it; test fixtures and target-path
- * snapshots may omit it and fall back to the Promise.race-based wrapper.
- */
-export function getTemporalConnection(
-  input: TemporalStoreBackendInput,
-): Connection | undefined {
-  const bundle = input.temporal as { connection?: Connection };
-  return bundle.connection;
-}
-
-/**
  * Typed error thrown when a change-scoped operation targets a change
  * owned by a different project than the current store binding.
  */
@@ -294,7 +297,7 @@ export class AdvProjectContextMismatchError extends Error {
 export async function getGuardedChangeHandle(
   input: TemporalStoreBackendInput,
   changeId: string,
-): Promise<WorkflowHandleLike> {
+): Promise<TemporalWorkflowHandle> {
   const cachedOwner = ownerGuardCache.get(input)?.get(changeId);
   if (cachedOwner === input.projectId) {
     return getChangeHandle(input, changeId);
@@ -553,7 +556,10 @@ export interface ChangeCommandOptions {
    * (e.g., artifact metadata) that must be processed before the command's
    * projection commit.
    */
-  postSignal?: (handle: WorkflowHandleLike) => Promise<void>;
+  postSignal?: (
+    owner: TemporalOperations,
+    handle: TemporalWorkflowHandle,
+  ) => Promise<void>;
   /**
    * Optional SC4 eligibility diagnostic. When supplied, the command is
    * refused against a mutation-ineligible workflow before any signal fires.
@@ -611,6 +617,8 @@ export async function changeCommand(
     postSignal,
     eligibility,
   } = options;
+  const owner = getTemporalOwner(deps.input);
+  const workflowId = buildChangeWorkflowId(deps.input.projectId, changeId);
   const handle = await getGuardedChangeHandle(deps.input, changeId);
   if (isPoisonedWorkflowForChange(deps.input.projectId, changeId)) {
     return {
@@ -618,14 +626,29 @@ export async function changeCommand(
       reason: `${commandKind} signal skipped for ${changeId}: workflow is known poisoned`,
     };
   }
+  const signalCtx = makeTemporalOperationContext(
+    deps.input.projectId,
+    workflowId,
+    "signal",
+    commandKind,
+    30_000,
+  );
   try {
     if (eligibility) {
       requireMutationEligible(eligibility);
     }
     await runTemporal(async () => {
-      await handle.signal(signal, ...signalArgs);
+      const signalResult = await owner.signal(
+        signalCtx,
+        handle,
+        signal as import("@temporalio/workflow").SignalDefinition<unknown[]>,
+        signalArgs,
+      );
+      if (signalResult.kind !== "confirmed") {
+        throw new TemporalMutationOutcomeError(signalResult);
+      }
       if (postSignal) {
-        await postSignal(handle);
+        await postSignal(owner, handle);
       }
     });
   } catch (err) {
@@ -645,13 +668,28 @@ export async function changeCommand(
     };
   }
 
+  const queryCtx = makeTemporalOperationContext(
+    deps.input.projectId,
+    workflowId,
+    "query",
+    `${commandKind}:ledger`,
+    30_000,
+  );
   let ledger: OperationLedgerEntry | undefined;
   try {
     ledger = await waitForQueryPredicate(
-      () =>
-        handle.query(getOperationLedgerOutcomeQuery, operationId) as Promise<
-          OperationLedgerEntry | undefined
-        >,
+      async () => {
+        const outcome = await owner.query(
+          queryCtx,
+          handle,
+          getOperationLedgerOutcomeQuery,
+          operationId,
+        );
+        if (outcome.kind !== "complete") {
+          throw new TemporalReadOutcomeError(outcome);
+        }
+        return outcome.value;
+      },
       (entry) =>
         entry?.outcome === "accepted" ||
         entry?.outcome === "idempotent_replay" ||
@@ -691,9 +729,13 @@ export async function changeCommand(
 
   let state: ChangeWorkflowState;
   try {
-    state = (await runTemporal(async () =>
-      handle.query(changeStateQuery),
-    )) as ChangeWorkflowState;
+    const stateOutcome = await runTemporal(async () =>
+      owner.query(queryCtx, handle, changeStateQuery),
+    );
+    if (stateOutcome.kind !== "complete") {
+      throw new TemporalReadOutcomeError(stateOutcome);
+    }
+    state = stateOutcome.value as ChangeWorkflowState;
   } catch (err) {
     return {
       kind: "outcome_unknown_readback_unavailable",
@@ -809,13 +851,22 @@ async function hasPoisonedWorkflowDescription(
   changeId: string,
   deadline?: TemporalReadDeadline,
 ): Promise<boolean> {
+  const owner = getTemporalOwner(input);
   const handle = getChangeHandle(input, changeId);
-  if (typeof handle.describe !== "function") return false;
+  const ctx = makeTemporalOperationContext(
+    input.projectId,
+    buildChangeWorkflowId(input.projectId, changeId),
+    "describe",
+    "poisonedProbe",
+    1_000,
+  );
   try {
-    const description = await runTemporal(async () => handle.describe?.(), {
-      timeoutMs: 1_000,
-      deadline,
-    });
+    const descriptionOutcome = await runTemporal(
+      async () => owner.describe(ctx, handle),
+      { timeoutMs: 1_000, deadline },
+    );
+    if (descriptionOutcome.kind !== "complete") return false;
+    const description = descriptionOutcome.value;
     const evidence = stringifyEvidence(description);
     // Also treat terminal workflows as poisoned-from-read-perspective:
     // queries to terminated/closed workflows on abandoned session queues
@@ -835,9 +886,9 @@ export interface TemporalReadFailureClassification {
   /**
    * Typed reason for the read failure. `query_failed` means the workflow
    * state is unknown — it NEVER authorizes mutation. Recovery paths that
-   * mutate (re-seed) or project must require BOTH `errorClass ===
+   * mutate or project must require BOTH `errorClass ===
    * "fallback"` AND a `ProjectionRecoveryReason` (i.e. recoveryReason !==
-   * "query_failed").
+   * "query_failed`).
    */
   recoveryReason?: RecoveryReason;
   /**
@@ -912,6 +963,26 @@ export async function classifyTemporalReadFailure(
   };
 }
 
+export type ProjectionSource = "disk" | "archive";
+
+export function withProjectionRecovery(
+  change: Change,
+  source: ProjectionSource,
+  reason: ProjectionRecoveryReason,
+): Change & {
+  _source: ProjectionSource;
+  _recovery: {
+    mode: "temporal_query_fallback";
+    reason: ProjectionRecoveryReason;
+  };
+} {
+  return {
+    ...change,
+    _source: source,
+    _recovery: { mode: "temporal_query_fallback", reason },
+  };
+}
+
 export interface StoreDeps {
   input: TemporalStoreBackendInput;
   legacy: Store;
@@ -955,24 +1026,9 @@ export interface StoreDeps {
     state: ChangeWorkflowState,
   ) => Promise<void>;
   dualWriteAfterMutation: (changeId: string) => Promise<void>;
-  getTemporalWorkflowClient: () => {
-    workflow: {
-      start: (...args: unknown[]) => Promise<WorkflowHandleLike>;
-      getHandle: (workflowId: string) => WorkflowHandleLike;
-      /**
-       * Optional Visibility enumeration. Forwarded from the underlying
-       * Temporal Client when available; absent in test fixtures that only
-       * stub start/getHandle.
-       */
-      list?: (opts: { query: string }) => AsyncIterable<{
-        workflowId: string;
-        taskQueue: string;
-        status: { name: string };
-      }>;
-    };
-  };
+  getTemporalOwner: () => TemporalOperations;
   resolveStateOrQuery: (
-    getHandle: () => WorkflowHandleLike | Promise<WorkflowHandleLike>,
+    getHandle: () => TemporalWorkflowHandle | Promise<TemporalWorkflowHandle>,
     result: unknown,
   ) => Promise<ChangeWorkflowState>;
   indexTasksFromState: (state: ChangeWorkflowState) => void;
@@ -996,8 +1052,4 @@ export interface StoreDeps {
     deadline?: TemporalReadDeadline,
     options?: { candidateLimit?: number; hydrationConcurrency?: number },
   ) => Promise<import("../store-types").ResolvedChangeList>;
-  reseedChangeFromDisk: (
-    changeId: string,
-    reason?: ProjectionRecoveryReason,
-  ) => Promise<Change | null>;
 }

--- a/plugin/src/storage/store-temporal/spec-deltas.disk-projection.test.ts
+++ b/plugin/src/storage/store-temporal/spec-deltas.disk-projection.test.ts
@@ -10,6 +10,7 @@ import { saveChange } from "../json";
 import { commitChangeProjection } from "../change-projection-transaction";
 import { projectTemporalStateOntoLatest } from "./shared";
 import type { DiskPersistOutcome } from "./disk-persist";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 
 const ADD_DELTA = {
   id: "dl-AAA11111",
@@ -34,8 +35,9 @@ const ADD_DELTA = {
 const signalMock = vi.fn();
 const queryMock = vi.fn();
 
-function makeHandle() {
+function makeHandle(changeId: string) {
   return {
+    workflowId: `adv/change/pid-delta-disk/${changeId}`,
     signal: signalMock,
     query: queryMock,
   };
@@ -60,22 +62,20 @@ async function makeDeps(
   } as Change);
   await saveChange(changesDir, seed);
 
-  const handle = makeHandle();
+  const handle = makeHandle(changeId);
   return {
     input: {
-      projectId: "pid-delta-disk",
+      projectId: "00dde00ad0000000000000000000000000000000",
       legacy: {
         changes: {
           get: vi.fn().mockResolvedValue({ success: true, data: null }),
         },
       },
-      temporal: {
-        client: {
-          workflow: {
-            getHandle: vi.fn().mockReturnValue(handle),
-          },
+      temporal: createMockOwnerFromClient({
+        workflow: {
+          getHandle: vi.fn().mockReturnValue(handle),
         },
-      },
+      }),
     },
     legacy: {
       specDeltas: {},

--- a/plugin/src/storage/store-temporal/spec-deltas.test.ts
+++ b/plugin/src/storage/store-temporal/spec-deltas.test.ts
@@ -8,6 +8,10 @@ import {
 import { DiskProjectionPersistError } from "./disk-persist";
 import { commitChangeProjectionWithSummary } from "../change-summary-shard";
 
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
+
+const PROJECT_ID = "0".repeat(40);
+
 const { signalMock, queryMock } = vi.hoisted(() => ({
   signalMock: vi.fn(),
   queryMock: vi.fn(),
@@ -120,19 +124,19 @@ function makeDeps(stateAfterSignal: unknown) {
   const handle = makeHandle(stateAfterSignal);
   return {
     input: {
-      projectId: "pid-spec-delta",
+      projectId: PROJECT_ID,
       legacy: {
         changes: {
           get: vi.fn().mockResolvedValue({ success: true, data: null }),
         },
       },
-      temporal: {
+      temporal: createMockOwnerFromClient({
         client: {
           workflow: {
             getHandle: vi.fn().mockReturnValue(handle),
           },
         },
-      },
+      }),
     },
     legacy: {
       specDeltas: {},

--- a/plugin/src/storage/store-temporal/tasks.durability.test.ts
+++ b/plugin/src/storage/store-temporal/tasks.durability.test.ts
@@ -4,6 +4,7 @@ import { createTaskOps } from "./tasks";
 import { DiskProjectionPersistError } from "./disk-persist";
 import { commitChangeProjectionWithSummary } from "../change-summary-shard";
 import { CHANGE_WORKFLOW_QUERY_NAMES } from "../../temporal/contracts";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import {
   createToolOperationContext,
   withToolOperationContext,
@@ -72,6 +73,7 @@ function makeHandle(stateAfterSignal: unknown) {
     return stateAfterSignal;
   });
   return {
+    workflowId: `adv/change/pid-task/${CHANGE_ID}`,
     signal: signalMock,
     query: queryMock,
   };
@@ -81,19 +83,17 @@ function makeDeps(stateAfterSignal: unknown) {
   const handle = makeHandle(stateAfterSignal);
   return {
     input: {
-      projectId: "pid-task",
+      projectId: "00d0a00000000000000000000000000000000000",
       legacy: {
         changes: {
           get: vi.fn().mockResolvedValue({ success: true, data: null }),
         },
       },
-      temporal: {
-        client: {
-          workflow: {
-            getHandle: vi.fn().mockReturnValue(handle),
-          },
+      temporal: createMockOwnerFromClient({
+        workflow: {
+          getHandle: vi.fn().mockReturnValue(handle),
         },
-      },
+      }),
     },
     legacy: {
       tasks: {},

--- a/plugin/src/storage/store-temporal/wisdom.durability.test.ts
+++ b/plugin/src/storage/store-temporal/wisdom.durability.test.ts
@@ -4,6 +4,7 @@ import { createWisdomOps } from "./wisdom";
 import { DiskProjectionPersistError } from "./disk-persist";
 import { commitChangeProjectionWithSummary } from "../change-summary-shard";
 import { CHANGE_WORKFLOW_QUERY_NAMES } from "../../temporal/contracts";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import {
   createToolOperationContext,
   withToolOperationContext,
@@ -65,6 +66,7 @@ function makeHandle() {
     return STATE;
   });
   return {
+    workflowId: `adv/change/pid-wisdom/${CHANGE_ID}`,
     signal: signalMock,
     query: queryMock,
   };
@@ -74,19 +76,17 @@ function makeDeps() {
   const handle = makeHandle();
   return {
     input: {
-      projectId: "pid-wisdom",
+      projectId: "00d000d000000000000000000000000000000000",
       legacy: {
         changes: {
           get: vi.fn().mockResolvedValue({ success: true, data: null }),
         },
       },
-      temporal: {
-        client: {
-          workflow: {
-            getHandle: vi.fn().mockReturnValue(handle),
-          },
+      temporal: createMockOwnerFromClient({
+        workflow: {
+          getHandle: vi.fn().mockReturnValue(handle),
         },
-      },
+      }),
     },
     legacy: {
       wisdom: {},

--- a/plugin/src/storage/store.ts
+++ b/plugin/src/storage/store.ts
@@ -14,7 +14,10 @@
  */
 
 import { getProjectId } from "../utils/project-id";
-import type { TemporalClientBundle } from "../temporal/client";
+import {
+  TemporalOperationsOwner,
+  type TemporalOperations,
+} from "../temporal/operations";
 import { createTemporalStoreBackend } from "./store-temporal";
 import { createDiskStore } from "./store-disk";
 
@@ -38,9 +41,16 @@ import type { ProductContext } from "./product-context";
 
 export interface CreateStoreOptions {
   externalRoot?: string;
-  temporalBundle: TemporalClientBundle;
+  temporalBundle: TemporalOperations;
   projectIdOverride?: string;
   productContext?: ProductContext;
+}
+
+function asTemporalOperations(bundle: TemporalOperations): TemporalOperations {
+  if (bundle instanceof TemporalOperationsOwner) {
+    return bundle;
+  }
+  return bundle;
 }
 
 export async function createStore(
@@ -68,7 +78,7 @@ export async function createStore(
 
   const store = createTemporalStoreBackend({
     legacy,
-    temporal: options.temporalBundle,
+    temporal: asTemporalOperations(options.temporalBundle),
     projectId,
   });
   store.productContext = options.productContext;

--- a/plugin/src/temporal/__tests__/archive-phase9-splitbrain.itest.ts
+++ b/plugin/src/temporal/__tests__/archive-phase9-splitbrain.itest.ts
@@ -225,7 +225,7 @@ describe("AC3 — phase9 split-brain recovery via archive re-run (live Temporal)
           // Real STSL so getService() inside recordPhase9Status resolves and
           // the phase9 signal routes through a live Temporal client.
           resetStsl();
-          const bundle = await initStsl({
+          const bundle = await initStsl(projectId!, {
             ADV_TEMPORAL_ADDRESS: env.address ?? "127.0.0.1:7233",
             ADV_TEMPORAL_NAMESPACE: namespace,
             ADV_TEMPORAL_ALLOW_REMOTE: "true",

--- a/plugin/src/temporal/__tests__/concurrent-signaling.itest.ts
+++ b/plugin/src/temporal/__tests__/concurrent-signaling.itest.ts
@@ -48,7 +48,7 @@ const fixtureContract: ChangeContract = {
 
 function makeChangeInput(changeId: string): ChangeWorkflowInput {
   return {
-    projectId: "concurrent-signaling-test-project",
+    projectId: "c00c000e000000a00000e000000ec00000000000",
     changeId,
     title: `Concurrent signaling test: ${changeId}`,
     initializedAt: "2026-05-05T00:00:00.000Z",

--- a/plugin/src/temporal/__tests__/continue-as-new.itest.ts
+++ b/plugin/src/temporal/__tests__/continue-as-new.itest.ts
@@ -25,7 +25,7 @@ type StartedChangeWorkflowHandle = WorkflowHandleWithStartDetails<
 
 function makeChangeInput(changeId: string): ChangeWorkflowInput {
   return {
-    projectId: "continue-as-new-test-project",
+    projectId: "c000000ea00e00e000000ec00000000000000000",
     changeId,
     title: `Continue-as-new test: ${changeId}`,
     initializedAt: "2026-05-05T00:00:00.000Z",

--- a/plugin/src/temporal/__tests__/legacy-copoll.itest.ts
+++ b/plugin/src/temporal/__tests__/legacy-copoll.itest.ts
@@ -17,7 +17,6 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { Worker, bundleWorkflowCode } from "@temporalio/worker";
-import type { WorkflowHandle } from "@temporalio/client";
 import { withTimeSkippingTestWorkflowEnvironment } from "./with-test-env";
 import { ensureChangeWorkflowStarted } from "../workflow-start";
 import { createDefaultGates } from "../../types";
@@ -25,12 +24,24 @@ import type { ChangeWorkflowInput } from "../contracts";
 import { buildProjectTaskQueue, buildSessionTaskQueue } from "../client";
 import { changeStateQuery, proposalUpdatedSignal } from "../messages";
 import { requiredAdvSearchAttributes } from "../observability";
+import { TemporalOperationsOwner } from "../operations";
 import type { TestWorkflowEnvironment } from "@temporalio/testing";
+
+function ownerFromEnv(env: TestWorkflowEnvironment): TemporalOperationsOwner {
+  return new TemporalOperationsOwner(
+    {
+      client: env.client,
+      connection: env.connection,
+      namespace: env.namespace ?? "default",
+    },
+    "c".repeat(40),
+  );
+}
 
 const workflowsPath = fileURLToPath(
   new URL("../workflows.ts", import.meta.url),
 );
-const PROJECT_ID = "proj-legacy-copoll-001";
+const PROJECT_ID = "c".repeat(40);
 const SESSION_ID = "sess_LegacyCopoll1";
 
 async function registerAdvSearchAttributes(
@@ -144,21 +155,23 @@ describe("AC3: legacy queue co-polling (isolateAdvWorkerTaskQueues)", () => {
           try {
             // Legacy workflow: started WITHOUT sessionId → routes to project queue.
             const legacyHandle = await ensureChangeWorkflowStarted(
-              env.client,
+              ownerFromEnv(env),
               makeChangeInput("legacy-copoll-change"),
             );
 
+            const legacyRawHandle = env.client.workflow.getHandle(
+              legacyHandle.workflowId,
+            );
+
             // Confirm routing: legacy is on the project queue, not session.
-            const legacyDesc = await legacyHandle.describe();
+            const legacyDesc = await legacyRawHandle.describe();
             expect(legacyDesc.taskQueue).toBe(projectQueue);
 
             // Bounded poller-readiness seam: prove the legacy workflow has
             // been started and is reachable on the project queue before the
             // first signal/query. This closes the "signal sent before the
             // first workflow task" race that can hang in time-skipping envs.
-            await waitForWorkflowReachable(
-              legacyHandle as WorkflowHandle<unknown>,
-            );
+            await waitForWorkflowReachable(legacyRawHandle);
 
             // AC3: signal the legacy workflow and prove it's processed.
             // The signal call resolves once the workflow's signal handler
@@ -167,7 +180,7 @@ describe("AC3: legacy queue co-polling (isolateAdvWorkerTaskQueues)", () => {
             // The query answering at all proves the project-queue worker is
             // actively polling (otherwise the workflow would be unreachable
             // with a "workflow execution not found" or query-timeout error).
-            await legacyHandle.signal(proposalUpdatedSignal, {
+            await legacyRawHandle.signal(proposalUpdatedSignal, {
               contentHash: "ac3-legacy-copoll-proof",
               source: "test",
               updatedAt: new Date().toISOString(),
@@ -177,7 +190,7 @@ describe("AC3: legacy queue co-polling (isolateAdvWorkerTaskQueues)", () => {
             // (a) the workflow on the project queue is reachable, and (b)
             // the worker polling that queue is processing both workflow
             // tasks AND queries. Both are required for legacy co-polling.
-            const stateAfter = await legacyHandle.query(changeStateQuery);
+            const stateAfter = await legacyRawHandle.query(changeStateQuery);
             expect(stateAfter).toBeDefined();
             expect((stateAfter as { status?: string }).status).toBe("draft");
           } finally {

--- a/plugin/src/temporal/__tests__/mock-owner.ts
+++ b/plugin/src/temporal/__tests__/mock-owner.ts
@@ -1,0 +1,567 @@
+import { vi } from "vitest";
+import { changeWorkflow, epicWorkflow } from "../workflows";
+import { classifyTemporalWorkflowFailure } from "../diagnostics";
+import type {
+  TemporalOperations,
+  TemporalOperationContext,
+  TemporalReadOutcome,
+  TemporalWorkflowHandle,
+  TemporalMutationServerOutcome,
+  WorkflowRunDescription,
+  WorkflowQueueMode,
+  TemporalListOutcome,
+  TemporalLifecycleContext,
+} from "../operations";
+import type { ChangeWorkflowInput, EpicWorkflowInput } from "../contracts";
+import {
+  ChangeCreationHashConflictError,
+  resolveCreationIdempotency,
+} from "../../storage/store-temporal/creation-hash";
+import { changeStateQuery } from "../messages";
+import { buildProjectTaskQueue, buildSessionTaskQueue } from "../client";
+import { hasActiveSessionPinnedWorkflows } from "../list-orphan-session-queues";
+import { IncompatibleActiveSessionQueuesError } from "../operations";
+import { buildTemporalSearchAttributes } from "../observability";
+
+/**
+ * Wrap a raw low-level RPC function into a TemporalOperations read outcome.
+ *
+ * Tests that simulate the service layer pass functions that return raw values
+ * (or throw NotFound-style errors). The owner API expects a
+ * `TemporalReadOutcome`, so we wrap them here.
+ */
+function wrapToReadOutcome<T>(
+  fn: (arg?: string) => Promise<T>,
+  extractArg?: (
+    ctx: TemporalOperationContext | TemporalLifecycleContext,
+  ) => string | undefined,
+): (
+  ctx: TemporalOperationContext | TemporalLifecycleContext,
+) => Promise<TemporalReadOutcome<T>> {
+  return async (ctx) => {
+    try {
+      const result = extractArg ? await fn(extractArg(ctx)) : await fn();
+      if (
+        result !== null &&
+        typeof result === "object" &&
+        "kind" in result &&
+        ["complete", "not_found", "degraded"].includes(
+          (result as { kind: string }).kind,
+        )
+      ) {
+        return result as unknown as TemporalReadOutcome<T>;
+      }
+      return { kind: "complete", value: result } as TemporalReadOutcome<T>;
+    } catch (error) {
+      const diagnostic = classifyTemporalWorkflowFailure(error);
+      if (diagnostic.class === "not_found") {
+        return {
+          kind: "not_found",
+          error,
+          diagnostic,
+        } as TemporalReadOutcome<T>;
+      }
+      return { kind: "degraded", error, diagnostic } as TemporalReadOutcome<T>;
+    }
+  };
+}
+
+/**
+ * Build a partial mock TemporalOperations owner for unit tests.
+ *
+ * Every method is a no-op `vi.fn()` that throws "not implemented" by default.
+ * Pass overrides for the methods the test cares about.
+ */
+export function createMockOwner(
+  overrides: Partial<TemporalOperations> = {},
+): TemporalOperations {
+  const notImplemented = (name: string) =>
+    vi.fn(() => {
+      throw new Error(`mock owner method ${name} not implemented`);
+    });
+
+  const describeNamespaceOverride = overrides.describeNamespace;
+  const describeWorkflowExecutionOverride = overrides.describeWorkflowExecution;
+
+  // Remove the raw overrides so we can replace them with wrapped versions.
+  const {
+    describeNamespace: _,
+    describeWorkflowExecution: __,
+    ...restOverrides
+  } = overrides;
+
+  return {
+    start: notImplemented("start"),
+    startChangeWorkflow: notImplemented("startChangeWorkflow"),
+    startEpicWorkflow: notImplemented("startEpicWorkflow"),
+    getHandle: notImplemented("getHandle"),
+    query: notImplemented("query"),
+    describe: notImplemented("describe"),
+    signal: notImplemented("signal"),
+    terminate: notImplemented("terminate"),
+    cancel: notImplemented("cancel"),
+    list: notImplemented("list"),
+    describeTaskQueue: notImplemented("describeTaskQueue"),
+    checkSearchAttributes: notImplemented("checkSearchAttributes"),
+    registerSearchAttributes: notImplemented("registerSearchAttributes"),
+    verifySearchAttributes: notImplemented("verifySearchAttributes"),
+    describeNamespace:
+      typeof describeNamespaceOverride === "function"
+        ? (vi.fn(
+            wrapToReadOutcome(
+              describeNamespaceOverride as unknown as (
+                arg?: string,
+              ) => Promise<unknown>,
+            ),
+          ) as TemporalOperations["describeNamespace"])
+        : "describeNamespace" in overrides
+          ? (undefined as unknown as TemporalOperations["describeNamespace"])
+          : notImplemented("describeNamespace"),
+    describeWorkflowExecution:
+      typeof describeWorkflowExecutionOverride === "function"
+        ? (vi.fn(
+            wrapToReadOutcome(
+              describeWorkflowExecutionOverride as unknown as (
+                arg?: string,
+              ) => Promise<unknown>,
+              (ctx) => ("workflowId" in ctx ? ctx.workflowId : undefined),
+            ),
+          ) as TemporalOperations["describeWorkflowExecution"])
+        : "describeWorkflowExecution" in overrides
+          ? (undefined as unknown as TemporalOperations["describeWorkflowExecution"])
+          : notImplemented("describeWorkflowExecution"),
+    ...restOverrides,
+  };
+}
+
+interface LegacyWorkflowClientMock {
+  list?: (opts: { query: string }) => AsyncIterable<unknown>;
+  start?: (
+    workflowType: string,
+    opts: {
+      workflowId: string;
+      taskQueue: string;
+      args: unknown[];
+      searchAttributes?: Record<string, unknown[]>;
+    },
+  ) => Promise<unknown>;
+  getHandle?: (workflowId: string, runId?: string) => unknown;
+}
+
+interface LegacyConnectionMock {
+  workflowService?: {
+    describeTaskQueue?: (req: {
+      namespace: string;
+      taskQueue: { name: string };
+      taskQueueType: number;
+    }) => Promise<unknown>;
+    describeNamespace?: (req: { namespace: string }) => Promise<unknown>;
+    describeWorkflowExecution?: (req: {
+      namespace: string;
+      execution: { workflowId: string };
+    }) => Promise<unknown>;
+  };
+}
+
+interface LegacyClientBundle {
+  client?: { workflow?: LegacyWorkflowClientMock };
+  workflow?: LegacyWorkflowClientMock;
+  connection?: LegacyConnectionMock;
+}
+
+interface RawWorkflowHandleShape {
+  query: <T>(d: unknown, ...a: unknown[]) => Promise<T>;
+  signal: (n: unknown, ...a: unknown[]) => Promise<void>;
+  describe: () => Promise<unknown>;
+  terminate: (r: string) => Promise<void>;
+  cancel: () => Promise<void>;
+}
+
+/**
+ * Wrap a legacy Temporal Client mock (the object exposed by `getService()`
+ * before the owner refactor) into a minimal TemporalOperations mock.
+ *
+ * This is a temporary bridge for tests that still have a `client` mock with
+ * `workflow.start`, `workflow.getHandle`, `workflow.list` etc. It maps the
+ * owner methods to the client/connection methods used by the old helpers.
+ */
+export function createMockOwnerFromClient(client: unknown): TemporalOperations {
+  // Accept both the direct `{ workflow: {...} }` shape and the legacy
+  // STSL bundle shape `{ client: { workflow: {...} }, connection: {...} }`.
+  const bundle = client as LegacyClientBundle;
+  const c = bundle.client?.workflow ?? bundle.workflow ?? {};
+  const connection =
+    bundle.connection ?? (bundle as LegacyClientBundle).connection;
+
+  const wrapLocalHandle = (
+    workflowId: string,
+    raw: unknown,
+  ): TemporalWorkflowHandle =>
+    Object.assign({}, raw as Record<string, unknown>, {
+      workflowId,
+    }) as unknown as TemporalWorkflowHandle;
+
+  const asRawHandle = (
+    handle: TemporalWorkflowHandle,
+  ): RawWorkflowHandleShape => handle as unknown as RawWorkflowHandleShape;
+
+  const overrides: Partial<TemporalOperations> = {
+    getHandle: vi.fn((ctx: TemporalOperationContext, runId?: string) => {
+      if (!c.getHandle) {
+        throw new Error("WorkflowHandle.getHandle unavailable");
+      }
+      const raw = c.getHandle(ctx.workflowId, runId);
+      return wrapLocalHandle(ctx.workflowId, raw);
+    }),
+    start: vi.fn(
+      async (
+        ctx: TemporalOperationContext,
+        workflowType: string,
+        options: {
+          workflowId: string;
+          taskQueue: string;
+          args: unknown[];
+          searchAttributes?: unknown;
+        },
+      ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>> => {
+        if (!c.start) {
+          return {
+            kind: "confirmed_failure",
+            error: new Error("WorkflowClient.start unavailable"),
+            diagnostic: { reachable: true, class: "reachable" },
+          };
+        }
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const handle = await c.start(workflowType as any, {
+            workflowId: options.workflowId,
+            taskQueue: options.taskQueue,
+            args: options.args,
+            ...(options.searchAttributes
+              ? { searchAttributes: options.searchAttributes as any }
+              : {}),
+          });
+          return {
+            kind: "confirmed",
+            value: wrapLocalHandle(options.workflowId, handle),
+          };
+        } catch (error) {
+          return {
+            kind: "confirmed_failure",
+            error,
+            diagnostic: classifyTemporalWorkflowFailure(error),
+          };
+        }
+      },
+    ),
+    startChangeWorkflow: vi.fn(
+      async (
+        ctx: TemporalOperationContext,
+        input: ChangeWorkflowInput,
+        options?: {
+          workflowQueueMode?: WorkflowQueueMode;
+          sessionId?: string | null;
+        },
+      ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>> => {
+        if (!c.start) {
+          return {
+            kind: "confirmed_failure",
+            error: new Error("WorkflowClient.start unavailable"),
+            diagnostic: { reachable: true, class: "reachable" },
+          };
+        }
+        const sessionId = options?.sessionId ?? input.sessionId;
+        const taskQueue =
+          options?.workflowQueueMode === "project" || !sessionId
+            ? buildProjectTaskQueue(ctx.projectId)
+            : buildSessionTaskQueue(ctx.projectId, sessionId);
+        if (options?.workflowQueueMode === "project") {
+          const owner = createMockOwner(overrides);
+          const hasSessionPinned = await hasActiveSessionPinnedWorkflows(
+            owner,
+            ctx.projectId,
+          );
+          if (hasSessionPinned.kind === "complete" && hasSessionPinned.value) {
+            return {
+              kind: "confirmed_failure",
+              error: new IncompatibleActiveSessionQueuesError(
+                `Project-queue singleton mode is incompatible with active session-pinned workflows for project ${ctx.projectId}.`,
+              ),
+              diagnostic: { reachable: true, class: "reachable" },
+            };
+          }
+        }
+        try {
+          const seed = (input.seedState ?? {}) as {
+            origin?: { issue_number?: number };
+            epic_membership?: { epic_id?: string };
+          };
+          const searchAttributes =
+            input.searchAttributesEnabled !== false
+              ? buildTemporalSearchAttributes({
+                  projectId: input.projectId,
+                  changeId: input.changeId,
+                  changeStatus: "draft",
+                  activeGate: "proposal",
+                  backlogIssueNumber: seed.origin?.issue_number,
+                  epicId: seed.epic_membership?.epic_id,
+                })
+              : undefined;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const handle = await c.start(changeWorkflow as any, {
+            workflowId: ctx.workflowId,
+            taskQueue,
+            args: [input],
+            ...(searchAttributes ? { searchAttributes } : {}),
+          });
+          return {
+            kind: "confirmed",
+            value: wrapLocalHandle(ctx.workflowId, handle),
+          };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error ?? "");
+          const alreadyStarted =
+            /already started|already exists|Workflow execution already started/i.test(
+              message,
+            );
+          if (!alreadyStarted) {
+            return {
+              kind: "confirmed_failure",
+              error,
+              diagnostic: classifyTemporalWorkflowFailure(error),
+            };
+          }
+          if (!c.getHandle) {
+            return {
+              kind: "confirmed_failure",
+              error: new Error("WorkflowHandle.getHandle unavailable", {
+                cause: error,
+              }),
+              diagnostic: classifyTemporalWorkflowFailure(error),
+            };
+          }
+          const rawHandle = c.getHandle(ctx.workflowId);
+          const handle = wrapLocalHandle(ctx.workflowId, rawHandle);
+          if (input.creationRequestHash) {
+            const state = await asRawHandle(handle).query(changeStateQuery);
+            const existingHash =
+              (state as { creation_request_hash?: string } | null)
+                ?.creation_request_hash ?? "";
+            const decision = resolveCreationIdempotency({
+              existingHash,
+              computedHash: input.creationRequestHash,
+            });
+            if (decision.kind === "hash_conflict") {
+              return {
+                kind: "confirmed_failure",
+                error: new ChangeCreationHashConflictError({
+                  changeId: input.changeId,
+                  existingHash: decision.existing_hash,
+                  computedHash: decision.computed_hash,
+                }),
+                diagnostic: { reachable: true, class: "reachable" },
+              };
+            }
+          }
+          return { kind: "confirmed", value: handle };
+        }
+      },
+    ),
+    startEpicWorkflow: vi.fn(
+      async (
+        ctx: TemporalOperationContext,
+        input: EpicWorkflowInput,
+      ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>> => {
+        if (!c.start) {
+          return {
+            kind: "confirmed_failure",
+            error: new Error("WorkflowClient.start unavailable"),
+            diagnostic: { reachable: true, class: "reachable" },
+          };
+        }
+        const taskQueue = buildProjectTaskQueue(ctx.projectId);
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const handle = await c.start(epicWorkflow as any, {
+            workflowId: ctx.workflowId,
+            taskQueue,
+            args: [input],
+          });
+          return {
+            kind: "confirmed",
+            value: wrapLocalHandle(ctx.workflowId, handle),
+          };
+        } catch (error) {
+          return {
+            kind: "confirmed_failure",
+            error,
+            diagnostic: classifyTemporalWorkflowFailure(error),
+          };
+        }
+      },
+    ),
+    query: vi.fn(
+      async (
+        _ctx: TemporalOperationContext,
+        handle: TemporalWorkflowHandle,
+        def: unknown,
+        ...args: unknown[]
+      ): Promise<TemporalReadOutcome<unknown>> => {
+        return {
+          kind: "complete",
+          value: await asRawHandle(handle).query(def, ...args),
+        };
+      },
+    ) as unknown as TemporalOperations["query"],
+    signal: vi.fn(
+      async (
+        _ctx: TemporalOperationContext,
+        handle: TemporalWorkflowHandle,
+        def: unknown,
+        args: unknown[],
+      ): Promise<TemporalMutationServerOutcome<unknown>> => {
+        try {
+          await asRawHandle(handle).signal(def, ...args);
+          return { kind: "confirmed", value: undefined };
+        } catch (error) {
+          const diagnostic = classifyTemporalWorkflowFailure(error);
+          if (
+            diagnostic.class === "deadline" ||
+            diagnostic.class === "resource_exhaustion"
+          ) {
+            return { kind: "timeout_unavailable", error, diagnostic };
+          }
+          return { kind: "confirmed_failure", error, diagnostic };
+        }
+      },
+    ) as unknown as TemporalOperations["signal"],
+    describe: vi.fn(
+      async (
+        _ctx: TemporalOperationContext,
+        handle: TemporalWorkflowHandle,
+      ): Promise<TemporalReadOutcome<WorkflowRunDescription>> => {
+        return {
+          kind: "complete",
+          value: (await asRawHandle(
+            handle,
+          ).describe()) as WorkflowRunDescription,
+        };
+      },
+    ),
+    terminate: vi.fn(
+      async (
+        _ctx: TemporalOperationContext,
+        handle: TemporalWorkflowHandle,
+        reason: string,
+      ): Promise<TemporalMutationServerOutcome<void>> => {
+        try {
+          await asRawHandle(handle).terminate(reason);
+          return { kind: "confirmed", value: undefined };
+        } catch (error) {
+          const diagnostic = classifyTemporalWorkflowFailure(error);
+          if (
+            diagnostic.class === "deadline" ||
+            diagnostic.class === "resource_exhaustion"
+          ) {
+            return { kind: "timeout_unavailable", error, diagnostic };
+          }
+          return { kind: "confirmed_failure", error, diagnostic };
+        }
+      },
+    ),
+    cancel: vi.fn(
+      async (
+        _ctx: TemporalOperationContext,
+        handle: TemporalWorkflowHandle,
+      ): Promise<TemporalMutationServerOutcome<void>> => {
+        try {
+          await asRawHandle(handle).cancel();
+          return { kind: "confirmed", value: undefined };
+        } catch (error) {
+          const diagnostic = classifyTemporalWorkflowFailure(error);
+          if (
+            diagnostic.class === "deadline" ||
+            diagnostic.class === "resource_exhaustion"
+          ) {
+            return { kind: "timeout_unavailable", error, diagnostic };
+          }
+          return { kind: "confirmed_failure", error, diagnostic };
+        }
+      },
+    ),
+    list: vi.fn(
+      async <T extends { workflowId: string }>(
+        _ctx: TemporalOperationContext,
+        query: string,
+        options?: { limit?: number; nextPageToken?: string },
+      ): Promise<TemporalListOutcome<T[]>> => {
+        const list = c.list;
+        if (!list) {
+          return { kind: "complete", value: [], truncated: false };
+        }
+        const limit = options?.limit ?? 1000;
+        const items: T[] = [];
+        for await (const item of list({ query })) {
+          items.push(item as T);
+          if (items.length >= limit) {
+            return { kind: "complete", value: items, truncated: true };
+          }
+        }
+        return { kind: "complete", value: items, truncated: false };
+      },
+    ) as unknown as TemporalOperations["list"],
+    describeTaskQueue: vi.fn(
+      async (
+        _ctx: TemporalOperationContext,
+        taskQueue: string,
+      ): Promise<TemporalReadOutcome<unknown>> => {
+        const describeTaskQueue =
+          connection?.workflowService?.describeTaskQueue;
+        if (!describeTaskQueue) {
+          throw new Error("WorkflowService.describeTaskQueue unavailable");
+        }
+        const value = await describeTaskQueue({
+          namespace: "default",
+          taskQueue: { name: taskQueue },
+          taskQueueType: 1,
+        });
+        return { kind: "complete", value } as TemporalReadOutcome<unknown>;
+      },
+    ),
+    describeNamespace: vi.fn(
+      async (
+        _ctx: TemporalLifecycleContext,
+      ): Promise<TemporalReadOutcome<unknown>> => {
+        const describeNamespace =
+          connection?.workflowService?.describeNamespace;
+        if (!describeNamespace) {
+          throw new Error("WorkflowService.describeNamespace unavailable");
+        }
+        const value = await describeNamespace({ namespace: "default" });
+        return { kind: "complete", value } as TemporalReadOutcome<unknown>;
+      },
+    ),
+    describeWorkflowExecution: vi.fn(
+      async (
+        ctx: TemporalOperationContext,
+      ): Promise<TemporalReadOutcome<unknown>> => {
+        const describeWorkflowExecution =
+          connection?.workflowService?.describeWorkflowExecution;
+        if (!describeWorkflowExecution) {
+          throw new Error(
+            "WorkflowService.describeWorkflowExecution unavailable",
+          );
+        }
+        const value = await describeWorkflowExecution({
+          namespace: "default",
+          execution: { workflowId: ctx.workflowId },
+        });
+        return { kind: "complete", value } as TemporalReadOutcome<unknown>;
+      },
+    ),
+  };
+
+  const owner = createMockOwner(overrides);
+  return owner;
+}

--- a/plugin/src/temporal/__tests__/orphan-session-adoption.itest.ts
+++ b/plugin/src/temporal/__tests__/orphan-session-adoption.itest.ts
@@ -35,8 +35,9 @@ import type { OrphanListClient } from "../list-orphan-session-queues";
 import { OrphanQueueAdopter } from "../orphan-queue-adopter";
 import { attachWorkerWithAdoption } from "../../plugin-init";
 import { withTimeSkippingTestWorkflowEnvironment } from "./with-test-env";
+import { createMockOwnerFromClient } from "./mock-owner";
 
-const PROJECT_ID = "orphan-adopt-001";
+const PROJECT_ID = "0000000000000000000000000000000000000000";
 const SESSION_ID = "sess_AdoptE2E1";
 const CHANGE_ID = "orphan-adopt-change-1";
 
@@ -110,7 +111,7 @@ describe("rq-isolSessionTaskQueue05: orphan session queue adoption (real worker 
         await new Promise((resolve) => setTimeout(resolve, POLLER_SETTLE_MS));
       });
       const adopter = new OrphanQueueAdopter({
-        client: stubClient,
+        owner: createMockOwnerFromClient(stubClient),
         projectId: PROJECT_ID,
         worker: {
           registerQueue,
@@ -224,7 +225,7 @@ describe("rq-isolSessionTaskQueue05: orphan session queue adoption (real worker 
         // 4. Attach via the restart-path seam.
         const { stopDriver } = attachWorkerWithAdoption(worker, {
           projectId: PROJECT_ID,
-          client: stubClient as unknown as import("@temporalio/client").Client,
+          owner: createMockOwnerFromClient(stubClient),
         });
 
         // 5. Wait for the 10s driver tick to fire and adoption to complete.

--- a/plugin/src/temporal/__tests__/session-routing.itest.ts
+++ b/plugin/src/temporal/__tests__/session-routing.itest.ts
@@ -27,10 +27,22 @@ import { createDefaultGates } from "../../types";
 import type { ChangeWorkflowInput, EpicWorkflowInput } from "../contracts";
 import { buildProjectTaskQueue, buildSessionTaskQueue } from "../client";
 import { requiredAdvSearchAttributes } from "../observability";
+import { TemporalOperationsOwner } from "../operations";
 import type { TestWorkflowEnvironment } from "@temporalio/testing";
 
-const PROJECT_ID = "proj-session-route-001";
+const PROJECT_ID = "b".repeat(40);
 const SESSION_ID = "sess_RouteItest1";
+
+function ownerFromEnv(env: TestWorkflowEnvironment): TemporalOperationsOwner {
+  return new TemporalOperationsOwner(
+    {
+      client: env.client,
+      connection: env.connection,
+      namespace: env.namespace ?? "default",
+    },
+    PROJECT_ID,
+  );
+}
 
 async function registerAdvSearchAttributes(
   env: TestWorkflowEnvironment,
@@ -98,12 +110,14 @@ describe("AC1 + AC5: workflow task-queue routing (isolateAdvWorkerTaskQueues)", 
 
       await worker.runUntil(async () => {
         const handle = await ensureChangeWorkflowStarted(
-          env.client,
+          ownerFromEnv(env),
           makeChangeInput("routing-ac1-change", SESSION_ID),
         );
 
         // AC1 verification: the workflow's task queue is the session queue.
-        const description = await handle.describe();
+        const description = await env.client.workflow
+          .getHandle(handle.workflowId)
+          .describe();
         expect(description.taskQueue).toBe(sessionQueue);
         expect(description.taskQueue).toBe(
           `advance-${PROJECT_ID}-${SESSION_ID}`,
@@ -125,12 +139,14 @@ describe("AC1 + AC5: workflow task-queue routing (isolateAdvWorkerTaskQueues)", 
 
       await worker.runUntil(async () => {
         const handle = await ensureChangeWorkflowStarted(
-          env.client,
+          ownerFromEnv(env),
           // sessionId intentionally omitted — legacy / pre-init / tests
           makeChangeInput("routing-legacy-change"),
         );
 
-        const description = await handle.describe();
+        const description = await env.client.workflow
+          .getHandle(handle.workflowId)
+          .describe();
         expect(description.taskQueue).toBe(projectQueue);
         expect(description.taskQueue).toBe(`advance-${PROJECT_ID}`);
       });
@@ -150,13 +166,15 @@ describe("AC1 + AC5: workflow task-queue routing (isolateAdvWorkerTaskQueues)", 
 
       await worker.runUntil(async () => {
         const handle = await ensureEpicWorkflowStarted(
-          env.client,
+          ownerFromEnv(env),
           makeEpicInput("routing-ac5-epic"),
         );
 
         // AC5 verification: epic workflow is on the permanent project queue,
         // NOT on a session-scoped queue. Epic lifecycle spans sessions (UD2).
-        const description = await handle.describe();
+        const description = await env.client.workflow
+          .getHandle(handle.workflowId)
+          .describe();
         expect(description.taskQueue).toBe(projectQueue);
         expect(description.taskQueue).toBe(`advance-${PROJECT_ID}`);
         expect(description.taskQueue).not.toContain(SESSION_ID);

--- a/plugin/src/temporal/__tests__/wedge-isolation.itest.ts
+++ b/plugin/src/temporal/__tests__/wedge-isolation.itest.ts
@@ -27,12 +27,24 @@ import type { ChangeWorkflowInput } from "../contracts";
 import { buildSessionTaskQueue } from "../client";
 import { changeStateQuery, proposalUpdatedSignal } from "../messages";
 import { requiredAdvSearchAttributes } from "../observability";
+import { TemporalOperationsOwner } from "../operations";
 import type { TestWorkflowEnvironment } from "@temporalio/testing";
 
-const PROJECT_ID = "proj-wedge-isolation-001";
+const PROJECT_ID = "a".repeat(40);
 const SESSION_S2 = "sess_WedgeS2Active";
 // SESSION_S1 has NO worker in this test — simulates wedge / not-yet-spawned.
 const SESSION_S1_ABSENT = "sess_WedgeS1Absent";
+
+function ownerFromEnv(env: TestWorkflowEnvironment): TemporalOperationsOwner {
+  return new TemporalOperationsOwner(
+    {
+      client: env.client,
+      connection: env.connection,
+      namespace: env.namespace ?? "default",
+    },
+    PROJECT_ID,
+  );
+}
 
 async function registerAdvSearchAttributes(
   env: TestWorkflowEnvironment,
@@ -92,15 +104,17 @@ describe("AC2: peer-session wedge isolation (isolateAdvWorkerTaskQueues)", () =>
       await s2Worker.runUntil(async () => {
         // S2 workflow — should be processed by S2's worker.
         const s2Handle = await ensureChangeWorkflowStarted(
-          env.client,
+          ownerFromEnv(env),
           makeChangeInput("wedge-s2-active", SESSION_S2),
         );
 
-        const s2Desc = await s2Handle.describe();
+        const s2RawHandle = env.client.workflow.getHandle(s2Handle.workflowId);
+
+        const s2Desc = await s2RawHandle.describe();
         expect(s2Desc.taskQueue).toBe(s2Queue);
 
         // Send a signal to S2's workflow.
-        await s2Handle.signal(proposalUpdatedSignal, {
+        await s2RawHandle.signal(proposalUpdatedSignal, {
           contentHash: "ac2-s2-isolation-proof",
           source: "test",
           updatedAt: new Date().toISOString(),
@@ -110,7 +124,7 @@ describe("AC2: peer-session wedge isolation (isolateAdvWorkerTaskQueues)", () =>
         // workflow on S2's queue. Under the legacy shared-queue model, the
         // absence of S1's worker would block S2's workflow too. Under
         // per-session routing, S2's worker polls S2's queue independently.
-        const s2State = await s2Handle.query(changeStateQuery);
+        const s2State = await s2RawHandle.query(changeStateQuery);
         expect(s2State).toBeDefined();
         expect((s2State as { status?: string }).status).toBe("draft");
 

--- a/plugin/src/temporal/__tests__/workflow-termination.itest.ts
+++ b/plugin/src/temporal/__tests__/workflow-termination.itest.ts
@@ -63,7 +63,7 @@ async function waitForCompleted(
 
 function makeChangeInput(changeId: string): ChangeWorkflowInput {
   return {
-    projectId: "proj-term-001",
+    projectId: "00000e0000100000000000000000000000000000",
     changeId,
     title: `Termination test: ${changeId}`,
     initializedAt: new Date().toISOString(),

--- a/plugin/src/temporal/__tests__/workflows.release-notes.itest.ts
+++ b/plugin/src/temporal/__tests__/workflows.release-notes.itest.ts
@@ -19,7 +19,7 @@ import type { ReleaseNotesSetSignalPayload } from "../../types";
 
 function makeChangeInput(changeId: string): ChangeWorkflowInput {
   return {
-    projectId: "proj-release-notes-001",
+    projectId: "00000e0ea0e000e0001000000000000000000000",
     changeId,
     title: `Release notes test: ${changeId}`,
     initializedAt: new Date().toISOString(),

--- a/plugin/src/temporal/activities.disk-projection.test.ts
+++ b/plugin/src/temporal/activities.disk-projection.test.ts
@@ -10,7 +10,7 @@ import { LauncherProjectionSchema } from "../storage/launcher-projection";
 
 function makeState(changeId = "projection-change"): ChangeWorkflowState {
   return {
-    projectId: "projection-project",
+    projectId: "0000ec00000000ec000000000000000000000000",
     changeId,
     id: changeId,
     title: "Projection test",

--- a/plugin/src/temporal/archive-activity.test.ts
+++ b/plugin/src/temporal/archive-activity.test.ts
@@ -16,7 +16,7 @@ const exec = promisify(execFile);
 
 function makeState(changeId = "archive-change"): ChangeWorkflowState {
   return {
-    projectId: "archive-project",
+    projectId: "a0c000e0000ec000000000000000000000000000",
     changeId,
     id: changeId,
     title: "Archive durable trinity",

--- a/plugin/src/temporal/change-state.batch-close.test.ts
+++ b/plugin/src/temporal/change-state.batch-close.test.ts
@@ -31,7 +31,7 @@ function baseState(changeId = "chg-batch-1") {
     title: "Batch close test",
     createdAt: at,
   });
-  state.projectId = "proj-1";
+  state.projectId = "0000100000000000000000000000000000000000";
   return state;
 }
 

--- a/plugin/src/temporal/change-state.close-reducer.test.ts
+++ b/plugin/src/temporal/change-state.close-reducer.test.ts
@@ -26,7 +26,7 @@ function baseState() {
     title: "T",
     createdAt: at,
   });
-  state.projectId = "proj-1";
+  state.projectId = "0000100000000000000000000000000000000000";
   return state;
 }
 

--- a/plugin/src/temporal/change-state.coordination-claim.test.ts
+++ b/plugin/src/temporal/change-state.coordination-claim.test.ts
@@ -27,7 +27,7 @@ function baseState() {
     title: "Coordination claim change",
     createdAt: at,
   });
-  state.projectId = "proj-1";
+  state.projectId = "0000100000000000000000000000000000000000";
   state.lifecycleState = "open";
   state.state_revision = 5;
   return state;

--- a/plugin/src/temporal/change-state.operation-ledger.test.ts
+++ b/plugin/src/temporal/change-state.operation-ledger.test.ts
@@ -31,7 +31,7 @@ function baseState() {
     title: "T",
     createdAt: at,
   });
-  state.projectId = "proj-1";
+  state.projectId = "0000100000000000000000000000000000000000";
   return state;
 }
 

--- a/plugin/src/temporal/change-state.release-notes.test.ts
+++ b/plugin/src/temporal/change-state.release-notes.test.ts
@@ -25,7 +25,7 @@ function baseState() {
     title: "Release notes change",
     createdAt: at,
   });
-  state.projectId = "proj-1";
+  state.projectId = "0000100000000000000000000000000000000000";
   state.state_revision = 5;
   return state;
 }

--- a/plugin/src/temporal/client.ts
+++ b/plugin/src/temporal/client.ts
@@ -1,4 +1,3 @@
-import { Client, Connection } from "@temporalio/client";
 import {
   ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX,
   CHANGE_WORKFLOW_PREFIX,
@@ -22,9 +21,6 @@ function allowRemoteTemporal(env: NodeJS.ProcessEnv): boolean {
 }
 
 const SAFE_NAMESPACE_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
-
-type TemporalEnv = NodeJS.ProcessEnv &
-  Partial<Record<"ADV_TEMPORAL_ADDRESS" | "ADV_TEMPORAL_NAMESPACE", string>>;
 
 export function getTemporalAddress(
   env: NodeJS.ProcessEnv = process.env,
@@ -72,26 +68,4 @@ export function buildChangeWorkflowId(
 
 export function buildEpicWorkflowId(projectId: string, epicId: string): string {
   return `${EPIC_WORKFLOW_PREFIX}${projectId}/${epicId}`;
-}
-
-export interface TemporalClientBundle {
-  address: string;
-  namespace: string;
-  connection: Connection;
-  client: Client;
-}
-
-export async function createTemporalClientBundle(
-  env: TemporalEnv = process.env,
-): Promise<TemporalClientBundle> {
-  const address = getTemporalAddress(env);
-  const namespace = getTemporalNamespace(env);
-  const connection = await Connection.connect({ address });
-
-  return {
-    address,
-    namespace,
-    connection,
-    client: new Client({ connection, namespace }),
-  };
 }

--- a/plugin/src/temporal/contracts.test.ts
+++ b/plugin/src/temporal/contracts.test.ts
@@ -122,7 +122,7 @@ describe("continue-as-new seed durability", () => {
       createdAt: "2026-07-25T00:00:00.000Z",
     });
 
-    state.projectId = "proj-durability";
+    state.projectId = "0000d00ab0000000000000000000000000000000";
     state.initializedAt = "2026-07-25T00:00:00.000Z";
     state.title = "Durability test";
     state.worker_bundle_impact = {
@@ -167,7 +167,7 @@ describe("continue-as-new seed durability", () => {
   }
 
   const input: ChangeWorkflowInput = {
-    projectId: "proj-durability",
+    projectId: "0000d00ab0000000000000000000000000000000",
     changeId: "c-durability",
     title: "Durability test",
     initializedAt: "2026-07-25T00:00:00.000Z",
@@ -345,7 +345,7 @@ describe("continue-as-new seed durability", () => {
 
     const seed = changeSeedStateFromChange(change);
     const reseededInput: ChangeWorkflowInput = {
-      projectId: "proj-durability",
+      projectId: "0000d00ab0000000000000000000000000000000",
       changeId: "c-durability",
       title: "Durability test",
       initializedAt: "2026-07-25T00:00:00.000Z",

--- a/plugin/src/temporal/gate-readiness.acceptance-criteria.test.ts
+++ b/plugin/src/temporal/gate-readiness.acceptance-criteria.test.ts
@@ -16,7 +16,7 @@ function makeState(
   overrides: Partial<ChangeWorkflowState> = {},
 ): ChangeWorkflowState {
   return {
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     changeId: "change-1",
     title: "Test change",
     initializedAt: "2026-05-20T00:00:00.000Z",

--- a/plugin/src/temporal/gate-readiness.test.ts
+++ b/plugin/src/temporal/gate-readiness.test.ts
@@ -21,7 +21,7 @@ function makeState(
   overrides: Partial<ChangeWorkflowState> = {},
 ): ChangeWorkflowState {
   return {
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     changeId: "change-1",
     title: "Test change",
     initializedAt: "2026-05-20T00:00:00.000Z",

--- a/plugin/src/temporal/health-monitor.test.ts
+++ b/plugin/src/temporal/health-monitor.test.ts
@@ -3,6 +3,7 @@ import {
   composeWorkerHealthProbe,
   createHealthMonitor,
 } from "./health-monitor";
+import { createMockOwner } from "./__tests__/mock-owner";
 
 // P1.6 — Health-probed worker restart.
 //
@@ -258,21 +259,24 @@ describe("createHealthMonitor (P1.6)", () => {
 // the monitor's outer probeTimeoutMs and routed through the existing
 // restart budget.
 describe("composeWorkerHealthProbe (P1.10 zombie detection)", () => {
-  function makeBundle(svc: unknown) {
-    return {
-      namespace: "default",
-      connection: { workflowService: svc },
-    };
+  function makeOwner(svc: {
+    describeNamespace?: () => Promise<unknown>;
+    describeWorkflowExecution?: (workflowId: string) => Promise<unknown>;
+  }) {
+    return createMockOwner({
+      describeNamespace: svc.describeNamespace,
+      describeWorkflowExecution: svc.describeWorkflowExecution,
+    });
   }
 
-  it("returns false when bundle is null (STSL not initialized)", async () => {
-    const probe = composeWorkerHealthProbe({ getBundle: () => null });
+  it("returns false when owner is null (STSL not initialized)", async () => {
+    const probe = composeWorkerHealthProbe({ getOwner: () => null });
     expect(await probe()).toBe(false);
   });
 
   it("returns false when workflowService methods are missing", async () => {
     const probe = composeWorkerHealthProbe({
-      getBundle: () => makeBundle({ describeNamespace: undefined }),
+      getOwner: () => makeOwner({ describeNamespace: undefined }),
     });
     expect(await probe()).toBe(false);
   });
@@ -286,8 +290,8 @@ describe("composeWorkerHealthProbe (P1.10 zombie detection)", () => {
       throw err;
     });
     const probe = composeWorkerHealthProbe({
-      getBundle: () =>
-        makeBundle({ describeNamespace, describeWorkflowExecution }),
+      getOwner: () =>
+        makeOwner({ describeNamespace, describeWorkflowExecution }),
     });
     expect(await probe()).toBe(true);
     expect(describeNamespace).toHaveBeenCalledTimes(1);
@@ -296,8 +300,8 @@ describe("composeWorkerHealthProbe (P1.10 zombie detection)", () => {
 
   it("returns true when sentinel actually exists (still healthy)", async () => {
     const probe = composeWorkerHealthProbe({
-      getBundle: () =>
-        makeBundle({
+      getOwner: () =>
+        makeOwner({
           describeNamespace: vi.fn(async () => ({})),
           describeWorkflowExecution: vi.fn(async () => ({
             workflowExecutionInfo: { execution: { workflowId: "sentinel" } },
@@ -309,8 +313,8 @@ describe("composeWorkerHealthProbe (P1.10 zombie detection)", () => {
 
   it("propagates non-NotFound errors from sentinel describe (caught by monitor)", async () => {
     const probe = composeWorkerHealthProbe({
-      getBundle: () =>
-        makeBundle({
+      getOwner: () =>
+        makeOwner({
           describeNamespace: vi.fn(async () => ({})),
           describeWorkflowExecution: vi.fn(async () => {
             throw new Error("Unavailable: server overloaded");
@@ -323,8 +327,8 @@ describe("composeWorkerHealthProbe (P1.10 zombie detection)", () => {
   it("propagates describeNamespace failures (leg 1 short-circuits)", async () => {
     const describeWorkflowExecution = vi.fn(async () => ({}));
     const probe = composeWorkerHealthProbe({
-      getBundle: () =>
-        makeBundle({
+      getOwner: () =>
+        makeOwner({
           describeNamespace: vi.fn(async () => {
             throw new Error("ECONNREFUSED");
           }),
@@ -340,17 +344,16 @@ describe("composeWorkerHealthProbe (P1.10 zombie detection)", () => {
       throw new Error("NotFound");
     });
     const probe = composeWorkerHealthProbe({
-      getBundle: () =>
-        makeBundle({
+      getOwner: () =>
+        makeOwner({
           describeNamespace: vi.fn(async () => ({})),
           describeWorkflowExecution,
         }),
     });
     await probe();
-    expect(describeWorkflowExecution).toHaveBeenCalledWith({
-      namespace: "default",
-      execution: { workflowId: "adv-healthcheck-sentinel" },
-    });
+    expect(describeWorkflowExecution).toHaveBeenCalledWith(
+      "adv-healthcheck-sentinel",
+    );
   });
 
   it("respects custom sentinelWorkflowId override", async () => {
@@ -358,26 +361,25 @@ describe("composeWorkerHealthProbe (P1.10 zombie detection)", () => {
       throw new Error("NotFound");
     });
     const probe = composeWorkerHealthProbe({
-      getBundle: () =>
-        makeBundle({
+      getOwner: () =>
+        makeOwner({
           describeNamespace: vi.fn(async () => ({})),
           describeWorkflowExecution,
         }),
       sentinelWorkflowId: "custom-sentinel-id",
     });
     await probe();
-    expect(describeWorkflowExecution).toHaveBeenCalledWith({
-      namespace: "default",
-      execution: { workflowId: "custom-sentinel-id" },
-    });
+    expect(describeWorkflowExecution).toHaveBeenCalledWith(
+      "custom-sentinel-id",
+    );
   });
 
   it("hanging sentinel describe is caught by the monitor's probeTimeoutMs (zombie scenario)", async () => {
     vi.useFakeTimers();
     try {
       const probe = composeWorkerHealthProbe({
-        getBundle: () =>
-          makeBundle({
+        getOwner: () =>
+          makeOwner({
             describeNamespace: vi.fn(async () => ({})),
             describeWorkflowExecution: vi.fn(
               () => new Promise<unknown>(() => {}), // hangs forever

--- a/plugin/src/temporal/health-monitor.ts
+++ b/plugin/src/temporal/health-monitor.ts
@@ -26,8 +26,16 @@
  */
 
 import { createLogger } from "../utils/debug-log";
+import { TemporalReadOutcomeError } from "./outcome-errors";
+import {
+  makeTemporalLifecycleContext,
+  makeTemporalOperationContext,
+  type TemporalOperations,
+} from "./operations";
 
 const logger = createLogger("health-monitor");
+
+const HEALTH_PROBE_PROJECT_ID = "0000000000000000000000000000000000000000";
 
 const DEFAULT_INTERVAL_MS = 30_000;
 const DEFAULT_PROBE_TIMEOUT_MS = 3_000;
@@ -98,61 +106,58 @@ export interface HealthMonitor {
  * the underlying RPC error (caller catches via `probeWithTimeout`).
  */
 export function composeWorkerHealthProbe(input: {
-  getBundle: () => {
-    namespace: string;
-    connection: unknown;
-  } | null;
+  getOwner: () => TemporalOperations | null;
   /** Sentinel workflow ID for the round-trip leg. Default: `adv-healthcheck-sentinel`. */
   sentinelWorkflowId?: string;
 }): () => Promise<boolean> {
   const sentinelId = input.sentinelWorkflowId ?? "adv-healthcheck-sentinel";
   return async () => {
-    const bundle = input.getBundle();
-    if (!bundle) return false;
-    const svc = (
-      bundle.connection as unknown as {
-        workflowService?: {
-          describeNamespace?: (req: { namespace: string }) => Promise<unknown>;
-          describeWorkflowExecution?: (req: {
-            namespace: string;
-            execution: { workflowId: string };
-          }) => Promise<unknown>;
-        };
-      }
-    ).workflowService;
+    const owner = input.getOwner();
+    if (!owner) return false;
     if (
-      !svc ||
-      typeof svc.describeNamespace !== "function" ||
-      typeof svc.describeWorkflowExecution !== "function"
+      typeof owner.describeNamespace !== "function" ||
+      typeof owner.describeWorkflowExecution !== "function"
     ) {
       return false;
     }
 
     // Leg 1: connection liveness
-    await svc.describeNamespace({ namespace: bundle.namespace });
+    const nsOutcome = await owner.describeNamespace(
+      makeTemporalLifecycleContext(
+        HEALTH_PROBE_PROJECT_ID,
+        "healthProbe.describeNamespace",
+        5_000,
+      ),
+    );
+    if (nsOutcome.kind !== "complete") {
+      throw nsOutcome.error;
+    }
 
     // Leg 2: server↔worker round-trip via sentinel describe.
-    // A `NotFound` rejection is the healthy outcome — server processed
-    // the request promptly. We catch and treat as success.
-    try {
-      await svc.describeWorkflowExecution({
-        namespace: bundle.namespace,
-        execution: { workflowId: sentinelId },
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (
-        /NotFound|not[\s_]?found|NOT_FOUND|WorkflowExecutionNotFound/i.test(msg)
-      ) {
-        // Expected — server processed our request, sentinel just doesn't exist.
-        return true;
-      }
-      // Other errors (Unavailable, ResourceExhausted, etc.) propagate
-      // so the monitor can route through restart.
-      throw err;
+    // A `NotFound` outcome is the healthy outcome — server processed
+    // the request promptly. We treat it as success.
+    const sentinelCtx = makeTemporalOperationContext(
+      HEALTH_PROBE_PROJECT_ID,
+      sentinelId,
+      "describe",
+      "healthProbe.describeWorkflowExecution",
+      5_000,
+    );
+    const outcome = await owner.describeWorkflowExecution(sentinelCtx);
+    if (outcome.kind === "complete") return true;
+    const msg =
+      outcome.error instanceof Error
+        ? outcome.error.message
+        : String(outcome.error);
+    if (
+      /NotFound|not[\s_]?found|NOT_FOUND|WorkflowExecutionNotFound/i.test(msg)
+    ) {
+      // Expected — server processed our request, sentinel just doesn't exist.
+      return true;
     }
-    // Sentinel actually existed (rare but harmless) — still healthy.
-    return true;
+    // Other errors (Unavailable, ResourceExhausted, etc.) propagate
+    // so the monitor can route through restart.
+    throw new TemporalReadOutcomeError(outcome);
   };
 }
 

--- a/plugin/src/temporal/health-probe.test.ts
+++ b/plugin/src/temporal/health-probe.test.ts
@@ -3,6 +3,7 @@ import {
   getTemporalHealth,
   resetTemporalHealthProbeState,
 } from "./health-probe";
+import { createMockOwner } from "./__tests__/mock-owner";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -74,10 +75,7 @@ describe("getTemporalHealth — server poller probe integration", () => {
     mockGetTemporalAddress.mockReturnValue("127.0.0.1:7233");
     mockGetTemporalNamespace.mockReturnValue("default");
     mockBuildProjectTaskQueue.mockImplementation((pid: string) => `adv-${pid}`);
-    mockGetService.mockReturnValue({
-      connection: { workflowService: { describeTaskQueue: vi.fn() } },
-      namespace: "default",
-    });
+    mockGetService.mockReturnValue(createMockOwner());
     mockGetTemporalRetryTelemetry.mockReturnValue({
       lastOpAt: null,
       lastError: null,
@@ -223,10 +221,7 @@ describe("getTemporalHealth — multi-queue probing", () => {
     mockGetTemporalAddress.mockReturnValue("127.0.0.1:7233");
     mockGetTemporalNamespace.mockReturnValue("default");
     mockBuildProjectTaskQueue.mockImplementation((pid: string) => `adv-${pid}`);
-    mockGetService.mockReturnValue({
-      connection: { workflowService: { describeTaskQueue: vi.fn() } },
-      namespace: "default",
-    });
+    mockGetService.mockReturnValue(createMockOwner());
     mockGetTemporalRetryTelemetry.mockReturnValue({
       lastOpAt: null,
       lastError: null,

--- a/plugin/src/temporal/health-probe.ts
+++ b/plugin/src/temporal/health-probe.ts
@@ -19,6 +19,7 @@ import { getService } from "./service";
 export interface QueueProbeTarget {
   queueName: string;
   queueType: "session" | "project";
+  projectId: string;
 }
 
 export interface QueueProbeResult {
@@ -114,10 +115,8 @@ async function probeQueues(
     } else {
       try {
         probe = await probeTaskQueuePollers({
-          connection: bundle.connection as unknown as Parameters<
-            typeof probeTaskQueuePollers
-          >[0]["connection"],
-          namespace: bundle.namespace,
+          owner: bundle,
+          projectId: target.projectId ?? "",
           taskQueue: target.queueName,
         });
         pollerProbeCache.set(target.queueName, {
@@ -163,6 +162,7 @@ export async function getTemporalHealth(
           {
             queueName: buildProjectTaskQueue(_projectIdOrTargets),
             queueType: "project",
+            projectId: _projectIdOrTargets,
           },
         ]
       : [];

--- a/plugin/src/temporal/list-change-workflows.test.ts
+++ b/plugin/src/temporal/list-change-workflows.test.ts
@@ -16,11 +16,15 @@
 
 import { describe, expect, it } from "vitest";
 import { performance } from "node:perf_hooks";
+import { createMockOwnerFromClient } from "./__tests__/mock-owner";
 
 import {
   listChangeWorkflowIds,
   buildVisibilityQuery,
 } from "./list-change-workflows";
+
+const PROJECT_ID = "0000000000000000000000000000000000000001";
+const OTHER_PROJECT_ID = "0000000000000000000000000000000000000002";
 
 interface FakeWorkflow {
   workflowId: string;
@@ -107,13 +111,16 @@ describe("buildVisibilityQuery", () => {
 describe("listChangeWorkflowIds", () => {
   it("returns change IDs from matching workflows", async () => {
     const fakeClient = makeFakeClient([
-      { workflowId: "adv/change/proj1/changeA" },
-      { workflowId: "adv/change/proj1/changeB" },
+      { workflowId: `adv/change/${PROJECT_ID}/changeA` },
+      { workflowId: `adv/change/${PROJECT_ID}/changeB` },
     ]);
-    const ids = await listChangeWorkflowIds(fakeClient, {
-      projectId: "proj1",
-    });
-    expect(ids.sort((a, b) => a.localeCompare(b))).toEqual([
+    const ids = await listChangeWorkflowIds(
+      createMockOwnerFromClient({ client: fakeClient }),
+      {
+        projectId: PROJECT_ID,
+      },
+    );
+    expect(ids.value.sort((a, b) => a.localeCompare(b))).toEqual([
       "changeA",
       "changeB",
     ]);
@@ -121,36 +128,47 @@ describe("listChangeWorkflowIds", () => {
 
   it("filters out workflow IDs that do not belong to the project", async () => {
     const fakeClient = makeFakeClient([
-      { workflowId: "adv/change/proj1/changeA" },
-      { workflowId: "adv/change/proj2/changeStranger" },
-      { workflowId: "adv/project/proj1" }, // PSW workflow, must skip
+      { workflowId: `adv/change/${PROJECT_ID}/changeA` },
+      { workflowId: `adv/change/${OTHER_PROJECT_ID}/changeStranger` },
+      { workflowId: `adv/project/${PROJECT_ID}` }, // PSW workflow, must skip
       { workflowId: "totally-unrelated" },
     ]);
-    const ids = await listChangeWorkflowIds(fakeClient, {
-      projectId: "proj1",
-    });
-    expect(ids).toEqual(["changeA"]);
+    const ids = await listChangeWorkflowIds(
+      createMockOwnerFromClient({ client: fakeClient }),
+      {
+        projectId: PROJECT_ID,
+      },
+    );
+    expect(ids.value).toEqual(["changeA"]);
   });
 
   it("respects the `limit` cap and stops iteration early", async () => {
     const workflows: FakeWorkflow[] = Array.from({ length: 50 }, (_, i) => ({
-      workflowId: `adv/change/proj1/c${i}`,
+      workflowId: `adv/change/${PROJECT_ID}/c${i}`,
     }));
     const fakeClient = makeFakeClient(workflows);
-    const ids = await listChangeWorkflowIds(fakeClient, {
-      projectId: "proj1",
-      limit: 10,
-    });
-    expect(ids).toHaveLength(10);
+    const ids = await listChangeWorkflowIds(
+      createMockOwnerFromClient({ client: fakeClient }),
+      {
+        projectId: PROJECT_ID,
+        limit: 10,
+      },
+    );
+    expect(ids.value).toHaveLength(10);
   });
 
   it("constructs the correct visibility query for the SDK", async () => {
     const fakeClient = makeFakeClient([]);
-    await listChangeWorkflowIds(fakeClient, {
-      projectId: "proj1",
-      statuses: ["draft"],
-    });
-    expect(fakeClient.lastQuery).toContain('AdvAffectedProjects = "proj1"');
+    await listChangeWorkflowIds(
+      createMockOwnerFromClient({ client: fakeClient }),
+      {
+        projectId: PROJECT_ID,
+        statuses: ["draft"],
+      },
+    );
+    expect(fakeClient.lastQuery).toContain(
+      `AdvAffectedProjects = "${PROJECT_ID}"`,
+    );
     expect(fakeClient.lastQuery).toContain('AdvLifecycleState = "open"');
     expect(fakeClient.lastQuery).toContain('ExecutionStatus = "Running"');
   });
@@ -158,34 +176,40 @@ describe("listChangeWorkflowIds", () => {
   it("handles 1500 paginated results without dropping any", async () => {
     const N = 1500;
     const workflows: FakeWorkflow[] = Array.from({ length: N }, (_, i) => ({
-      workflowId: `adv/change/proj1/c${i}`,
+      workflowId: `adv/change/${PROJECT_ID}/c${i}`,
     }));
     const fakeClient = makeFakeClient(workflows);
-    const ids = await listChangeWorkflowIds(fakeClient, {
-      projectId: "proj1",
-    });
-    expect(ids).toHaveLength(N);
+    const ids = await listChangeWorkflowIds(
+      createMockOwnerFromClient({ client: fakeClient }),
+      {
+        projectId: PROJECT_ID,
+      },
+    );
+    expect(ids.value).toHaveLength(N);
     // Spot-check edge ids
-    expect(ids).toContain("c0");
-    expect(ids).toContain("c1499");
+    expect(ids.value).toContain("c0");
+    expect(ids.value).toContain("c1499");
   });
 
   // AC1 measurement: 552 changes in <2s p99 for the listChangeWorkflowIds path
   it("processes 552 changes well under AC1 budget (<2s p99)", async () => {
     const N = 552;
     const workflows: FakeWorkflow[] = Array.from({ length: N }, (_, i) => ({
-      workflowId: `adv/change/proj1/c${i}`,
+      workflowId: `adv/change/${PROJECT_ID}/c${i}`,
     }));
 
     const samples: number[] = [];
     for (let iter = 0; iter < 10; iter++) {
       const fakeClient = makeFakeClient(workflows);
       const t = performance.now();
-      const ids = await listChangeWorkflowIds(fakeClient, {
-        projectId: "proj1",
-      });
+      const ids = await listChangeWorkflowIds(
+        createMockOwnerFromClient({ client: fakeClient }),
+        {
+          projectId: PROJECT_ID,
+        },
+      );
       samples.push(performance.now() - t);
-      expect(ids).toHaveLength(N);
+      expect(ids.value).toHaveLength(N);
     }
 
     samples.sort((a, b) => a - b);
@@ -199,26 +223,29 @@ describe("listChangeWorkflowIds", () => {
   it("remains an ID-only enumerator even when records carry search attributes", async () => {
     const fakeClient = makeFakeClient([
       {
-        workflowId: "adv/change/proj1/changeA",
+        workflowId: `adv/change/${PROJECT_ID}/changeA`,
         searchAttributes: {
           AdvLastSignalAt: ["2026-07-18T12:00:00.000Z"],
           AdvCreatedAt: ["2026-07-18T10:00:00.000Z"],
         },
       },
       {
-        workflowId: "adv/change/proj1/changeB",
+        workflowId: `adv/change/${PROJECT_ID}/changeB`,
         searchAttributes: {
           AdvLastSignalAt: ["2026-07-18T11:00:00.000Z"],
           AdvCreatedAt: ["2026-07-18T09:00:00.000Z"],
         },
       },
     ]);
-    const ids = await listChangeWorkflowIds(fakeClient, {
-      projectId: "proj1",
-    });
-    expect(Array.isArray(ids)).toBe(true);
-    expect(ids.every((id) => typeof id === "string")).toBe(true);
-    expect(ids.sort((a, b) => a.localeCompare(b))).toEqual([
+    const ids = await listChangeWorkflowIds(
+      createMockOwnerFromClient({ client: fakeClient }),
+      {
+        projectId: PROJECT_ID,
+      },
+    );
+    expect(ids.kind).toBe("complete");
+    expect(ids.value.every((id) => typeof id === "string")).toBe(true);
+    expect(ids.value.sort((a, b) => a.localeCompare(b))).toEqual([
       "changeA",
       "changeB",
     ]);

--- a/plugin/src/temporal/list-change-workflows.ts
+++ b/plugin/src/temporal/list-change-workflows.ts
@@ -15,11 +15,8 @@
  *     signals — so the listed IDs from Visibility are mostly used at cold
  *     start before Memo warms up.
  *
- * Pagination: the Temporal SDK's `client.workflow.list({ query })` returns
- * an AsyncIterable that handles cursor-based pagination internally
- * (default page size 1000). Consumers iterate; the SDK fetches more pages
- * as needed. This module wraps the iteration with project-scoped
- * filtering and an optional hard `limit` cap.
+ * Pagination: the TemporalOperations owner materializes the list into a
+ * bounded result set so callers never hold an open AsyncIterable.
  *
  * Search-attribute strategy: ADV registers `AdvAffectedProjects`
  * (KeywordList), `AdvLifecycleState` (Keyword), and `AdvChangeStatus`
@@ -33,6 +30,8 @@
  */
 
 import type { ChangeStatus } from "../types";
+import type { TemporalListOutcome, TemporalOperations } from "./operations";
+import { makeTemporalOperationContext } from "./operations";
 import {
   escapeVisibilityValue,
   isLegacyOpenStatusSet,
@@ -57,32 +56,25 @@ export interface ListChangeWorkflowIdsOptions {
    * the status filter entirely.
    */
   statuses?: ChangeStatus[] | null;
+  /**
+   * Optional execution-status filter (e.g. `"Running"`). Useful for
+   * worker-free status readers that must exclude stale completed workflows.
+   */
+  executionStatus?: string;
   /** Hard cap on result count — stops iteration early. */
   limit?: number;
-}
-
-/**
- * Minimal `Client` shape used by listChangeWorkflowIds. Real
- * `@temporalio/client` Client satisfies this structurally.
- */
-export interface ListClient {
-  workflow: {
-    list: (opts: { query: string }) => AsyncIterable<{
-      workflowId: string;
-    }>;
-  };
 }
 
 /**
  * Build the visibility-API query string for change-workflow enumeration.
  *
  * Exposed for testing (and for callers that need to tweak the query and
- * pass it directly to `client.workflow.list`).
+ * pass it directly to the owner).
  */
 export function buildVisibilityQuery(
   options: ListChangeWorkflowIdsOptions,
 ): string {
-  const { projectId, statuses } = options;
+  const { projectId, statuses, executionStatus } = options;
   const parts: string[] = [];
 
   // Escape double-quotes in projectId. SHA-based project IDs never
@@ -117,6 +109,10 @@ export function buildVisibilityQuery(
     }
   }
 
+  if (executionStatus) {
+    parts.push(`ExecutionStatus = "${executionStatus}"`);
+  }
+
   return parts.join(" AND ");
 }
 
@@ -125,15 +121,31 @@ export function buildVisibilityQuery(
  * via Temporal Visibility API pagination.
  */
 export async function listChangeWorkflowIds(
-  client: ListClient,
+  owner: TemporalOperations,
   options: ListChangeWorkflowIdsOptions,
-): Promise<string[]> {
+): Promise<TemporalListOutcome<string[]>> {
   const query = buildVisibilityQuery(options);
   const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${options.projectId}/`;
   const limit = options.limit;
-  const ids: string[] = [];
+  const placeholderWorkflowId = `${projectPrefix}change-enumeration`;
+  const effectiveLimit = limit ?? 1_000_000;
+  const ctx = makeTemporalOperationContext(
+    options.projectId,
+    placeholderWorkflowId,
+    "list",
+    "listChangeWorkflowIds",
+    10_000,
+  );
+  const outcome = await owner.list<{ workflowId: string }>(ctx, query, {
+    limit: effectiveLimit,
+  });
 
-  for await (const wf of client.workflow.list({ query })) {
+  if (outcome.kind !== "complete") {
+    return outcome;
+  }
+
+  const ids: string[] = [];
+  for (const wf of outcome.value) {
     const wfid = wf.workflowId;
     // Defensive: visibility may include workflows that match the search
     // attributes but use a non-change workflow ID format (e.g. project
@@ -145,5 +157,5 @@ export async function listChangeWorkflowIds(
     if (limit !== undefined && ids.length >= limit) break;
   }
 
-  return ids;
+  return { kind: "complete", value: ids, truncated: outcome.truncated };
 }

--- a/plugin/src/temporal/list-epic-workflows.test.ts
+++ b/plugin/src/temporal/list-epic-workflows.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
 
 import {
   buildEpicVisibilityQuery,
@@ -7,11 +8,18 @@ import {
 } from "./list-epic-workflows";
 import { EPIC_WORKFLOW_NAME } from "./contracts";
 
-function makeClient(
+/** Canonical 40-character lowercase hex project ID used across these tests. */
+const PROJECT_ID = "0".repeat(40);
+const EPIC_PREFIX = `adv/epic/${PROJECT_ID}/`;
+
+function makeOwner(
   results: Array<{ workflowId: string; startTime?: Date | null }>,
 ): {
-  workflow: {
-    list: ReturnType<typeof vi.fn>;
+  owner: ReturnType<typeof createMockOwnerFromClient>;
+  client: {
+    workflow: {
+      list: ReturnType<typeof vi.fn>;
+    };
   };
 } {
   const list = vi.fn(({ query: _query }: { query: string }) => {
@@ -19,41 +27,52 @@ function makeClient(
       for (const r of results) yield r;
     })();
   });
-  return { workflow: { list } };
+  const client = { workflow: { list } };
+  return { owner: createMockOwnerFromClient(client), client };
 }
 
 describe("listEpicWorkflowIds", () => {
   const startTime = new Date("2026-06-25T10:00:00.000Z");
 
   it("defaults to active/running mode and filters project scope by workflow ID prefix", async () => {
-    const client = makeClient([
-      { workflowId: "adv/epic/pid-abc/cardIdentity", startTime },
-      { workflowId: "adv/epic/other-pid/providerArchitecture", startTime },
-      { workflowId: "adv/change/pid-abc/notAnEpic", startTime },
-      { workflowId: "adv/epic/pid-abc/simplifiedChineseCardData", startTime },
+    const otherProjectId = "1".repeat(40);
+    const { owner, client } = makeOwner([
+      { workflowId: `${EPIC_PREFIX}cardIdentity`, startTime },
+      {
+        workflowId: `adv/epic/${otherProjectId}/providerArchitecture`,
+        startTime,
+      },
+      { workflowId: `adv/change/${PROJECT_ID}/notAnEpic`, startTime },
+      { workflowId: `${EPIC_PREFIX}simplifiedChineseCardData`, startTime },
     ]);
 
-    const ids = await listEpicWorkflowIds(client, { projectId: "pid-abc" });
+    const outcome = await listEpicWorkflowIds(owner, {
+      projectId: PROJECT_ID,
+    });
 
-    expect(ids).toEqual(["cardIdentity", "simplifiedChineseCardData"]);
+    expect(outcome.kind).toBe("complete");
+    expect((outcome as { kind: "complete"; value: string[] }).value).toEqual([
+      "cardIdentity",
+      "simplifiedChineseCardData",
+    ]);
     expect(client.workflow.list).toHaveBeenCalledWith({
       query: `WorkflowType = "${EPIC_WORKFLOW_NAME}" AND AdvEpicStatus = "active" AND ExecutionStatus = "Running"`,
     });
   });
 
   it("uses structural Epic status so merged/completed running workflows do not leak into active CLI lists", () => {
-    expect(buildEpicVisibilityQuery("pid-abc")).toContain(
+    expect(buildEpicVisibilityQuery(PROJECT_ID)).toContain(
       'AdvEpicStatus = "active"',
     );
   });
 
   it("supports all-executions mode with no ExecutionStatus filter", async () => {
-    const client = makeClient([
-      { workflowId: "adv/epic/pid-abc/cardIdentity", startTime },
+    const { owner, client } = makeOwner([
+      { workflowId: `${EPIC_PREFIX}cardIdentity`, startTime },
     ]);
 
-    await listEpicWorkflowIds(client, {
-      projectId: "pid-abc",
+    await listEpicWorkflowIds(owner, {
+      projectId: PROJECT_ID,
       status: "all",
     });
 
@@ -63,35 +82,39 @@ describe("listEpicWorkflowIds", () => {
   });
 
   it("does not use WorkflowId LIKE in visibility query", () => {
-    expect(buildEpicVisibilityQuery("pid-abc")).toBe(
+    expect(buildEpicVisibilityQuery(PROJECT_ID)).toBe(
       `WorkflowType = "${EPIC_WORKFLOW_NAME}" AND AdvEpicStatus = "active" AND ExecutionStatus = "Running"`,
     );
   });
 
   it("builds all-executions query without ExecutionStatus", () => {
-    expect(buildEpicVisibilityQuery("pid-abc", "all")).toBe(
+    expect(buildEpicVisibilityQuery(PROJECT_ID, "all")).toBe(
       `WorkflowType = "${EPIC_WORKFLOW_NAME}"`,
     );
   });
 
   it("builds running-all repair query without AdvEpicStatus but with ExecutionStatus = Running", () => {
-    expect(buildEpicVisibilityQuery("pid-abc", "running")).toBe(
+    expect(buildEpicVisibilityQuery(PROJECT_ID, "running")).toBe(
       `WorkflowType = "${EPIC_WORKFLOW_NAME}" AND ExecutionStatus = "Running"`,
     );
   });
 
   it("lists running Epic workflows without AdvEpicStatus filter", async () => {
-    const client = makeClient([
-      { workflowId: "adv/epic/pid-abc/cardIdentity", startTime },
-      { workflowId: "adv/epic/pid-abc/addLauncherRows", startTime },
+    const { owner, client } = makeOwner([
+      { workflowId: `${EPIC_PREFIX}cardIdentity`, startTime },
+      { workflowId: `${EPIC_PREFIX}addLauncherRows`, startTime },
     ]);
 
-    const ids = await listEpicWorkflowIds(client, {
-      projectId: "pid-abc",
+    const outcome = await listEpicWorkflowIds(owner, {
+      projectId: PROJECT_ID,
       status: "running",
     });
 
-    expect(ids).toEqual(["cardIdentity", "addLauncherRows"]);
+    expect(outcome.kind).toBe("complete");
+    expect((outcome as { kind: "complete"; value: string[] }).value).toEqual([
+      "cardIdentity",
+      "addLauncherRows",
+    ]);
     expect(client.workflow.list).toHaveBeenCalledWith({
       query: `WorkflowType = "${EPIC_WORKFLOW_NAME}" AND ExecutionStatus = "Running"`,
     });
@@ -99,34 +122,54 @@ describe("listEpicWorkflowIds", () => {
 
   it("lists Epic workflow entries with Visibility startTime", async () => {
     const secondStart = new Date("2026-06-25T11:00:00.000Z");
-    const client = makeClient([
-      { workflowId: "adv/epic/pid-abc/cardIdentity", startTime },
+    const { owner } = makeOwner([
+      { workflowId: `${EPIC_PREFIX}cardIdentity`, startTime },
       {
-        workflowId: "adv/epic/pid-abc/addLauncherRows",
+        workflowId: `${EPIC_PREFIX}addLauncherRows`,
         startTime: secondStart,
       },
     ]);
 
-    const epics = await listEpicWorkflows(client, { projectId: "pid-abc" });
+    const outcome = await listEpicWorkflows(owner, {
+      projectId: PROJECT_ID,
+    });
 
-    expect(epics).toEqual([
+    expect(outcome.kind).toBe("complete");
+    expect(
+      (
+        outcome as {
+          kind: "complete";
+          value: { id: string; startTime: Date | null }[];
+        }
+      ).value,
+    ).toEqual([
       { id: "cardIdentity", startTime },
       { id: "addLauncherRows", startTime: secondStart },
     ]);
   });
 
   it("keeps an Epic entry with null startTime when Visibility row lacks a valid Date", async () => {
-    const client = makeClient([
-      { workflowId: "adv/epic/pid-abc/missingStart" },
+    const { owner } = makeOwner([
+      { workflowId: `${EPIC_PREFIX}missingStart` },
       {
-        workflowId: "adv/epic/pid-abc/invalidStart",
+        workflowId: `${EPIC_PREFIX}invalidStart`,
         startTime: new Date("invalid"),
       },
     ]);
 
-    const epics = await listEpicWorkflows(client, { projectId: "pid-abc" });
+    const outcome = await listEpicWorkflows(owner, {
+      projectId: PROJECT_ID,
+    });
 
-    expect(epics).toEqual([
+    expect(outcome.kind).toBe("complete");
+    expect(
+      (
+        outcome as {
+          kind: "complete";
+          value: { id: string; startTime: Date | null }[];
+        }
+      ).value,
+    ).toEqual([
       { id: "missingStart", startTime: null },
       { id: "invalidStart", startTime: null },
     ]);

--- a/plugin/src/temporal/list-epic-workflows.ts
+++ b/plugin/src/temporal/list-epic-workflows.ts
@@ -8,6 +8,8 @@
  * rq-epicCliList01
  */
 
+import type { TemporalListOutcome, TemporalOperations } from "./operations";
+import { makeTemporalOperationContext } from "./operations";
 import { EPIC_WORKFLOW_NAME, EPIC_WORKFLOW_PREFIX } from "./contracts";
 
 export interface ListEpicWorkflowIdsOptions {
@@ -33,18 +35,6 @@ function normalizeVisibilityStartTime(value: unknown): Date | null {
   if (!(value instanceof Date)) return null;
   if (Number.isNaN(value.getTime())) return null;
   return value;
-}
-
-/**
- * Minimal `Client` shape used by listEpicWorkflowIds.
- */
-export interface ListEpicClient {
-  workflow: {
-    list: (opts: { query: string }) => AsyncIterable<{
-      workflowId: string;
-      startTime?: Date | null;
-    }>;
-  };
 }
 
 /**
@@ -75,15 +65,33 @@ export function buildEpicVisibilityQuery(
  * Default `status` is "active", which enumerates running workflows only.
  */
 export async function listEpicWorkflows(
-  client: ListEpicClient,
+  owner: TemporalOperations,
   options: ListEpicWorkflowIdsOptions,
-): Promise<EpicWorkflowListEntry[]> {
-  const query = buildEpicVisibilityQuery(options.projectId, options.status);
-  const projectPrefix = `${EPIC_WORKFLOW_PREFIX}${options.projectId}/`;
-  const limit = options.limit;
-  const epics: EpicWorkflowListEntry[] = [];
+): Promise<TemporalListOutcome<EpicWorkflowListEntry[]>> {
+  const { projectId, status, limit } = options;
+  const query = buildEpicVisibilityQuery(projectId, status);
+  const projectPrefix = `${EPIC_WORKFLOW_PREFIX}${projectId}/`;
+  const effectiveLimit = limit ?? 1000;
+  const placeholderWorkflowId = `${projectPrefix}epic-enumeration`;
 
-  for await (const wf of client.workflow.list({ query })) {
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    placeholderWorkflowId,
+    "list",
+    "listEpicWorkflows",
+    10_000,
+  );
+  const outcome = await owner.list<{
+    workflowId: string;
+    startTime?: Date | null;
+  }>(ctx, query, { limit: effectiveLimit });
+
+  if (outcome.kind !== "complete") {
+    return outcome;
+  }
+
+  const epics: EpicWorkflowListEntry[] = [];
+  for (const wf of outcome.value) {
     const wfid = wf.workflowId;
     if (!wfid.startsWith(projectPrefix)) continue;
     const epicId = wfid.slice(projectPrefix.length);
@@ -95,7 +103,7 @@ export async function listEpicWorkflows(
     if (limit !== undefined && epics.length >= limit) break;
   }
 
-  return epics;
+  return { kind: "complete", value: epics, truncated: outcome.truncated };
 }
 
 /**
@@ -105,9 +113,16 @@ export async function listEpicWorkflows(
  * Default `status` is "active", which enumerates running workflows only.
  */
 export async function listEpicWorkflowIds(
-  client: ListEpicClient,
+  owner: TemporalOperations,
   options: ListEpicWorkflowIdsOptions,
-): Promise<string[]> {
-  const epics = await listEpicWorkflows(client, options);
-  return epics.map((epic) => epic.id);
+): Promise<TemporalListOutcome<string[]>> {
+  const epics = await listEpicWorkflows(owner, options);
+  if (epics.kind !== "complete") {
+    return epics;
+  }
+  return {
+    kind: "complete",
+    value: epics.value.map((epic) => epic.id),
+    truncated: epics.truncated,
+  };
 }

--- a/plugin/src/temporal/list-orphan-session-queues.test.ts
+++ b/plugin/src/temporal/list-orphan-session-queues.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, test } from "vitest";
 import type { AsyncIterable } from "node:stream";
 import { listOrphanSessionQueues } from "./list-orphan-session-queues";
 import { ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX } from "./contracts";
+import { createMockOwnerFromClient } from "./__tests__/mock-owner";
+
+/** Canonical 40-character lowercase hex project ID used across these tests. */
+const PROJECT_ID = "0".repeat(40);
+const CHANGE_PREFIX = `adv/change/${PROJECT_ID}/`;
+const PROJ_Q = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PROJECT_ID}`;
+const SESS_DEAD_1 = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PROJECT_ID}-sess_deadOne`;
+const SESS_DEAD_2 = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PROJECT_ID}-sess_deadTwo`;
+const SESS_LIVE = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PROJECT_ID}-sess_live`;
 
 /** Build a mock Visibility entry. */
 function entry(
@@ -22,11 +31,14 @@ function makeList(
   };
 }
 
-const PID = "pid-abc";
-const PROJ_Q = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PID}`;
-const SESS_DEAD_1 = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PID}-sess_deadOne`;
-const SESS_DEAD_2 = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PID}-sess_deadTwo`;
-const SESS_LIVE = `${ADVANCE_TEMPORAL_TASK_QUEUE_PREFIX}-${PID}-sess_live`;
+function unwrapOrphans(
+  outcome: Awaited<ReturnType<typeof listOrphanSessionQueues>>,
+): { queue: string; oldestStartTime: Date }[] {
+  if (outcome.kind !== "complete") {
+    throw new Error(`Unexpected outcome: ${outcome.kind}`);
+  }
+  return outcome.value;
+}
 
 describe("listOrphanSessionQueues", () => {
   test("discovers session-scoped queues not already polled, sorted by oldest startTime", async () => {
@@ -36,19 +48,22 @@ describe("listOrphanSessionQueues", () => {
       workflow: {
         list: makeList([
           [
-            entry("adv/change/pid-abc/changeA", SESS_DEAD_1, t0),
-            entry("adv/change/pid-abc/changeB", SESS_DEAD_2, t1),
-            entry("adv/change/pid-abc/changeC", PROJ_Q, t0),
-            entry("adv/change/pid-abc/changeD", SESS_LIVE, t0),
+            entry(`${CHANGE_PREFIX}changeA`, SESS_DEAD_1, t0),
+            entry(`${CHANGE_PREFIX}changeB`, SESS_DEAD_2, t1),
+            entry(`${CHANGE_PREFIX}changeC`, PROJ_Q, t0),
+            entry(`${CHANGE_PREFIX}changeD`, SESS_LIVE, t0),
           ],
         ]),
       },
     };
 
-    const result = await listOrphanSessionQueues(client, PID, [
-      SESS_LIVE,
-      PROJ_Q,
-    ]);
+    const result = unwrapOrphans(
+      await listOrphanSessionQueues(
+        createMockOwnerFromClient(client),
+        PROJECT_ID,
+        [SESS_LIVE, PROJ_Q],
+      ),
+    );
 
     // Dead queues discovered; project + live excluded; sorted oldest-first
     expect(result).toHaveLength(2);
@@ -65,13 +80,19 @@ describe("listOrphanSessionQueues", () => {
       workflow: {
         // Page 2 has the older entry — Visibility may return unordered
         list: makeList([
-          [entry("adv/change/pid-abc/newer", SESS_DEAD_2, tNew)],
-          [entry("adv/change/pid-abc/older", SESS_DEAD_1, tOld)],
+          [entry(`${CHANGE_PREFIX}newer`, SESS_DEAD_2, tNew)],
+          [entry(`${CHANGE_PREFIX}older`, SESS_DEAD_1, tOld)],
         ]),
       },
     };
 
-    const result = await listOrphanSessionQueues(client, PID, [PROJ_Q]);
+    const result = unwrapOrphans(
+      await listOrphanSessionQueues(
+        createMockOwnerFromClient(client),
+        PROJECT_ID,
+        [PROJ_Q],
+      ),
+    );
 
     // Sorted by oldest startTime regardless of page order
     expect(result[0].queue).toBe(SESS_DEAD_1);
@@ -84,14 +105,20 @@ describe("listOrphanSessionQueues", () => {
       workflow: {
         list: makeList([
           [
-            entry("adv/change/pid-abc/changeA", SESS_DEAD_1, t),
-            entry("adv/epic/pid-abc/someEpic", SESS_DEAD_2, t),
+            entry(`${CHANGE_PREFIX}changeA`, SESS_DEAD_1, t),
+            entry(`adv/epic/${PROJECT_ID}/someEpic`, SESS_DEAD_2, t),
           ],
         ]),
       },
     };
 
-    const result = await listOrphanSessionQueues(client, PID, [PROJ_Q]);
+    const result = unwrapOrphans(
+      await listOrphanSessionQueues(
+        createMockOwnerFromClient(client),
+        PROJECT_ID,
+        [PROJ_Q],
+      ),
+    );
     expect(result).toEqual([{ queue: SESS_DEAD_1, oldestStartTime: t }]);
   });
 
@@ -101,14 +128,20 @@ describe("listOrphanSessionQueues", () => {
       workflow: {
         list: makeList([
           [
-            entry("adv/change/pid-abc/running", SESS_DEAD_1, t, "RUNNING"),
-            entry("adv/change/pid-abc/completed", SESS_DEAD_2, t, "COMPLETED"),
+            entry(`${CHANGE_PREFIX}running`, SESS_DEAD_1, t, "RUNNING"),
+            entry(`${CHANGE_PREFIX}completed`, SESS_DEAD_2, t, "COMPLETED"),
           ],
         ]),
       },
     };
 
-    const result = await listOrphanSessionQueues(client, PID, [PROJ_Q]);
+    const result = unwrapOrphans(
+      await listOrphanSessionQueues(
+        createMockOwnerFromClient(client),
+        PROJECT_ID,
+        [PROJ_Q],
+      ),
+    );
     expect(result).toEqual([{ queue: SESS_DEAD_1, oldestStartTime: t }]);
   });
 
@@ -118,17 +151,20 @@ describe("listOrphanSessionQueues", () => {
       workflow: {
         list: makeList([
           [
-            entry("adv/change/pid-abc/a", PROJ_Q, t),
-            entry("adv/change/pid-abc/b", SESS_LIVE, t),
+            entry(`${CHANGE_PREFIX}a`, PROJ_Q, t),
+            entry(`${CHANGE_PREFIX}b`, SESS_LIVE, t),
           ],
         ]),
       },
     };
 
-    const result = await listOrphanSessionQueues(client, PID, [
-      PROJ_Q,
-      SESS_LIVE,
-    ]);
+    const result = unwrapOrphans(
+      await listOrphanSessionQueues(
+        createMockOwnerFromClient(client),
+        PROJECT_ID,
+        [PROJ_Q, SESS_LIVE],
+      ),
+    );
     expect(result).toEqual([]);
   });
 
@@ -139,14 +175,20 @@ describe("listOrphanSessionQueues", () => {
       workflow: {
         list: makeList([
           [
-            entry("adv/change/pid-abc/newer", SESS_DEAD_1, tNew),
-            entry("adv/change/pid-abc/older", SESS_DEAD_1, tOld),
+            entry(`${CHANGE_PREFIX}newer`, SESS_DEAD_1, tNew),
+            entry(`${CHANGE_PREFIX}older`, SESS_DEAD_1, tOld),
           ],
         ]),
       },
     };
 
-    const result = await listOrphanSessionQueues(client, PID, [PROJ_Q]);
+    const result = unwrapOrphans(
+      await listOrphanSessionQueues(
+        createMockOwnerFromClient(client),
+        PROJECT_ID,
+        [PROJ_Q],
+      ),
+    );
     expect(result).toHaveLength(1);
     expect(result[0].oldestStartTime).toBe(tOld);
   });

--- a/plugin/src/temporal/list-orphan-session-queues.ts
+++ b/plugin/src/temporal/list-orphan-session-queues.ts
@@ -15,6 +15,13 @@ import {
   CHANGE_WORKFLOW_PREFIX,
 } from "./contracts";
 import { escapeVisibilityValue } from "./lifecycle-visibility";
+import type {
+  TemporalListOutcome,
+  TemporalOperations,
+  TemporalReadOutcome,
+  TemporalLifecycleContext,
+} from "./operations";
+import { makeTemporalOperationContext } from "./operations";
 
 /**
  * Hard cap on inspected workflows (safety bound). FIFO selection is
@@ -23,39 +30,6 @@ import { escapeVisibilityValue } from "./lifecycle-visibility";
  * later heartbeat. Bounded by realistic project sizes (tens to low hundreds).
  */
 const INSPECTION_LIMIT = 500;
-
-/**
- * Minimal client shape for Visibility enumeration.
- * `@temporalio/client` Client satisfies this structurally.
- */
-export interface OrphanListClient {
-  workflow: {
-    list: (opts: { query: string }) => AsyncIterable<{
-      workflowId: string;
-      taskQueue: string;
-      startTime: Date;
-      status: { name: string };
-    }>;
-  };
-  /**
-   * Optional gRPC connection handle. `@temporalio/client` Client satisfies this
-   * structurally.
-   *
-   * This is the ONLY cancellation surface available for Visibility enumeration:
-   * `ListOptions` is `{ pageSize?, query? }` — it carries no `abortSignal` and
-   * no deadline (SDK v1.16). Cancellation is scoped at the connection via
-   * `withAbortSignal`, which cancels ongoing gRPC requests inside `fn`.
-   *
-   * Without this, a Visibility stream that stalls before yielding its first
-   * page cannot be torn down, and each driver tick leaks another stream (#327).
-   */
-  connection?: {
-    withAbortSignal?: <T>(
-      signal: AbortSignal,
-      fn: () => Promise<T>,
-    ) => Promise<T>;
-  };
-}
 
 export interface OrphanSessionQueue {
   /** Session-scoped task queue name (advance-{P}-sess_{id}). */
@@ -71,27 +45,49 @@ export interface OrphanSessionQueue {
  * existing session-pinned workflows would be stranded without a poller.
  */
 export async function hasActiveSessionPinnedWorkflows(
-  client: OrphanListClient,
+  owner: TemporalOperations,
   projectId: string,
-): Promise<boolean> {
+  preflightCtx?: TemporalLifecycleContext,
+): Promise<TemporalReadOutcome<boolean>> {
   const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
   const sessionPrefix = buildSessionQueuePrefix(projectId);
   const safeProjectId = escapeVisibilityValue(projectId);
   const query = `AdvAffectedProjects = "${safeProjectId}"`;
+  const placeholderWorkflowId = `${projectPrefix}session-pin-check`;
 
-  for await (const wf of client.workflow.list({ query })) {
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    placeholderWorkflowId,
+    "list",
+    "hasActiveSessionPinnedWorkflows",
+    preflightCtx?.budgetMs ?? 10_000,
+    preflightCtx?.abortSignal,
+  );
+  const outcome = await owner.list<{
+    workflowId: string;
+    taskQueue: string;
+    status: { name: string };
+  }>(ctx, query);
+  if (outcome.kind !== "complete") {
+    return {
+      kind: "degraded",
+      error: outcome.error,
+      diagnostic: outcome.diagnostic,
+    };
+  }
+  for (const wf of outcome.value) {
     if (wf.status.name !== "RUNNING") continue;
     if (!wf.workflowId.startsWith(projectPrefix)) continue;
     if (!wf.taskQueue.startsWith(sessionPrefix)) continue;
-    return true;
+    return { kind: "complete", value: true };
   }
-  return false;
+  return { kind: "complete", value: false };
 }
 
 export interface ListOrphanSessionQueuesOptions {
   /**
    * Cancels the underlying Visibility gRPC calls when aborted (routed through
-   * `client.connection.withAbortSignal`). Also breaks the collection loop.
+   * the TemporalOperations owner). Also breaks the collection loop.
    */
   signal?: AbortSignal;
   /**
@@ -120,11 +116,11 @@ function buildSessionQueuePrefix(projectId: string): string {
  * orphans found.
  */
 export async function listOrphanSessionQueues(
-  client: OrphanListClient,
+  owner: TemporalOperations,
   projectId: string,
   polledQueues: readonly string[],
   options: ListOrphanSessionQueuesOptions = {},
-): Promise<OrphanSessionQueue[]> {
+): Promise<TemporalListOutcome<OrphanSessionQueue[]>> {
   const { signal, deadlineMs, now = () => Date.now() } = options;
   const startedAt = now();
 
@@ -134,58 +130,64 @@ export async function listOrphanSessionQueues(
   const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
   const sessionPrefix = buildSessionQueuePrefix(projectId);
   const polled = new Set(polledQueues);
+  const placeholderWorkflowId = `${projectPrefix}orphan-session-queues`;
 
-  const collect = async (): Promise<OrphanSessionQueue[]> => {
-    // Collect per-queue oldest startTime
-    const queueOldestStart = new Map<string, Date>();
-    let inspected = 0;
+  // Collect per-queue oldest startTime
+  const queueOldestStart = new Map<string, Date>();
+  let inspected = 0;
 
-    // `break` (not `return`) so the async iterator's `return()` runs and the
-    // underlying Visibility stream is released rather than left dangling.
-    for await (const wf of client.workflow.list({ query })) {
-      if (signal?.aborted) break;
-      if (deadlineMs !== undefined && now() - startedAt >= deadlineMs) break;
-      if (inspected >= INSPECTION_LIMIT) break;
-      inspected++;
-
-      // Only change workflows (exclude epics)
-      if (!wf.workflowId.startsWith(projectPrefix)) continue;
-
-      // Only RUNNING workflows need a poller
-      if (wf.status.name !== "RUNNING") continue;
-
-      // Only session-scoped queues can be orphaned
-      if (!wf.taskQueue.startsWith(sessionPrefix)) continue;
-
-      // Skip queues already being polled
-      if (polled.has(wf.taskQueue)) continue;
-
-      // Keep the oldest startTime per queue (for deterministic FIFO sort)
-      const existing = queueOldestStart.get(wf.taskQueue);
-      if (!existing || wf.startTime < existing) {
-        queueOldestStart.set(wf.taskQueue, wf.startTime);
-      }
-    }
-
-    // Sort by oldest startTime ascending (FIFO — oldest orphans first)
-    const result = [...queueOldestStart.entries()].map(
-      ([queue, oldestStartTime]) => ({
-        queue,
-        oldestStartTime,
-      }),
-    );
-    result.sort(
-      (a, b) => a.oldestStartTime.getTime() - b.oldestStartTime.getTime(),
-    );
-
-    return result;
-  };
-
-  // Scope the enumeration to the caller's abort signal when the client exposes
-  // a real connection, so aborting actually cancels the in-flight gRPC call.
-  const connection = client.connection;
-  if (signal && typeof connection?.withAbortSignal === "function") {
-    return await connection.withAbortSignal(signal, collect);
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    placeholderWorkflowId,
+    "list",
+    "listOrphanSessionQueues",
+    10_000,
+    signal,
+  );
+  const outcome = await owner.list<{
+    workflowId: string;
+    taskQueue: string;
+    startTime: Date;
+    status: { name: string };
+  }>(ctx, query, { limit: INSPECTION_LIMIT });
+  if (outcome.kind !== "complete") {
+    return outcome;
   }
-  return await collect();
+  for (const wf of outcome.value) {
+    if (signal?.aborted) break;
+    if (deadlineMs !== undefined && now() - startedAt >= deadlineMs) break;
+    if (inspected >= INSPECTION_LIMIT) break;
+    inspected++;
+
+    // Only change workflows (exclude epics)
+    if (!wf.workflowId.startsWith(projectPrefix)) continue;
+
+    // Only RUNNING workflows need a poller
+    if (wf.status.name !== "RUNNING") continue;
+
+    // Only session-scoped queues can be orphaned
+    if (!wf.taskQueue.startsWith(sessionPrefix)) continue;
+
+    // Skip queues already being polled
+    if (polled.has(wf.taskQueue)) continue;
+
+    // Keep the oldest startTime per queue (for deterministic FIFO sort)
+    const existing = queueOldestStart.get(wf.taskQueue);
+    if (!existing || wf.startTime < existing) {
+      queueOldestStart.set(wf.taskQueue, wf.startTime);
+    }
+  }
+
+  // Sort by oldest startTime ascending (FIFO — oldest orphans first)
+  const orphans = [...queueOldestStart.entries()].map(
+    ([queue, oldestStartTime]) => ({
+      queue,
+      oldestStartTime,
+    }),
+  );
+  orphans.sort(
+    (a, b) => a.oldestStartTime.getTime() - b.oldestStartTime.getTime(),
+  );
+
+  return { kind: "complete", value: orphans, truncated: outcome.truncated };
 }

--- a/plugin/src/temporal/list-source-ranked-candidates.test.ts
+++ b/plugin/src/temporal/list-source-ranked-candidates.test.ts
@@ -10,24 +10,28 @@ import { describe, expect, it } from "vitest";
 import {
   listSourceRankedCandidates,
   type SourceRankedCandidate,
-  type SourceRankedListClient,
 } from "./list-source-ranked-candidates";
+import type { TemporalListOutcome, TemporalOperations } from "./operations";
+
+/** Canonical 40-character lowercase hex project ID used across these tests. */
+const PROJECT_ID = "0".repeat(40);
+const CHANGE_PREFIX = `adv/change/${PROJECT_ID}/`;
 
 interface VisibilityRecord {
   workflowId: string;
   searchAttributes?: Record<string, unknown>;
 }
 
-function makeClient(records: VisibilityRecord[]): SourceRankedListClient {
+function makeOwner(records: VisibilityRecord[]): TemporalOperations {
   return {
-    workflow: {
-      list: () => ({
-        async *[Symbol.asyncIterator]() {
-          for (const record of records) yield record;
-        },
-      }),
+    list: async function <T extends { workflowId: string }>(
+      _ctx: unknown,
+      _query: string,
+      _options?: { limit?: number },
+    ): Promise<TemporalListOutcome<T[]>> {
+      return { kind: "complete", value: records as T[], truncated: false };
     },
-  };
+  } as unknown as TemporalOperations;
 }
 
 function visibilityRecord(
@@ -36,7 +40,7 @@ function visibilityRecord(
   createdAt: string,
 ): VisibilityRecord {
   return {
-    workflowId: `adv/change/proj/${changeId}`,
+    workflowId: `${CHANGE_PREFIX}${changeId}`,
     searchAttributes: {
       AdvLastSignalAt: [lastSignalAt],
       AdvCreatedAt: [createdAt],
@@ -65,7 +69,7 @@ function shuffleWithSeed<T>(input: T[], seed: number): T[] {
 
 describe("listSourceRankedCandidates", () => {
   it("ranks by Visibility AdvLastSignalAt descending, then AdvCreatedAt", async () => {
-    const client = makeClient([
+    const client = makeOwner([
       // Older by lastSignalAt but appears first in enumeration.
       visibilityRecord(
         "alpha",
@@ -87,7 +91,7 @@ describe("listSourceRankedCandidates", () => {
     ]);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 3,
     });
 
@@ -100,15 +104,15 @@ describe("listSourceRankedCandidates", () => {
   });
 
   it("falls back to AdvCreatedAt when AdvLastSignalAt is absent", async () => {
-    const client = makeClient([
+    const client = makeOwner([
       {
-        workflowId: "adv/change/proj/newer",
+        workflowId: `${CHANGE_PREFIX}newer`,
         searchAttributes: {
           AdvCreatedAt: ["2026-07-18T12:00:00.000Z"],
         },
       },
       {
-        workflowId: "adv/change/proj/older",
+        workflowId: `${CHANGE_PREFIX}older`,
         searchAttributes: {
           AdvCreatedAt: ["2026-07-18T10:00:00.000Z"],
         },
@@ -116,7 +120,7 @@ describe("listSourceRankedCandidates", () => {
     ]);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 2,
     });
 
@@ -124,7 +128,7 @@ describe("listSourceRankedCandidates", () => {
   });
 
   it("includes durable disk-only projection candidates", async () => {
-    const client = makeClient([
+    const client = makeOwner([
       visibilityRecord(
         "visible",
         "2026-07-18T10:00:00.000Z",
@@ -133,7 +137,7 @@ describe("listSourceRankedCandidates", () => {
     ]);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 2,
       diskCandidates: [
         diskCandidate(
@@ -152,7 +156,7 @@ describe("listSourceRankedCandidates", () => {
   it("does not let memo warmth or input order outrank source timestamps", async () => {
     // Input order (which could represent memo-warm iteration) is intentionally
     // oldest-first. Source-backed timestamps must still win.
-    const client = makeClient([
+    const client = makeOwner([
       visibilityRecord(
         "old-but-warm",
         "2026-07-18T08:00:00.000Z",
@@ -166,7 +170,7 @@ describe("listSourceRankedCandidates", () => {
     ]);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 2,
     });
 
@@ -177,7 +181,7 @@ describe("listSourceRankedCandidates", () => {
   });
 
   it("tie-breaks equal timestamps by canonical ID ascending", async () => {
-    const client = makeClient([
+    const client = makeOwner([
       visibilityRecord(
         "zebra",
         "2026-07-18T10:00:00.000Z",
@@ -191,7 +195,7 @@ describe("listSourceRankedCandidates", () => {
     ]);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 2,
     });
 
@@ -212,10 +216,10 @@ describe("listSourceRankedCandidates", () => {
       ),
     );
     const shuffledRecords = shuffleWithSeed(records, 12345);
-    const client = makeClient(shuffledRecords);
+    const client = makeOwner(shuffledRecords);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 10,
     });
 
@@ -225,7 +229,7 @@ describe("listSourceRankedCandidates", () => {
   });
 
   it("hydrates only the admitted IDs", async () => {
-    const client = makeClient([
+    const client = makeOwner([
       visibilityRecord(
         "a",
         "2026-07-18T12:00:00.000Z",
@@ -244,7 +248,7 @@ describe("listSourceRankedCandidates", () => {
     ]);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 2,
     });
 
@@ -261,10 +265,10 @@ describe("listSourceRankedCandidates", () => {
         `2026-07-${String(18 - index).padStart(2, "0")}T08:00:00.000Z`,
       ),
     );
-    const client = makeClient(shuffleWithSeed(records, 42));
+    const client = makeOwner(shuffleWithSeed(records, 42));
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 10,
     });
 
@@ -273,17 +277,17 @@ describe("listSourceRankedCandidates", () => {
     expect(result.omittedIds.length).toBeLessThanOrEqual(20);
     // Deterministic for the same inputs.
     const result2 = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 10,
     });
     expect(result2.omittedIds).toEqual(result.omittedIds);
   });
 
   it("degrades for invalid/missing timestamps instead of using enumeration order", async () => {
-    const client = makeClient([
+    const client = makeOwner([
       // Missing lastSignalAt, invalid createdAt.
       {
-        workflowId: "adv/change/proj/bad",
+        workflowId: `${CHANGE_PREFIX}bad`,
         searchAttributes: {
           AdvCreatedAt: ["not-a-date"],
         },
@@ -296,13 +300,13 @@ describe("listSourceRankedCandidates", () => {
       ),
       // Missing both.
       {
-        workflowId: "adv/change/proj/missing",
+        workflowId: `${CHANGE_PREFIX}missing`,
         searchAttributes: {},
       },
     ]);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 3,
     });
 
@@ -315,14 +319,15 @@ describe("listSourceRankedCandidates", () => {
   });
 
   it("omits candidates whose workflow IDs do not match the project prefix", async () => {
-    const client = makeClient([
+    const otherProjectId = "1".repeat(40);
+    const client = makeOwner([
       visibilityRecord(
         "valid",
         "2026-07-18T10:00:00.000Z",
         "2026-07-18T08:00:00.000Z",
       ),
       {
-        workflowId: "adv/change/other-project/stranger",
+        workflowId: `adv/change/${otherProjectId}/stranger`,
         searchAttributes: {
           AdvLastSignalAt: ["2026-07-18T12:00:00.000Z"],
           AdvCreatedAt: ["2026-07-18T10:00:00.000Z"],
@@ -331,7 +336,7 @@ describe("listSourceRankedCandidates", () => {
     ]);
 
     const result = await listSourceRankedCandidates(client, {
-      projectId: "proj",
+      projectId: PROJECT_ID,
       limit: 2,
     });
 

--- a/plugin/src/temporal/list-source-ranked-candidates.ts
+++ b/plugin/src/temporal/list-source-ranked-candidates.ts
@@ -18,6 +18,8 @@
 import type { ChangeStatus } from "../types";
 import { CHANGE_WORKFLOW_PREFIX } from "./contracts";
 import { buildVisibilityQuery } from "./list-change-workflows";
+import type { TemporalOperations } from "./operations";
+import { makeTemporalOperationContext } from "./operations";
 
 export interface SourceRankedCandidate {
   id: string;
@@ -26,15 +28,6 @@ export interface SourceRankedCandidate {
   lastSignalAt?: string;
   /** ISO 8601 timestamp from the source (AdvCreatedAt for Visibility). */
   createdAt?: string;
-}
-
-export interface SourceRankedListClient {
-  workflow: {
-    list: (opts: { query: string }) => AsyncIterable<{
-      workflowId: string;
-      searchAttributes?: Record<string, unknown>;
-    }>;
-  };
 }
 
 export interface ListSourceRankedCandidatesOptions {
@@ -114,7 +107,7 @@ function compareCandidates(
 }
 
 export async function listSourceRankedCandidates(
-  client: SourceRankedListClient,
+  owner: TemporalOperations,
   options: ListSourceRankedCandidatesOptions,
 ): Promise<ListSourceRankedCandidatesResult> {
   const { projectId, statuses, limit, diskCandidates = [] } = options;
@@ -122,10 +115,23 @@ export async function listSourceRankedCandidates(
   const effectiveLimit = limit ?? 10;
 
   const query = buildVisibilityQuery({ projectId, statuses });
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    "source-ranked-list",
+    "list",
+    "listSourceRankedCandidates",
+    5_000,
+  );
   const candidates: SourceRankedCandidate[] = [];
   const seenIds = new Set<string>();
-
-  for await (const record of client.workflow.list({ query })) {
+  const result = await owner.list<{
+    workflowId: string;
+    searchAttributes?: Record<string, unknown>;
+  }>(ctx, query, { limit: effectiveLimit * 2 });
+  if (result.kind !== "complete") {
+    throw result.error;
+  }
+  for (const record of result.value) {
     const wfid = record.workflowId;
     // Defensive prefix filter: Visibility may return workflows that match the
     // search attributes but belong to a different project or workflow type.

--- a/plugin/src/temporal/mutation-receipt.test.ts
+++ b/plugin/src/temporal/mutation-receipt.test.ts
@@ -39,7 +39,7 @@ function baseChangeState(): ReturnType<typeof createChangeWorkflowState> {
     title: "T",
     createdAt: "2026-01-01T00:00:00.000Z",
   });
-  state.projectId = "proj-1";
+  state.projectId = "0000100000000000000000000000000000000000";
   state.initializedAt = "2026-01-01T00:00:00.000Z";
   return state;
 }

--- a/plugin/src/temporal/observability.test.ts
+++ b/plugin/src/temporal/observability.test.ts
@@ -69,7 +69,7 @@ describe("temporal observability helpers", () => {
 
   it("builds a minimal search attribute map for change workflows", () => {
     const attrs = buildTemporalSearchAttributes({
-      projectId: "proj1",
+      projectId: "0000100000000000000000000000000000000000",
       changeId: "chg1",
       changeStatus: "active",
       activeGate: "execution",
@@ -78,14 +78,14 @@ describe("temporal observability helpers", () => {
     expect(attrs).toEqual({
       AdvChangeId: ["chg1"],
       AdvChangeStatus: ["active"],
-      AdvAffectedProjects: ["proj1"],
+      AdvAffectedProjects: ["0000100000000000000000000000000000000000"],
       AdvCurrentGate: ["execution"],
     });
   });
 
   it("includes AdvEpicId when epicId is provided", () => {
     const attrs = buildTemporalSearchAttributes({
-      projectId: "proj1",
+      projectId: "0000100000000000000000000000000000000000",
       changeId: "chg1",
       changeStatus: "active",
       activeGate: "execution",
@@ -97,7 +97,7 @@ describe("temporal observability helpers", () => {
 
   it("omits AdvEpicId when epicId is not provided", () => {
     const attrs = buildTemporalSearchAttributes({
-      projectId: "proj1",
+      projectId: "0000100000000000000000000000000000000000",
       changeId: "chg1",
       changeStatus: "active",
       activeGate: "execution",

--- a/plugin/src/temporal/observability.ts
+++ b/plugin/src/temporal/observability.ts
@@ -37,6 +37,7 @@ export interface WrongTypeAdvSearchAttribute {
 }
 
 export interface AdvSearchAttributeCheckResult {
+  projectId: string;
   ok: boolean;
   verificationStatus: "verified" | "unverified";
   present: RequiredAdvSearchAttribute[];
@@ -46,6 +47,7 @@ export interface AdvSearchAttributeCheckResult {
 }
 
 export interface AdvSearchAttributeRegistrationResult {
+  projectId: string;
   ok: boolean;
   method: "operatorService.addSearchAttributes" | "unavailable";
   verificationStatus: "verified" | "unverified";
@@ -104,11 +106,13 @@ function extractIndexedValueType(value: unknown): number | null {
 export async function checkAdvSearchAttributes(
   connection: SearchAttributeConnectionLike,
   namespace: string,
+  projectId: string,
 ): Promise<AdvSearchAttributeCheckResult> {
   const required = requiredAdvSearchAttributes();
   const operatorService = connection.operatorService;
   if (!operatorService?.listSearchAttributes) {
     return {
+      projectId,
       ok: false,
       verificationStatus: "unverified",
       present: [],
@@ -146,6 +150,7 @@ export async function checkAdvSearchAttributes(
     }
 
     return {
+      projectId,
       ok: missing.length === 0 && wrongType.length === 0,
       verificationStatus: "verified",
       present,
@@ -154,6 +159,7 @@ export async function checkAdvSearchAttributes(
     };
   } catch (err) {
     return {
+      projectId,
       ok: false,
       verificationStatus: "unverified",
       present: [],
@@ -167,12 +173,18 @@ export async function checkAdvSearchAttributes(
 export async function registerMissingAdvSearchAttributes(
   connection: SearchAttributeConnectionLike,
   namespace: string,
+  projectId: string,
 ): Promise<AdvSearchAttributeRegistrationResult> {
-  const check = await checkAdvSearchAttributes(connection, namespace);
+  const check = await checkAdvSearchAttributes(
+    connection,
+    namespace,
+    projectId,
+  );
   const operatorService = connection.operatorService;
 
   if (check.wrongType.length > 0) {
     return {
+      projectId,
       ok: false,
       method: "operatorService.addSearchAttributes",
       verificationStatus: check.verificationStatus,
@@ -185,6 +197,7 @@ export async function registerMissingAdvSearchAttributes(
 
   if (check.missing.length === 0) {
     return {
+      projectId,
       ok: check.ok,
       method: operatorService?.addSearchAttributes
         ? "operatorService.addSearchAttributes"
@@ -199,6 +212,7 @@ export async function registerMissingAdvSearchAttributes(
 
   if (!operatorService?.addSearchAttributes) {
     return {
+      projectId,
       ok: false,
       method: "unavailable",
       verificationStatus: check.verificationStatus,
@@ -218,6 +232,7 @@ export async function registerMissingAdvSearchAttributes(
     // Call through the service object instead of destructuring the method.
     await operatorService.addSearchAttributes({ namespace, searchAttributes });
     return {
+      projectId,
       ok: true,
       method: "operatorService.addSearchAttributes",
       verificationStatus: check.verificationStatus,
@@ -227,6 +242,7 @@ export async function registerMissingAdvSearchAttributes(
     };
   } catch (err) {
     return {
+      projectId,
       ok: false,
       method: "operatorService.addSearchAttributes",
       verificationStatus: check.verificationStatus,

--- a/plugin/src/temporal/operations-boundary.test.ts
+++ b/plugin/src/temporal/operations-boundary.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from "vitest";
+import { glob } from "node:fs/promises";
+import path from "node:path";
+import { readFile, mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+/**
+ * Structural source boundary test for the Temporal client-operation owner.
+ *
+ * Only `src/temporal/operations.ts` may directly import, hold, or invoke the
+ * raw `@temporalio/client` SDK surface. All other production code routes
+ * Temporal client RPCs through the typed owner API (`TemporalOperations`).
+ *
+ * The detector is intentionally conservative: if a production file contains any
+ * of the forbidden patterns, it is a boundary violation. Test files, the worker
+ * bundle root (`src/temporal/workflows.ts`), and worker construction files are
+ * exempt from import checks but still guarded from raw-handle storage and
+ * structural client interfaces.
+ *
+ * Patterns guarded:
+ *   - named/default/namespace/dynamic imports from `@temporalio/client`
+ *   - raw bundle factories: `TemporalClientBundle`, `createTemporalClientBundle`
+ *   - raw handle storage: `__handle`, `WorkflowHandleLike`, `WorkflowClientLike`
+ *   - structural client interfaces: `workflow: { list|getHandle|start... }`,
+ *     `connection: { workflowService|withDeadline|... }`, `workflowService: {...}`
+ *   - direct SDK access: `client.workflow.*`, `connection.workflowService.*`,
+ *     `connection.withDeadline`, `connection.withAbortSignal`, `connection.close`
+ *   - iterator escape: `AsyncIterable` used for visibility lists
+ *   - optional/hardcoded 30s budget holes in Temporal operation contexts
+ */
+
+const OWNER_FILE = path.normalize("temporal/operations.ts");
+
+const WORKER_CONSTRUCTION_FILES = new Set([
+  path.normalize("temporal/worker.ts"),
+  path.normalize("temporal/worker-multi.ts"),
+  path.normalize("temporal/in-process-worker.ts"),
+]);
+
+/** Raw client import patterns (named, default, namespace, dynamic, aliased). */
+const CLIENT_IMPORT_RE =
+  /import\s+(?:type\s+)?(?:\*\s+as\s+\w+|\w+|\{[^}]*\})\s*,?\s*(?:\*\s+as\s+\w+)?\s*from\s+["']@temporalio\/client["']|import\s*\(\s*["']@temporalio\/client["']\s*\)|const\s+\{\s*[^}]*\}\s*=\s*await\s+import\s*\(\s*["']@temporalio\/client["']\s*\)/;
+
+/** Raw bundle factories that must be private to the owner. */
+const BUNDLE_FACTORY_RE =
+  /\b(TemporalClientBundle|createTemporalClientBundle)\b/;
+
+/** Raw handle storage patterns. */
+const RAW_HANDLE_STORAGE_RE =
+  /\b(__handle|WorkflowHandleLike|WorkflowClientLike)\b/;
+
+/** Direct client/connection RPC access, including optional chaining. */
+const DIRECT_SDK_ACCESS_RES = [
+  /\bclient\.?workflow\.?(list|getHandle|start|signalWithStart|cancel|terminate|query|describe)\b/,
+  /\bconnection\.?workflowService\b/,
+  /\bconnection\.?(withDeadline|withAbortSignal)\b/,
+  /\bconnection\.?close\s*\(/,
+];
+
+/** Structural interface definitions that mimic the raw SDK client surface. */
+const STRUCTURAL_CLIENT_INTERFACE_RE =
+  /interface\s+\w+[^}]*\{[^}]*(?:workflow\s*:\s*\{[^}]*(?:list|getHandle|start|signalWithStart)\b|connection\s*:\s*\{[^}]*(?:workflowService|withDeadline|withAbortSignal)\b|workflowService\s*:\s*\{[^}]*(?:describeNamespace|describeWorkflowExecution|describeTaskQueue)\b)/;
+
+/** Iterator escape: AsyncIterable used for visibility workflow lists. */
+const ITERATOR_ESCAPE_RE = /\bAsyncIterable\s*<[^>]*workflowId/;
+
+/** Optional budget holes and legacy 30s defaults. */
+const OPTIONAL_BUDGET_RE = /\bbudgetMs\s*(\?\s*:|=\s*30_000)\b/;
+
+/** Strip line and block comments to avoid false-positives in prose. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+/** Variable aliases and destructuring that can bypass the literal access checks. */
+const ALIAS_RE = [
+  /(?:const|let|var)\s+\w+\s*=\s*(client|connection)\b(?!\.)/,
+  /(?:const|let|var)\s*\{\s*[^}]*\b(?:workflow|workflowService)\b[^}]*\}\s*=\s*(client|connection)\b/,
+];
+
+/** Detect all boundary violations in a single source file. */
+function detectViolations(relativePath: string, rawSource: string): string[] {
+  const violations: string[] = [];
+  const isOwner = relativePath === OWNER_FILE;
+  const isWorkerConstructionFile = WORKER_CONSTRUCTION_FILES.has(relativePath);
+  const source = stripComments(rawSource);
+
+  if (!isOwner) {
+    const importMatch = source.match(CLIENT_IMPORT_RE);
+    if (importMatch) {
+      violations.push(`${relativePath}: ${importMatch[0]}`);
+    }
+  }
+
+  if (!isOwner) {
+    const bundleMatch = source.match(BUNDLE_FACTORY_RE);
+    if (bundleMatch) {
+      violations.push(`${relativePath}: ${bundleMatch[0]}`);
+    }
+  }
+
+  if (!isOwner) {
+    const handleMatch = source.match(RAW_HANDLE_STORAGE_RE);
+    if (handleMatch) {
+      violations.push(`${relativePath}: ${handleMatch[0]}`);
+    }
+  }
+
+  if (!isOwner) {
+    // Worker construction files use @temporalio/worker's NativeConnection, not
+    // the @temporalio/client Connection surface; skip direct SDK access checks.
+    if (!isWorkerConstructionFile) {
+      for (const re of DIRECT_SDK_ACCESS_RES) {
+        const match = source.match(re);
+        if (match) {
+          violations.push(`${relativePath}: ${match[0]}`);
+        }
+      }
+      for (const re of ALIAS_RE) {
+        const match = source.match(re);
+        if (match) {
+          violations.push(`${relativePath}: alias/destructuring ${match[0]}`);
+        }
+      }
+    }
+  }
+
+  if (!isOwner) {
+    const structuralMatch = source.match(STRUCTURAL_CLIENT_INTERFACE_RE);
+    if (structuralMatch) {
+      violations.push(`${relativePath}: structural client interface`);
+    }
+  }
+
+  if (!isOwner) {
+    const iterMatch = source.match(ITERATOR_ESCAPE_RE);
+    if (iterMatch) {
+      violations.push(`${relativePath}: ${iterMatch[0]}`);
+    }
+  }
+
+  if (!isOwner) {
+    const budgetMatch = source.match(OPTIONAL_BUDGET_RE);
+    if (budgetMatch) {
+      violations.push(`${relativePath}: ${budgetMatch[0]}`);
+    }
+  }
+
+  return violations;
+}
+
+async function findProductionFiles(srcRoot: string): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of glob("**/*.ts", { cwd: srcRoot })) {
+    const relative = path.normalize(entry);
+    if (relative.startsWith("__tests__/")) continue;
+    if (relative.startsWith("__fixtures__/")) continue;
+    if (relative.startsWith("__mocks__/")) continue;
+    if (relative.includes("/__tests__/")) continue;
+    if (relative.includes("/__fixtures__/")) continue;
+    if (relative.includes("/__mocks__/")) continue;
+    if (
+      relative.endsWith(".test.ts") ||
+      relative.endsWith(".itest.ts") ||
+      relative.endsWith(".assets.test.ts")
+    ) {
+      continue;
+    }
+    if (relative.endsWith(".d.ts")) continue;
+    files.push(relative);
+  }
+  return files;
+}
+
+async function scanForViolations(root: string): Promise<string[]> {
+  const files = await findProductionFiles(root);
+  const violations: string[] = [];
+  for (const relative of files) {
+    const content = await readFile(path.join(root, relative), "utf-8");
+    violations.push(...detectViolations(relative, content));
+  }
+  return violations;
+}
+
+describe("Temporal client-operation boundary", () => {
+  const srcRoot = path.resolve(import.meta.dirname, "..");
+  const binRoot = path.resolve(import.meta.dirname, "..", "..", "..", "bin");
+  const scriptsRoot = path.resolve(import.meta.dirname, "..", "..", "scripts");
+  const rootScriptsRoot = path.resolve(
+    import.meta.dirname,
+    "..",
+    "..",
+    "..",
+    "scripts",
+  );
+
+  it("no production module imports from @temporalio/client except the owner", async () => {
+    expect(await scanForViolations(srcRoot)).toEqual([]);
+  });
+
+  it("no root CLI production file imports from @temporalio/client or the raw bundle factory", async () => {
+    expect(await scanForViolations(binRoot)).toEqual([]);
+  });
+
+  it("no scripts production file imports from @temporalio/client or the raw bundle factory", async () => {
+    expect(await scanForViolations(scriptsRoot)).toEqual([]);
+  });
+
+  it("no root scripts production file imports from @temporalio/client or the raw bundle factory", async () => {
+    expect(await scanForViolations(rootScriptsRoot)).toEqual([]);
+  });
+
+  it("detector catches synthetic violating fixtures", async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), "adv-boundary-"));
+    try {
+      const fixtures: Array<{ name: string; source: string; expect: string }> =
+        [
+          {
+            name: "named-import.ts",
+            source: `import { Client } from "@temporalio/client";\n`,
+            expect: "@temporalio/client",
+          },
+          {
+            name: "type-import.ts",
+            source: `import type { Connection } from "@temporalio/client";\n`,
+            expect: "@temporalio/client",
+          },
+          {
+            name: "dynamic-import.ts",
+            source: `const { Client } = await import("@temporalio/client");\n`,
+            expect: "@temporalio/client",
+          },
+          {
+            name: "bundle-factory.ts",
+            source: `import { createTemporalClientBundle } from "./temporal/operations";\nconst b = createTemporalClientBundle();\n`,
+            expect: "createTemporalClientBundle",
+          },
+          {
+            name: "raw-handle-storage.ts",
+            source: `export function wrap(h: any) { return { __handle: h }; }\n`,
+            expect: "__handle",
+          },
+          {
+            name: "structural-client.ts",
+            source: `export interface ListClient { workflow: { list(opts: { query: string }): AsyncIterable<{ workflowId: string }> } }\n`,
+            expect: "structural client interface",
+          },
+          {
+            name: "direct-client-list.ts",
+            source: `for await (const x of client.workflow.list({ query: "" })) {}\n`,
+            expect: "client.workflow.list",
+          },
+          {
+            name: "direct-connection-close.ts",
+            source: `await connection.close();\n`,
+            expect: "connection.close",
+          },
+          {
+            name: "iterator-escape.ts",
+            source: `export function list(): AsyncIterable<{ workflowId: string }> { throw new Error(); }\n`,
+            expect: "AsyncIterable",
+          },
+          {
+            name: "optional-budget.ts",
+            source: `function makeCtx(budgetMs = 30_000) { return { budgetMs }; }\n`,
+            expect: "budgetMs = 30_000",
+          },
+          {
+            name: "bin-raw-client-import.ts",
+            source: `import { Client } from "@temporalio/client";\n`,
+            expect: "@temporalio/client",
+          },
+          {
+            name: "bin-bundle-factory-from-boundary.ts",
+            source: `import { createTemporalClientBundle } from "../../plugin/src/cli/temporal-boundary";\n`,
+            expect: "createTemporalClientBundle",
+          },
+          {
+            name: "bin-direct-getHandle-query.ts",
+            source: `await client.workflow.getHandle("wf").query("q");\n`,
+            expect: "client.workflow.getHandle",
+          },
+          {
+            name: "root-scripts-raw-client-import.ts",
+            source: `import { Client } from "@temporalio/client";\n`,
+            expect: "@temporalio/client",
+          },
+          {
+            name: "root-scripts-bundle-factory.ts",
+            source: `import { createTemporalClientBundle } from "../plugin/src/temporal/operations";\n`,
+            expect: "createTemporalClientBundle",
+          },
+        ];
+
+      for (const f of fixtures) {
+        await writeFile(path.join(tmp, f.name), f.source, "utf-8");
+      }
+
+      for (const f of fixtures) {
+        const content = await readFile(path.join(tmp, f.name), "utf-8");
+        const violations = detectViolations(f.name, content);
+        expect(violations.length).toBeGreaterThan(0);
+        expect(violations.some((v) => v.includes(f.expect))).toBe(true);
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("owner file is allowed to hold the raw SDK surface", async () => {
+    const content = await readFile(path.join(srcRoot, OWNER_FILE), "utf-8");
+    const violations = detectViolations(OWNER_FILE, content);
+    expect(violations).toEqual([]);
+  });
+
+  it("only the canonical operations.ts owner is allowed across all scanned roots", async () => {
+    const srcViolations = await scanForViolations(srcRoot);
+    const binViolations = await scanForViolations(binRoot);
+    const scriptsViolations = await scanForViolations(scriptsRoot);
+    const rootScriptsViolations = await scanForViolations(rootScriptsRoot);
+    expect(srcViolations).toEqual([]);
+    expect(binViolations).toEqual([]);
+    expect(scriptsViolations).toEqual([]);
+    expect(rootScriptsViolations).toEqual([]);
+  });
+
+  it("synthetic second owner file is detected as a boundary violation", async () => {
+    const tmp = await mkdtemp(
+      path.join(tmpdir(), "adv-boundary-second-owner-"),
+    );
+    try {
+      const ownerDir = path.join(tmp, "temporal");
+      await mkdir(ownerDir, { recursive: true });
+      await writeFile(
+        path.join(ownerDir, "operations2.ts"),
+        `import { Client } from "@temporalio/client";\n`,
+        "utf-8",
+      );
+      const violations = await scanForViolations(tmp);
+      expect(violations.length).toBeGreaterThan(0);
+      expect(
+        violations.some(
+          (v) =>
+            v.includes("operations2.ts") && v.includes("@temporalio/client"),
+        ),
+      ).toBe(true);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("synthetic root scripts owner file is detected as a boundary violation", async () => {
+    const tmp = await mkdtemp(
+      path.join(tmpdir(), "adv-boundary-root-scripts-owner-"),
+    );
+    try {
+      const scriptsDir = path.join(tmp, "scripts");
+      await mkdir(scriptsDir, { recursive: true });
+      await writeFile(
+        path.join(scriptsDir, "temporal-owner.ts"),
+        `import { Client } from "@temporalio/client";\n`,
+        "utf-8",
+      );
+      const violations = await scanForViolations(tmp);
+      expect(violations.length).toBeGreaterThan(0);
+      expect(
+        violations.some(
+          (v) =>
+            v.includes("temporal-owner.ts") && v.includes("@temporalio/client"),
+        ),
+      ).toBe(true);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("worker construction files are allowed NativeConnection lifecycle", async () => {
+    const workerFile = path.join(srcRoot, "temporal", "worker.ts");
+    const content = await readFile(workerFile, "utf-8");
+    const violations = detectViolations("temporal/worker.ts", content);
+    expect(violations).toEqual([]);
+  });
+});
+
+export { detectViolations };

--- a/plugin/src/temporal/operations.test.ts
+++ b/plugin/src/temporal/operations.test.ts
@@ -1,0 +1,512 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  TemporalOperationsOwner,
+  type TemporalOperationContext,
+  type TemporalClientBundle,
+} from "./operations";
+import { buildChangeWorkflowId, buildEpicWorkflowId } from "./client";
+import { changeStateQuery } from "./messages";
+import { proposalUpdatedSignal } from "./messages";
+import type { QueryDefinition, SignalDefinition } from "@temporalio/workflow";
+
+const mockHasActiveSessionPinnedWorkflows = vi.hoisted(() => vi.fn());
+vi.mock("./list-orphan-session-queues", () => ({
+  hasActiveSessionPinnedWorkflows: mockHasActiveSessionPinnedWorkflows,
+}));
+
+/** Build a mock Temporal client/connection that records every operation. */
+function buildMockBundle(
+  overrides: {
+    query?: (
+      def: QueryDefinition<unknown, unknown[], string>,
+      ...args: unknown[]
+    ) => Promise<unknown>;
+    signal?: (
+      def: SignalDefinition<unknown[], string>,
+      ...args: unknown[]
+    ) => Promise<void>;
+    describe?: () => Promise<{
+      runId?: string;
+      status?: { name: string };
+      searchAttributes?: Record<string, unknown>;
+    }>;
+    terminate?: (reason: string) => Promise<void>;
+    cancel?: () => Promise<void>;
+    start?: (
+      workflow: unknown,
+      options: { workflowId: string; taskQueue: string; args: [unknown] },
+    ) => Promise<unknown>;
+    list?: (opts: { query: string }) => AsyncIterable<{ workflowId: string }>;
+  } = {},
+): {
+  bundle: TemporalClientBundle;
+  calls: {
+    starts: Array<{
+      workflow: unknown;
+      options: { workflowId: string; taskQueue: string; args: [unknown] };
+    }>;
+    queries: Array<{ def: unknown; args: unknown[] }>;
+    signals: Array<{ def: unknown; args: unknown[] }>;
+    describes: number;
+    terminates: Array<string>;
+    cancels: number;
+    lists: Array<string>;
+  };
+} {
+  const calls = {
+    starts: [],
+    queries: [],
+    signals: [],
+    describes: 0,
+    terminates: [],
+    cancels: 0,
+    lists: [],
+  } as unknown as typeof calls;
+
+  const handle = {
+    query: vi.fn(async (def, ...args) => {
+      calls.queries.push({ def, args });
+      return overrides.query?.(def, ...args) ?? {};
+    }),
+    signal: vi.fn(async (def, ...args) => {
+      calls.signals.push({ def, args });
+      await overrides.signal?.(def, ...args);
+    }),
+    describe: vi.fn(async () => {
+      calls.describes++;
+      return (
+        overrides.describe?.() ?? {
+          runId: "run-1",
+          status: { name: "RUNNING" },
+        }
+      );
+    }),
+    terminate: vi.fn(async (reason: string) => {
+      calls.terminates.push(reason);
+      await overrides.terminate?.(reason);
+    }),
+    cancel: vi.fn(async () => {
+      calls.cancels++;
+      await overrides.cancel?.();
+    }),
+    workflowId: "",
+  };
+
+  const client = {
+    workflow: {
+      start: vi.fn(async (workflow, options) => {
+        calls.starts.push({ workflow, options });
+        if (overrides.start) return overrides.start(workflow, options);
+        return handle;
+      }),
+      getHandle: vi.fn((workflowId: string) => {
+        handle.workflowId = workflowId;
+        return handle;
+      }),
+      list: vi.fn(async function* (_opts: { query: string }) {
+        calls.lists.push(_opts.query);
+        if (overrides.list) {
+          yield* overrides.list(_opts);
+        } else {
+          yield { workflowId: "wf-1" };
+        }
+      }),
+    },
+  };
+
+  const connection = {
+    withDeadline: vi.fn(
+      async (deadlineAt: number, fn: () => Promise<unknown>) => fn(),
+    ),
+    withAbortSignal: vi.fn(
+      async (signal: AbortSignal, fn: () => Promise<unknown>) => fn(),
+    ),
+    close: vi.fn(),
+  };
+
+  return {
+    bundle: {
+      address: "localhost:7233",
+      namespace: "default",
+      connection: connection as unknown as TemporalClientBundle["connection"],
+      client: client as unknown as TemporalClientBundle["client"],
+    },
+    calls,
+  };
+}
+
+function changeCtx(
+  projectId: string,
+  changeId: string,
+): TemporalOperationContext {
+  return {
+    projectId,
+    workflowId: buildChangeWorkflowId(projectId, changeId),
+    opKind: "query",
+    opType: "testQuery",
+    budgetMs: 1000,
+  };
+}
+
+function epicCtx(projectId: string, epicId: string): TemporalOperationContext {
+  return {
+    projectId,
+    workflowId: buildEpicWorkflowId(projectId, epicId),
+    opKind: "query",
+    opType: "testQuery",
+    budgetMs: 1000,
+  };
+}
+
+describe("TemporalOperationsOwner", () => {
+  const projectId = "a000000000000000000000000000000000000000";
+
+  it("rejects a context missing required fields", () => {
+    const { bundle } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    expect(() =>
+      owner.getHandle({
+        projectId: "",
+        workflowId: buildChangeWorkflowId(projectId, "c1"),
+        opKind: "query",
+        opType: "t",
+        budgetMs: 1,
+      }),
+    ).toThrow(
+      /ProjectId must be a non-empty string|40-character lowercase hex|projectId is required/i,
+    );
+  });
+
+  it("rejects a handle targeting a workflow outside the context project", () => {
+    const { bundle } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    expect(() =>
+      owner.getHandle({
+        projectId,
+        workflowId: "adv/change/0000000000000000000000000000000000000001/c1",
+        opKind: "query",
+        opType: "t",
+        budgetMs: 1,
+      }),
+    ).toThrow(/Project context mismatch/);
+  });
+
+  it("startChangeWorkflow produces an opaque handle and records start", async () => {
+    const { bundle, calls } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const result = await owner.startChangeWorkflow(changeCtx(projectId, "c1"), {
+      projectId,
+      changeId: "c1",
+      title: "Test change",
+      initializedAt: new Date().toISOString(),
+    } as unknown as import("./contracts").ChangeWorkflowInput);
+    expect(result.kind).toBe("confirmed");
+    if (result.kind !== "confirmed") {
+      throw new Error("expected confirmed outcome");
+    }
+    expect(result.value.workflowId).toBe(
+      buildChangeWorkflowId(projectId, "c1"),
+    );
+    expect(calls.starts).toHaveLength(1);
+    expect(calls.starts[0].options.workflowId).toBe(
+      buildChangeWorkflowId(projectId, "c1"),
+    );
+  });
+
+  it("startChangeWorkflow reuses existing handle on already-started", async () => {
+    const { bundle } = buildMockBundle({
+      start: vi.fn(async () => {
+        throw new Error("Workflow execution already started");
+      }),
+    });
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const result = await owner.startChangeWorkflow(changeCtx(projectId, "c1"), {
+      projectId,
+      changeId: "c1",
+      title: "Test change",
+      initializedAt: new Date().toISOString(),
+    } as unknown as import("./contracts").ChangeWorkflowInput);
+    expect(result.kind).toBe("confirmed");
+    if (result.kind !== "confirmed") {
+      throw new Error("expected confirmed outcome");
+    }
+    expect(result.value.workflowId).toBe(
+      buildChangeWorkflowId(projectId, "c1"),
+    );
+  });
+
+  it("startEpicWorkflow produces a handle and records start", async () => {
+    const { bundle, calls } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const result = await owner.startEpicWorkflow(epicCtx(projectId, "e1"), {
+      projectId,
+      epicId: "e1",
+      title: "Test epic",
+      narrative: "",
+      initializedAt: new Date().toISOString(),
+    } as unknown as import("./contracts").EpicWorkflowInput);
+    expect(result.kind).toBe("confirmed");
+    if (result.kind !== "confirmed") {
+      throw new Error("expected confirmed outcome");
+    }
+    expect(result.value.workflowId).toBe(buildEpicWorkflowId(projectId, "e1"));
+    expect(calls.starts).toHaveLength(1);
+    expect(calls.starts[0].options.workflowId).toBe(
+      buildEpicWorkflowId(projectId, "e1"),
+    );
+  });
+
+  it("query returns complete outcome on success", async () => {
+    const { bundle } = buildMockBundle({
+      query: async () => ({ changeId: "c1" }),
+    });
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const handle = owner.getHandle(changeCtx(projectId, "c1"));
+    const result = await owner.query(
+      changeCtx(projectId, "c1"),
+      handle,
+      changeStateQuery as unknown as QueryDefinition<
+        unknown,
+        unknown[],
+        string
+      >,
+    );
+    expect(result.kind).toBe("complete");
+    expect((result as { value: unknown }).value).toEqual({ changeId: "c1" });
+  });
+
+  it("describe returns complete outcome with status", async () => {
+    const { bundle } = buildMockBundle({
+      describe: async () => ({ runId: "run-1", status: { name: "RUNNING" } }),
+    });
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const handle = owner.getHandle(changeCtx(projectId, "c1"));
+    const result = await owner.describe(changeCtx(projectId, "c1"), handle);
+    expect(result.kind).toBe("complete");
+    expect((result as { value: unknown }).value).toEqual({
+      runId: "run-1",
+      status: { name: "RUNNING" },
+      searchAttributes: undefined,
+    });
+  });
+
+  it("signal returns confirmed when signal and readback both succeed", async () => {
+    const { bundle } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const handle = owner.getHandle(changeCtx(projectId, "c1"));
+    const result = await owner.signal(
+      changeCtx(projectId, "c1"),
+      handle,
+      proposalUpdatedSignal as unknown as SignalDefinition<unknown[], string>,
+      [{ title: "Updated" }],
+      {
+        readback: async () => ({ revision: 2 }),
+      },
+    );
+    expect(result.kind).toBe("confirmed");
+    expect((result as { value: unknown }).value).toEqual({ revision: 2 });
+  });
+
+  it("signal returns outcome_unknown when signal succeeds but readback fails", async () => {
+    const { bundle } = buildMockBundle({
+      query: vi.fn().mockRejectedValue(new Error("readback hung")),
+    });
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const handle = owner.getHandle(changeCtx(projectId, "c1"));
+    const result = await owner.signal(
+      { ...changeCtx(projectId, "c1"), budgetMs: 100 },
+      handle,
+      proposalUpdatedSignal as unknown as SignalDefinition<unknown[], string>,
+      [{ title: "Updated" }],
+      {
+        readback: async () => {
+          throw new Error("readback hung");
+        },
+      },
+    );
+    expect(result.kind).toBe("outcome_unknown");
+  });
+
+  it("signal returns confirmed_failure when signal itself fails", async () => {
+    const { bundle } = buildMockBundle({
+      signal: async () => {
+        throw new Error("workflow already completed");
+      },
+    });
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const handle = owner.getHandle(changeCtx(projectId, "c1"));
+    const result = await owner.signal(
+      changeCtx(projectId, "c1"),
+      handle,
+      proposalUpdatedSignal as unknown as SignalDefinition<unknown[], string>,
+      [{ title: "Updated" }],
+    );
+    expect(result.kind).toBe("confirmed_failure");
+  });
+
+  it("terminate returns confirmed on success", async () => {
+    const { bundle, calls } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const handle = owner.getHandle(changeCtx(projectId, "c1"));
+    const result = await owner.terminate(
+      changeCtx(projectId, "c1"),
+      handle,
+      "test termination",
+    );
+    expect(result.kind).toBe("confirmed");
+    expect(calls.terminates).toEqual(["test termination"]);
+  });
+
+  it("cancel returns confirmed on success", async () => {
+    const { bundle, calls } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const handle = owner.getHandle(changeCtx(projectId, "c1"));
+    const result = await owner.cancel(changeCtx(projectId, "c1"), handle);
+    expect(result.kind).toBe("confirmed");
+    expect(calls.cancels).toBe(1);
+  });
+
+  it("list delegates to the client workflow list and is bounded by caller limit", async () => {
+    const { bundle, calls } = buildMockBundle({
+      list: async function* (_opts: { query: string }) {
+        yield { workflowId: "wf-1" };
+        yield { workflowId: "wf-2" };
+      },
+    });
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const result = await owner.list(
+      { ...changeCtx(projectId, "c1"), opKind: "list", opType: "visibility" },
+      `WorkflowId LIKE 'adv/change/${projectId}/%'`,
+      { limit: 1 },
+    );
+    expect(result.kind).toBe("complete");
+    if (result.kind !== "complete") {
+      throw new Error("expected complete outcome");
+    }
+    expect(result.value).toHaveLength(1);
+    expect(result.truncated).toBe(true);
+    expect(result.value[0].workflowId).toBe("wf-1");
+    expect(calls.lists).toHaveLength(1);
+  });
+
+  it("aborts an in-flight query when the abort signal fires", async () => {
+    const controller = new AbortController();
+    const { bundle } = buildMockBundle({
+      query: async () => {
+        controller.abort();
+        return { changeId: "c1" };
+      },
+    });
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    const handle = owner.getHandle(changeCtx(projectId, "c1"));
+    const result = await owner.query(
+      { ...changeCtx(projectId, "c1"), abortSignal: controller.signal },
+      handle,
+      changeStateQuery as unknown as QueryDefinition<
+        unknown,
+        unknown[],
+        string
+      >,
+    );
+    // The abort is registered; the read-context may degrade depending on timing.
+    expect(["complete", "degraded"]).toContain(result.kind);
+  });
+});
+
+describe("aggregate start budget", () => {
+  const projectId = "a000000000000000000000000000000000000000";
+
+  function changeCtx(
+    projectId: string,
+    changeId: string,
+    budgetMs: number,
+  ): TemporalOperationContext {
+    return {
+      projectId,
+      workflowId: buildChangeWorkflowId(projectId, changeId),
+      opKind: "start",
+      opType: "aggregateBudgetTest",
+      budgetMs,
+    };
+  }
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  it("refuses start when hydration exhausts the aggregate budget and does not call client.start", async () => {
+    const { bundle, calls } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    vi.spyOn(owner as any, "hydrateChangeWorkflowInput").mockImplementation(
+      async (input: unknown) => {
+        await sleep(60);
+        return input;
+      },
+    );
+
+    const result = await owner.startChangeWorkflow(
+      changeCtx(projectId, "hydrationBudget", 50),
+      {
+        projectId,
+        changeId: "hydrationBudget",
+        title: "Hydration budget",
+        initializedAt: new Date().toISOString(),
+      } as unknown as import("./contracts").ChangeWorkflowInput,
+    );
+
+    expect(result.kind).toBe("timeout_unavailable");
+    expect(calls.starts).toHaveLength(0);
+  });
+
+  it("refuses start when preflight + hydration exhaust the aggregate budget in project-queue mode", async () => {
+    mockHasActiveSessionPinnedWorkflows.mockImplementation(async () => {
+      await sleep(80);
+      return { kind: "complete", value: false };
+    });
+    const { bundle, calls } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+    vi.spyOn(owner as any, "hydrateChangeWorkflowInput").mockImplementation(
+      async (input: unknown) => {
+        await sleep(80);
+        return input;
+      },
+    );
+
+    const result = await owner.startChangeWorkflow(
+      changeCtx(projectId, "preflightHydrationBudget", 150),
+      {
+        projectId,
+        changeId: "preflightHydrationBudget",
+        title: "Preflight hydration budget",
+        initializedAt: new Date().toISOString(),
+      } as unknown as import("./contracts").ChangeWorkflowInput,
+      { workflowQueueMode: "project" },
+    );
+
+    expect(result.kind).toBe("timeout_unavailable");
+    expect(calls.starts).toHaveLength(0);
+  });
+
+  it("starts with the remaining budget when preflight and hydration fit within the aggregate budget", async () => {
+    mockHasActiveSessionPinnedWorkflows.mockResolvedValue({
+      kind: "complete",
+      value: false,
+    });
+    const { bundle, calls } = buildMockBundle();
+    const owner = new TemporalOperationsOwner(bundle, projectId);
+
+    const result = await owner.startChangeWorkflow(
+      changeCtx(projectId, "budgetFit", 1000),
+      {
+        projectId,
+        changeId: "budgetFit",
+        title: "Budget fit",
+        initializedAt: new Date().toISOString(),
+      } as unknown as import("./contracts").ChangeWorkflowInput,
+      { workflowQueueMode: "project" },
+    );
+
+    expect(result.kind).toBe("confirmed");
+    expect(calls.starts).toHaveLength(1);
+  });
+});

--- a/plugin/src/temporal/operations.ts
+++ b/plugin/src/temporal/operations.ts
@@ -1,0 +1,1436 @@
+/**
+ * Temporal Client Operation Owner
+ *
+ * Single production module authorized to construct, hold, and invoke the
+ * Temporal SDK Client/Connection/WorkflowHandle RPC surface. All other
+ * ADV code routes Temporal client operations through this API.
+ *
+ * Design constraints:
+ *   - One owner: only this file imports `{Client, Connection, WorkflowHandle}`
+ *     from `@temporalio/client` for production use.
+ *   - Closed operation kinds: describe, query, signal, start, list, terminate,
+ *     cancel. No open-ended `(...args) => Promise<unknown>` passthrough.
+ *   - Every operation receives a non-optional typed context/budget.
+ *   - Mutations return typed outcomes distinguishing success, confirmed failure,
+ *     timeout/unavailable, and outcome-unknown (signal-ack with readback fail).
+ *   - Reads return a bounded/degradable result so routine projection reads stay
+ *     projection-only and never silently block on a wedged workflow.
+ *   - Project identity is carried in the operation context; cross-project calls
+ *     are rejected before RPC.
+ */
+
+import { Client, Connection, type WorkflowHandle } from "@temporalio/client";
+import type { QueryDefinition, SignalDefinition } from "@temporalio/workflow";
+import {
+  buildChangeWorkflowId,
+  buildEpicWorkflowId,
+  buildProjectTaskQueue,
+  buildSessionTaskQueue,
+  getTemporalAddress,
+  getTemporalNamespace,
+} from "./client";
+import { changeWorkflow, epicWorkflow } from "./workflows";
+import { changeStateQuery } from "./messages";
+import { readDiskArtifactsForHydration } from "../storage/store-temporal/hydrate-documents";
+import { hasActiveSessionPinnedWorkflows } from "./list-orphan-session-queues";
+import {
+  resolveCreationIdempotency,
+  ChangeCreationHashConflictError,
+} from "../storage/store-temporal/creation-hash";
+import type {
+  ChangeWorkflowInput,
+  EpicWorkflowInput,
+  ChangeWorkflowState,
+} from "./contracts";
+import {
+  buildTemporalSearchAttributes,
+  checkAdvSearchAttributes,
+  registerMissingAdvSearchAttributes,
+  type AdvSearchAttributeCheckResult,
+  type AdvSearchAttributeRegistrationResult,
+} from "./observability";
+import {
+  classifyTemporalWorkflowFailure,
+  type TemporalWorkflowDiagnostic,
+} from "./diagnostics";
+import {
+  composeTypedMutationResult,
+  type TypedMutationResult,
+} from "./mutation-safety";
+import {
+  abortTemporalRead,
+  createTemporalReadContext,
+  runTemporalRead,
+  type TemporalReadResult,
+} from "../storage/store-temporal/read-context";
+import { createLogger } from "../utils/debug-log";
+
+const logger = createLogger("temporal-operations");
+
+/** Branded ADV project identifier validated at the operation boundary. */
+declare const __projectIdBrand: unique symbol;
+export type ProjectId = string & { readonly [__projectIdBrand]: true };
+
+const PROJECT_ID_RE = /^[0-9a-f]{40}$/;
+
+/** Validate a raw project id string into a branded ProjectId. */
+export function validateProjectId(id: string): ProjectId {
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error("ProjectId must be a non-empty string");
+  }
+  const canonical = id.toLowerCase();
+  if (!PROJECT_ID_RE.test(canonical)) {
+    throw new Error(
+      `ProjectId must be a 40-character lowercase hex string (got ${id.length} chars)`,
+    );
+  }
+  return canonical as ProjectId;
+}
+
+/** Closed set of client-side Temporal operations routed through the owner. */
+export type TemporalOperationKind =
+  | "describe"
+  | "query"
+  | "signal"
+  | "start"
+  | "list"
+  | "terminate"
+  | "cancel";
+
+/** Non-optional operation context. Every RPC carries project + budget + kind. */
+export interface TemporalOperationContext {
+  /** ADV project identity that owns the targeted workflow. */
+  projectId: ProjectId;
+  /** Target workflow ID. */
+  workflowId: string;
+  /** Closed operation kind label. */
+  opKind: TemporalOperationKind;
+  /** Operation-type label for telemetry/diagnostics (e.g. "changeStateQuery"). */
+  opType: string;
+  /** Wall-clock budget in milliseconds for the whole operation. */
+  budgetMs: number;
+  /** Optional abort signal for cancellation propagation. */
+  abortSignal?: AbortSignal;
+}
+
+/** Build a typed operation context. */
+export function makeTemporalOperationContext(
+  projectId: string,
+  workflowId: string,
+  opKind: TemporalOperationKind,
+  opType: string,
+  budgetMs: number,
+  abortSignal?: AbortSignal,
+): TemporalOperationContext {
+  const canonicalProjectId = validateProjectId(projectId);
+  if (
+    typeof budgetMs !== "number" ||
+    !Number.isFinite(budgetMs) ||
+    budgetMs <= 0
+  ) {
+    throw new Error(
+      "TemporalOperationContext.budgetMs must be a positive finite number",
+    );
+  }
+  if (budgetMs > HOST_OPERATION_BUDGET_CEILING_MS) {
+    logger.debug(
+      `Clamping TemporalOperationContext.budgetMs from ${budgetMs}ms to the host ceiling of ${HOST_OPERATION_BUDGET_CEILING_MS}ms`,
+    );
+    budgetMs = HOST_OPERATION_BUDGET_CEILING_MS;
+  }
+  if (!opType || typeof opType !== "string") {
+    throw new Error("TemporalOperationContext.opType is required");
+  }
+  if (!workflowId || typeof workflowId !== "string") {
+    throw new Error("TemporalOperationContext.workflowId is required");
+  }
+  return {
+    projectId: canonicalProjectId,
+    workflowId,
+    opKind,
+    opType,
+    budgetMs,
+    abortSignal,
+  };
+}
+
+/** Non-optional context for lifecycle operations that do not target a workflow. */
+export interface TemporalLifecycleContext {
+  /** ADV project identity that owns the targeted namespace. */
+  projectId: ProjectId;
+  /** Operation-type label for telemetry/diagnostics. */
+  opType: string;
+  /** Wall-clock budget in milliseconds for the whole operation. */
+  budgetMs: number;
+  /** Optional abort signal for cancellation propagation. */
+  abortSignal?: AbortSignal;
+}
+
+/** Build a typed lifecycle context. */
+export function makeTemporalLifecycleContext(
+  projectId: string,
+  opType: string,
+  budgetMs: number,
+  abortSignal?: AbortSignal,
+): TemporalLifecycleContext {
+  const canonicalProjectId = validateProjectId(projectId);
+  if (
+    typeof budgetMs !== "number" ||
+    !Number.isFinite(budgetMs) ||
+    budgetMs <= 0
+  ) {
+    throw new Error(
+      "TemporalLifecycleContext.budgetMs must be a positive finite number",
+    );
+  }
+  if (budgetMs > HOST_OPERATION_BUDGET_CEILING_MS) {
+    logger.debug(
+      `Clamping TemporalLifecycleContext.budgetMs from ${budgetMs}ms to the host ceiling of ${HOST_OPERATION_BUDGET_CEILING_MS}ms`,
+    );
+    budgetMs = HOST_OPERATION_BUDGET_CEILING_MS;
+  }
+  if (!opType || typeof opType !== "string") {
+    throw new Error("TemporalLifecycleContext.opType is required");
+  }
+  return {
+    projectId: canonicalProjectId,
+    opType,
+    budgetMs,
+    abortSignal,
+  };
+}
+
+/** Wall-clock budget ceiling enforced for every public Temporal operation. */
+const HOST_OPERATION_BUDGET_CEILING_MS = 10_000;
+
+/** Queue-mode routing for change workflows. */
+export type WorkflowQueueMode = "session" | "project";
+
+/**
+ * Thrown when explicit singleton routing would strand existing session-pinned
+ * workflows by moving new workflows to the project queue while a session
+ * queue still has running workflows and no poller.
+ */
+export class IncompatibleActiveSessionQueuesError extends Error {
+  readonly name = "IncompatibleActiveSessionQueuesError";
+  readonly code = "INCOMPATIBLE_ACTIVE_SESSION_QUEUES";
+  constructor(
+    message = "Cannot activate project-queue singleton mode while session-pinned workflows are still running.",
+  ) {
+    super(message);
+  }
+}
+
+/** Outcome discriminator for server-ack/mutation operations. */
+export type TemporalMutationServerOutcome<T> =
+  | { kind: "confirmed"; value: T }
+  | {
+      kind: "confirmed_failure";
+      error: unknown;
+      diagnostic: TemporalWorkflowDiagnostic;
+    }
+  | {
+      kind: "timeout_unavailable";
+      error: unknown;
+      diagnostic: TemporalWorkflowDiagnostic;
+    }
+  | {
+      kind: "outcome_unknown";
+      error: unknown;
+      diagnostic: TemporalWorkflowDiagnostic;
+    };
+
+/** Outcome discriminator for bounded reads. */
+export type TemporalReadOutcome<T> =
+  | { kind: "complete"; value: T }
+  | { kind: "degraded"; error: unknown; diagnostic: TemporalWorkflowDiagnostic }
+  | {
+      kind: "not_found";
+      error: unknown;
+      diagnostic: TemporalWorkflowDiagnostic;
+    };
+
+/** Outcome discriminator for bounded visibility lists. */
+export type TemporalListOutcome<T> =
+  | { kind: "complete"; value: T; truncated: boolean; nextPageToken?: string }
+  | { kind: "degraded"; error: unknown; diagnostic: TemporalWorkflowDiagnostic }
+  | { kind: "timeout"; error: unknown; diagnostic: TemporalWorkflowDiagnostic }
+  | {
+      kind: "unavailable";
+      error: unknown;
+      diagnostic: TemporalWorkflowDiagnostic;
+    };
+
+export interface TemporalOperations {
+  /** Start a change workflow. Idempotent on already-started. */
+  startChangeWorkflow(
+    ctx: TemporalOperationContext,
+    input: ChangeWorkflowInput,
+    options?: {
+      workflowQueueMode?: "session" | "project";
+      sessionId?: string | null;
+    },
+  ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>>;
+
+  /** Start an epic workflow. Idempotent on already-started. */
+  startEpicWorkflow(
+    ctx: TemporalOperationContext,
+    input: EpicWorkflowInput,
+  ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>>;
+
+  /** Generic start for a named workflow type. */
+  start(
+    ctx: TemporalOperationContext,
+    workflowType: string,
+    options: {
+      workflowId: string;
+      taskQueue: string;
+      args: unknown[];
+      searchAttributes?: unknown;
+    },
+  ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>>;
+
+  /** Get a handle for an existing workflow by ID. No RPC. */
+  getHandle(
+    ctx: TemporalOperationContext,
+    runId?: string,
+  ): TemporalWorkflowHandle;
+
+  /** Bounded workflow query. */
+  query<T = unknown>(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+    def: QueryDefinition<T, unknown[]>,
+    ...args: unknown[]
+  ): Promise<TemporalReadOutcome<T>>;
+
+  /** Bounded workflow describe. */
+  describe(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+  ): Promise<TemporalReadOutcome<WorkflowRunDescription>>;
+
+  /** Signal with optional post-signal readback for outcome confirmation. */
+  signal<T = unknown>(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+    def: SignalDefinition<unknown[], string>,
+    args: unknown[],
+    options?: { readback?: () => Promise<T> },
+  ): Promise<TemporalMutationServerOutcome<T>>;
+
+  /** Terminate a workflow. */
+  terminate(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+    reason: string,
+  ): Promise<TemporalMutationServerOutcome<void>>;
+
+  /** Cancel a workflow. */
+  cancel(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+  ): Promise<TemporalMutationServerOutcome<void>>;
+
+  /** Bounded visibility list of workflow executions. */
+  list<T extends { workflowId: string }>(
+    ctx: TemporalOperationContext,
+    query: string,
+    options?: { limit?: number; nextPageToken?: string },
+  ): Promise<TemporalListOutcome<T[]>>;
+
+  /** Describe a task queue to discover poller freshness. */
+  describeTaskQueue(
+    ctx: TemporalOperationContext,
+    taskQueue: string,
+  ): Promise<TemporalReadOutcome<unknown>>;
+
+  /** Check whether the required ADV search attributes are registered. */
+  checkSearchAttributes(
+    ctx: TemporalLifecycleContext,
+  ): Promise<AdvSearchAttributeCheckResult>;
+
+  /** Register missing ADV search attributes and log the outcome. */
+  registerSearchAttributes(ctx: TemporalLifecycleContext): Promise<void>;
+
+  /** Verify required ADV search attributes propagated; retry with backoff. */
+  verifySearchAttributes(
+    ctx: TemporalLifecycleContext,
+    maxAttempts?: number,
+    delayMs?: number,
+  ): Promise<AdvSearchAttributeCheckResult>;
+
+  /** Describe the namespace (health probe). */
+  describeNamespace(
+    ctx: TemporalLifecycleContext,
+  ): Promise<TemporalReadOutcome<unknown>>;
+
+  /** Describe a workflow execution by workflow ID (health probe). */
+  describeWorkflowExecution(
+    ctx: TemporalOperationContext,
+  ): Promise<TemporalReadOutcome<unknown>>;
+}
+
+/** Opaque reference to a workflow handle. Production value is the SDK handle. */
+export interface TemporalWorkflowHandle {
+  readonly workflowId: string;
+}
+
+const handleRegistry = new WeakMap<TemporalWorkflowHandle, WorkflowHandle>();
+const HANDLE_BRAND = Symbol("TemporalWorkflowHandle.brand");
+
+export interface WorkflowRunDescription {
+  runId?: string;
+  status?: { name: string };
+  searchAttributes?: Record<string, unknown>;
+}
+
+function wrapHandle(
+  workflowId: string,
+  handle: WorkflowHandle,
+): TemporalWorkflowHandle {
+  const wrapped: TemporalWorkflowHandle = {
+    workflowId,
+    [HANDLE_BRAND]: true,
+  } as TemporalWorkflowHandle;
+  handleRegistry.set(wrapped, handle);
+  return wrapped;
+}
+
+function unwrapHandle(handle: TemporalWorkflowHandle): WorkflowHandle {
+  const raw = handleRegistry.get(handle);
+  if (raw === undefined) {
+    throw new Error(
+      "Invalid TemporalWorkflowHandle: not produced by the operation owner",
+    );
+  }
+  return raw;
+}
+
+function validateContext(
+  ctx: TemporalOperationContext | TemporalLifecycleContext,
+  ownerProjectId?: ProjectId,
+): void {
+  if (!ctx.projectId || typeof ctx.projectId !== "string") {
+    throw new Error("TemporalOperationContext.projectId is required");
+  }
+  if (
+    ownerProjectId !== undefined &&
+    ctx.projectId.toLowerCase() !== ownerProjectId.toLowerCase()
+  ) {
+    throw new Error(
+      `TemporalOperationContext.projectId mismatch: context '${ctx.projectId}' does not belong to owner '${ownerProjectId}'`,
+    );
+  }
+  if (!ctx.opType || typeof ctx.opType !== "string") {
+    throw new Error("TemporalOperationContext.opType is required");
+  }
+  if (
+    typeof ctx.budgetMs !== "number" ||
+    !Number.isFinite(ctx.budgetMs) ||
+    ctx.budgetMs <= 0
+  ) {
+    throw new Error(
+      "TemporalOperationContext.budgetMs must be a positive finite number",
+    );
+  }
+  if (ctx.budgetMs > HOST_OPERATION_BUDGET_CEILING_MS) {
+    logger.debug(
+      `Clamping TemporalOperationContext.budgetMs from ${ctx.budgetMs}ms to the host ceiling of ${HOST_OPERATION_BUDGET_CEILING_MS}ms`,
+    );
+    ctx.budgetMs = HOST_OPERATION_BUDGET_CEILING_MS;
+  }
+  if ("opKind" in ctx) {
+    if (!ctx.workflowId || typeof ctx.workflowId !== "string") {
+      throw new Error("TemporalOperationContext.workflowId is required");
+    }
+  }
+}
+
+function guardProjectId(
+  ctx: TemporalOperationContext,
+  actualWorkflowId: string,
+): void {
+  const expectedPrefix = buildChangeWorkflowId(ctx.projectId, "");
+  const epicPrefix = buildEpicWorkflowId(ctx.projectId, "");
+  if (
+    !actualWorkflowId.startsWith(expectedPrefix) &&
+    !actualWorkflowId.startsWith(epicPrefix)
+  ) {
+    throw new Error(
+      `Project context mismatch: workflow '${actualWorkflowId}' does not belong to project '${ctx.projectId}'`,
+    );
+  }
+}
+
+function diagnosticOf(error: unknown): TemporalWorkflowDiagnostic {
+  return classifyTemporalWorkflowFailure(error);
+}
+
+function readOutcome<T>(result: TemporalReadResult<T>): TemporalReadOutcome<T> {
+  if (result.complete && result.data !== undefined) {
+    return { kind: "complete", value: result.data };
+  }
+  const error =
+    result.error ?? new Error("Temporal read incomplete with no error");
+  const diagnostic = diagnosticOf(error);
+  if (diagnostic.class === "not_found") {
+    return { kind: "not_found", error, diagnostic };
+  }
+  return { kind: "degraded", error, diagnostic };
+}
+
+function isTimeoutDiagnostic(diagnostic: TemporalWorkflowDiagnostic): boolean {
+  return (
+    diagnostic.class === "deadline" ||
+    diagnostic.class === "resource_exhaustion"
+  );
+}
+
+function listOutcomeOf<T>(
+  result: TemporalReadResult<{ items: T[]; truncated: boolean }>,
+): TemporalListOutcome<T[]> {
+  if (result.complete && result.data) {
+    return {
+      kind: "complete",
+      value: result.data.items,
+      truncated: result.data.truncated,
+    };
+  }
+  const error =
+    result.error ?? new Error("Temporal list incomplete with no error");
+  const diagnostic = diagnosticOf(error);
+  if (isTimeoutDiagnostic(diagnostic)) {
+    return { kind: "timeout", error, diagnostic };
+  }
+  const code = diagnostic.cause?.code;
+  if (code === 14 || code === 13) {
+    return { kind: "unavailable", error, diagnostic };
+  }
+  return { kind: "degraded", error, diagnostic };
+}
+
+function mutationOutcome<T>(
+  result: TypedMutationResult<T>,
+): TemporalMutationServerOutcome<T> {
+  if (result.outcome === "confirmed") {
+    return { kind: "confirmed", value: result.readback.value as T };
+  }
+
+  if (result.signal.error) {
+    const error = result.signal.error;
+    const diagnostic = diagnosticOf(error);
+    if (isTimeoutDiagnostic(diagnostic)) {
+      return { kind: "timeout_unavailable", error, diagnostic };
+    }
+    return {
+      kind: "confirmed_failure",
+      error,
+      diagnostic,
+    };
+  }
+
+  if (result.readback.error) {
+    const error = result.readback.error;
+    const diagnostic = diagnosticOf(error);
+    if (isTimeoutDiagnostic(diagnostic)) {
+      return { kind: "timeout_unavailable", error, diagnostic };
+    }
+    return {
+      kind: "outcome_unknown",
+      error,
+      diagnostic,
+    };
+  }
+
+  // Fallback for malformed result (no error but not confirmed).
+  const fallback = new Error("mutation outcome incomplete with no error");
+  return {
+    kind: "outcome_unknown",
+    error: fallback,
+    diagnostic: diagnosticOf(fallback),
+  };
+}
+
+interface TemporalClientBundle {
+  address: string;
+  namespace: string;
+  connection: Connection;
+  client: Client;
+}
+
+async function createTemporalClientBundle(
+  env: NodeJS.ProcessEnv = process.env,
+  connectTimeoutMs?: number,
+): Promise<TemporalClientBundle> {
+  const address = getTemporalAddress(env);
+  const namespace = getTemporalNamespace(env);
+  const connection = await Connection.connect({
+    address,
+    connectTimeout: connectTimeoutMs ?? 10_000,
+  });
+  return {
+    address,
+    namespace,
+    connection,
+    client: new Client({ connection, namespace }),
+  };
+}
+
+export class TemporalOperationsOwner implements TemporalOperations {
+  /** Raw connection surface — private to enforce the single-owner boundary. */
+  private connection: Connection;
+  /** Raw client surface — private to enforce the single-owner boundary. */
+  private client: Client;
+  public readonly address: string;
+  public readonly namespace: string;
+  /** Project identity that owns this connection; used for lifecycle audit context. */
+  public readonly projectId: ProjectId;
+
+  constructor(bundle: TemporalClientBundle, projectId: ProjectId | string) {
+    this.connection = bundle.connection;
+    this.client = bundle.client;
+    this.address = bundle.address;
+    this.namespace = bundle.namespace;
+    this.projectId = validateProjectId(projectId);
+  }
+
+  getProjectId(): ProjectId {
+    return this.projectId;
+  }
+
+  getAddress(): string {
+    return this.address;
+  }
+
+  getNamespace(): string {
+    return this.namespace;
+  }
+
+  private runWithDeadline<T>(
+    deadlineAt: number,
+    abortSignal: AbortSignal,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    return this.connection.withDeadline(deadlineAt, () =>
+      this.connection.withAbortSignal(abortSignal, fn),
+    );
+  }
+
+  private runWithOperationDeadline<T>(
+    ctx: TemporalOperationContext | TemporalLifecycleContext,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const deadlineAt = Date.now() + ctx.budgetMs;
+    const signal = ctx.abortSignal ?? new AbortController().signal;
+    return this.runWithDeadline(deadlineAt, signal, fn);
+  }
+
+  /** Create an operation owner from a fresh client bundle for a specific project. */
+  static async fromEnv(
+    projectId: string | ProjectId,
+    env?: NodeJS.ProcessEnv,
+    options?: { connectTimeoutMs?: number },
+  ): Promise<TemporalOperationsOwner> {
+    return new TemporalOperationsOwner(
+      await createTemporalClientBundle(env, options?.connectTimeoutMs),
+      validateProjectId(projectId),
+    );
+  }
+
+  /** Close the underlying connection. Idempotent. */
+  async close(): Promise<void> {
+    try {
+      await this.connection.close();
+    } catch (e) {
+      logger.debug(
+        `TemporalOperationsOwner.close error: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
+  /** Replace the underlying connection+client in place. */
+  async reconnect(): Promise<void> {
+    try {
+      await this.close();
+    } catch (e) {
+      logger.debug(
+        `TemporalOperationsOwner.reconnect close error: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    const bundle = await createTemporalClientBundle({
+      ADV_TEMPORAL_ADDRESS: this.address,
+      ADV_TEMPORAL_NAMESPACE: this.namespace,
+    });
+    this.connection = bundle.connection;
+    this.client = bundle.client;
+  }
+
+  private async doRegisterMissingSearchAttributes(
+    ctx: TemporalLifecycleContext,
+  ): Promise<AdvSearchAttributeRegistrationResult> {
+    return this.runWithOperationDeadline(ctx, () =>
+      registerMissingAdvSearchAttributes(
+        this.connection,
+        this.namespace,
+        ctx.projectId,
+      ),
+    );
+  }
+
+  private async doCheckSearchAttributes(
+    ctx: TemporalLifecycleContext,
+  ): Promise<AdvSearchAttributeCheckResult> {
+    return this.runWithOperationDeadline(ctx, () =>
+      checkAdvSearchAttributes(this.connection, this.namespace, ctx.projectId),
+    );
+  }
+
+  async registerMissingSearchAttributes(
+    ctx: TemporalLifecycleContext,
+  ): Promise<AdvSearchAttributeRegistrationResult> {
+    validateContext(ctx, this.projectId);
+    return this.doRegisterMissingSearchAttributes(ctx);
+  }
+
+  async checkSearchAttributes(
+    ctx: TemporalLifecycleContext,
+  ): Promise<AdvSearchAttributeCheckResult> {
+    validateContext(ctx, this.projectId);
+    return this.doCheckSearchAttributes(ctx);
+  }
+
+  async registerSearchAttributes(ctx: TemporalLifecycleContext): Promise<void> {
+    validateContext(ctx, this.projectId);
+    const result = await this.doRegisterMissingSearchAttributes(ctx);
+    if (result.created.length > 0) {
+      logger.debug(
+        `Registered ADV search attributes for ${result.projectId}: ${result.created.map((a) => a.name).join(", ")}`,
+      );
+    }
+    if (result.skipped.length > 0) {
+      logger.debug(
+        `ADV search attributes already registered for ${result.projectId}: ${result.skipped.map((a) => a.name).join(", ")}`,
+      );
+    }
+    if (result.refused.length > 0) {
+      logger.warn(
+        `ADV search attributes refused for ${result.projectId} (wrong type): ${result.refused
+          .map((a) => `${a.name} (expected ${a.expected}, got ${a.actualCode})`)
+          .join(", ")}`,
+      );
+    }
+    if (result.error) {
+      const isAlreadyExists = /already\s*exists|ALREADY_EXISTS/i.test(
+        result.error,
+      );
+      if (isAlreadyExists) {
+        logger.debug(
+          `ADV search attributes already registered for ${result.projectId} (idempotent no-op): ${result.error}`,
+        );
+      } else if (result.method === "unavailable") {
+        logger.debug(
+          `OperatorService.addSearchAttributes unavailable for ${result.projectId} — skipping search-attribute registration: ${result.error}`,
+        );
+      } else {
+        logger.error(
+          `Failed to register ADV search attributes for ${result.projectId} (Visibility queries may fail): ${result.error}`,
+        );
+      }
+    }
+  }
+
+  async verifySearchAttributes(
+    ctx: TemporalLifecycleContext,
+    maxAttempts = 20,
+    delayMs = 500,
+  ): Promise<AdvSearchAttributeCheckResult> {
+    validateContext(ctx, this.projectId);
+    const deadlineAt = Date.now() + ctx.budgetMs;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () => controller.abort(), {
+        once: true,
+      });
+    }
+    let lastResult: AdvSearchAttributeCheckResult | undefined;
+    try {
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (controller.signal.aborted) break;
+        const remaining = Math.max(0, deadlineAt - Date.now());
+        if (remaining <= 0) break;
+        const subCtx: TemporalLifecycleContext = {
+          ...ctx,
+          budgetMs: remaining,
+          abortSignal: controller.signal,
+        };
+        lastResult = await this.doCheckSearchAttributes(subCtx);
+        if (lastResult.ok) {
+          logger.debug(
+            `verifySearchAttributes(${ctx.projectId}): ok after ${attempt + 1}/${maxAttempts} attempts`,
+          );
+          return lastResult;
+        }
+        if (attempt < maxAttempts - 1) {
+          const wait = Math.min(
+            delayMs,
+            Math.max(0, deadlineAt - Date.now() - 1),
+          );
+          if (wait <= 0) break;
+          logger.debug(
+            `verifySearchAttributes(${ctx.projectId}): attempt ${attempt + 1}/${maxAttempts} — ${lastResult.missing.length} missing, retrying in ${wait}ms`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, wait));
+        }
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!lastResult) {
+      lastResult = await this.doCheckSearchAttributes({
+        ...ctx,
+        budgetMs: 1,
+        abortSignal: controller.signal,
+      });
+    }
+    if (!lastResult.ok) {
+      logger.warn(
+        `verifySearchAttributes(${ctx.projectId}): still not ok after bounded attempts — ${lastResult.missing.length} missing, ${lastResult.wrongType.length} wrong type`,
+      );
+    }
+    return lastResult;
+  }
+
+  /** Probe whether the server is reachable within the supplied budget. */
+  async isReachable(ctx: TemporalLifecycleContext): Promise<boolean> {
+    validateContext(ctx, this.projectId);
+    const deadline = Date.now() + ctx.budgetMs;
+    try {
+      await this.connection.withDeadline(deadline, async () => {
+        // Lightweight health check: list namespaces or similar.
+        // Calling workflow.list with a query that matches nothing is safe.
+        for await (const _ of this.client.workflow.list({ query: "1=0" })) {
+          // no-op
+        }
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async describeNamespace(
+    ctx: TemporalLifecycleContext,
+  ): Promise<TemporalReadOutcome<unknown>> {
+    validateContext(ctx, this.projectId);
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+    const result = await runTemporalRead(
+      this.runWithDeadline.bind(this),
+      async () => {
+        const svc = this.connection.workflowService;
+        if (!svc?.describeNamespace) {
+          throw new Error("WorkflowService.describeNamespace unavailable");
+        }
+        return svc.describeNamespace({ namespace: this.namespace });
+      },
+      readCtx,
+      { opType: ctx.opType, timeoutMs: ctx.budgetMs },
+    );
+    return readOutcome<unknown>(result);
+  }
+
+  async describeWorkflowExecution(
+    ctx: TemporalOperationContext,
+  ): Promise<TemporalReadOutcome<unknown>> {
+    validateContext(ctx, this.projectId);
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+    const result = await runTemporalRead(
+      this.runWithDeadline.bind(this),
+      async () => {
+        const svc = this.connection.workflowService;
+        if (!svc?.describeWorkflowExecution) {
+          throw new Error(
+            "WorkflowService.describeWorkflowExecution unavailable",
+          );
+        }
+        return svc.describeWorkflowExecution({
+          namespace: this.namespace,
+          execution: { workflowId: ctx.workflowId },
+        });
+      },
+      readCtx,
+      { opType: ctx.opType, timeoutMs: ctx.budgetMs },
+    );
+    return readOutcome<unknown>(result);
+  }
+
+  getHandle(
+    ctx: TemporalOperationContext,
+    runId?: string,
+  ): TemporalWorkflowHandle {
+    validateContext(ctx, this.projectId);
+    guardProjectId(ctx, ctx.workflowId);
+    const handle = runId
+      ? this.client.workflow.getHandle(ctx.workflowId, runId)
+      : this.client.workflow.getHandle(ctx.workflowId);
+    return wrapHandle(ctx.workflowId, handle);
+  }
+
+  private classifyStartFailure(error: unknown): {
+    kind: Exclude<TemporalMutationServerOutcome<never>["kind"], "confirmed">;
+    diagnostic: TemporalWorkflowDiagnostic;
+  } {
+    if (error instanceof ChangeCreationHashConflictError) {
+      return {
+        kind: "confirmed_failure",
+        diagnostic: {
+          reachable: true,
+          class: "reachable",
+          evidence: error.message,
+        },
+      };
+    }
+    const diagnostic = classifyTemporalWorkflowFailure(error);
+    if (
+      diagnostic.class === "deadline" ||
+      diagnostic.class === "resource_exhaustion"
+    ) {
+      return { kind: "timeout_unavailable", diagnostic };
+    }
+    if (diagnostic.class === "unknown") {
+      return { kind: "outcome_unknown", diagnostic };
+    }
+    return { kind: "confirmed_failure", diagnostic };
+  }
+
+  async start(
+    ctx: TemporalOperationContext,
+    workflowType: string,
+    options: {
+      workflowId: string;
+      taskQueue: string;
+      args: unknown[];
+      searchAttributes?: unknown;
+    },
+  ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>> {
+    validateContext(ctx, this.projectId);
+    if (ctx.workflowId !== options.workflowId) {
+      return {
+        kind: "confirmed_failure",
+        error: new Error(
+          `start context workflowId '${ctx.workflowId}' does not match '${options.workflowId}'`,
+        ),
+        diagnostic: { reachable: true, class: "reachable" },
+      };
+    }
+    const startOpts = {
+      workflowId: options.workflowId,
+      taskQueue: options.taskQueue,
+      args: options.args as [unknown],
+      ...(options.searchAttributes
+        ? { searchAttributes: options.searchAttributes }
+        : {}),
+    };
+    try {
+      const handle = await this.runWithOperationDeadline(ctx, () =>
+        this.client.workflow.start(
+          workflowType as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          startOpts as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        ),
+      );
+      return {
+        kind: "confirmed",
+        value: wrapHandle(options.workflowId, handle as WorkflowHandle),
+      };
+    } catch (error) {
+      if (isAlreadyStartedError(error)) {
+        const handle = this.client.workflow.getHandle(options.workflowId);
+        return {
+          kind: "confirmed",
+          value: wrapHandle(options.workflowId, handle),
+        };
+      }
+      const { kind, diagnostic } = this.classifyStartFailure(error);
+      return { kind, error, diagnostic };
+    }
+  }
+
+  private async listWorkflowExecutions<T extends { workflowId: string }>(
+    query: string,
+  ): Promise<T[]> {
+    const results: T[] = [];
+    for await (const item of this.client.workflow.list({ query })) {
+      results.push(item as unknown as T);
+    }
+    return results;
+  }
+
+  private async hydrateChangeWorkflowInput(
+    input: ChangeWorkflowInput,
+  ): Promise<ChangeWorkflowInput> {
+    if (
+      input.seedState?.documents ||
+      !input.projectionChangesDir ||
+      !input.changeId
+    ) {
+      return input;
+    }
+    const hydrated = await readDiskArtifactsForHydration(
+      input.projectionChangesDir,
+      input.changeId,
+    );
+    if (hydrated.warnings.length > 0) {
+      logger.warn(
+        `Hydration warnings for ${input.changeId}: ${hydrated.warnings.map((w) => `${w.kind} ${w.path}${w.actual ? ` (${w.actual} bytes)` : ""}`).join(", ")}`,
+      );
+    }
+    if (!hydrated.documents) return input;
+    return {
+      ...input,
+      seedState: {
+        ...(input.seedState ?? {}),
+        documents: hydrated.documents,
+      },
+    };
+  }
+
+  async startChangeWorkflow(
+    ctx: TemporalOperationContext,
+    input: ChangeWorkflowInput,
+    options?: {
+      workflowQueueMode?: WorkflowQueueMode;
+      sessionId?: string | null;
+    },
+  ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>> {
+    validateContext(ctx, this.projectId);
+    const workflowId = buildChangeWorkflowId(ctx.projectId, input.changeId);
+    if (ctx.workflowId !== workflowId) {
+      return {
+        kind: "confirmed_failure",
+        error: new Error(
+          `startChangeWorkflow context workflowId '${ctx.workflowId}' does not match derived '${workflowId}'`,
+        ),
+        diagnostic: { reachable: true, class: "reachable" },
+      };
+    }
+
+    const sessionId = options?.sessionId ?? input.sessionId;
+
+    const taskQueue =
+      options?.workflowQueueMode === "project" || !sessionId
+        ? buildProjectTaskQueue(ctx.projectId)
+        : buildSessionTaskQueue(ctx.projectId, sessionId);
+
+    const startDeadline = Date.now() + ctx.budgetMs;
+
+    if (options?.workflowQueueMode === "project") {
+      const preflightBudgetMs = Math.min(5_000, Math.max(1, ctx.budgetMs - 1));
+      const preflightCtx = makeTemporalLifecycleContext(
+        ctx.projectId,
+        "startChangeWorkflow.sessionPreflight",
+        preflightBudgetMs,
+        ctx.abortSignal,
+      );
+      const hasSessionPinned = await hasActiveSessionPinnedWorkflows(
+        this,
+        ctx.projectId,
+        preflightCtx,
+      );
+      const preflightRemaining = Math.max(0, startDeadline - Date.now());
+      if (preflightRemaining <= 0) {
+        return {
+          kind: "timeout_unavailable",
+          error: new Error(
+            "Start budget exhausted after session-pinned preflight",
+          ),
+          diagnostic: { class: "deadline", reachable: true },
+        };
+      }
+      if (hasSessionPinned.kind !== "complete" || hasSessionPinned.value) {
+        return {
+          kind: "confirmed_failure",
+          error: new IncompatibleActiveSessionQueuesError(
+            `Project-queue singleton mode is incompatible with active session-pinned workflows or degraded visibility for project ${ctx.projectId}.`,
+          ),
+          diagnostic:
+            hasSessionPinned.kind !== "complete"
+              ? hasSessionPinned.diagnostic
+              : { reachable: true, class: "reachable" },
+        };
+      }
+    }
+
+    const inputWithHydration = await this.hydrateChangeWorkflowInput(input);
+
+    const remainingAfterHydration = Math.max(0, startDeadline - Date.now());
+    if (remainingAfterHydration <= 0) {
+      return {
+        kind: "timeout_unavailable",
+        error: new Error("Start budget exhausted after document hydration"),
+        diagnostic: { class: "deadline", reachable: true },
+      };
+    }
+    const startCtx = makeTemporalOperationContext(
+      ctx.projectId,
+      workflowId,
+      "start",
+      ctx.opType,
+      remainingAfterHydration,
+      ctx.abortSignal,
+    );
+
+    const searchAttributes =
+      inputWithHydration.searchAttributesEnabled !== false
+        ? (buildTemporalSearchAttributes({
+            projectId: inputWithHydration.projectId,
+            changeId: inputWithHydration.changeId,
+            changeStatus: "draft",
+            activeGate: "proposal",
+            backlogIssueNumber:
+              inputWithHydration.seedState?.origin?.issue_number,
+            epicId: inputWithHydration.seedState?.epic_membership?.epic_id,
+          }) as unknown as import("@temporalio/workflow").SearchAttributes)
+        : undefined;
+
+    const startOutcome = await this.start(startCtx, changeWorkflow as any, {
+      workflowId,
+      taskQueue,
+      args: [inputWithHydration] as [unknown],
+      searchAttributes,
+    });
+    if (startOutcome.kind !== "confirmed") {
+      return startOutcome;
+    }
+
+    if (inputWithHydration.creationRequestHash) {
+      const remainingForHash = Math.max(0, startDeadline - Date.now());
+      if (remainingForHash <= 0) {
+        return {
+          kind: "outcome_unknown",
+          error: new Error(
+            "Start budget exhausted before creation-request hash reconciliation",
+          ),
+          diagnostic: { class: "deadline", reachable: true },
+        };
+      }
+      const queryCtx = makeTemporalOperationContext(
+        ctx.projectId,
+        workflowId,
+        "query",
+        "startChangeWorkflow.hashReconcile",
+        Math.min(remainingForHash, 5_000),
+        ctx.abortSignal,
+      );
+      const outcome = await this.query(
+        queryCtx,
+        startOutcome.value,
+        changeStateQuery as QueryDefinition<
+          ChangeWorkflowState,
+          unknown[],
+          string
+        >,
+      );
+      if (outcome.kind === "complete") {
+        const decision = resolveCreationIdempotency({
+          existingHash: outcome.value.creation_request_hash,
+          computedHash: inputWithHydration.creationRequestHash,
+        });
+        if (decision.kind === "hash_conflict") {
+          return {
+            kind: "confirmed_failure",
+            error: new ChangeCreationHashConflictError({
+              changeId: inputWithHydration.changeId,
+              existingHash: decision.existing_hash,
+              computedHash: decision.computed_hash,
+            }),
+            diagnostic: { reachable: true, class: "reachable" },
+          };
+        }
+      } else {
+        return {
+          kind: "outcome_unknown",
+          error: outcome.error,
+          diagnostic: outcome.diagnostic,
+        };
+      }
+    }
+    return startOutcome;
+  }
+
+  async startEpicWorkflow(
+    ctx: TemporalOperationContext,
+    input: EpicWorkflowInput,
+  ): Promise<TemporalMutationServerOutcome<TemporalWorkflowHandle>> {
+    validateContext(ctx, this.projectId);
+    const workflowId = buildEpicWorkflowId(ctx.projectId, input.epicId);
+    if (ctx.workflowId !== workflowId) {
+      return {
+        kind: "confirmed_failure",
+        error: new Error(
+          `startEpicWorkflow context workflowId '${ctx.workflowId}' does not match derived '${workflowId}'`,
+        ),
+        diagnostic: { reachable: true, class: "reachable" },
+      };
+    }
+    return this.start(
+      ctx,
+      epicWorkflow as any,
+      {
+        workflowId,
+        taskQueue: buildProjectTaskQueue(ctx.projectId),
+        args: [input] as [unknown],
+      } as any,
+    );
+  }
+
+  async query<T = unknown>(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+    def: QueryDefinition<T, unknown[], string>,
+    ...args: unknown[]
+  ): Promise<TemporalReadOutcome<T>> {
+    validateContext(ctx, this.projectId);
+    const internal = unwrapHandle(handle);
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+    const result = await runTemporalRead(
+      this.runWithDeadline.bind(this),
+      async () => internal.query(def, ...args) as Promise<T>,
+      readCtx,
+      { opType: ctx.opType, timeoutMs: ctx.budgetMs },
+    );
+    return readOutcome<T>(result);
+  }
+
+  async describe(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+  ): Promise<TemporalReadOutcome<WorkflowRunDescription>> {
+    validateContext(ctx, this.projectId);
+    const internal = unwrapHandle(handle);
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+    const result = await runTemporalRead(
+      this.runWithDeadline.bind(this),
+      async () => {
+        const desc = await internal.describe();
+        return {
+          runId: desc.runId,
+          status: desc.status,
+          searchAttributes: desc.searchAttributes,
+        } as WorkflowRunDescription;
+      },
+      readCtx,
+      { opType: ctx.opType, timeoutMs: ctx.budgetMs },
+    );
+    return readOutcome<WorkflowRunDescription>(result);
+  }
+
+  async signal<T = unknown>(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+    def: SignalDefinition<unknown[], string>,
+    args: unknown[],
+    options?: { readback?: () => Promise<T> },
+  ): Promise<TemporalMutationServerOutcome<T>> {
+    validateContext(ctx, this.projectId);
+    const internal = unwrapHandle(handle);
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+
+    let signalError: unknown | undefined;
+    let readbackError: unknown | undefined;
+    let readbackValue: T | undefined;
+
+    try {
+      await this.runWithOperationDeadline(ctx, () =>
+        internal.signal(def, ...args),
+      );
+    } catch (error) {
+      signalError = error;
+    }
+
+    if (signalError === undefined && options?.readback) {
+      try {
+        const rbResult = await runTemporalRead(
+          this.runWithDeadline.bind(this),
+          options.readback,
+          readCtx,
+          { opType: `${ctx.opType}:readback`, timeoutMs: ctx.budgetMs },
+        );
+        if (!rbResult.complete) {
+          readbackError = rbResult.error ?? new Error("readback incomplete");
+        } else {
+          readbackValue = rbResult.data as T;
+        }
+      } catch (error) {
+        readbackError = error;
+      }
+    }
+
+    const result = composeTypedMutationResult<T>({
+      signalError,
+      readbackError,
+      readbackValue,
+    });
+    return mutationOutcome<T>(result);
+  }
+
+  async terminate(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+    reason: string,
+  ): Promise<TemporalMutationServerOutcome<void>> {
+    validateContext(ctx, this.projectId);
+    const internal = unwrapHandle(handle);
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+    const result = await runTemporalRead(
+      this.runWithDeadline.bind(this),
+      () => internal.terminate(reason),
+      readCtx,
+      { opType: ctx.opType, timeoutMs: ctx.budgetMs },
+    );
+    if (result.complete) {
+      return { kind: "confirmed", value: undefined };
+    }
+    const error =
+      result.error ?? new Error("Temporal terminate incomplete with no error");
+    const diagnostic = diagnosticOf(error);
+    if (result.degraded || isTimeoutDiagnostic(diagnostic)) {
+      return { kind: "timeout_unavailable", error, diagnostic };
+    }
+    return { kind: "confirmed_failure", error, diagnostic };
+  }
+
+  async cancel(
+    ctx: TemporalOperationContext,
+    handle: TemporalWorkflowHandle,
+  ): Promise<TemporalMutationServerOutcome<void>> {
+    validateContext(ctx, this.projectId);
+    const internal = unwrapHandle(handle);
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+    const result = await runTemporalRead(
+      this.runWithDeadline.bind(this),
+      () => internal.cancel(),
+      readCtx,
+      {
+        opType: ctx.opType,
+        timeoutMs: ctx.budgetMs,
+      },
+    );
+    if (result.complete) {
+      return { kind: "confirmed", value: undefined };
+    }
+    const error =
+      result.error ?? new Error("Temporal cancel incomplete with no error");
+    const diagnostic = diagnosticOf(error);
+    if (result.degraded || isTimeoutDiagnostic(diagnostic)) {
+      return { kind: "timeout_unavailable", error, diagnostic };
+    }
+    return { kind: "confirmed_failure", error, diagnostic };
+  }
+
+  async list<T extends { workflowId: string }>(
+    ctx: TemporalOperationContext,
+    query: string,
+    options?: { limit?: number; nextPageToken?: string },
+  ): Promise<TemporalListOutcome<T[]>> {
+    validateContext(ctx, this.projectId);
+    const limit = options?.limit ?? 1000;
+    if (limit <= 0) {
+      return { kind: "complete", value: [], truncated: false };
+    }
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+    const result = await runTemporalRead(
+      this.runWithDeadline.bind(this),
+      async () => {
+        const items: T[] = [];
+        for await (const item of this.client.workflow.list({ query })) {
+          items.push(item as unknown as T);
+          if (items.length >= limit) {
+            return { items, truncated: true };
+          }
+        }
+        return { items, truncated: false };
+      },
+      readCtx,
+      { opType: ctx.opType, timeoutMs: ctx.budgetMs },
+    );
+    return listOutcomeOf(result);
+  }
+
+  async describeTaskQueue(
+    ctx: TemporalOperationContext,
+    taskQueue: string,
+  ): Promise<TemporalReadOutcome<unknown>> {
+    validateContext(ctx, this.projectId);
+    const readCtx = createTemporalReadContext(ctx.budgetMs);
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener("abort", () =>
+        abortTemporalRead(readCtx),
+      );
+    }
+    const result = await runTemporalRead(
+      this.runWithDeadline.bind(this),
+      async () => {
+        const svc = this.connection.workflowService;
+        if (!svc?.describeTaskQueue) {
+          throw new Error("WorkflowService.describeTaskQueue unavailable");
+        }
+        return svc.describeTaskQueue({
+          namespace: this.namespace,
+          taskQueue: { name: taskQueue },
+          taskQueueType: 1,
+        });
+      },
+      readCtx,
+      { opType: ctx.opType, timeoutMs: ctx.budgetMs },
+    );
+    return readOutcome<unknown>(result);
+  }
+}
+
+function isAlreadyStartedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /already started|already exists|Workflow execution already started/i.test(
+    message,
+  );
+}

--- a/plugin/src/temporal/orphan-queue-adopter.scan-resilience.test.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.scan-resilience.test.ts
@@ -15,7 +15,6 @@
  * These tests pin the bound, the cancellation, and the observability.
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import type { OrphanListClient } from "./list-orphan-session-queues";
 import { listOrphanSessionQueues } from "./list-orphan-session-queues";
 import {
   ORPHAN_MAX_CONSECUTIVE_SCAN_FAILURES,
@@ -25,10 +24,15 @@ import {
   type OrphanQueueAdoptionDiagnostics,
 } from "./orphan-queue-adopter";
 import { resetReadinessState } from "./session-readiness";
+import {
+  createMockOwner,
+  createMockOwnerFromClient,
+} from "./__tests__/mock-owner";
+import type { TemporalOperations } from "./operations";
 
-const PROJECT = "P";
-const Q1 = "advance-P-sess_aaa";
-const Q2 = "advance-P-sess_bbb";
+const PROJECT_ID = "0000000000000000000000000000000000000000";
+const Q1 = `advance-${PROJECT_ID}-sess_aaa`;
+const Q2 = `advance-${PROJECT_ID}-sess_bbb`;
 const T0 = new Date("2026-07-22T00:00:00Z");
 
 /** Per-tick bound used across these tests; small enough to keep them fast. */
@@ -43,7 +47,7 @@ type VisRecord = {
 
 function record(queue: string, startTime = T0): VisRecord {
   return {
-    workflowId: `adv/change/${PROJECT}/${queue}/wf1`,
+    workflowId: `adv/change/${PROJECT_ID}/${queue}/wf1`,
     taskQueue: queue,
     startTime,
     status: { name: "RUNNING" },
@@ -79,18 +83,25 @@ function mockWorker(initialQueues: string[] = []) {
 }
 
 function adopterFor(
-  client: OrphanListClient,
+  owner: TemporalOperations,
   worker: ReturnType<typeof mockWorker>,
 ) {
   return new OrphanQueueAdopter({
-    client,
-    projectId: PROJECT,
+    owner,
+    projectId: PROJECT_ID,
     worker: {
       registerQueue: worker.registerQueue,
       queues: worker.polledQueues,
     },
     tickTimeoutMs: TICK_MS,
   });
+}
+
+function adopterForClient(
+  client: unknown,
+  worker: ReturnType<typeof mockWorker>,
+) {
+  return adopterFor(createMockOwnerFromClient(client), worker);
 }
 
 beforeEach(() => {
@@ -100,7 +111,10 @@ beforeEach(() => {
 describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
   it("releases single-flight when the Visibility stream never yields", async () => {
     const worker = mockWorker();
-    const adopter = adopterFor({ workflow: { list: hangingIterable } }, worker);
+    const adopter = adopterForClient(
+      { workflow: { list: hangingIterable } },
+      worker,
+    );
 
     await adopter.adoptNextOrphan();
 
@@ -111,7 +125,10 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
 
   it("counts the stall instead of failing silently", async () => {
     const worker = mockWorker();
-    const adopter = adopterFor({ workflow: { list: hangingIterable } }, worker);
+    const adopter = adopterForClient(
+      { workflow: { list: hangingIterable } },
+      worker,
+    );
 
     await adopter.adoptNextOrphan();
 
@@ -123,7 +140,10 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
 
   it("keeps advancing the failure counter across repeated hung ticks", async () => {
     const worker = mockWorker();
-    const adopter = adopterFor({ workflow: { list: hangingIterable } }, worker);
+    const adopter = adopterForClient(
+      { workflow: { list: hangingIterable } },
+      worker,
+    );
 
     await adopter.adoptNextOrphan();
     await adopter.adoptNextOrphan();
@@ -134,30 +154,25 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
     expect(adopter.getState().scanInFlight).toBe(false);
   });
 
-  it("aborts the in-flight Visibility RPC so streams are not leaked per tick", async () => {
+  it("times out hung enumeration without leaking the scan latch", async () => {
     const worker = mockWorker();
-    let captured: AbortSignal | undefined;
-    const client: OrphanListClient = {
-      workflow: { list: hangingIterable },
-      connection: {
-        withAbortSignal: async (signal, fn) => {
-          captured = signal;
-          return await fn();
-        },
-      },
-    };
+    const owner = createMockOwner({
+      list: vi.fn(async function* () {
+        // Never yield; the tick timeout must release the latch.
+        await new Promise<void>(() => {});
+        yield record(Q1);
+      }),
+    });
 
-    await adopterFor(client, worker).adoptNextOrphan();
+    await adopterFor(owner, worker).adoptNextOrphan();
 
-    expect(captured).toBeDefined();
-    // ListOptions carries no abortSignal/deadline (SDK v1.16), so the
-    // connection scope is the only teardown path available.
-    expect(captured?.aborted).toBe(true);
+    expect(owner.list).toHaveBeenCalledTimes(1);
+    expect(worker.registerQueue).not.toHaveBeenCalled();
   });
 
   it("records a scan failure when Visibility rejects with context canceled", async () => {
     const worker = mockWorker();
-    const client: OrphanListClient = {
+    const client = {
       workflow: {
         list: () =>
           ({
@@ -171,7 +186,7 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
       },
     };
 
-    const adopter = adopterFor(client, worker);
+    const adopter = adopterForClient(client, worker);
     await adopter.adoptNextOrphan();
 
     expect(adopter.getState().scanInFlight).toBe(false);
@@ -182,7 +197,7 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
   it("recovers and adopts once enumeration succeeds again", async () => {
     const worker = mockWorker();
     let healthy = false;
-    const client: OrphanListClient = {
+    const client = {
       workflow: {
         list: () =>
           healthy
@@ -193,7 +208,7 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
       },
     };
 
-    const adopter = adopterFor(client, worker);
+    const adopter = adopterForClient(client, worker);
     await adopter.adoptNextOrphan();
     expect(adopter.getDiagnostics().consecutiveScanFailures).toBe(1);
 
@@ -213,7 +228,7 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
     worker.setRegisterImpl(async () => {
       throw new Error('Cannot register queue "x" — worker is shutting down');
     });
-    const client: OrphanListClient = {
+    const client = {
       workflow: {
         list: () =>
           (async function* () {
@@ -222,7 +237,7 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
       },
     };
 
-    const adopter = adopterFor(client, worker);
+    const adopter = adopterForClient(client, worker);
     await adopter.adoptNextOrphan();
 
     const diag = adopter.getDiagnostics();
@@ -234,48 +249,33 @@ describe("OrphanQueueAdopter — Visibility scan resilience (#327)", () => {
 });
 
 describe("listOrphanSessionQueues — bounded enumeration", () => {
-  it("stops at the deadline and releases the stream via iterator return()", async () => {
-    let now = 1_000;
-    const onReturn = vi.fn();
-    const items = [record(Q1), record(Q2, new Date(T0.getTime() + 5_000))];
-    let index = 0;
+  it("stops at the deadline and returns partial results", async () => {
+    let calls = 0;
+    const owner = createMockOwner({
+      list: async () => ({
+        kind: "complete",
+        value: [record(Q1), record(Q2, new Date(T0.getTime() + 5_000))],
+        truncated: false,
+      }),
+    });
 
-    const client: OrphanListClient = {
-      workflow: {
-        list: () =>
-          ({
-            [Symbol.asyncIterator]() {
-              return {
-                next: async () => {
-                  if (index >= items.length) {
-                    return { value: undefined, done: true };
-                  }
-                  const value = items[index++];
-                  // Blow the deadline only from the SECOND record onward, so
-                  // the first is processed and the bound is observed between
-                  // records (not before the first one is ever seen).
-                  if (index > 1) now += 500;
-                  return { value, done: false };
-                },
-                return: async () => {
-                  onReturn();
-                  return { value: undefined, done: true };
-                },
-              };
-            },
-          }) as AsyncIterable<VisRecord>,
-      },
-    };
-
-    const result = await listOrphanSessionQueues(client, PROJECT, [], {
+    const outcome = await listOrphanSessionQueues(owner, PROJECT_ID, [], {
       deadlineMs: 100,
-      now: () => now,
+      now: () => {
+        // startedAt and the first loop check are at 1000ms; the second check
+        // advances past the 100ms deadline so only the first record is kept.
+        calls++;
+        return calls <= 2 ? 1_000 : 1_500;
+      },
     });
 
     // Partial results are still adoptable; the caller re-enumerates next tick.
-    expect(result.map((r) => r.queue)).toEqual([Q1]);
-    // `break` (not `return`) is what triggers this — it is the stream teardown.
-    expect(onReturn).toHaveBeenCalledTimes(1);
+    expect(outcome.kind).toBe("complete");
+    expect(
+      (outcome as { kind: "complete"; value: { queue: string }[] }).value.map(
+        (r) => r.queue,
+      ),
+    ).toEqual([Q1]);
   });
 
   it("stops immediately when the signal is already aborted", async () => {
@@ -283,7 +283,7 @@ describe("listOrphanSessionQueues — bounded enumeration", () => {
     controller.abort();
 
     const result = await listOrphanSessionQueues(
-      {
+      createMockOwnerFromClient({
         workflow: {
           list: () =>
             (async function* () {
@@ -291,55 +291,65 @@ describe("listOrphanSessionQueues — bounded enumeration", () => {
               yield record(Q2);
             })(),
         },
-      },
-      PROJECT,
+      }),
+      PROJECT_ID,
       [],
       { signal: controller.signal },
     );
 
-    expect(result).toEqual([]);
+    expect(result.kind).toBe("complete");
+    expect(
+      (result as { kind: "complete"; value: { queue: string }[] }).value,
+    ).toEqual([]);
   });
 
-  it("routes enumeration through connection.withAbortSignal when available", async () => {
-    const withAbortSignal = vi.fn(
-      async <T>(_s: AbortSignal, fn: () => Promise<T>) => await fn(),
-    );
-    const client: OrphanListClient = {
-      workflow: {
-        list: () =>
-          (async function* () {
-            yield record(Q1);
-          })(),
-      },
-      connection: { withAbortSignal },
-    };
+  it("routes enumeration through the TemporalOperations owner list API", async () => {
+    const list = vi.fn(async () => ({
+      kind: "complete",
+      value: [record(Q1)],
+      truncated: false,
+    }));
+    const owner = createMockOwner({
+      list,
+    });
 
-    const result = await listOrphanSessionQueues(client, PROJECT, [], {
+    const outcome = await listOrphanSessionQueues(owner, PROJECT_ID, [], {
       signal: new AbortController().signal,
     });
 
-    expect(withAbortSignal).toHaveBeenCalledTimes(1);
-    expect(result.map((r) => r.queue)).toEqual([Q1]);
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(outcome.kind).toBe("complete");
+    expect(
+      (outcome as { kind: "complete"; value: { queue: string }[] }).value.map(
+        (r) => r.queue,
+      ),
+    ).toEqual([Q1]);
   });
 
-  it("skips the connection scope when no signal is supplied (back-compat)", async () => {
-    const withAbortSignal = vi.fn(
-      async <T>(_s: AbortSignal, fn: () => Promise<T>) => await fn(),
-    );
-    const client: OrphanListClient = {
-      workflow: {
-        list: () =>
-          (async function* () {
-            yield record(Q1);
-          })(),
-      },
-      connection: { withAbortSignal },
-    };
+  it("breaks iteration when the signal is aborted mid-enumeration", async () => {
+    const controller = new AbortController();
+    function* recordsWithAbort() {
+      yield record(Q1);
+      controller.abort();
+      yield record(Q2);
+    }
+    const list = vi.fn(async () => ({
+      kind: "complete",
+      value: { [Symbol.iterator]: recordsWithAbort } as unknown as VisRecord[],
+      truncated: false,
+    }));
+    const owner = createMockOwner({ list });
 
-    const result = await listOrphanSessionQueues(client, PROJECT, []);
+    const outcome = await listOrphanSessionQueues(owner, PROJECT_ID, [], {
+      signal: controller.signal,
+    });
 
-    expect(withAbortSignal).not.toHaveBeenCalled();
-    expect(result.map((r) => r.queue)).toEqual([Q1]);
+    expect(outcome.kind).toBe("complete");
+    expect(
+      (outcome as { kind: "complete"; value: { queue: string }[] }).value.map(
+        (r) => r.queue,
+      ),
+    ).toEqual([Q1]);
   });
 });
 
@@ -443,10 +453,13 @@ describe("evaluateOrphanAdoptionHealth", () => {
 });
 
 describe("OrphanQueueAdopter — batched adoption", () => {
-  const many = Array.from({ length: 12 }, (_, i) => `advance-P-sess_q${i}`);
+  const many = Array.from(
+    { length: 12 },
+    (_, i) => `advance-${PROJECT_ID}-sess_q${i}`,
+  );
 
-  function clientWith(queues: string[]): OrphanListClient {
-    return {
+  function ownerWith(queues: string[]) {
+    return createMockOwnerFromClient({
       workflow: {
         list: () =>
           (async function* () {
@@ -455,14 +468,14 @@ describe("OrphanQueueAdopter — batched adoption", () => {
             }
           })(),
       },
-    };
+    });
   }
 
   it("adopts up to maxAdoptionsPerTick in a single tick", async () => {
     const worker = mockWorker();
     const adopter = new OrphanQueueAdopter({
-      client: clientWith(many),
-      projectId: PROJECT,
+      owner: ownerWith(many),
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -479,8 +492,8 @@ describe("OrphanQueueAdopter — batched adoption", () => {
   it("preserves FIFO order across the batch", async () => {
     const worker = mockWorker();
     const adopter = new OrphanQueueAdopter({
-      client: clientWith(many),
-      projectId: PROJECT,
+      owner: ownerWith(many),
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -502,8 +515,8 @@ describe("OrphanQueueAdopter — batched adoption", () => {
       throw new Error("worker is shutting down");
     });
     const adopter = new OrphanQueueAdopter({
-      client: clientWith(many),
-      projectId: PROJECT,
+      owner: ownerWith(many),
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -527,8 +540,8 @@ describe("OrphanQueueAdopter — batched adoption", () => {
       clock += 1000;
     });
     const adopter = new OrphanQueueAdopter({
-      client: clientWith(many),
-      projectId: PROJECT,
+      owner: ownerWith(many),
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -552,8 +565,8 @@ describe("OrphanQueueAdopter — batched adoption", () => {
       if (failing && queue === many[0]) throw new Error("boom");
     });
     const adopter = new OrphanQueueAdopter({
-      client: clientWith(many.slice(0, 3)),
-      projectId: PROJECT,
+      owner: ownerWith(many.slice(0, 3)),
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,

--- a/plugin/src/temporal/orphan-queue-adopter.test.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.test.ts
@@ -8,12 +8,13 @@
  * idempotency via worker.queues.
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import type { OrphanListClient } from "./list-orphan-session-queues";
 import {
   evaluateTargetReadiness,
   resetReadinessState,
   type QueryProbe,
 } from "./session-readiness";
+import { createMockOwnerFromClient } from "./__tests__/mock-owner";
+const PROJECT_ID = "0000000000000000000000000000000000000000";
 
 // Late-import so the RED run fails on the missing module before GREEN creates it.
 async function loadAdopter() {
@@ -40,28 +41,27 @@ function mockWorker(initialQueues: string[] = []) {
   };
 }
 
-/** Build a mock Visibility client returning the given orphan queue set. */
-function mockClient(
-  orphans: Array<{ queue: string; oldestStartTime: Date }>,
-): OrphanListClient {
+/** Build a mock Visibility owner returning the given orphan queue set. */
+function mockOwner(orphans: Array<{ queue: string; oldestStartTime: Date }>) {
   const items = orphans.flatMap((o) => [
     {
-      workflowId: `adv/change/P/${o.queue}/wf1`,
+      workflowId: `adv/change/${PROJECT_ID}/${o.queue}/wf1`,
       taskQueue: o.queue,
       startTime: o.oldestStartTime,
       status: { name: "RUNNING" },
     },
   ]);
-  return {
+  const client = {
     workflow: {
       list: async function* () {
         for (const item of items) yield item;
       },
     },
   };
+  return createMockOwnerFromClient(client);
 }
 
-const Q = (n: number, t: string) => `advance-P-sess_${n}${t}`;
+const Q = (n: number, t: string) => `advance-${PROJECT_ID}-sess_${n}${t}`;
 const T0 = new Date("2026-07-22T00:00:00Z");
 
 beforeEach(() => {
@@ -71,14 +71,14 @@ beforeEach(() => {
 describe("OrphanQueueAdopter", () => {
   it("adopts orphans oldest-first via registerQueue", async () => {
     const worker = mockWorker();
-    const client = mockClient([
+    const owner = mockOwner([
       { queue: Q(2, ""), oldestStartTime: new Date(T0.getTime() + 2000) },
       { queue: Q(1, ""), oldestStartTime: T0 }, // oldest → FIFO first
     ]);
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -95,14 +95,14 @@ describe("OrphanQueueAdopter", () => {
 
   it("skips a queue already in worker.queues (idempotent)", async () => {
     const worker = mockWorker([Q(1, "")]);
-    const client = mockClient([
+    const owner = mockOwner([
       { queue: Q(1, ""), oldestStartTime: T0 }, // already polled
       { queue: Q(2, ""), oldestStartTime: new Date(T0.getTime() + 1000) },
     ]);
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -115,11 +115,11 @@ describe("OrphanQueueAdopter", () => {
 
   it("does nothing when there are no orphans", async () => {
     const worker = mockWorker();
-    const client = mockClient([]);
+    const owner = mockOwner([]);
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -131,15 +131,15 @@ describe("OrphanQueueAdopter", () => {
 
   it("enforces single-flight: concurrent ticks do not overlap", async () => {
     const worker = mockWorker();
-    const client = mockClient([{ queue: Q(1, ""), oldestStartTime: T0 }]);
+    const owner = mockOwner([{ queue: Q(1, ""), oldestStartTime: T0 }]);
     let resolveRegister!: () => void;
     worker.setRegisterImpl(
       () => new Promise<void>((resolve) => (resolveRegister = resolve)),
     );
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -158,13 +158,13 @@ describe("OrphanQueueAdopter", () => {
 
   it("releases single-flight in finally even when registerQueue times out", async () => {
     const worker = mockWorker();
-    const client = mockClient([{ queue: Q(1, ""), oldestStartTime: T0 }]);
+    const owner = mockOwner([{ queue: Q(1, ""), oldestStartTime: T0 }]);
     // registerQueue never resolves → tick timeout must fire + release.
     worker.setRegisterImpl(() => new Promise<void>(() => {}));
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -182,15 +182,15 @@ describe("OrphanQueueAdopter", () => {
 
   it("applies cooldown after 3 failed attempts and re-attempts after cooldown expires", async () => {
     const worker = mockWorker();
-    const client = mockClient([{ queue: Q(1, ""), oldestStartTime: T0 }]);
+    const owner = mockOwner([{ queue: Q(1, ""), oldestStartTime: T0 }]);
     worker.setRegisterImpl(async () => {
       throw new Error("run-error: worker failed");
     });
     let now = 10_000;
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -218,11 +218,11 @@ describe("OrphanQueueAdopter", () => {
 
   it("resets attempt state on a successful adoption", async () => {
     const worker = mockWorker();
-    const client = mockClient([{ queue: Q(1, ""), oldestStartTime: T0 }]);
+    const owner = mockOwner([{ queue: Q(1, ""), oldestStartTime: T0 }]);
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -251,14 +251,14 @@ describe("OrphanQueueAdopter", () => {
 
   it("suppresses shutdown-class errors without bumping attempts", async () => {
     const worker = mockWorker();
-    const client = mockClient([{ queue: Q(1, ""), oldestStartTime: T0 }]);
+    const owner = mockOwner([{ queue: Q(1, ""), oldestStartTime: T0 }]);
     worker.setRegisterImpl(async () => {
       throw new Error("worker is shutting down");
     });
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -274,14 +274,14 @@ describe("OrphanQueueAdopter", () => {
 
   it("marks the target queue stale when the worker dies during adoption (AC4)", async () => {
     const worker = mockWorker();
-    const client = mockClient([{ queue: Q(1, ""), oldestStartTime: T0 }]);
+    const owner = mockOwner([{ queue: Q(1, ""), oldestStartTime: T0 }]);
     worker.setRegisterImpl(async () => {
       throw new Error("worker is shutting down");
     });
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -321,13 +321,13 @@ describe("OrphanQueueAdopter", () => {
 
   it("marks the target queue stale when registerQueue times out (worker unresponsive)", async () => {
     const worker = mockWorker();
-    const client = mockClient([{ queue: Q(1, ""), oldestStartTime: T0 }]);
+    const owner = mockOwner([{ queue: Q(1, ""), oldestStartTime: T0 }]);
     // Never resolves → tick timeout wins.
     worker.setRegisterImpl(() => new Promise<void>(() => {}));
     const { OrphanQueueAdopter } = await loadAdopter();
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId: PROJECT_ID,
       worker: {
         registerQueue: worker.registerQueue,
         queues: worker.polledQueues,
@@ -434,10 +434,10 @@ describe("review remediation — failure accounting + late-settlement safety", (
   ) {
     // Late-import to exercise the real module.
     return loadAdopter().then(({ OrphanQueueAdopter }) => {
-      const client = mockClient([{ queue: Q(1, ""), oldestStartTime: T0 }]);
+      const owner = mockOwner([{ queue: Q(1, ""), oldestStartTime: T0 }]);
       return new OrphanQueueAdopter({
-        client,
-        projectId: "P",
+        owner,
+        projectId: PROJECT_ID,
         worker: {
           registerQueue: worker.registerQueue,
           queues: worker.polledQueues,

--- a/plugin/src/temporal/orphan-queue-adopter.ts
+++ b/plugin/src/temporal/orphan-queue-adopter.ts
@@ -17,10 +17,8 @@
  * surface. Phase B wires this into the heartbeat `onBeat` (env-gated).
  */
 import { listOrphanSessionQueues } from "./list-orphan-session-queues";
-import type {
-  OrphanListClient,
-  OrphanSessionQueue,
-} from "./list-orphan-session-queues";
+import type { OrphanSessionQueue } from "./list-orphan-session-queues";
+import type { TemporalOperations } from "./operations";
 import { markStale } from "./session-readiness";
 
 /** Minimal worker shape the coordinator depends on (structural). */
@@ -31,7 +29,7 @@ export interface OrphanAdopterWorker {
 }
 
 export interface OrphanQueueAdopterOptions {
-  client: OrphanListClient;
+  owner: TemporalOperations;
   projectId: string;
   worker: OrphanAdopterWorker;
   /** Per-tick hard timeout (DDC2; default 8 s, just under the 10 s heartbeat). */
@@ -239,7 +237,7 @@ export function isOrphanQueueAdoptionEnabled(
 }
 
 export class OrphanQueueAdopter {
-  private readonly client: OrphanListClient;
+  private readonly owner: TemporalOperations;
   private readonly projectId: string;
   private readonly worker: OrphanAdopterWorker;
   private readonly tickTimeoutMs: number;
@@ -261,7 +259,7 @@ export class OrphanQueueAdopter {
   private suppressedShutdownCount = 0;
 
   constructor(options: OrphanQueueAdopterOptions) {
-    this.client = options.client;
+    this.owner = options.owner;
     this.projectId = options.projectId;
     this.worker = options.worker;
     this.tickTimeoutMs = options.tickTimeoutMs ?? DEFAULT_TICK_TIMEOUT_MS;
@@ -422,7 +420,7 @@ export class OrphanQueueAdopter {
     this.lastScanStartedAt = this.now();
 
     const scan = listOrphanSessionQueues(
-      this.client,
+      this.owner,
       this.projectId,
       this.worker.queues,
       {
@@ -434,10 +432,17 @@ export class OrphanQueueAdopter {
 
     try {
       const outcome = await Promise.race([
-        scan.then((queues) => ({ ok: true as const, queues })),
+        scan.then((listOutcome) => ({ ok: true as const, listOutcome })),
         timeout.promise.then(() => ({ ok: false as const })),
       ]);
-      if (outcome.ok) return outcome.queues;
+      if (outcome.ok) {
+        if (outcome.listOutcome.kind !== "complete") {
+          throw new Error(
+            `Visibility list failed: ${outcome.listOutcome.kind}`,
+          );
+        }
+        return outcome.listOutcome.value;
+      }
 
       controller.abort();
       // `Promise.race` already attached handlers to both branches, so a late

--- a/plugin/src/temporal/out-of-process-worker.itest.ts
+++ b/plugin/src/temporal/out-of-process-worker.itest.ts
@@ -66,7 +66,7 @@ describe.skipIf(!canRun)("createOutOfProcessWorker integration", () => {
             namespace: "default",
             queues: ["advance-oop-itest"],
             workerScript: script!.path,
-            projectId: "oop-itest",
+            projectId: "00000e0000000000000000000000000000000000",
           });
           await waitForWorkerAlive(w, 5_000, 100);
           return w;

--- a/plugin/src/temporal/out-of-process-worker.test.ts
+++ b/plugin/src/temporal/out-of-process-worker.test.ts
@@ -169,7 +169,7 @@ describe("createOutOfProcessWorker", () => {
       namespace: "default",
       queues: ["advance-proj-a", "advance-proj-b"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "proj-a",
+      projectId: "0000a00000000000000000000000000000000000",
     });
 
     // Shared worker: only ONE spawn for all queues
@@ -181,7 +181,7 @@ describe("createOutOfProcessWorker", () => {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
       ADV_TEMPORAL_MULTI_QUEUE: "1",
-      ADV_TEMPORAL_PROJECT_ID: "proj-a",
+      ADV_TEMPORAL_PROJECT_ID: "0000a00000000000000000000000000000000000",
     });
     expect(opts.env.ADV_TEMPORAL_TASK_QUEUES).toContain("advance-proj-a");
     expect(opts.env.ADV_TEMPORAL_TASK_QUEUES).toContain("advance-proj-b");
@@ -202,7 +202,7 @@ describe("createOutOfProcessWorker", () => {
       namespace: "default",
       queues: ["advance-a"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "a",
+      projectId: "a000000000000000000000000000000000000000",
     });
 
     expect(worker.queues).toEqual(["advance-a"]);
@@ -227,7 +227,7 @@ describe("createOutOfProcessWorker", () => {
       namespace: "default",
       queues: ["advance-dup"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "dup",
+      projectId: "d000000000000000000000000000000000000000",
     });
 
     await worker.registerQueue("advance-dup");
@@ -248,7 +248,7 @@ describe("createOutOfProcessWorker", () => {
       namespace: "default",
       queues: ["advance-q"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "q",
+      projectId: "0000000000000000000000000000000000000000",
     });
 
     await worker.shutdown();
@@ -271,7 +271,7 @@ describe("createOutOfProcessWorker", () => {
       namespace: "default",
       queues: ["advance-stuck"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "stuck",
+      projectId: "000c000000000000000000000000000000000000",
     });
 
     const shutdownPromise = worker.shutdown();
@@ -296,7 +296,7 @@ describe("createOutOfProcessWorker", () => {
       namespace: "default",
       queues: ["advance-diag"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "diag",
+      projectId: "d0a0000000000000000000000000000000000000",
     });
 
     expect(typeof worker.getDiagnostics).toBe("function");
@@ -330,7 +330,7 @@ describe("createOutOfProcessWorker", () => {
         namespace: "default",
         queues: ["advance-q"],
         workerScript: "/plugin/dist/temporal/worker.js",
-        projectId: "q",
+        projectId: "0000000000000000000000000000000000000000",
       }),
     ).rejects.toThrow(/Install Node|Node executable/);
   });
@@ -347,7 +347,7 @@ describe("createOutOfProcessWorker", () => {
         namespace: "default",
         queues: ["advance-q"],
         workerScript: "/nonexistent/path/worker.js",
-        projectId: "q",
+        projectId: "0000000000000000000000000000000000000000",
       }),
     ).rejects.toThrow(/worker script not found/);
   });
@@ -364,7 +364,7 @@ describe("createOutOfProcessWorker", () => {
       namespace: "default",
       queues: ["advance-sanitize"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "sanitize",
+      projectId: "0a00000e00000000000000000000000000000000",
     });
 
     // Emit a chunk with control characters and a huge payload
@@ -435,7 +435,7 @@ describe("createOutOfProcessWorker restart policy", () => {
       namespace: "default",
       queues: ["advance-crasher"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "crasher",
+      projectId: "c0a00e0000000000000000000000000000000000",
     });
 
     expect(spawnCount).toBe(1);
@@ -482,7 +482,7 @@ describe("createOutOfProcessWorker restart policy", () => {
       namespace: "default",
       queues: ["advance-q"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "q",
+      projectId: "0000000000000000000000000000000000000000",
     });
 
     // Start shutdown, then crash the child
@@ -508,7 +508,7 @@ describe("createOutOfProcessWorker restart policy", () => {
       namespace: "default",
       queues: ["advance-q"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "q",
+      projectId: "0000000000000000000000000000000000000000",
     });
 
     child.exitCode = 0;
@@ -537,7 +537,7 @@ describe("createOutOfProcessWorker restart policy", () => {
       namespace: "default",
       queues: ["advance-q"],
       workerScript: "/plugin/dist/temporal/worker.js",
-      projectId: "q",
+      projectId: "0000000000000000000000000000000000000000",
     });
 
     await worker.restartChild();

--- a/plugin/src/temporal/outcome-errors.ts
+++ b/plugin/src/temporal/outcome-errors.ts
@@ -1,0 +1,89 @@
+import type {
+  TemporalListOutcome,
+  TemporalMutationServerOutcome,
+  TemporalReadOutcome,
+} from "./operations";
+
+/**
+ * Typed error wrapping a non-confirmed Temporal mutation outcome (signal,
+ * start, terminate, cancel). Preserves the exact outcome kind, the underlying
+ * cause error, and the workflow diagnostic so callers can branch on
+ * `confirmed_failure` vs `timeout_unavailable` vs `outcome_unknown` instead of
+ * parsing a generic error message.
+ */
+export class TemporalMutationOutcomeError extends Error {
+  override readonly name = "TemporalMutationOutcomeError";
+  constructor(
+    public readonly outcome: Exclude<
+      TemporalMutationServerOutcome<unknown>,
+      { kind: "confirmed" }
+    >,
+  ) {
+    super(
+      `Temporal mutation outcome: ${outcome.kind}${
+        outcome.error instanceof Error ? ` — ${outcome.error.message}` : ""
+      }`,
+    );
+  }
+}
+
+export function isTemporalMutationOutcomeError(
+  error: unknown,
+): error is TemporalMutationOutcomeError {
+  return error instanceof TemporalMutationOutcomeError;
+}
+
+/**
+ * Typed error wrapping a non-complete Temporal read outcome (query, describe,
+ * list). Preserves the exact kind (`degraded`/`timeout`/`unavailable`) so
+ * callers can distinguish transient unavailability from a confirmed absence.
+ */
+export class TemporalReadOutcomeError extends Error {
+  override readonly name = "TemporalReadOutcomeError";
+  constructor(
+    public readonly outcome: Exclude<
+      TemporalReadOutcome<unknown>,
+      { kind: "complete" }
+    >,
+  ) {
+    super(
+      `Temporal read outcome: ${outcome.kind}${
+        outcome.error instanceof Error ? ` — ${outcome.error.message}` : ""
+      }`,
+    );
+  }
+}
+
+export function isTemporalReadOutcomeError(
+  error: unknown,
+): error is TemporalReadOutcomeError {
+  return error instanceof TemporalReadOutcomeError;
+}
+
+/**
+ * Typed error wrapping a non-complete Temporal visibility-list outcome
+ * (`degraded`/`timeout`/`unavailable`). Preserves the exact kind, underlying
+ * cause, and workflow diagnostic so callers can branch on it instead of
+ * parsing a generic "list failed" error.
+ */
+export class TemporalListOutcomeError extends Error {
+  override readonly name = "TemporalListOutcomeError";
+  constructor(
+    public readonly outcome: Exclude<
+      TemporalListOutcome<unknown>,
+      { kind: "complete" }
+    >,
+  ) {
+    super(
+      `Temporal list outcome: ${outcome.kind}${
+        outcome.error instanceof Error ? ` — ${outcome.error.message}` : ""
+      }`,
+    );
+  }
+}
+
+export function isTemporalListOutcomeError(
+  error: unknown,
+): error is TemporalListOutcomeError {
+  return error instanceof TemporalListOutcomeError;
+}

--- a/plugin/src/temporal/queue-serviceability.test.ts
+++ b/plugin/src/temporal/queue-serviceability.test.ts
@@ -5,11 +5,12 @@ import {
   evaluateQueueReadiness,
   probeTaskQueuePollers,
 } from "./queue-serviceability";
+import { createMockOwner } from "./__tests__/mock-owner";
 
 describe("classifyQueueServiceability", () => {
   it("treats a locally owned ready worker as serviceable without server poller evidence", () => {
     const result = classifyQueueServiceability({
-      projectId: "proj-a",
+      projectId: "0000a00000000000000000000000000000000000",
       expectedQueue: "advance-proj-a",
       localRegistered: true,
       localWorkerAlive: true,
@@ -26,7 +27,7 @@ describe("classifyQueueServiceability", () => {
 
   it("treats a fresh server poller as serviceable for peer-owned queues", () => {
     const result = classifyQueueServiceability({
-      projectId: "proj-a",
+      projectId: "0000a00000000000000000000000000000000000",
       expectedQueue: "advance-proj-a",
       localRegistered: false,
       localWorkerAlive: false,
@@ -42,7 +43,7 @@ describe("classifyQueueServiceability", () => {
 
   it("does not claim peer-owned PID-only evidence is serviceable when poller evidence is unavailable", () => {
     const result = classifyQueueServiceability({
-      projectId: "proj-a",
+      projectId: "0000a00000000000000000000000000000000000",
       expectedQueue: "advance-proj-a",
       localRegistered: false,
       localWorkerAlive: false,
@@ -58,7 +59,7 @@ describe("classifyQueueServiceability", () => {
 
   it("marks stale or missing evidence with stale running workflows as not serviceable", () => {
     const result = classifyQueueServiceability({
-      projectId: "proj-a",
+      projectId: "0000a00000000000000000000000000000000000",
       expectedQueue: "advance-proj-a",
       localRegistered: false,
       localWorkerAlive: false,
@@ -151,13 +152,18 @@ describe("evaluateQueueReadiness", () => {
 
 describe("probeTaskQueuePollers", () => {
   it("reports fresh when describeTaskQueue returns a recent poller", async () => {
-    const describeTaskQueue = vi.fn(async () => ({
-      pollers: [{ identity: "worker-1", lastAccessTime: new Date(90_000) }],
-    }));
+    const owner = createMockOwner({
+      describeTaskQueue: vi.fn(async (_ctx, _taskQueue: string) => ({
+        kind: "complete" as const,
+        value: {
+          pollers: [{ identity: "worker-1", lastAccessTime: new Date(90_000) }],
+        },
+      })),
+    });
 
     const result = await probeTaskQueuePollers({
-      connection: { workflowService: { describeTaskQueue } },
-      namespace: "default",
+      owner,
+      projectId: "0000a00000000000000000000000000000000000",
       taskQueue: "advance-proj-a",
       nowMs: () => 100_000,
       freshPollerMs: 60_000,
@@ -169,23 +175,21 @@ describe("probeTaskQueuePollers", () => {
       pollerCount: 1,
       lastPollerAt: "1970-01-01T00:01:30.000Z",
     });
-    expect(describeTaskQueue).toHaveBeenCalledWith({
-      namespace: "default",
-      taskQueue: { name: "advance-proj-a" },
-      taskQueueType: 1,
-    });
   });
 
   it("reports stale when all pollers are older than the freshness budget", async () => {
-    const result = await probeTaskQueuePollers({
-      connection: {
-        workflowService: {
-          describeTaskQueue: vi.fn(async () => ({
-            pollers: [{ lastAccessTime: "1970-01-01T00:00:10.000Z" }],
-          })),
+    const owner = createMockOwner({
+      describeTaskQueue: vi.fn(async () => ({
+        kind: "complete" as const,
+        value: {
+          pollers: [{ lastAccessTime: "1970-01-01T00:00:10.000Z" }],
         },
-      },
-      namespace: "default",
+      })),
+    });
+
+    const result = await probeTaskQueuePollers({
+      owner,
+      projectId: "0000a00000000000000000000000000000000000",
       taskQueue: "advance-proj-a",
       nowMs: () => 100_000,
       freshPollerMs: 60_000,
@@ -202,8 +206,12 @@ describe("probeTaskQueuePollers", () => {
   it("reports unavailable when describeTaskQueue is missing or throws", async () => {
     await expect(
       probeTaskQueuePollers({
-        connection: {},
-        namespace: "default",
+        owner: createMockOwner({
+          describeTaskQueue: vi.fn(async () => {
+            throw new Error("unsupported");
+          }),
+        }),
+        projectId: "0000a00000000000000000000000000000000000",
         taskQueue: "advance-proj-a",
       }),
     ).resolves.toMatchObject({
@@ -215,14 +223,8 @@ describe("probeTaskQueuePollers", () => {
 
     await expect(
       probeTaskQueuePollers({
-        connection: {
-          workflowService: {
-            describeTaskQueue: vi.fn(async () => {
-              throw new Error("unsupported");
-            }),
-          },
-        },
-        namespace: "default",
+        owner: createMockOwner(),
+        projectId: "0000a00000000000000000000000000000000000",
         taskQueue: "advance-proj-a",
       }),
     ).resolves.toMatchObject({

--- a/plugin/src/temporal/queue-serviceability.ts
+++ b/plugin/src/temporal/queue-serviceability.ts
@@ -1,3 +1,6 @@
+import type { TemporalOperations } from "./operations";
+import { makeTemporalOperationContext } from "./operations";
+
 export type QueueServiceabilityStatus =
   | "serviceable"
   | "not_serviceable"
@@ -177,48 +180,43 @@ export function classifyQueueServiceability(
   };
 }
 
-export interface DescribeTaskQueueConnectionLike {
-  workflowService?: {
-    describeTaskQueue?: (req: {
-      namespace: string;
-      taskQueue: { name: string };
-      taskQueueType: number;
-    }) => Promise<unknown>;
-  };
-}
-
 export interface ProbeTaskQueuePollersInput {
-  connection: DescribeTaskQueueConnectionLike;
-  namespace: string;
+  owner: TemporalOperations;
+  projectId: string;
   taskQueue: string;
   nowMs?: () => number;
   freshPollerMs?: number;
 }
 
 const DEFAULT_FRESH_POLLER_MS = 60_000;
-const TASK_QUEUE_TYPE_WORKFLOW = 1;
 
 export async function probeTaskQueuePollers(
   input: ProbeTaskQueuePollersInput,
 ): Promise<ServerPollerProbe> {
-  const describeTaskQueue = input.connection.workflowService?.describeTaskQueue;
-  if (!describeTaskQueue) {
-    return {
-      status: "unavailable",
-      lastAccessMs: null,
-      pollerCount: 0,
-      lastPollerAt: null,
-      error: "WorkflowService.describeTaskQueue unavailable",
-    };
-  }
-
   try {
-    const response = await describeTaskQueue({
-      namespace: input.namespace,
-      taskQueue: { name: input.taskQueue },
-      taskQueueType: TASK_QUEUE_TYPE_WORKFLOW,
-    });
-    const pollers = extractPollers(response);
+    const outcome = await input.owner.describeTaskQueue(
+      makeTemporalOperationContext(
+        input.projectId,
+        input.taskQueue,
+        "describe",
+        "describeTaskQueue",
+        5_000,
+      ),
+      input.taskQueue,
+    );
+    if (outcome.kind !== "complete") {
+      return {
+        status: "unavailable",
+        lastAccessMs: null,
+        pollerCount: 0,
+        lastPollerAt: null,
+        error:
+          outcome.error instanceof Error
+            ? outcome.error.message
+            : String(outcome.error),
+      };
+    }
+    const pollers = extractPollers(outcome.value);
     if (pollers.length === 0)
       return {
         status: "none",

--- a/plugin/src/temporal/reconcile-terminal-deps.ts
+++ b/plugin/src/temporal/reconcile-terminal-deps.ts
@@ -10,9 +10,10 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { listChangeDirs } from "../storage/change-projection-reader";
-import { CHANGE_WORKFLOW_PREFIX } from "./contracts";
 import { archiveChangeSignal } from "./messages";
+import type { TemporalOperations } from "./operations";
 import type { TerminalReconcileDeps } from "./reconcile-terminal-workflows";
+import { getChangeHandle } from "../tools/_adapters";
 
 /** Change statuses that mean the workflow SHOULD have completed. */
 const TERMINAL_STATUSES = new Set(["archived", "closed"]);
@@ -132,21 +133,6 @@ export function terminalChangeIdsFromStatuses(
   return terminal;
 }
 
-export interface TerminalSignalClient {
-  workflow: {
-    getHandle: (workflowId: string) => {
-      signal: (sig: unknown) => Promise<void>;
-    };
-  };
-}
-
-export function buildChangeWorkflowId(
-  projectId: string,
-  changeId: string,
-): string {
-  return `${CHANGE_WORKFLOW_PREFIX}${projectId}/${changeId}`;
-}
-
 /**
  * Build the deps for a real sweep.
  *
@@ -160,7 +146,7 @@ export function buildTerminalReconcileDeps(input: {
   projectId: string;
   archiveDir: string | undefined;
   changesDir: string | undefined;
-  client: TerminalSignalClient;
+  owner: TemporalOperations;
 }): TerminalReconcileDeps {
   // One projection read per sweep, shared by both lookups.
   let statusesPromise: Promise<Map<string, string>> | null = null;
@@ -185,9 +171,7 @@ export function buildTerminalReconcileDeps(input: {
     listActiveChangeIds: async () =>
       activeChangeIdsFromStatuses(await statuses()),
     fireTerminal: async (changeId: string) => {
-      const handle = input.client.workflow.getHandle(
-        buildChangeWorkflowId(input.projectId, changeId),
-      );
+      const handle = getChangeHandle(input.owner, input.projectId, changeId);
       await handle.signal(archiveChangeSignal);
     },
   };

--- a/plugin/src/temporal/reconcile-terminal-workflows.test.ts
+++ b/plugin/src/temporal/reconcile-terminal-workflows.test.ts
@@ -13,7 +13,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   reconcileTerminalWorkflows,
-  type TerminalReconcileClient,
   type TerminalReconcileDeps,
 } from "./reconcile-terminal-workflows";
 import {
@@ -22,30 +21,32 @@ import {
   isTerminalChangeStatus,
   terminalChangeIdsFromStatuses,
 } from "./reconcile-terminal-deps";
+import { createMockOwnerFromClient } from "./__tests__/mock-owner";
+import type { TemporalOperations } from "./operations";
 
-const PROJECT = "proj1";
+const PROJECT = "0".repeat(40);
 const WF = (changeId: string) => `adv/change/${PROJECT}/${changeId}`;
 
 function client(
   entries: Array<{ workflowId: string; status?: string }>,
   terminate: () => Promise<void> = vi.fn(async () => {}),
-): TerminalReconcileClient & {
-  workflow: { terminate: () => Promise<void> };
-} {
-  return {
-    workflow: {
-      list: () =>
-        (async function* () {
-          for (const e of entries) {
-            yield {
-              workflowId: e.workflowId,
-              status: { name: e.status ?? "RUNNING" },
-            };
-          }
-        })(),
-      terminate,
+): TemporalOperations {
+  return createMockOwnerFromClient({
+    client: {
+      workflow: {
+        list: () =>
+          (async function* () {
+            for (const e of entries) {
+              yield {
+                workflowId: e.workflowId,
+                status: { name: e.status ?? "RUNNING" },
+              };
+            }
+          })(),
+        terminate,
+      },
     },
-  };
+  });
 }
 
 function deps(
@@ -224,7 +225,9 @@ describe("reconcileTerminalWorkflows", () => {
       })(),
     );
     const result = await reconcileTerminalWorkflows(
-      { workflow: { list } },
+      createMockOwnerFromClient({
+        client: { workflow: { list } },
+      }),
       PROJECT,
       deps({ listArchivedChangeIds: async () => new Set<string>() }),
     );

--- a/plugin/src/temporal/reconcile-terminal-workflows.ts
+++ b/plugin/src/temporal/reconcile-terminal-workflows.ts
@@ -32,25 +32,14 @@
 
 import { CHANGE_WORKFLOW_PREFIX } from "./contracts";
 import { escapeVisibilityValue } from "./lifecycle-visibility";
+import type { TemporalOperations } from "./operations";
+import { makeTemporalOperationContext } from "./operations";
 
 /** Hard cap on inspected workflows per sweep (safety bound). */
 const INSPECTION_LIMIT = 500;
 
 /** Default cap on terminal signals fired per sweep. */
 const DEFAULT_MAX_RECONCILE_PER_SWEEP = 25;
-
-/**
- * Minimal Visibility client shape. `@temporalio/client` Client satisfies this
- * structurally.
- */
-export interface TerminalReconcileClient {
-  workflow: {
-    list: (opts: { query: string }) => AsyncIterable<{
-      workflowId: string;
-      status: { name: string };
-    }>;
-  };
-}
 
 export interface TerminalReconcileDeps {
   /**
@@ -109,7 +98,7 @@ function summarize(err: unknown): string {
  * re-signalling an already-archived workflow is a no-op.
  */
 export async function reconcileTerminalWorkflows(
-  client: TerminalReconcileClient,
+  owner: TemporalOperations,
   projectId: string,
   deps: TerminalReconcileDeps,
   options: TerminalReconcileOptions = {},
@@ -142,7 +131,21 @@ export async function reconcileTerminalWorkflows(
   const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
 
   const candidates: string[] = [];
-  for await (const wf of client.workflow.list({ query })) {
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    `${projectPrefix}terminal-reconcile`,
+    "list",
+    "reconcileTerminalWorkflows",
+    10_000,
+  );
+  const listResult = await owner.list<{
+    workflowId: string;
+    status: { name: string };
+  }>(ctx, query, { limit: INSPECTION_LIMIT });
+  if (listResult.kind !== "complete") {
+    throw listResult.error;
+  }
+  for (const wf of listResult.value) {
     if (result.inspected >= INSPECTION_LIMIT) break;
 
     // Change workflows only (exclude epics and anything else).

--- a/plugin/src/temporal/retry-wrapper.ts
+++ b/plugin/src/temporal/retry-wrapper.ts
@@ -1,4 +1,3 @@
-import { Connection } from "@temporalio/client";
 import { collectErrorText } from "./error-text";
 
 export type TemporalErrorClass = "transient" | "fallback" | "fatal";
@@ -251,7 +250,7 @@ export function resetTemporalRetryTelemetry(): void {
   lastWorkerRunError = null;
 }
 
-interface RetryOptions {
+interface RetryOptions<T = unknown> {
   maxAttempts?: number;
   initialDelayMs?: number;
   maxDelayMs?: number;
@@ -267,20 +266,25 @@ interface RetryOptions {
    */
   deadline?: TemporalReadDeadline;
   /**
-   * SDK connection to use for native gRPC deadline/abort propagation.
-   * When provided alongside `deadline`, `Promise.race` is no longer the
-   * RPC timeout authority — the SDK's `Connection.withDeadline` and
-   * `withAbortSignal` cancel the in-flight RPC instead.
+   * Owner-provided deadline/abort executor. When provided alongside
+   * `deadline`, `Promise.race` is no longer the RPC timeout authority —
+   * the closure cancels the in-flight RPC instead. This closure is the
+   * only thing that may touch the raw SDK Connection; it is supplied by
+   * the operation owner so the retry wrapper itself stays client-free.
    */
-  connection?: Connection;
+  runWithDeadline?: (
+    deadlineAt: number,
+    abortSignal: AbortSignal,
+    fn: () => Promise<T>,
+  ) => Promise<T>;
   /**
-   * Request-scoped abort signal. When provided, the SDK cancels the
+   * Request-scoped abort signal. When provided, the executor cancels the
    * in-flight RPC if the signal is aborted.
    */
   abortSignal?: AbortSignal;
 }
 
-function delayMs(attempt: number, options: RetryOptions): number {
+function delayMs<T>(attempt: number, options: RetryOptions<T>): number {
   const initial = options.initialDelayMs ?? 250;
   const coefficient = options.backoffCoefficient ?? 2;
   const max = options.maxDelayMs ?? 2_000;
@@ -307,7 +311,7 @@ async function withTimeout<T>(op: Promise<T>, timeoutMs?: number): Promise<T> {
 
 export async function withTemporalRetry<T>(
   op: () => Promise<T>,
-  options: RetryOptions = {},
+  options: RetryOptions<T> = {},
 ): Promise<T> {
   const maxAttempts = options.maxAttempts ?? 3;
   const deadline = options.deadline;
@@ -328,19 +332,18 @@ export async function withTemporalRetry<T>(
         : options.timeoutMs;
     try {
       let result: T;
-      if (deadline && options.connection) {
-        // rq-boundedAuthoritativeRead02: use the SDK's native gRPC deadline
-        // and abort propagation as the RPC timeout authority. The per-attempt
+      if (deadline && options.runWithDeadline) {
+        // rq-boundedAuthoritativeRead02: use the owner-provided gRPC deadline
+        // and abort executor as the RPC timeout authority. The per-attempt
         // deadline is the same cap that the legacy Promise.race fallback
         // would have applied, but the SDK cancels the in-flight RPC instead
         // of merely resolving a local race.
         const attemptDeadlineAt =
           Date.now() + (attemptTimeoutMs ?? remainingDeadlineMs(deadline));
-        result = await options.connection.withDeadline(attemptDeadlineAt, () =>
-          options.connection!.withAbortSignal(
-            options.abortSignal ?? new AbortController().signal,
-            op,
-          ),
+        result = await options.runWithDeadline(
+          attemptDeadlineAt,
+          options.abortSignal ?? new AbortController().signal,
+          op,
         );
       } else {
         result = await withTimeout(op(), attemptTimeoutMs);

--- a/plugin/src/temporal/runtime-manager.test.ts
+++ b/plugin/src/temporal/runtime-manager.test.ts
@@ -37,7 +37,7 @@ describe("temporal runtime manager helpers", () => {
       taskQueue: "adv-change-proj1",
       address: "127.0.0.1:7233",
       namespace: "default",
-      projectId: "proj1",
+      projectId: "0000100000000000000000000000000000000000",
     });
 
     expect(spec.env[ADV_TEMPORAL_WORKER_SELF_ROLL_ENV]).toBe(
@@ -51,7 +51,7 @@ describe("temporal runtime manager helpers", () => {
       taskQueue: "adv-change-proj1",
       address: "127.0.0.1:7233",
       namespace: "default",
-      projectId: "proj1",
+      projectId: "0000100000000000000000000000000000000000",
       sessionId: "sess_TestRoute123",
     });
 
@@ -64,7 +64,7 @@ describe("temporal runtime manager helpers", () => {
       taskQueue: "adv-change-proj1",
       address: "127.0.0.1:7233",
       namespace: "default",
-      projectId: "proj1",
+      projectId: "0000100000000000000000000000000000000000",
     });
 
     expect(spec.env.ADV_TEMPORAL_SESSION_ID).toBeUndefined();

--- a/plugin/src/temporal/search-attributes.test.ts
+++ b/plugin/src/temporal/search-attributes.test.ts
@@ -12,7 +12,7 @@ import {
 function makeState(): ChangeWorkflowState {
   return {
     id: "chg1",
-    projectId: "proj1",
+    projectId: "0000100000000000000000000000000000000000",
     changeId: "chg1",
     title: "Exact title",
     status: "active",

--- a/plugin/src/temporal/service-reconnect.test.ts
+++ b/plugin/src/temporal/service-reconnect.test.ts
@@ -34,6 +34,8 @@ const mocks = vi.hoisted(() => {
   const connection = {
     close: connectionClose,
     operatorService: { addSearchAttributes, listSearchAttributes },
+    withDeadline: vi.fn((_deadline: unknown, fn: () => unknown) => fn()),
+    withAbortSignal: vi.fn((_signal: unknown, fn: () => unknown) => fn()),
   };
   const client = {};
   const connect = vi.fn().mockResolvedValue(connection);
@@ -67,6 +69,8 @@ import {
 } from "./service";
 import { withTemporalRetry } from "./retry-wrapper";
 
+const TEST_PROJECT_ID = "a".repeat(40);
+
 /**
  * The closure pattern wired into runTemporal / runTemporalQuery
  * (Task 3 — KD-2, KD-4). Built per-op so `reconnected` is local and
@@ -86,6 +90,20 @@ function makeReconnectingHook(): () => Promise<void> {
   };
 }
 
+function makeReinitConnection() {
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+    operatorService: {
+      addSearchAttributes: vi.fn().mockResolvedValue({}),
+      listSearchAttributes: vi.fn().mockResolvedValue({
+        customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
+      }),
+    },
+    withDeadline: vi.fn((_deadline: unknown, fn: () => unknown) => fn()),
+    withAbortSignal: vi.fn((_signal: unknown, fn: () => unknown) => fn()),
+  };
+}
+
 describe("STSL reconnect via withTemporalRetry (Task 3 integration)", () => {
   beforeEach(async () => {
     resetStsl();
@@ -94,7 +112,7 @@ describe("STSL reconnect via withTemporalRetry (Task 3 integration)", () => {
     mocks.connectionClose.mockResolvedValue(undefined);
     mocks.addSearchAttributes.mockResolvedValue({});
     mocks.connect.mockResolvedValue(mocks.connection);
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -106,15 +124,7 @@ describe("STSL reconnect via withTemporalRetry (Task 3 integration)", () => {
 
   it("op fails transient once → reinit fires → retry succeeds against new connection", async () => {
     // Stub a different connection for the reinit.
-    const newConnection = {
-      close: vi.fn().mockResolvedValue(undefined),
-      operatorService: {
-        addSearchAttributes: vi.fn().mockResolvedValue({}),
-        listSearchAttributes: vi.fn().mockResolvedValue({
-          customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
-        }),
-      },
-    };
+    const newConnection = makeReinitConnection();
     mocks.connect.mockResolvedValueOnce(newConnection);
 
     const op = vi
@@ -155,15 +165,7 @@ describe("STSL reconnect via withTemporalRetry (Task 3 integration)", () => {
   // This test asserts the END-TO-END recovery path: classifier → retry →
   // onTransientFailure → reinitStsl → fresh connection → op succeeds.
   it("op fails with SDK-wrapped channel-shutdown → reinit fires → retry succeeds (AC4)", async () => {
-    const newConnection = {
-      close: vi.fn().mockResolvedValue(undefined),
-      operatorService: {
-        addSearchAttributes: vi.fn().mockResolvedValue({}),
-        listSearchAttributes: vi.fn().mockResolvedValue({
-          customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
-        }),
-      },
-    };
+    const newConnection = makeReinitConnection();
     mocks.connect.mockResolvedValueOnce(newConnection);
 
     const sdkWrappedError = new Error(
@@ -192,15 +194,7 @@ describe("STSL reconnect via withTemporalRetry (Task 3 integration)", () => {
   it("op fails 3 transient times → reinit called only once (per-op idempotent)", async () => {
     // First reinit returns a fresh connection; subsequent reinits would
     // also return fresh ones, but the per-op hook must suppress them.
-    const newConnection = {
-      close: vi.fn().mockResolvedValue(undefined),
-      operatorService: {
-        addSearchAttributes: vi.fn().mockResolvedValue({}),
-        listSearchAttributes: vi.fn().mockResolvedValue({
-          customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
-        }),
-      },
-    };
+    const newConnection = makeReinitConnection();
     mocks.connect.mockResolvedValue(newConnection);
 
     const op = vi
@@ -277,15 +271,7 @@ describe("STSL reconnect via withTemporalRetry (Task 3 integration)", () => {
       return { query: newHandleQuery };
     });
 
-    const newConnection = {
-      close: vi.fn().mockResolvedValue(undefined),
-      operatorService: {
-        addSearchAttributes: vi.fn().mockResolvedValue({}),
-        listSearchAttributes: vi.fn().mockResolvedValue({
-          customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
-        }),
-      },
-    };
+    const newConnection = makeReinitConnection();
     mocks.connect.mockResolvedValueOnce(newConnection);
     mocks.ClientCtor.mockImplementationOnce(function (this: unknown) {
       return newClient;
@@ -319,15 +305,7 @@ describe("STSL reconnect via withTemporalRetry (Task 3 integration)", () => {
 
   it("two parallel ops each get their own per-op idempotent hook", async () => {
     // First reinit only — single-flight at the STSL level.
-    const newConnection = {
-      close: vi.fn().mockResolvedValue(undefined),
-      operatorService: {
-        addSearchAttributes: vi.fn().mockResolvedValue({}),
-        listSearchAttributes: vi.fn().mockResolvedValue({
-          customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
-        }),
-      },
-    };
+    const newConnection = makeReinitConnection();
     mocks.connect.mockResolvedValueOnce(newConnection);
 
     const op1 = vi

--- a/plugin/src/temporal/service.test.ts
+++ b/plugin/src/temporal/service.test.ts
@@ -29,6 +29,12 @@ const mocks = vi.hoisted(() => {
   const connection = {
     close: connectionClose,
     operatorService: { addSearchAttributes, listSearchAttributes },
+    withDeadline: vi.fn((_deadline: unknown, fn: () => Promise<unknown>) =>
+      fn(),
+    ),
+    withAbortSignal: vi.fn((_signal: unknown, fn: () => Promise<unknown>) =>
+      fn(),
+    ),
   };
   const client = {};
   const connect = vi.fn().mockResolvedValue(connection);
@@ -64,6 +70,8 @@ import {
   verifyAdvSearchAttributes,
 } from "./service";
 
+const TEST_PROJECT_ID = "a".repeat(40);
+
 describe("STSL (Shared Temporal Service Layer)", () => {
   beforeEach(() => {
     resetStsl();
@@ -80,14 +88,17 @@ describe("STSL (Shared Temporal Service Layer)", () => {
       ADV_TEMPORAL_NAMESPACE: "test-ns",
     };
 
-    const bundle = await initStsl(env);
+    const bundle = await initStsl(TEST_PROJECT_ID, env);
 
     expect(bundle).toBeDefined();
     expect(bundle.address).toBe("127.0.0.1:7233");
     expect(bundle.namespace).toBe("test-ns");
     expect(bundle.connection).toBe(mocks.connection);
     expect(bundle.client).toBe(mocks.client);
-    expect(mocks.connect).toHaveBeenCalledWith({ address: "127.0.0.1:7233" });
+    expect(mocks.connect).toHaveBeenCalledWith({
+      address: "127.0.0.1:7233",
+      connectTimeout: 10_000,
+    });
     expect(mocks.ClientCtor).toHaveBeenCalledWith({
       connection: mocks.connection,
       namespace: "test-ns",
@@ -104,7 +115,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
         customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
       });
 
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -137,7 +148,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
 
   it("initStsl skips registration when SAs already present", async () => {
     // Default mock has all SAs present → registration should be skipped
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -153,7 +164,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
 
     // Must not throw
     await expect(
-      initStsl({
+      initStsl(TEST_PROJECT_ID, {
         ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
         ADV_TEMPORAL_NAMESPACE: "default",
       }),
@@ -167,7 +178,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
 
     // Must not throw even on non-AlreadyExists failure
     await expect(
-      initStsl({
+      initStsl(TEST_PROJECT_ID, {
         ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
         ADV_TEMPORAL_NAMESPACE: "default",
       }),
@@ -208,7 +219,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
       .mockImplementation(() => undefined);
 
     try {
-      await initStsl({
+      await initStsl(TEST_PROJECT_ID, {
         ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
         ADV_TEMPORAL_NAMESPACE: "default",
       });
@@ -263,7 +274,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
       .mockImplementation(() => undefined);
 
     try {
-      await initStsl({
+      await initStsl(TEST_PROJECT_ID, {
         ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
         ADV_TEMPORAL_NAMESPACE: "default",
       });
@@ -283,7 +294,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
   });
 
   it("getService returns the initialized bundle", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -301,7 +312,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
   it("isStslInitialized reports state correctly", async () => {
     expect(isStslInitialized()).toBe(false);
 
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -315,21 +326,21 @@ describe("STSL (Shared Temporal Service Layer)", () => {
       ADV_TEMPORAL_NAMESPACE: "default",
     };
 
-    const first = await initStsl(env);
-    const second = await initStsl(env);
+    const first = await initStsl(TEST_PROJECT_ID, env);
+    const second = await initStsl(TEST_PROJECT_ID, env);
 
     expect(first).toBe(second);
     expect(mocks.connect).toHaveBeenCalledTimes(1);
   });
 
   it("double-init with different env throws (prevent accidental re-init)", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "ns-a",
     });
 
     await expect(
-      initStsl({
+      initStsl(TEST_PROJECT_ID, {
         ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
         ADV_TEMPORAL_NAMESPACE: "ns-b",
       }),
@@ -337,7 +348,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
   });
 
   it("closeStsl closes the connection and clears the service", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -352,7 +363,7 @@ describe("STSL (Shared Temporal Service Layer)", () => {
   });
 
   it("closeStsl is idempotent (no error on double close)", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -391,7 +402,7 @@ describe("reinitStsl (Task 2 — comprehensive coverage)", () => {
     };
     newClient: object;
   }> => {
-    const bundleBefore = await initStsl({
+    const bundleBefore = await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -405,6 +416,12 @@ describe("reinitStsl (Task 2 — comprehensive coverage)", () => {
           customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
         }),
       },
+      withDeadline: vi.fn((_deadline: unknown, fn: () => Promise<unknown>) =>
+        fn(),
+      ),
+      withAbortSignal: vi.fn((_signal: unknown, fn: () => Promise<unknown>) =>
+        fn(),
+      ),
     };
     const newClient = {};
     mocks.connect.mockResolvedValueOnce(newConnection);
@@ -466,7 +483,7 @@ describe("reinitStsl (Task 2 — comprehensive coverage)", () => {
   });
 
   it("propagates Connection.connect failure to caller; increments reconnectFailureCount", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -516,7 +533,7 @@ describe("reinitStsl (Task 2 — comprehensive coverage)", () => {
   });
 
   it("resetStsl clears reconnect counters and inflight state", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -530,7 +547,7 @@ describe("reinitStsl (Task 2 — comprehensive coverage)", () => {
     expect(getStslStats().reconnectFailureCount).toBe(0);
     // After reset, a fresh init must work again (proves inFlightReconnect cleared).
     await expect(
-      initStsl({
+      initStsl(TEST_PROJECT_ID, {
         ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
         ADV_TEMPORAL_NAMESPACE: "default",
       }),
@@ -543,7 +560,7 @@ describe("reinitStsl (Task 2 — comprehensive coverage)", () => {
   });
 
   it("concurrent reinitStsl calls — both observers see the rejection from the first", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -574,6 +591,7 @@ describe("verifyAdvSearchAttributes", () => {
     const result = await verifyAdvSearchAttributes(
       mocks.connection,
       "test-ns",
+      TEST_PROJECT_ID,
       3,
       10,
     );
@@ -591,6 +609,7 @@ describe("verifyAdvSearchAttributes", () => {
     const result = await verifyAdvSearchAttributes(
       mocks.connection,
       "test-ns",
+      TEST_PROJECT_ID,
       5,
       10,
     );
@@ -608,6 +627,7 @@ describe("verifyAdvSearchAttributes", () => {
     const result = await verifyAdvSearchAttributes(
       mocks.connection,
       "test-ns",
+      TEST_PROJECT_ID,
       3,
       1, // minimal delay for tests
     );
@@ -634,6 +654,7 @@ describe("verifyAdvSearchAttributes", () => {
     const result = await verifyAdvSearchAttributes(
       mocks.connection,
       "test-ns",
+      TEST_PROJECT_ID,
       2,
       1, // minimal delay for tests
     );
@@ -673,7 +694,7 @@ describe("initStsl verification integration", () => {
       ADV_TEMPORAL_NAMESPACE: "test-ns",
     };
 
-    await initStsl(env);
+    await initStsl(TEST_PROJECT_ID, env);
 
     const stats = getStslStats();
     expect(stats.saVerification).toBeDefined();
@@ -690,7 +711,7 @@ describe("initStsl verification integration", () => {
       ADV_TEMPORAL_NAMESPACE: "test-ns",
     };
 
-    const initPromise = initStsl(env);
+    const initPromise = initStsl(TEST_PROJECT_ID, env);
     // Advance through all setTimeout calls in the poll loop
     await vi.advanceTimersByTimeAsync(10_000);
     await initPromise;
@@ -702,7 +723,7 @@ describe("initStsl verification integration", () => {
   });
 
   it("reinitStsl updates saVerification after reconnect", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });
@@ -715,6 +736,12 @@ describe("initStsl verification integration", () => {
           customAttributes: { ...mocks.ADV_SA_FULL_PRESENT },
         }),
       },
+      withDeadline: vi.fn((_deadline: unknown, fn: () => Promise<unknown>) =>
+        fn(),
+      ),
+      withAbortSignal: vi.fn((_signal: unknown, fn: () => Promise<unknown>) =>
+        fn(),
+      ),
     };
     mocks.connect.mockResolvedValueOnce(newConnection);
 
@@ -726,7 +753,7 @@ describe("initStsl verification integration", () => {
   });
 
   it("resetStsl clears saVerification", async () => {
-    await initStsl({
+    await initStsl(TEST_PROJECT_ID, {
       ADV_TEMPORAL_ADDRESS: "127.0.0.1:7233",
       ADV_TEMPORAL_NAMESPACE: "default",
     });

--- a/plugin/src/temporal/service.ts
+++ b/plugin/src/temporal/service.ts
@@ -1,144 +1,34 @@
 /**
  * Shared Temporal Service Layer (STSL)
  *
- * Singleton Client+Connection lifecycle for ADV's Temporal integration.
- * Replaces per-call `createTemporalClientBundle` with a session-scoped
- * shared connection that all consumers use via `getService()`.
+ * Singleton TemporalOperationsOwner lifecycle for ADV's Temporal integration.
+ * Replaces per-call raw client access with the closed operation-owner API.
  *
  * Lifecycle:
- *   1. `initStsl(env)` — create + cache the bundle (idempotent for same env)
- *   2. `getService()` — read the cached bundle (null before init)
- *   3. `closeStsl()` — close the connection + clear the cache
+ *   1. `initStsl(env)` — create + cache the owner (idempotent for same env)
+ *   2. `getService()` — read the cached owner (null before init)
+ *   3. `closeStsl()` — close the owner connection + clear the cache
  *
  * Thread safety: single-process, single-threaded (Bun/Node). No mutex needed.
  */
 
-import { Client, Connection } from "@temporalio/client";
+import {
+  TemporalOperationsOwner,
+  type TemporalOperations,
+  makeTemporalLifecycleContext,
+} from "./operations";
 import { getTemporalAddress, getTemporalNamespace } from "./client";
 import {
   checkAdvSearchAttributes,
-  registerMissingAdvSearchAttributes,
+  type AdvSearchAttributeCheckResult,
+  type SearchAttributeConnectionLike,
 } from "./observability";
-import type { AdvSearchAttributeCheckResult } from "./observability";
-import { appendDebugLog, createLogger } from "../utils/debug-log";
+import { createLogger } from "../utils/debug-log";
 import { getTemporalOpTelemetry } from "./retry-wrapper";
 
-function formatErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-const debugLog = (msg: string): void => appendDebugLog("stsl", msg);
 const logger = createLogger("stsl");
 
-/**
- * Register the ADV custom search attributes with the Temporal server.
- * Idempotent: already-registered attributes produce `AlreadyExists` which
- * is treated as success. Any other failure is logged and swallowed — a
- * missing search-attribute registry on a self-hosted Temporal isn't
- * fatal to plugin init (workflows without search attrs still run), but
- * the downstream Visibility API queries will fail until operators run
- * `temporal operator search-attribute create` manually.
- *
- * Delegates to `registerMissingAdvSearchAttributes` in `./observability`
- * so the attribute definitions live in a single place.
- */
-async function registerAdvSearchAttributes(
-  connection: Connection,
-  namespace: string,
-): Promise<void> {
-  const result = await registerMissingAdvSearchAttributes(
-    connection,
-    namespace,
-  );
-  if (result.created.length > 0) {
-    logger.debug(
-      `Registered ADV search attributes: ${result.created.map((a) => a.name).join(", ")}`,
-    );
-  }
-  if (result.skipped.length > 0) {
-    logger.debug(
-      `ADV search attributes already registered: ${result.skipped.map((a) => a.name).join(", ")}`,
-    );
-  }
-  if (result.refused.length > 0) {
-    logger.warn(
-      `ADV search attributes refused (wrong type): ${result.refused
-        .map((a) => `${a.name} (expected ${a.expected}, got ${a.actualCode})`)
-        .join(", ")}`,
-    );
-  }
-  if (result.error) {
-    const isAlreadyExists = /already\s*exists|ALREADY_EXISTS/i.test(
-      result.error,
-    );
-    if (isAlreadyExists) {
-      logger.debug(
-        `ADV search attributes already registered (idempotent no-op): ${result.error}`,
-      );
-    } else if (result.method === "unavailable") {
-      logger.debug(
-        `OperatorService.addSearchAttributes unavailable — skipping search-attribute registration: ${result.error}`,
-      );
-    } else {
-      // Real registration failure (not AlreadyExists, not operator-API
-      // unavailable). Elevated from warn to error so agents/operators see
-      // it without scraping debug logs. Idempotent per session — runs once
-      // per initStsl call. See change fixTemporalSearchAttrTypeCodes (AC-5).
-      logger.error(
-        `Failed to register ADV search attributes (Visibility queries may fail): ${result.error}`,
-      );
-    }
-  }
-}
-
-/**
- * Verify that ADV search attributes are queryable by polling
- * `checkAdvSearchAttributes` after registration. Covers Temporal's
- * documented propagation delay (up to 10s on SQLite backends).
- *
- * Non-throwing: returns the final check result regardless of outcome.
- * Logs each poll at debug level; warns on timeout.
- */
-export async function verifyAdvSearchAttributes(
-  connection: Connection,
-  namespace: string,
-  maxAttempts = 20,
-  delayMs = 500,
-): Promise<AdvSearchAttributeCheckResult> {
-  let lastResult: AdvSearchAttributeCheckResult;
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    lastResult = await checkAdvSearchAttributes(connection, namespace);
-    if (lastResult.ok) {
-      debugLog(
-        `verifyAdvSearchAttributes: ok after ${attempt + 1}/${maxAttempts} attempts`,
-      );
-      return lastResult;
-    }
-    if (attempt < maxAttempts - 1) {
-      debugLog(
-        `verifyAdvSearchAttributes: attempt ${attempt + 1}/${maxAttempts} — ${lastResult.missing.length} missing, retrying in ${delayMs}ms`,
-      );
-      await new Promise((r) => setTimeout(r, delayMs));
-    }
-  }
-  // Final check after all attempts exhausted
-  lastResult = await checkAdvSearchAttributes(connection, namespace);
-  if (!lastResult.ok) {
-    logger.warn(
-      `verifyAdvSearchAttributes: still not ok after ${maxAttempts} attempts — ${lastResult.missing.length} missing, ${lastResult.wrongType.length} wrong type`,
-    );
-  }
-  return lastResult;
-}
-
-interface StslBundle {
-  address: string;
-  namespace: string;
-  connection: Connection;
-  client: Client;
-}
-
-let cachedBundle: StslBundle | null = null;
+let cachedOwner: TemporalOperationsOwner | null = null;
 let getServiceCallCount = 0;
 let newConnectionCount = 0;
 let reconnectCount = 0;
@@ -149,6 +39,10 @@ let lastSaVerification: { ok: boolean; checkedAt: number } | null = null;
 export interface StslStats {
   getServiceCalls: number;
   newConnections: number;
+  /**
+   * Ratio of getService calls to new connections created. Reused bundles
+   * make this number high; each connection serves many callers.
+   */
   reuseRate: number;
   /**
    * Number of times reinitStsl successfully replaced the cached
@@ -169,90 +63,102 @@ export interface StslStats {
 
 /**
  * Initialize the shared Temporal service layer. Idempotent when called with
- * the same address/namespace — returns the existing bundle without creating
+ * the same address/namespace — returns the existing owner without creating
  * a new connection. Throws if already initialized with different parameters
  * (prevents accidental env drift).
+ *
+ * The caller must supply the actual typed project identity; the namespace is
+ * used only for the Temporal gRPC namespace, never as the ADV project id.
  */
 export async function initStsl(
+  projectId: string,
   env: NodeJS.ProcessEnv = process.env,
-): Promise<StslBundle> {
+): Promise<TemporalOperationsOwner> {
   const address = getTemporalAddress(env);
   const namespace = getTemporalNamespace(env);
 
-  if (cachedBundle) {
+  if (cachedOwner) {
     if (
-      cachedBundle.address === address &&
-      cachedBundle.namespace === namespace
+      cachedOwner.getAddress() === address &&
+      cachedOwner.getNamespace() === namespace &&
+      cachedOwner.getProjectId() === projectId
     ) {
-      debugLog(`initStsl: returning existing bundle (${address}/${namespace})`);
-      return cachedBundle;
+      logger.debug(
+        `initStsl: returning existing owner (${address}/${namespace}/${projectId})`,
+      );
+      return cachedOwner;
     }
     throw new Error(
       `STSL already initialized with different parameters ` +
-        `(existing: ${cachedBundle.address}/${cachedBundle.namespace}, ` +
-        `requested: ${address}/${namespace}). Call closeStsl() first.`,
+        `(existing: ${cachedOwner.getAddress()}/${cachedOwner.getNamespace()}/${cachedOwner.getProjectId()}, ` +
+        `requested: ${address}/${namespace}/${projectId}). Call closeStsl() first.`,
     );
   }
 
-  debugLog(`initStsl: creating new bundle (${address}/${namespace})`);
-  const connection = await Connection.connect({ address });
-  const client = new Client({ connection, namespace });
+  logger.debug(
+    `initStsl: creating new owner (${address}/${namespace}/${projectId})`,
+  );
+  const owner = await TemporalOperationsOwner.fromEnv(projectId, env);
   newConnectionCount++;
+
+  const lifecycleCtx = makeTemporalLifecycleContext(
+    projectId,
+    "initStsl",
+    10_000,
+  );
 
   // Register ADV custom search attributes with the server so Visibility
   // API queries and workflow.start() search-attribute payloads work.
   // Idempotent; failure is non-fatal (warned, not thrown).
-  await registerAdvSearchAttributes(connection, namespace);
+  await owner.registerSearchAttributes(lifecycleCtx);
 
   // Verify SAs propagated (covers Temporal's documented propagation delay).
-  const verification = await verifyAdvSearchAttributes(connection, namespace);
+  const verification = await owner.verifySearchAttributes(lifecycleCtx);
   lastSaVerification = { ok: verification.ok, checkedAt: Date.now() };
 
-  cachedBundle = { address, namespace, connection, client };
-  debugLog(`initStsl: bundle ready`);
-  return cachedBundle;
+  cachedOwner = owner;
+  logger.debug(`initStsl: owner ready`);
+  return cachedOwner;
 }
 
 /**
- * Get the cached STSL bundle. Returns null before initialization.
+ * Get the cached Temporal operation owner. Returns null before initialization.
  */
-export function getService(): StslBundle | null {
+export function getService(): TemporalOperationsOwner | null {
   getServiceCallCount++;
-  return cachedBundle;
+  return cachedOwner;
 }
+
+export type { TemporalOperations };
 
 /**
  * Check whether the STSL has been initialized.
  */
 export function isStslInitialized(): boolean {
-  return cachedBundle !== null;
+  return cachedOwner !== null;
 }
 
 /**
- * Close the shared Temporal connection and clear the cached bundle.
+ * Close the shared Temporal connection and clear the cached owner.
  * Idempotent — safe to call multiple times or when not initialized.
  */
 export async function closeStsl(): Promise<void> {
-  if (!cachedBundle) {
-    debugLog(`closeStsl: no bundle to close`);
+  if (!cachedOwner) {
+    logger.debug(`closeStsl: no owner to close`);
     return;
   }
 
-  debugLog(`closeStsl: closing connection`);
-  try {
-    await cachedBundle.connection.close();
-  } catch (e) {
-    debugLog(`closeStsl: connection.close error: ${formatErrorMessage(e)}`);
-  }
-  cachedBundle = null;
-  debugLog(`closeStsl: complete`);
+  logger.debug(`closeStsl: closing owner connection`);
+  await cachedOwner.close();
+  cachedOwner = null;
+  logger.debug(`closeStsl: complete`);
 }
 
 /**
  * Reset the STSL state. For testing only — does NOT close the connection.
  */
 export function resetStsl(): void {
-  cachedBundle = null;
+  cachedOwner = null;
   getServiceCallCount = 0;
   newConnectionCount = 0;
   reconnectCount = 0;
@@ -274,26 +180,41 @@ export function getStslStats(): StslStats {
   };
 }
 
+export async function verifyAdvSearchAttributes(
+  connection: SearchAttributeConnectionLike,
+  namespace: string,
+  projectId: string,
+  maxAttempts = 20,
+  delayMs = 500,
+): Promise<AdvSearchAttributeCheckResult> {
+  let lastResult: AdvSearchAttributeCheckResult | undefined;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    lastResult = await checkAdvSearchAttributes(
+      connection,
+      namespace,
+      projectId,
+    );
+    if (lastResult.ok) return lastResult;
+    if (attempt < maxAttempts - 1) {
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  lastResult = await checkAdvSearchAttributes(connection, namespace, projectId);
+  return lastResult;
+}
+
 /**
  * Replace the cached Temporal connection + client in-place after a
  * stale-connection failure (server restart, gRPC GOAWAY, broken pipe).
  *
  * Behavior (KD-1, KD-3, KD-5):
- *   - Mutates `cachedBundle.connection` and `cachedBundle.client` in place;
- *     the bundle object identity is preserved so existing closures (e.g.
- *     `createTemporalStoreBackend`'s captured `input.temporal`) pick up
- *     the new client/connection on the next per-call read.
+ *   - Delegates to `TemporalOperationsOwner.reconnect()`. The owner preserves
+ *     its own identity, so existing closures that captured the owner pick up
+ *     the new connection/client on the next operation.
  *   - Single-flight: concurrent callers await the same in-flight promise.
- *     JS event-loop semantics make TOCTOU impossible — the IIFE assignment
- *     below is synchronous, so a second caller arriving before the first
- *     `await` yields will observe a non-null `inFlightReconnect`.
- *   - Best-effort close: a rejecting `connection.close()` is logged and
- *     ignored; reinit proceeds to `Connection.connect`.
- *   - Re-registers ADV search attributes (idempotent on `AlreadyExists`).
- *   - On `Connection.connect` failure, increments `reconnectFailureCount`,
- *     clears the in-flight guard, and rethrows so the caller (typically
- *     a per-op `onTransientFailure` hook in `runTemporal`/
- *     `runTemporalQuery`) can record + suppress.
+ *     JS event-loop semantics make TOCTOU impossible.
+ *   - On reconnect failure, increments `reconnectFailureCount` and rethrows so
+ *     the caller's per-op retry hook can classify + suppress.
  *
  * Throws if STSL is not initialized — production callers always come
  * through the store backend after `initStsl` ran in `plugin-init.ts`.
@@ -302,41 +223,36 @@ export async function reinitStsl(): Promise<void> {
   if (inFlightReconnect) {
     return inFlightReconnect;
   }
-  if (!cachedBundle) {
+  if (!cachedOwner) {
     throw new Error("reinitStsl: STSL not initialized — call initStsl first");
   }
 
-  const bundle = cachedBundle;
+  const owner = cachedOwner;
   const promise = (async () => {
     try {
-      try {
-        await bundle.connection.close();
-      } catch (e) {
-        debugLog(
-          `reinitStsl: close error (continuing): ${formatErrorMessage(e)}`,
-        );
-      }
-      const newConnection = await Connection.connect({
-        address: bundle.address,
-      });
-      const newClient = new Client({
-        connection: newConnection,
-        namespace: bundle.namespace,
-      });
-      bundle.connection = newConnection;
-      bundle.client = newClient;
-      newConnectionCount++;
-      await registerAdvSearchAttributes(newConnection, bundle.namespace);
-      const verification = await verifyAdvSearchAttributes(
-        newConnection,
-        bundle.namespace,
+      await owner.reconnect();
+
+      // Re-register ADV search attributes after reconnect. The new connection
+      // may point at a fresh Temporal server or namespace, so idempotent
+      // registration is required before visibility queries can succeed.
+      const lifecycleCtx = makeTemporalLifecycleContext(
+        owner.getProjectId(),
+        "reinitStsl",
+        10_000,
       );
+      await owner.registerSearchAttributes(lifecycleCtx);
+      const verification = await owner.verifySearchAttributes(lifecycleCtx);
       lastSaVerification = { ok: verification.ok, checkedAt: Date.now() };
+
       reconnectCount++;
-      debugLog(`reinitStsl: success (${bundle.address}/${bundle.namespace})`);
+      logger.debug(
+        `reinitStsl: success (${owner.getAddress()}/${owner.getNamespace()})`,
+      );
     } catch (err) {
       reconnectFailureCount++;
-      debugLog(`reinitStsl: failed: ${formatErrorMessage(err)}`);
+      logger.debug(
+        `reinitStsl: failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
       throw err;
     }
   })();

--- a/plugin/src/temporal/session-readiness.integration.test.ts
+++ b/plugin/src/temporal/session-readiness.integration.test.ts
@@ -25,20 +25,14 @@ import {
   isAdvSessionNotReady,
   ADV_SESSION_READINESS_RETRY_HINT,
 } from "./readiness-types";
-import type { OrphanListClient } from "./list-orphan-session-queues";
+import { createMockOwnerFromClient } from "./__tests__/mock-owner";
 
 const TARGET_PROJECT_ID = "a".repeat(40);
 const EXPECTED_QUEUE = `advance-${TARGET_PROJECT_ID}`;
 
 const mocks = vi.hoisted(() => {
-  const temporalBundle = {
-    client: { workflow: { getHandle: vi.fn() } },
-    connection: { workflowService: { describeTaskQueue: vi.fn() } },
-    namespace: "default",
-  };
-
   return {
-    temporalBundle,
+    temporalBundle: null as any,
     ensureProjectTemporalQueue: vi.fn(async () => {}),
     getRegisteredTemporalWorkerQueues: vi.fn(() => [] as string[]),
     getTemporalWorkerAliveness: vi.fn(() => false),
@@ -51,6 +45,12 @@ const mocks = vi.hoisted(() => {
     })),
     ensureChangeWorkflowStarted: vi.fn(),
   };
+});
+
+mocks.temporalBundle = createMockOwnerFromClient({
+  client: { workflow: { getHandle: vi.fn() } },
+  connection: { workflowService: { describeTaskQueue: vi.fn() } },
+  namespace: "default",
 });
 
 vi.mock("../plugin-init", () => ({
@@ -446,7 +446,7 @@ describe("acceptance matrix — fireSignalAndRefresh (AC1-AC7)", () => {
         },
       },
       {
-        projectId: "proj-abc",
+        projectId: "0000abc000000000000000000000000000000000",
         changeId: "chg-def",
         title: "Test Change",
         initializedAt: new Date().toISOString(),
@@ -572,7 +572,8 @@ describe("DDC budget compliance", () => {
   });
 
   test("DDC5: orphan adopter marks target queue stale within a single heartbeat tick on worker death", async () => {
-    const queue = `advance-P-sess_death`;
+    const projectId = "0000000000000000000000000000000000000000";
+    const queue = `advance-${projectId}-sess_death`;
     const { OrphanQueueAdopter } = await import("./orphan-queue-adopter");
 
     const worker = {
@@ -582,22 +583,24 @@ describe("DDC budget compliance", () => {
       }),
     };
 
-    const client: OrphanListClient = {
-      workflow: {
-        list: async function* () {
-          yield {
-            workflowId: `adv/change/P/${queue}/wf1`,
-            taskQueue: queue,
-            startTime: new Date("2026-07-22T00:00:00Z"),
-            status: { name: "RUNNING" },
-          };
+    const owner = createMockOwnerFromClient({
+      client: {
+        workflow: {
+          list: async function* () {
+            yield {
+              workflowId: `adv/change/${projectId}/${queue}/wf1`,
+              taskQueue: queue,
+              startTime: new Date("2026-07-22T00:00:00Z"),
+              status: { name: "RUNNING" },
+            };
+          },
         },
       },
-    };
+    });
 
     const adopter = new OrphanQueueAdopter({
-      client,
-      projectId: "P",
+      owner,
+      projectId,
       worker,
       tickTimeoutMs: 20,
       now: () => 1000,
@@ -648,7 +651,7 @@ describe("rq-isolSessionTaskQueue05 regression — worker startup non-blocking (
         },
       },
       {
-        projectId: "proj-abc",
+        projectId: "0000abc000000000000000000000000000000000",
         changeId: "chg-def",
         title: "Test Change",
         initializedAt: new Date().toISOString(),

--- a/plugin/src/temporal/visibility-claim-queries.test.ts
+++ b/plugin/src/temporal/visibility-claim-queries.test.ts
@@ -7,6 +7,11 @@ import {
   queryActiveChangesByIssueNumbers,
 } from "./visibility-claim-queries";
 
+import { createMockOwnerFromClient } from "./__tests__/mock-owner";
+
+const PROJECT_ID = "0".repeat(40);
+const PROJECT_PREFIX = `adv/change/${PROJECT_ID}/`;
+
 // Minimal client mock matching the shape used by visibility-claim-queries.
 function makeClient(
   results: Array<{
@@ -29,12 +34,12 @@ function makeClient(
 describe("visibility-claim-queries: query construction (rq-backlogCoord01, rq-backlogCoord02)", () => {
   it("builds claim-collision query scoped by AdvAffectedProjects + AdvBacklogIssueNumber + open lifecycle", () => {
     const query = buildClaimVisibilityQuery({
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       issueNumber: 42,
     });
 
     expect(query).toBe(
-      'AdvAffectedProjects = "pid-abc" AND AdvBacklogIssueNumber = "42" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"',
+      `AdvAffectedProjects = "${PROJECT_ID}" AND AdvBacklogIssueNumber = "42" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"`,
     );
   });
 
@@ -49,18 +54,18 @@ describe("visibility-claim-queries: query construction (rq-backlogCoord01, rq-ba
 
   it("builds bulk active-claims query for multiple issue numbers using IN operator", () => {
     const query = buildActiveClaimsVisibilityQuery({
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       issueNumbers: [51, 52, 60],
     });
 
     expect(query).toBe(
-      'AdvAffectedProjects = "pid-abc" AND AdvBacklogIssueNumber IN ("51", "52", "60") AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"',
+      `AdvAffectedProjects = "${PROJECT_ID}" AND AdvBacklogIssueNumber IN ("51", "52", "60") AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"`,
     );
   });
 
   it("returns null for the bulk query when issueNumbers is empty (caller should skip the Temporal call)", () => {
     const query = buildActiveClaimsVisibilityQuery({
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       issueNumbers: [],
     });
 
@@ -69,17 +74,16 @@ describe("visibility-claim-queries: query construction (rq-backlogCoord01, rq-ba
 });
 
 describe("visibility-claim-queries: queryClaimsByIssueNumber (rq-backlogCoord02 pre-create check)", () => {
-  const PROJECT_PREFIX = "adv/change/pid-abc/";
-
   it("returns matching change IDs scoped by project prefix", async () => {
     const client = makeClient([
       { workflowId: `${PROJECT_PREFIX}existingChange` },
       { workflowId: `${PROJECT_PREFIX}anotherProjectChange` },
     ]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const claims = await queryClaimsByIssueNumber(client, "pid-abc", 51);
+    const claims = await queryClaimsByIssueNumber(owner, PROJECT_ID, 51);
 
-    expect(claims).toEqual([
+    expect(claims.value).toEqual([
       { changeId: "existingChange" },
       { changeId: "anotherProjectChange" },
     ]);
@@ -94,24 +98,24 @@ describe("visibility-claim-queries: queryClaimsByIssueNumber (rq-backlogCoord02 
       { workflowId: "adv/change/other-pid/leaked" }, // wrong project — should be filtered
       { workflowId: "adv/project/pid-abc" }, // wrong shape — should be filtered
     ]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const claims = await queryClaimsByIssueNumber(client, "pid-abc", 42);
+    const claims = await queryClaimsByIssueNumber(owner, PROJECT_ID, 42);
 
-    expect(claims).toEqual([{ changeId: "myChange" }]);
+    expect(claims.value).toEqual([{ changeId: "myChange" }]);
   });
 
   it("returns empty array when no matching workflows exist", async () => {
     const client = makeClient([]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const claims = await queryClaimsByIssueNumber(client, "pid-abc", 999);
+    const claims = await queryClaimsByIssueNumber(owner, PROJECT_ID, 999);
 
-    expect(claims).toEqual([]);
+    expect(claims.value).toEqual([]);
   });
 });
 
 describe("visibility-claim-queries: queryActiveChangesByIssueNumbers (rq-backlogCoord05 O(1) lookup)", () => {
-  const PROJECT_PREFIX = "adv/change/pid-abc/";
-
   it("returns Map keyed by issue number for matching changes", async () => {
     const client = makeClient([
       {
@@ -123,42 +127,46 @@ describe("visibility-claim-queries: queryActiveChangesByIssueNumbers (rq-backlog
         searchAttributes: { AdvBacklogIssueNumber: ["52"] },
       },
     ]);
+    const owner = createMockOwnerFromClient({ client });
 
     const map = await queryActiveChangesByIssueNumbers(
-      client,
-      "pid-abc",
+      owner,
+      PROJECT_ID,
       [51, 52, 60],
     );
 
-    expect(map.get(51)).toEqual({ changeId: "changeForIssue51" });
-    expect(map.get(52)).toEqual({ changeId: "changeForIssue52" });
-    expect(map.get(60)).toBeUndefined();
-    expect(map.size).toBe(2);
+    expect(map.value.get(51)).toEqual({ changeId: "changeForIssue51" });
+    expect(map.value.get(52)).toEqual({ changeId: "changeForIssue52" });
+    expect(map.value.get(60)).toBeUndefined();
+    expect(map.value.size).toBe(2);
   });
 
   it("returns empty Map and does NOT call Temporal when issueNumbers is empty", async () => {
     const client = makeClient([{ workflowId: `${PROJECT_PREFIX}irrelevant` }]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const map = await queryActiveChangesByIssueNumbers(client, "pid-abc", []);
+    const map = await queryActiveChangesByIssueNumbers(owner, PROJECT_ID, []);
 
-    expect(map.size).toBe(0);
+    expect(map.value.size).toBe(0);
     expect(client.workflow.list).not.toHaveBeenCalled();
   });
 
   it("uses a single Visibility call for input arrays ≤ 100 issue numbers", async () => {
     const client = makeClient([]);
+    const owner = createMockOwnerFromClient({ client });
     const issueNumbers = Array.from({ length: 100 }, (_, i) => i + 1);
 
-    await queryActiveChangesByIssueNumbers(client, "pid-abc", issueNumbers);
+    await queryActiveChangesByIssueNumbers(owner, PROJECT_ID, issueNumbers);
 
     expect(client.workflow.list).toHaveBeenCalledTimes(1);
   });
 
   it("chunks the call into batches of 100 for larger inputs", async () => {
     const client = makeClient([]);
+    const owner = createMockOwnerFromClient({ client });
     const issueNumbers = Array.from({ length: 250 }, (_, i) => i + 1);
 
-    await queryActiveChangesByIssueNumbers(client, "pid-abc", issueNumbers);
+    await queryActiveChangesByIssueNumbers(owner, PROJECT_ID, issueNumbers);
 
     // 250 issues → ceil(250 / 100) = 3 batches
     expect(client.workflow.list).toHaveBeenCalledTimes(3);
@@ -175,10 +183,11 @@ describe("visibility-claim-queries: queryActiveChangesByIssueNumbers (rq-backlog
         searchAttributes: { AdvBacklogIssueNumber: ["51"] },
       },
     ]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const map = await queryActiveChangesByIssueNumbers(client, "pid-abc", [51]);
+    const map = await queryActiveChangesByIssueNumbers(owner, PROJECT_ID, [51]);
 
-    expect(map.size).toBe(1);
-    expect(map.get(51)?.changeId).toBe("validChange");
+    expect(map.value.size).toBe(1);
+    expect(map.value.get(51)?.changeId).toBe("validChange");
   });
 });

--- a/plugin/src/temporal/visibility-claim-queries.ts
+++ b/plugin/src/temporal/visibility-claim-queries.ts
@@ -17,6 +17,8 @@
  * and claim paths share one Visibility search-attribute contract.
  */
 
+import type { TemporalListOutcome, TemporalOperations } from "./operations";
+import { makeTemporalOperationContext } from "./operations";
 import {
   escapeVisibilityValue,
   openLifecycleVisibilityClauses,
@@ -43,19 +45,6 @@ export interface BulkClaimQueryOptions {
 
 export interface ClaimVisibilityResult {
   changeId: string;
-}
-
-/**
- * Minimal Visibility-list client shape. Real `@temporalio/client` Client
- * satisfies this structurally.
- */
-export interface VisibilityListClient {
-  workflow: {
-    list: (opts: { query: string }) => AsyncIterable<{
-      workflowId: string;
-      searchAttributes?: Record<string, unknown>;
-    }>;
-  };
 }
 
 /**
@@ -102,15 +91,27 @@ export function buildActiveClaimsVisibilityQuery(
  * rq-backlogCoord03).
  */
 export async function queryClaimsByIssueNumber(
-  client: VisibilityListClient,
+  owner: TemporalOperations,
   projectId: string,
   issueNumber: number,
-): Promise<ClaimVisibilityResult[]> {
+): Promise<TemporalListOutcome<ClaimVisibilityResult[]>> {
   const query = buildClaimVisibilityQuery({ projectId, issueNumber });
   const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
+  const placeholderWorkflowId = `${projectPrefix}claim-query-${issueNumber}`;
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    placeholderWorkflowId,
+    "list",
+    "queryClaimsByIssueNumber",
+    10_000,
+  );
+  const outcome = await owner.list<{ workflowId: string }>(ctx, query);
+  if (outcome.kind !== "complete") {
+    return outcome;
+  }
   const results: ClaimVisibilityResult[] = [];
 
-  for await (const wf of client.workflow.list({ query })) {
+  for (const wf of outcome.value) {
     const wfid = wf.workflowId;
     if (!wfid.startsWith(projectPrefix)) continue;
     const changeId = wfid.slice(projectPrefix.length);
@@ -118,7 +119,7 @@ export async function queryClaimsByIssueNumber(
     results.push({ changeId });
   }
 
-  return results;
+  return { kind: "complete", value: results, truncated: outcome.truncated };
 }
 
 /**
@@ -131,14 +132,18 @@ export async function queryClaimsByIssueNumber(
  * Empty input array skips the Temporal call entirely.
  */
 export async function queryActiveChangesByIssueNumbers(
-  client: VisibilityListClient,
+  owner: TemporalOperations,
   projectId: string,
   issueNumbers: number[],
-): Promise<Map<number, ClaimVisibilityResult>> {
+): Promise<TemporalListOutcome<Map<number, ClaimVisibilityResult>>> {
   const result = new Map<number, ClaimVisibilityResult>();
-  if (issueNumbers.length === 0) return result;
+  if (issueNumbers.length === 0) {
+    return { kind: "complete", value: result, truncated: false };
+  }
 
   const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
+  const placeholderWorkflowId = `${projectPrefix}bulk-claims`;
+  let truncated = false;
 
   // Chunk to stay under query-string length limits.
   for (let i = 0; i < issueNumbers.length; i += BULK_QUERY_CHUNK_SIZE) {
@@ -149,7 +154,26 @@ export async function queryActiveChangesByIssueNumbers(
     });
     if (query === null) continue;
 
-    for await (const wf of client.workflow.list({ query })) {
+    const ctx = makeTemporalOperationContext(
+      projectId,
+      placeholderWorkflowId,
+      "list",
+      "queryActiveChangesByIssueNumbers",
+      10_000,
+    );
+    const listOutcome = await owner.list<{
+      workflowId: string;
+      searchAttributes?: Record<string, unknown>;
+    }>(ctx, query, { limit: BULK_QUERY_CHUNK_SIZE * 2 });
+
+    if (listOutcome.kind !== "complete") {
+      return listOutcome;
+    }
+    if (listOutcome.truncated) {
+      truncated = true;
+    }
+
+    for (const wf of listOutcome.value) {
       const wfid = wf.workflowId;
       if (!wfid.startsWith(projectPrefix)) continue;
       const changeId = wfid.slice(projectPrefix.length);
@@ -180,5 +204,5 @@ export async function queryActiveChangesByIssueNumbers(
     }
   }
 
-  return result;
+  return { kind: "complete", value: result, truncated };
 }

--- a/plugin/src/temporal/visibility-epic-queries.test.ts
+++ b/plugin/src/temporal/visibility-epic-queries.test.ts
@@ -5,6 +5,11 @@ import {
   queryChangeIdsByEpicId,
 } from "./visibility-epic-queries";
 
+import { createMockOwnerFromClient } from "./__tests__/mock-owner";
+
+const PROJECT_ID = "0".repeat(40);
+const PROJECT_PREFIX = `adv/change/${PROJECT_ID}/`;
+
 // Minimal client mock matching the shape used by visibility-epic-queries.
 function makeClient(results: Array<{ workflowId: string }>): {
   workflow: {
@@ -22,12 +27,12 @@ function makeClient(results: Array<{ workflowId: string }>): {
 describe("visibility-epic-queries: query construction (rq-epicTemporalConstraints01)", () => {
   it("builds Epic-members query scoped by AdvAffectedProjects + AdvEpicId + open lifecycle", () => {
     const query = buildEpicMembersVisibilityQuery({
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       epicId: "addAuthEpic",
     });
 
     expect(query).toBe(
-      'AdvAffectedProjects = "pid-abc" AND AdvEpicId = "addAuthEpic" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"',
+      `AdvAffectedProjects = "${PROJECT_ID}" AND AdvEpicId = "addAuthEpic" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"`,
     );
   });
 
@@ -43,53 +48,52 @@ describe("visibility-epic-queries: query construction (rq-epicTemporalConstraint
 
   it("maps open draft status to open lifecycle filtering", () => {
     const query = buildEpicMembersVisibilityQuery({
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       epicId: "addAuthEpic",
       statuses: ["draft"],
     });
 
     expect(query).toBe(
-      'AdvAffectedProjects = "pid-abc" AND AdvEpicId = "addAuthEpic" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"',
+      `AdvAffectedProjects = "${PROJECT_ID}" AND AdvEpicId = "addAuthEpic" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"`,
     );
   });
 
   it("preserves explicit terminal status filtering for archive sweeps", () => {
     const query = buildEpicMembersVisibilityQuery({
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       epicId: "addAuthEpic",
       statuses: ["archived"],
     });
 
     expect(query).toBe(
-      'AdvAffectedProjects = "pid-abc" AND AdvEpicId = "addAuthEpic" AND AdvChangeStatus IN ("archived")',
+      `AdvAffectedProjects = "${PROJECT_ID}" AND AdvEpicId = "addAuthEpic" AND AdvChangeStatus IN ("archived")`,
     );
   });
 
   it("supports null statuses to disable status filter", () => {
     const query = buildEpicMembersVisibilityQuery({
-      projectId: "pid-abc",
+      projectId: PROJECT_ID,
       epicId: "addAuthEpic",
       statuses: null,
     });
 
     expect(query).toBe(
-      'AdvAffectedProjects = "pid-abc" AND AdvEpicId = "addAuthEpic"',
+      `AdvAffectedProjects = "${PROJECT_ID}" AND AdvEpicId = "addAuthEpic"`,
     );
   });
 });
 
 describe("visibility-epic-queries: queryChangeIdsByEpicId", () => {
-  const PROJECT_PREFIX = "adv/change/pid-abc/";
-
   it("returns matching change IDs scoped by project prefix", async () => {
     const client = makeClient([
       { workflowId: `${PROJECT_PREFIX}childOne` },
       { workflowId: `${PROJECT_PREFIX}childTwo` },
     ]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const ids = await queryChangeIdsByEpicId(client, "pid-abc", "addAuthEpic");
+    const ids = await queryChangeIdsByEpicId(owner, PROJECT_ID, "addAuthEpic");
 
-    expect(ids).toEqual(["childOne", "childTwo"]);
+    expect(ids.value).toEqual(["childOne", "childTwo"]);
     expect(client.workflow.list).toHaveBeenCalledWith({
       query: expect.stringContaining('AdvEpicId = "addAuthEpic"'),
     });
@@ -101,18 +105,20 @@ describe("visibility-epic-queries: queryChangeIdsByEpicId", () => {
       { workflowId: "adv/change/other-pid/leaked" },
       { workflowId: "adv/project/pid-abc" },
     ]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const ids = await queryChangeIdsByEpicId(client, "pid-abc", "addAuthEpic");
+    const ids = await queryChangeIdsByEpicId(owner, PROJECT_ID, "addAuthEpic");
 
-    expect(ids).toEqual(["myChange"]);
+    expect(ids.value).toEqual(["myChange"]);
   });
 
   it("returns empty array when no matching workflows exist", async () => {
     const client = makeClient([]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const ids = await queryChangeIdsByEpicId(client, "pid-abc", "missingEpic");
+    const ids = await queryChangeIdsByEpicId(owner, PROJECT_ID, "missingEpic");
 
-    expect(ids).toEqual([]);
+    expect(ids.value).toEqual([]);
   });
 
   it("respects the limit option", async () => {
@@ -121,11 +127,12 @@ describe("visibility-epic-queries: queryChangeIdsByEpicId", () => {
       { workflowId: `${PROJECT_PREFIX}childTwo` },
       { workflowId: `${PROJECT_PREFIX}childThree` },
     ]);
+    const owner = createMockOwnerFromClient({ client });
 
-    const ids = await queryChangeIdsByEpicId(client, "pid-abc", "addAuthEpic", {
+    const ids = await queryChangeIdsByEpicId(owner, PROJECT_ID, "addAuthEpic", {
       limit: 2,
     });
 
-    expect(ids).toEqual(["childOne", "childTwo"]);
+    expect(ids.value).toEqual(["childOne", "childTwo"]);
   });
 });

--- a/plugin/src/temporal/visibility-epic-queries.ts
+++ b/plugin/src/temporal/visibility-epic-queries.ts
@@ -11,6 +11,8 @@
  */
 
 import type { ChangeStatus } from "../types";
+import type { TemporalListOutcome, TemporalOperations } from "./operations";
+import { makeTemporalOperationContext } from "./operations";
 import {
   escapeVisibilityValue,
   isLegacyOpenStatusSet,
@@ -34,14 +36,6 @@ export interface EpicMembersQueryOptions {
    * to lifecycle filtering. Pass `null` to skip the filter entirely.
    */
   statuses?: ChangeStatus[] | null;
-}
-
-export interface EpicMembersVisibilityClient {
-  workflow: {
-    list: (opts: { query: string }) => AsyncIterable<{
-      workflowId: string;
-    }>;
-  };
 }
 
 /**
@@ -92,11 +86,11 @@ export interface QueryChangeIdsByEpicIdOptions {
  * the underlying change workflows. Use `limit` to bound the result set.
  */
 export async function queryChangeIdsByEpicId(
-  client: EpicMembersVisibilityClient,
+  owner: TemporalOperations,
   projectId: string,
   epicId: string,
   options: QueryChangeIdsByEpicIdOptions = {},
-): Promise<string[]> {
+): Promise<TemporalListOutcome<string[]>> {
   const query = buildEpicMembersVisibilityQuery({
     projectId,
     epicId,
@@ -104,9 +98,24 @@ export async function queryChangeIdsByEpicId(
   });
   const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
   const limit = options.limit;
+  const effectiveLimit = limit ?? 1000;
+  const placeholderWorkflowId = `${projectPrefix}epic-${epicId}-members`;
+  const ctx = makeTemporalOperationContext(
+    projectId,
+    placeholderWorkflowId,
+    "list",
+    "queryChangeIdsByEpicId",
+    10_000,
+  );
+  const result = await owner.list<{ workflowId: string }>(ctx, query, {
+    limit: effectiveLimit,
+  });
+  if (result.kind !== "complete") {
+    return result;
+  }
   const ids: string[] = [];
 
-  for await (const wf of client.workflow.list({ query })) {
+  for (const wf of result.value) {
     const wfid = wf.workflowId;
     if (!wfid.startsWith(projectPrefix)) continue;
     const changeId = wfid.slice(projectPrefix.length);
@@ -115,5 +124,5 @@ export async function queryChangeIdsByEpicId(
     if (limit !== undefined && ids.length >= limit) break;
   }
 
-  return ids;
+  return { kind: "complete", value: ids, truncated: result.truncated };
 }

--- a/plugin/src/temporal/worker-multi.test.ts
+++ b/plugin/src/temporal/worker-multi.test.ts
@@ -184,7 +184,7 @@ const baseInput = {
   namespace: "default",
   queues: ["adv-change-proj1", "adv-project-proj1"] as const,
   workerScript: "/fake/worker.ts",
-  projectId: "proj1",
+  projectId: "0000100000000000000000000000000000000000",
 };
 
 describe("Multi-queue worker host", () => {

--- a/plugin/src/temporal/workflow-start.test.ts
+++ b/plugin/src/temporal/workflow-start.test.ts
@@ -1,14 +1,32 @@
 import { describe, expect, test, vi } from "vitest";
 import {
   ensureChangeWorkflowStarted,
+  ensureEpicWorkflowStarted,
   reImportChangeState,
   IncompatibleActiveSessionQueuesError,
+  StartWorkflowOutcomeError,
 } from "./workflow-start";
+import {
+  createMockOwnerFromClient,
+  createMockOwner,
+} from "./__tests__/mock-owner";
+import {
+  buildProjectTaskQueue,
+  buildSessionTaskQueue,
+  buildChangeWorkflowId,
+} from "./client";
 import {
   ChangeCreationHashConflictError,
   CREATION_HASH_CONFLICT_CODE,
 } from "../storage/store-temporal/creation-hash";
 import type { Change } from "../types";
+
+const PROJECT_ID = "0".repeat(40);
+const PROJ_Q = buildProjectTaskQueue(PROJECT_ID);
+
+function ownerFrom(client: unknown) {
+  return createMockOwnerFromClient(client);
+}
 
 const contract: NonNullable<Change["contract"]> = {
   version: 1,
@@ -46,8 +64,8 @@ describe("ensureChangeWorkflowStarted", () => {
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };
 
-    await ensureChangeWorkflowStarted(client, {
-      projectId: "pid-abc",
+    await ensureChangeWorkflowStarted(ownerFrom(client), {
+      projectId: PROJECT_ID,
       changeId: "backlogFeature51",
       title: "Backlog feature 51",
       initializedAt: "2026-05-11T00:00:00.000Z",
@@ -71,8 +89,8 @@ describe("ensureChangeWorkflowStarted", () => {
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };
 
-    await ensureChangeWorkflowStarted(client, {
-      projectId: "pid-abc",
+    await ensureChangeWorkflowStarted(ownerFrom(client), {
+      projectId: PROJECT_ID,
       changeId: "epicChild",
       title: "Epic child",
       initializedAt: "2026-05-11T00:00:00.000Z",
@@ -102,8 +120,8 @@ describe("ensureChangeWorkflowStarted", () => {
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };
 
-    await ensureChangeWorkflowStarted(client, {
-      projectId: "pid-abc",
+    await ensureChangeWorkflowStarted(ownerFrom(client), {
+      projectId: PROJECT_ID,
       changeId: "sessionRouted",
       title: "Session routed",
       initializedAt: "2026-07-21T00:00:00.000Z",
@@ -113,7 +131,7 @@ describe("ensureChangeWorkflowStarted", () => {
     expect(start).toHaveBeenCalledWith(
       expect.any(Function),
       expect.objectContaining({
-        taskQueue: "advance-pid-abc-sess_RouteTest",
+        taskQueue: buildSessionTaskQueue(PROJECT_ID, "sess_RouteTest"),
       }),
     );
   });
@@ -123,8 +141,8 @@ describe("ensureChangeWorkflowStarted", () => {
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };
 
-    await ensureChangeWorkflowStarted(client, {
-      projectId: "pid-abc",
+    await ensureChangeWorkflowStarted(ownerFrom(client), {
+      projectId: PROJECT_ID,
       changeId: "legacyRoute",
       title: "Legacy route",
       initializedAt: "2026-07-21T00:00:00Z",
@@ -134,7 +152,7 @@ describe("ensureChangeWorkflowStarted", () => {
     expect(start).toHaveBeenCalledWith(
       expect.any(Function),
       expect.objectContaining({
-        taskQueue: "advance-pid-abc",
+        taskQueue: PROJ_Q,
       }),
     );
   });
@@ -146,9 +164,9 @@ describe("ensureChangeWorkflowStarted", () => {
     const client = { workflow: { start, getHandle: vi.fn(), list } };
 
     await ensureChangeWorkflowStarted(
-      client,
+      ownerFrom(client),
       {
-        projectId: "pid-abc",
+        projectId: PROJECT_ID,
         changeId: "singletonRoute",
         title: "Singleton route",
         initializedAt: "2026-07-21T00:00:00Z",
@@ -160,7 +178,7 @@ describe("ensureChangeWorkflowStarted", () => {
     expect(start).toHaveBeenCalledWith(
       expect.any(Function),
       expect.objectContaining({
-        taskQueue: "advance-pid-abc",
+        taskQueue: PROJ_Q,
       }),
     );
     expect(list).toHaveBeenCalledWith(
@@ -176,9 +194,9 @@ describe("ensureChangeWorkflowStarted", () => {
     const client = { workflow: { start, getHandle: vi.fn() } };
 
     await ensureChangeWorkflowStarted(
-      client,
+      ownerFrom(client),
       {
-        projectId: "pid-abc",
+        projectId: PROJECT_ID,
         changeId: "sessionMode",
         title: "Session mode",
         initializedAt: "2026-07-21T00:00:00Z",
@@ -190,7 +208,7 @@ describe("ensureChangeWorkflowStarted", () => {
     expect(start).toHaveBeenCalledWith(
       expect.any(Function),
       expect.objectContaining({
-        taskQueue: "advance-pid-abc-sess_DefaultSession",
+        taskQueue: buildSessionTaskQueue(PROJECT_ID, "sess_DefaultSession"),
       }),
     );
   });
@@ -199,8 +217,8 @@ describe("ensureChangeWorkflowStarted", () => {
     const start = vi.fn().mockResolvedValue({ query: vi.fn() });
     const list = vi.fn().mockReturnValue([
       {
-        workflowId: "adv/change/pid-abc/existingSessionPinned",
-        taskQueue: "advance-pid-abc-sess_existing",
+        workflowId: buildChangeWorkflowId(PROJECT_ID, "existingSessionPinned"),
+        taskQueue: buildSessionTaskQueue(PROJECT_ID, "sess_existing"),
         status: { name: "RUNNING" },
       },
     ]);
@@ -208,9 +226,9 @@ describe("ensureChangeWorkflowStarted", () => {
 
     await expect(
       ensureChangeWorkflowStarted(
-        client,
+        ownerFrom(client),
         {
-          projectId: "pid-abc",
+          projectId: PROJECT_ID,
           changeId: "singletonBlocked",
           title: "Singleton blocked",
           initializedAt: "2026-07-21T00:00:00Z",
@@ -229,9 +247,9 @@ describe("ensureChangeWorkflowStarted", () => {
     const client = { workflow: { start, getHandle: vi.fn() } };
 
     await ensureChangeWorkflowStarted(
-      client,
+      ownerFrom(client),
       {
-        projectId: "pid-abc",
+        projectId: PROJECT_ID,
         changeId: "singletonNoList",
         title: "Singleton no list",
         initializedAt: "2026-07-21T00:00:00Z",
@@ -241,6 +259,66 @@ describe("ensureChangeWorkflowStarted", () => {
     );
 
     expect(start).toHaveBeenCalled();
+  });
+
+  describe("typed start outcome errors", () => {
+    test("timeout_unavailable outcome throws StartWorkflowOutcomeError with kind timeout_unavailable", async () => {
+      const owner = createMockOwner({
+        startChangeWorkflow: vi.fn(async () => ({
+          kind: "timeout_unavailable",
+          error: new Error("deadline exceeded"),
+          diagnostic: { class: "deadline", reachable: true },
+        })),
+      });
+
+      await expect(
+        ensureChangeWorkflowStarted(owner, {
+          projectId: PROJECT_ID,
+          changeId: "timeoutChange",
+          title: "Timeout change",
+          initializedAt: "2026-07-21T00:00:00Z",
+        }),
+      ).rejects.toBeInstanceOf(StartWorkflowOutcomeError);
+    });
+
+    test("outcome_unknown outcome throws StartWorkflowOutcomeError with kind outcome_unknown", async () => {
+      const owner = createMockOwner({
+        startChangeWorkflow: vi.fn(async () => ({
+          kind: "outcome_unknown",
+          error: new Error("readback ambiguous"),
+          diagnostic: { class: "unknown", reachable: true },
+        })),
+      });
+
+      await expect(
+        ensureChangeWorkflowStarted(owner, {
+          projectId: PROJECT_ID,
+          changeId: "unknownChange",
+          title: "Unknown change",
+          initializedAt: "2026-07-21T00:00:00Z",
+        }),
+      ).rejects.toBeInstanceOf(StartWorkflowOutcomeError);
+    });
+
+    test("ensureEpicWorkflowStarted throws StartWorkflowOutcomeError on timeout_unavailable", async () => {
+      const owner = createMockOwner({
+        startEpicWorkflow: vi.fn(async () => ({
+          kind: "timeout_unavailable",
+          error: new Error("epic start deadline"),
+          diagnostic: { class: "deadline", reachable: true },
+        })),
+      });
+
+      await expect(
+        ensureEpicWorkflowStarted(owner, {
+          projectId: PROJECT_ID,
+          epicId: "timeoutEpic",
+          title: "Timeout epic",
+          narrative: "",
+          initializedAt: "2026-07-21T00:00:00Z",
+        }),
+      ).rejects.toBeInstanceOf(StartWorkflowOutcomeError);
+    });
   });
 
   describe("creation_request_hash idempotency on already-started path (rq-creationRequestHash01, tk-74c358188ffb)", () => {
@@ -273,8 +351,8 @@ describe("ensureChangeWorkflowStarted", () => {
         creation_request_hash: hash,
       });
 
-      const returned = await ensureChangeWorkflowStarted(client, {
-        projectId: "pid-abc",
+      const returned = await ensureChangeWorkflowStarted(ownerFrom(client), {
+        projectId: PROJECT_ID,
         changeId: "retryAfterTimeout",
         title: "Retry after timeout",
         initializedAt: "2026-07-22T00:00:00.000Z",
@@ -283,7 +361,7 @@ describe("ensureChangeWorkflowStarted", () => {
 
       expect(getHandle).toHaveBeenCalledTimes(1);
       expect(existingHandle.query).toHaveBeenCalledTimes(1);
-      expect(returned).toBe(existingHandle);
+      expect(returned).toMatchObject(existingHandle);
       // The original start attempt threw already-started; no second start.
       expect(start).toHaveBeenCalledTimes(1);
     });
@@ -298,8 +376,8 @@ describe("ensureChangeWorkflowStarted", () => {
       });
 
       await expect(
-        ensureChangeWorkflowStarted(client, {
-          projectId: "pid-abc",
+        ensureChangeWorkflowStarted(ownerFrom(client), {
+          projectId: PROJECT_ID,
           changeId: "sameSummaryDiffCapability",
           title: "Same summary diff capability",
           initializedAt: "2026-07-22T00:00:00.000Z",
@@ -314,8 +392,8 @@ describe("ensureChangeWorkflowStarted", () => {
 
       // Also satisfies instanceof for callers that key off the typed Error.
       await expect(
-        ensureChangeWorkflowStarted(client, {
-          projectId: "pid-abc",
+        ensureChangeWorkflowStarted(ownerFrom(client), {
+          projectId: PROJECT_ID,
           changeId: "sameSummaryDiffCapability",
           title: "Same summary diff capability",
           initializedAt: "2026-07-22T00:00:00.000Z",
@@ -333,15 +411,15 @@ describe("ensureChangeWorkflowStarted", () => {
         // creation_request_hash omitted
       });
 
-      const returned = await ensureChangeWorkflowStarted(client, {
-        projectId: "pid-abc",
+      const returned = await ensureChangeWorkflowStarted(ownerFrom(client), {
+        projectId: PROJECT_ID,
         changeId: "legacyWorkflowRetry",
         title: "Legacy workflow retry",
         initializedAt: "2026-07-22T00:00:00.000Z",
         creationRequestHash: computedHash,
       });
 
-      expect(returned).toBe(existingHandle);
+      expect(returned).toMatchObject(existingHandle);
     });
 
     test("omits hash check when caller does not supply creationRequestHash (backward compat)", async () => {
@@ -349,8 +427,8 @@ describe("ensureChangeWorkflowStarted", () => {
         creation_request_hash: "some-legacy-hash",
       });
 
-      const returned = await ensureChangeWorkflowStarted(client, {
-        projectId: "pid-abc",
+      const returned = await ensureChangeWorkflowStarted(ownerFrom(client), {
+        projectId: PROJECT_ID,
         changeId: "callerDidNotCompute",
         title: "Caller did not compute",
         initializedAt: "2026-07-22T00:00:00.000Z",
@@ -358,7 +436,7 @@ describe("ensureChangeWorkflowStarted", () => {
       });
 
       // Pre-existing behavior preserved: silent reuse, no state query.
-      expect(returned).toBe(existingHandle);
+      expect(returned).toMatchObject(existingHandle);
       expect(existingHandle.query).not.toHaveBeenCalled();
     });
 
@@ -379,8 +457,8 @@ describe("ensureChangeWorkflowStarted", () => {
       // A query failure must not be swallowed as "idempotent match".
       // Surface so the caller / P1.4 rollback can react.
       await expect(
-        ensureChangeWorkflowStarted(client, {
-          projectId: "pid-abc",
+        ensureChangeWorkflowStarted(ownerFrom(client), {
+          projectId: PROJECT_ID,
           changeId: "queryFailureSurfaces",
           title: "Query failure surfaces",
           initializedAt: "2026-07-22T00:00:00.000Z",
@@ -397,8 +475,8 @@ describe("reImportChangeState", () => {
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };
 
-    await reImportChangeState(client, {
-      projectId: "pid-abc",
+    await reImportChangeState(ownerFrom(client), {
+      projectId: PROJECT_ID,
       change: {
         id: "backlogFeature51",
         title: "Backlog feature 51",
@@ -439,8 +517,8 @@ describe("reImportChangeState", () => {
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };
 
-    await reImportChangeState(client, {
-      projectId: "pid-abc",
+    await reImportChangeState(ownerFrom(client), {
+      projectId: PROJECT_ID,
       change: {
         id: "epicChild",
         title: "Epic child",
@@ -474,8 +552,8 @@ describe("reImportChangeState", () => {
     const start = vi.fn().mockResolvedValue(handle);
     const client = { workflow: { start, getHandle: vi.fn() } };
 
-    await reImportChangeState(client, {
-      projectId: "pid-abc",
+    await reImportChangeState(ownerFrom(client), {
+      projectId: PROJECT_ID,
       change: {
         id: "contractRecovery",
         title: "Contract recovery",

--- a/plugin/src/temporal/workflow-start.ts
+++ b/plugin/src/temporal/workflow-start.ts
@@ -1,211 +1,126 @@
 import type { Change } from "../types";
+import type { TemporalWorkflowDiagnostic } from "./diagnostics";
 import {
-  buildChangeWorkflowId,
-  buildEpicWorkflowId,
-  buildProjectTaskQueue,
-  buildSessionTaskQueue,
-} from "./client";
+  TemporalOperationsOwner,
+  type TemporalOperations,
+  type TemporalWorkflowHandle,
+  makeTemporalOperationContext,
+  type WorkflowQueueMode,
+  type TemporalMutationServerOutcome,
+} from "./operations";
 import type { ChangeWorkflowInput, EpicWorkflowInput } from "./contracts";
 import { changeSeedStateFromChange } from "./change-state";
-import { buildTemporalSearchAttributes } from "./observability";
-import { readDiskArtifactsForHydration } from "../storage/store-temporal/hydrate-documents";
-import { changeStateQuery } from "./messages";
-import { changeWorkflow, epicWorkflow } from "./workflows";
-import { enforceMutationEligibilityForError } from "./mutation-safety";
-import { createLogger } from "../utils/debug-log";
-import {
-  resolveCreationIdempotency,
-  ChangeCreationHashConflictError,
-} from "../storage/store-temporal/creation-hash";
-import {
-  hasActiveSessionPinnedWorkflows,
-  type OrphanListClient,
-} from "./list-orphan-session-queues";
+import { buildChangeWorkflowId, buildEpicWorkflowId } from "./client";
 
-const logger = createLogger("workflow-start");
-
-export interface WorkflowHandleLike {
-  query: (definition: unknown, ...args: unknown[]) => Promise<unknown>;
-}
-
-export interface WorkflowClientLike {
-  start: (
-    workflow: unknown,
-    options: {
-      workflowId: string;
-      taskQueue: string;
-      args: [unknown];
-      searchAttributes?: Record<string, unknown[]>;
-    },
-  ) => Promise<WorkflowHandleLike>;
-  getHandle: (workflowId: string) => WorkflowHandleLike;
-  /**
-   * Optional Visibility enumeration surface. When present and
-   * `workflowQueueMode` is `project`, `ensureChangeWorkflowStarted` checks
-   * for active session-pinned workflows before entering singleton mode.
-   */
-  list?: (opts: { query: string }) => AsyncIterable<{
-    workflowId: string;
-    taskQueue: string;
-    status: { name: string };
-  }>;
-}
+export { IncompatibleActiveSessionQueuesError } from "./operations";
 
 /**
- * Thrown when explicit singleton routing would strand existing session-pinned
- * workflows by moving new workflows to the project queue while a session
- * queue still has running workflows and no poller.
+ * Distinct error thrown when a start workflow operation returns a non-confirmed
+ * outcome. Callers can branch on `kind` to distinguish timeout/unavailable,
+ * confirmed failure, and outcome-unknown.
  */
-export class IncompatibleActiveSessionQueuesError extends Error {
-  readonly name = "IncompatibleActiveSessionQueuesError";
-  readonly code = "INCOMPATIBLE_ACTIVE_SESSION_QUEUES";
+export class StartWorkflowOutcomeError extends Error {
+  readonly name = "StartWorkflowOutcomeError";
   constructor(
-    message = "Cannot activate project-queue singleton mode while session-pinned workflows are still running.",
+    readonly kind: Exclude<
+      TemporalMutationServerOutcome<unknown>["kind"],
+      "confirmed"
+    >,
+    readonly causeError: unknown,
+    readonly diagnostic: TemporalWorkflowDiagnostic,
+    message: string,
   ) {
     super(message);
   }
 }
 
-function isAlreadyStartedError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /already started|already exists|Workflow execution already started/i.test(
-    message,
+/**
+ * Backwards-compatible helpers that delegate to the closed TemporalOperationsOwner.
+ * Kept for a few callers that still import these names; new code should call
+ * owner.startChangeWorkflow / owner.startEpicWorkflow directly.
+ */
+
+function ownerFromTemporal(
+  temporal: TemporalOperations | TemporalOperationsOwner,
+): TemporalOperations {
+  return temporal;
+}
+
+function makeStartContext(
+  projectId: string,
+  workflowId: string,
+  budgetMs: number,
+) {
+  return makeTemporalOperationContext(
+    projectId,
+    workflowId,
+    "start",
+    "startWorkflow",
+    budgetMs,
   );
 }
 
 export async function ensureChangeWorkflowStarted(
-  client: { workflow: WorkflowClientLike },
+  temporal: TemporalOperations | TemporalOperationsOwner,
   input: ChangeWorkflowInput,
-  options?: { workflowQueueMode?: "session" | "project" },
-): Promise<WorkflowHandleLike> {
+  options?: {
+    workflowQueueMode?: WorkflowQueueMode;
+    budgetMs?: number;
+  },
+): Promise<TemporalWorkflowHandle> {
+  const owner = ownerFromTemporal(temporal);
   const workflowId = buildChangeWorkflowId(input.projectId, input.changeId);
-  // KD-10 / rq-isolSessionTaskQueue01: route to per-session task queue when
-  // the caller provides a sessionId. rq-isolSessionTaskQueue05: orphaned
-  // session queues (from dead sessions) are adopted at runtime by the
-  // OrphanQueueAdopter heartbeat coordinator.
-  // KD-2: explicit singleton mode (`workflowQueueMode: "project"`) routes
-  // new workflows to the permanent project queue so the single elected host
-  // can poll them.
-  const taskQueue =
-    options?.workflowQueueMode === "project" || !input.sessionId
-      ? buildProjectTaskQueue(input.projectId)
-      : buildSessionTaskQueue(input.projectId, input.sessionId);
-
-  if (options?.workflowQueueMode === "project" && client.workflow.list) {
-    const hasSessionPinned = await hasActiveSessionPinnedWorkflows(
-      client as unknown as OrphanListClient,
-      input.projectId,
+  const ctx = makeStartContext(
+    input.projectId,
+    workflowId,
+    options?.budgetMs ?? 10_000,
+  );
+  const outcome = await owner.startChangeWorkflow(ctx, input, {
+    workflowQueueMode: options?.workflowQueueMode,
+  });
+  if (outcome.kind !== "confirmed") {
+    if (outcome.kind === "confirmed_failure") {
+      throw outcome.error ?? new Error(`startChangeWorkflow ${outcome.kind}`);
+    }
+    throw new StartWorkflowOutcomeError(
+      outcome.kind,
+      outcome.error,
+      outcome.diagnostic,
+      `startChangeWorkflow ${outcome.kind}`,
     );
-    if (hasSessionPinned) {
-      throw new IncompatibleActiveSessionQueuesError(
-        `Project-queue singleton mode is incompatible with active session-pinned workflows for project ${input.projectId}.`,
-      );
-    }
   }
+  return outcome.value;
+}
 
-  // KD-5 workflow-start hydration: when starting a workflow for a pre-
-  // migration change whose disk artifacts pre-date Temporal-first writes,
-  // populate `seedState.documents` from disk so the first read sees
-  // Temporal-backed content. Idempotent + cold-start-only (re-runs after
-  // `already started` reuse the existing workflow's state.documents).
-  //
-  // Hydration is a no-op when:
-  //   - `seedState.documents` is already populated by the caller (new
-  //     change with content via options-object API).
-  //   - No `projectionChangesDir` is provided (tests / no-disk fixtures).
-  //   - The change directory doesn't exist on disk (brand-new change).
-  //   - No artifact file on disk has >=1 non-whitespace char (partial-write
-  //     robustness).
-  let inputWithHydration = input;
-  if (
-    !input.seedState?.documents &&
-    input.projectionChangesDir &&
-    input.changeId
-  ) {
-    const hydrated = await readDiskArtifactsForHydration(
-      input.projectionChangesDir,
-      input.changeId,
+export async function ensureEpicWorkflowStarted(
+  temporal: TemporalOperations | TemporalOperationsOwner,
+  input: EpicWorkflowInput,
+  options?: { budgetMs?: number },
+): Promise<TemporalWorkflowHandle> {
+  const owner = ownerFromTemporal(temporal);
+  const workflowId = buildEpicWorkflowId(input.projectId, input.epicId);
+  const ctx = makeStartContext(
+    input.projectId,
+    workflowId,
+    options?.budgetMs ?? 10_000,
+  );
+  const outcome = await owner.startEpicWorkflow(ctx, input);
+  if (outcome.kind !== "confirmed") {
+    if (outcome.kind === "confirmed_failure") {
+      throw outcome.error ?? new Error(`startEpicWorkflow ${outcome.kind}`);
+    }
+    throw new StartWorkflowOutcomeError(
+      outcome.kind,
+      outcome.error,
+      outcome.diagnostic,
+      `startEpicWorkflow ${outcome.kind}`,
     );
-    if (hydrated.documents) {
-      inputWithHydration = {
-        ...input,
-        seedState: {
-          ...(input.seedState ?? {}),
-          documents: hydrated.documents,
-        },
-      };
-    }
-    if (hydrated.warnings.length > 0) {
-      logger.warn(
-        `Hydration warnings for ${input.changeId}: ${hydrated.warnings.map((w) => `${w.kind} ${w.path}${w.actual ? ` (${w.actual} bytes)` : ""}`).join(", ")}`,
-      );
-    }
   }
-
-  try {
-    const startOpts: {
-      workflowId: string;
-      taskQueue: string;
-      args: [unknown];
-      searchAttributes?: Record<string, unknown[]>;
-    } = {
-      workflowId,
-      taskQueue,
-      args: [inputWithHydration],
-    };
-    if (inputWithHydration.searchAttributesEnabled !== false) {
-      startOpts.searchAttributes = buildTemporalSearchAttributes({
-        projectId: inputWithHydration.projectId,
-        changeId: inputWithHydration.changeId,
-        changeStatus: "draft",
-        activeGate: "proposal",
-        backlogIssueNumber: inputWithHydration.seedState?.origin?.issue_number,
-        epicId: inputWithHydration.seedState?.epic_membership?.epic_id,
-      });
-    }
-    return await client.workflow.start(changeWorkflow, startOpts);
-  } catch (error) {
-    if (isAlreadyStartedError(error)) {
-      const handle = client.workflow.getHandle(workflowId);
-      // rq-creationRequestHash01 (tk-74c358188ffb): when the caller supplies
-      // a canonical hash, verify the existing workflow's recorded hash before
-      // silently reusing its handle. This closes the post-commit-timeout
-      // duplicate-creation defect class — a retry whose business intent
-      // differs from the original (e.g. different capability, origin, or
-      // parent linkage) refuses with a typed conflict instead of silently
-      // masking the original request. A matching hash is the idempotent
-      // success path. When the caller omits the hash, the legacy silent-
-      // reuse behavior is preserved.
-      if (input.creationRequestHash) {
-        const state = (await handle.query(changeStateQuery)) as {
-          creation_request_hash?: string;
-        };
-        const decision = resolveCreationIdempotency({
-          existingHash: state?.creation_request_hash,
-          computedHash: input.creationRequestHash,
-        });
-        if (decision.kind === "hash_conflict") {
-          throw new ChangeCreationHashConflictError({
-            changeId: input.changeId,
-            existingHash: decision.existing_hash,
-            computedHash: decision.computed_hash,
-          });
-        }
-      }
-      return handle;
-    }
-    // SC4 mutation-eligibility guard: a workflow-start failure classified
-    // as mutation-ineligible (no-poller / query_failed_or_not_registered /
-    // deadline / unknown) must not be retried via the outer path. Surface
-    // `TemporalMutationIneligibleError` so callers can require an operator
-    // recovery action before retrying.
-    enforceMutationEligibilityForError(error);
-    throw error;
-  }
+  return outcome.value;
 }
 
 export async function reImportChangeState(
-  client: { workflow: WorkflowClientLike },
+  temporal: TemporalOperations | TemporalOperationsOwner,
   input: {
     projectId: string;
     change: Change;
@@ -213,8 +128,8 @@ export async function reImportChangeState(
     projectionChangesDir?: string;
     archiveProjects?: Array<{ projectPath: string }>;
   },
-): Promise<WorkflowHandleLike> {
-  return ensureChangeWorkflowStarted(client, {
+): Promise<TemporalWorkflowHandle> {
+  return ensureChangeWorkflowStarted(temporal, {
     projectId: input.projectId,
     changeId: input.change.id,
     title: input.change.title,
@@ -223,30 +138,4 @@ export async function reImportChangeState(
     archiveProjects: input.archiveProjects,
     seedState: changeSeedStateFromChange(input.change),
   });
-}
-
-export async function ensureEpicWorkflowStarted(
-  client: { workflow: WorkflowClientLike },
-  input: EpicWorkflowInput,
-): Promise<WorkflowHandleLike> {
-  const workflowId = buildEpicWorkflowId(input.projectId, input.epicId);
-  const taskQueue = buildProjectTaskQueue(input.projectId);
-
-  try {
-    const startOpts: {
-      workflowId: string;
-      taskQueue: string;
-      args: [unknown];
-    } = {
-      workflowId,
-      taskQueue,
-      args: [input],
-    };
-    return await client.workflow.start(epicWorkflow, startOpts);
-  } catch (error) {
-    if (isAlreadyStartedError(error)) {
-      return client.workflow.getHandle(workflowId);
-    }
-    throw error;
-  }
 }

--- a/plugin/src/temporal/workflows.epic.itest.ts
+++ b/plugin/src/temporal/workflows.epic.itest.ts
@@ -20,7 +20,7 @@ import { DEFAULT_CHANGE_HISTORY_THRESHOLD } from "./contracts";
 
 function makeEpicInput(): EpicWorkflowInput {
   return {
-    projectId: "epic-wf-test-project",
+    projectId: "e00c0f0e000000ec000000000000000000000000",
     epicId: `epic-${Date.now()}`,
     title: "Epic Workflow Test",
     narrative: "Testing epic workflow.",

--- a/plugin/src/temporal/workflows.lightweight-profile.itest.ts
+++ b/plugin/src/temporal/workflows.lightweight-profile.itest.ts
@@ -19,7 +19,7 @@ const timestamp = "2026-07-16T18:00:00.000Z";
 
 function makeChangeInput(changeId: string): ChangeWorkflowInput {
   return {
-    projectId: "lightweight-profile-test-project",
+    projectId: "000000e0000000f00e0e000000ec000000000000",
     changeId,
     title: `Lightweight profile test: ${changeId}`,
     initializedAt: timestamp,

--- a/plugin/src/temporal/workflows.ops-follow-up.itest.ts
+++ b/plugin/src/temporal/workflows.ops-follow-up.itest.ts
@@ -21,7 +21,7 @@ import { withTimeSkippingTestWorkflowEnvironment } from "./__tests__/with-test-e
 
 function makeChangeInput(changeId: string): ChangeWorkflowInput {
   return {
-    projectId: "ops-follow-up-test-project",
+    projectId: "000f00000000e000000ec0000000000000000000",
     changeId,
     title: `Ops follow-up test: ${changeId}`,
     initializedAt: "2026-06-20T04:00:00.000Z",

--- a/plugin/src/temporal/workflows.projection.itest.ts
+++ b/plugin/src/temporal/workflows.projection.itest.ts
@@ -16,7 +16,7 @@ function makeChangeInput(
   projectionChangesDir: string,
 ): ChangeWorkflowInput {
   return {
-    projectId: "projection-workflow-project",
+    projectId: "0000ec00000000f0000000ec0000000000000000",
     changeId,
     title: `Projection workflow: ${changeId}`,
     initializedAt: "2026-05-05T00:00:00.000Z",

--- a/plugin/src/temporal/workflows.queries.itest.ts
+++ b/plugin/src/temporal/workflows.queries.itest.ts
@@ -43,7 +43,7 @@ function makeChangeInput(): ChangeWorkflowInput {
   gates.execution = { status: "done" };
 
   return {
-    projectId: "query-test-project",
+    projectId: "00e000e000000ec0000000000000000000000000",
     changeId: "query-test-change",
     title: "Query handler test",
     initializedAt: "2026-05-05T00:00:00.000Z",

--- a/plugin/src/temporal/workflows.search-attrs.itest.ts
+++ b/plugin/src/temporal/workflows.search-attrs.itest.ts
@@ -37,7 +37,7 @@ async function registerSearchAttributes(
 
 function makeInput(): ChangeWorkflowInput {
   return {
-    projectId: "search-attrs-proj",
+    projectId: "0ea0c0a000000000000000000000000000000000",
     changeId: "search-attrs-change",
     title: "Search Attr Title",
     initializedAt: "2026-05-05T00:00:00.000Z",
@@ -58,7 +58,7 @@ function makeEpicInput(
   overrides: Partial<EpicWorkflowInput> = {},
 ): EpicWorkflowInput {
   return {
-    projectId: "search-attrs-proj",
+    projectId: "0ea0c0a000000000000000000000000000000000",
     epicId: `search-attrs-epic-${Date.now()}`,
     title: "Search Attr Epic",
     narrative: "Search attribute Epic test.",

--- a/plugin/src/tools/_adapters.test.ts
+++ b/plugin/src/tools/_adapters.test.ts
@@ -18,6 +18,8 @@ import {
   waitForAppliedReceipt,
   waitForQueryPredicate,
   MutationApplicationUnconfirmedError,
+  TemporalMutationOutcomeError,
+  TemporalReadOutcomeError,
   type ReachabilityDeps,
 } from "./_adapters";
 import { isAdvSessionNotReady } from "../temporal/readiness-types";
@@ -26,6 +28,15 @@ import {
   resetReadinessState,
 } from "../temporal/session-readiness";
 import { changeStateQuery } from "../temporal/messages";
+import { TemporalMutationIneligibleError } from "../temporal/mutation-safety";
+import { classifyTemporalWorkflowFailure } from "../temporal/diagnostics";
+import type {
+  TemporalMutationServerOutcome,
+  TemporalOperations,
+  TemporalReadOutcome,
+  TemporalWorkflowHandle,
+} from "../temporal/operations";
+import { createMockOwner as createMockOwnerBase } from "../temporal/__tests__/mock-owner";
 
 vi.mock("../temporal/session-readiness", async (importOriginal) => {
   const original =
@@ -66,7 +77,7 @@ describe("readiness mutation receipts", () => {
       recordedAt: "2026-07-19T20:00:00.000Z",
     });
     await expect(
-      waitForAppliedReceipt(handle as never, "mrec_exact", {
+      waitForAppliedReceipt(createMockProxy(handle), "mrec_exact", {
         attempts: 1,
         delayMs: 0,
       }),
@@ -80,7 +91,7 @@ describe("readiness mutation receipts", () => {
     const refresh = vi.fn();
     const store = { changes: { refresh } } as never;
     const pending = fireSignalAndRefresh(
-      handle as never,
+      createMockProxy(handle),
       store,
       "chg",
       {},
@@ -104,6 +115,7 @@ vi.mock("../temporal/workflow-start", () => ({
 }));
 
 import { ensureChangeWorkflowStarted } from "../temporal/workflow-start";
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
 
 function createMockHandle(): {
   query: ReturnType<typeof vi.fn>;
@@ -135,27 +147,6 @@ function createMockClient(handle: ReturnType<typeof createMockHandle>): {
   };
 }
 
-function createMockStoreInput(handle: ReturnType<typeof createMockHandle>) {
-  return {
-    projectId: "proj-123",
-    legacy: {
-      changes: {
-        get: vi.fn(async () => ({
-          success: true,
-          data: { adv_project_id: "proj-123" },
-        })),
-      },
-    },
-    temporal: {
-      client: {
-        workflow: {
-          getHandle: vi.fn(() => handle),
-        },
-      },
-    },
-  };
-}
-
 function createMockStore(): {
   changes: { refresh: ReturnType<typeof vi.fn> };
 } {
@@ -164,6 +155,46 @@ function createMockStore(): {
       refresh: vi.fn(async () => undefined),
     },
   };
+}
+
+function createMockOwner(handle: ReturnType<typeof createMockHandle>) {
+  return createMockOwnerFromClient({
+    workflow: { getHandle: vi.fn(() => handle) },
+  });
+}
+
+function createMockProxy(
+  handle: ReturnType<typeof createMockHandle>,
+  projectId = "0000000000000000000000000000000000000000",
+  changeId = "chg-456",
+) {
+  return getChangeHandle(createMockOwner(handle), projectId, changeId);
+}
+
+function createMockWorkflowHandle(): TemporalWorkflowHandle {
+  return {
+    workflowId: "adv/change/0000000000000000000000000000000000000000/chg-456",
+  } as TemporalWorkflowHandle;
+}
+
+function createMockOwnerWithSignalOutcome(
+  outcome: TemporalMutationServerOutcome<unknown>,
+): TemporalOperations {
+  const handle = createMockWorkflowHandle();
+  return createMockOwnerBase({
+    getHandle: vi.fn(() => handle),
+    signal: vi.fn(async () => outcome),
+  });
+}
+
+function createMockOwnerWithQueryOutcome(
+  outcome: TemporalReadOutcome<unknown>,
+): TemporalOperations {
+  const handle = createMockWorkflowHandle();
+  return createMockOwnerBase({
+    getHandle: vi.fn(() => handle),
+    query: vi.fn(async () => outcome),
+  });
 }
 
 describe("_adapters", () => {
@@ -176,8 +207,9 @@ describe("_adapters", () => {
       const handle = createMockHandle();
       const signalDef = { name: "testSignal" };
       const payload = { foo: "bar" };
+      const proxy = createMockProxy(handle);
 
-      await fireSignal(handle, signalDef, payload);
+      await fireSignal(proxy, signalDef, payload);
 
       expect(handle.signal).toHaveBeenCalledTimes(1);
       expect(handle.signal).toHaveBeenCalledWith(signalDef, payload);
@@ -186,8 +218,9 @@ describe("_adapters", () => {
     test("fires signal with multiple args", async () => {
       const handle = createMockHandle();
       const signalDef = { name: "multiArgSignal" };
+      const proxy = createMockProxy(handle);
 
-      await fireSignal(handle, signalDef, "arg1", 42, { nested: true });
+      await fireSignal(proxy, signalDef, "arg1", 42, { nested: true });
 
       expect(handle.signal).toHaveBeenCalledWith(signalDef, "arg1", 42, {
         nested: true,
@@ -196,6 +229,7 @@ describe("_adapters", () => {
 
     test("rejects when handle.signal throws", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       // 'signal failed' does not match any SC4 mutation-ineligible regex
       // (no poller/unregistered-query/deadline/query-rejected/permission/
       // resource-exhaustion/TMPRL1100), so it falls through to the
@@ -207,61 +241,50 @@ describe("_adapters", () => {
       const { TemporalMutationIneligibleError } =
         await import("../temporal/mutation-safety");
       await expect(
-        fireSignal(handle, { name: "bad" }, {}),
+        fireSignal(proxy, { name: "bad" }, {}),
       ).rejects.toBeInstanceOf(TemporalMutationIneligibleError);
-    });
-
-    test("resolves a guarded workflow handle from store input", async () => {
-      const handle = createMockHandle();
-      const input = createMockStoreInput(handle);
-      const signalDef = { name: "taskAdded" };
-      const payload = { taskId: "tk-1" };
-
-      await fireSignal(input, "chg-456", signalDef, payload);
-
-      expect(input.legacy.changes.get).toHaveBeenCalledWith("chg-456");
-      expect(input.temporal.client.workflow.getHandle).toHaveBeenCalledWith(
-        "adv/change/proj-123/chg-456",
-      );
-      expect(handle.signal).toHaveBeenCalledWith(signalDef, payload);
     });
 
     test("SC4: no_poller signal error → throws TemporalMutationIneligibleError", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       handle.signal.mockRejectedValue(
         new Error("no poller is currently polling this task queue"),
       );
       const { TemporalMutationIneligibleError } =
         await import("../temporal/mutation-safety");
       await expect(
-        fireSignal(handle, { name: "sc4-no-poller" }, {}),
+        fireSignal(proxy, { name: "sc4-no-poller" }, {}),
       ).rejects.toBeInstanceOf(TemporalMutationIneligibleError);
     });
 
     test("SC4: deadline signal error → throws TemporalMutationIneligibleError", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       handle.signal.mockRejectedValue(new Error("deadline exceeded"));
       const { TemporalMutationIneligibleError } =
         await import("../temporal/mutation-safety");
       await expect(
-        fireSignal(handle, { name: "sc4-deadline" }, {}),
+        fireSignal(proxy, { name: "sc4-deadline" }, {}),
       ).rejects.toBeInstanceOf(TemporalMutationIneligibleError);
     });
 
     test("SC4: 'Failed to query Workflow' signal error → throws TemporalMutationIneligibleError (unknown class)", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       handle.signal.mockRejectedValue(
         new Error("Failed to query Workflow: changeStateQuery"),
       );
       const { TemporalMutationIneligibleError } =
         await import("../temporal/mutation-safety");
       await expect(
-        fireSignal(handle, { name: "sc4-unknown-query" }, {}),
+        fireSignal(proxy, { name: "sc4-unknown-query" }, {}),
       ).rejects.toBeInstanceOf(TemporalMutationIneligibleError);
     });
 
     test("SC4: 'workflow execution already completed' signal error passes through (not_found is SC4-pass)", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       handle.signal.mockRejectedValue(
         new Error("workflow execution already completed"),
       );
@@ -271,18 +294,83 @@ describe("_adapters", () => {
       // not blocked by SC4 — the caller is responsible for surgical
       // recovery (e.g. internal status-repair writers).
       await expect(
-        fireSignal(handle, { name: "sc4-pass-not-found" }, {}),
+        fireSignal(proxy, { name: "sc4-pass-not-found" }, {}),
       ).rejects.not.toBeInstanceOf(TemporalMutationIneligibleError);
+    });
+  });
+
+  describe("fireSignal outcome discrimination", () => {
+    test("timeout_unavailable outcome is converted to TemporalMutationIneligibleError", async () => {
+      const error = new Error("deadline exceeded");
+      const diagnostic = classifyTemporalWorkflowFailure(error);
+      const owner = createMockOwnerWithSignalOutcome({
+        kind: "timeout_unavailable",
+        error,
+        diagnostic,
+      });
+      const proxy = getChangeHandle(
+        owner,
+        "0000000000000000000000000000000000000000",
+        "chg-456",
+      );
+      await expect(
+        fireSignal(proxy, { name: "timeout" }, {}),
+      ).rejects.toBeInstanceOf(TemporalMutationIneligibleError);
+    });
+
+    test("outcome_unknown outcome is converted to TemporalMutationIneligibleError", async () => {
+      const error = new Error("no poller is currently polling this task queue");
+      const diagnostic = classifyTemporalWorkflowFailure(error);
+      const owner = createMockOwnerWithSignalOutcome({
+        kind: "outcome_unknown",
+        error,
+        diagnostic,
+      });
+      const proxy = getChangeHandle(
+        owner,
+        "0000000000000000000000000000000000000000",
+        "chg-456",
+      );
+      await expect(
+        fireSignal(proxy, { name: "unknown" }, {}),
+      ).rejects.toBeInstanceOf(TemporalMutationIneligibleError);
+    });
+
+    test("confirmed_failure with not_found diagnostic is preserved as TemporalMutationOutcomeError", async () => {
+      const error = new Error("workflow execution already completed");
+      const diagnostic = classifyTemporalWorkflowFailure(error);
+      const owner = createMockOwnerWithSignalOutcome({
+        kind: "confirmed_failure",
+        error,
+        diagnostic,
+      });
+      const proxy = getChangeHandle(
+        owner,
+        "0000000000000000000000000000000000000000",
+        "chg-456",
+      );
+      let caught: unknown;
+      try {
+        await fireSignal(proxy, { name: "completed" }, {});
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(TemporalMutationOutcomeError);
+      expect(caught).not.toBeInstanceOf(TemporalMutationIneligibleError);
+      expect((caught as TemporalMutationOutcomeError).outcome.kind).toBe(
+        "confirmed_failure",
+      );
     });
   });
 
   describe("querySignal", () => {
     test("returns query result", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       const expected = { state: "active", tasks: [] };
       handle.query.mockResolvedValue(expected);
 
-      const result = await querySignal(handle, { name: "getState" });
+      const result = await querySignal(proxy, { name: "getState" });
 
       expect(handle.query).toHaveBeenCalledTimes(1);
       expect(handle.query).toHaveBeenCalledWith({ name: "getState" });
@@ -291,9 +379,10 @@ describe("_adapters", () => {
 
     test("passes query args through", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       handle.query.mockResolvedValue("result");
 
-      await querySignal(handle, { name: "getTask" }, "task-123");
+      await querySignal(proxy, { name: "getTask" }, "task-123");
 
       expect(handle.query).toHaveBeenCalledWith(
         { name: "getTask" },
@@ -303,37 +392,49 @@ describe("_adapters", () => {
 
     test("rejects when handle.query throws", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       handle.query.mockRejectedValue(new Error("query failed"));
 
-      await expect(querySignal(handle, { name: "bad" })).rejects.toThrow(
+      await expect(querySignal(proxy, { name: "bad" })).rejects.toThrow(
         "query failed",
       );
     });
 
-    test("queries via a guarded workflow handle from store input", async () => {
-      const handle = createMockHandle();
-      const input = createMockStoreInput(handle);
-      handle.query.mockResolvedValue({ tasks: [] });
-
-      await expect(
-        querySignal(input, "chg-456", { name: "getTasks" }, "done"),
-      ).resolves.toEqual({ tasks: [] });
-
-      expect(input.temporal.client.workflow.getHandle).toHaveBeenCalledWith(
-        "adv/change/proj-123/chg-456",
+    test("preserves degraded read outcome as TemporalReadOutcomeError", async () => {
+      const error = new Error("query failed");
+      const diagnostic = classifyTemporalWorkflowFailure(error);
+      const owner = createMockOwnerWithQueryOutcome({
+        kind: "degraded",
+        error,
+        diagnostic,
+      });
+      const proxy = getChangeHandle(
+        owner,
+        "0000000000000000000000000000000000000000",
+        "chg-456",
       );
-      expect(handle.query).toHaveBeenCalledWith({ name: "getTasks" }, "done");
+      let caught: unknown;
+      try {
+        await querySignal(proxy, { name: "bad" });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(TemporalReadOutcomeError);
+      expect((caught as TemporalReadOutcomeError).outcome.kind).toBe(
+        "degraded",
+      );
     });
   });
 
   describe("fireSignalAndQuery", () => {
     test("fires signal then queries for fresh state", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       const freshState = { status: "active", gates: {} };
       handle.query.mockResolvedValue(freshState);
 
       const result = await fireSignalAndQuery(
-        handle,
+        proxy,
         { name: "gateCompleted" },
         [{ gateId: "proposal" }],
         { name: "getState" },
@@ -352,10 +453,11 @@ describe("_adapters", () => {
 
     test("passes query args after signal args", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       handle.query.mockResolvedValue("task-result");
 
       await fireSignalAndQuery(
-        handle,
+        proxy,
         { name: "taskAdded" },
         [{ taskId: "tk-1" }],
         { name: "getTask" },
@@ -371,6 +473,7 @@ describe("_adapters", () => {
 
     test("rejects if signal fails without querying", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       // 'network reset' falls through to the SC4 `unknown` class — the
       // guard fires, so the call surfaces a typed
       // `TemporalMutationIneligibleError`.
@@ -379,44 +482,23 @@ describe("_adapters", () => {
         await import("../temporal/mutation-safety");
 
       await expect(
-        fireSignalAndQuery(handle, { name: "bad" }, [{}], { name: "getState" }),
+        fireSignalAndQuery(proxy, { name: "bad" }, [{}], { name: "getState" }),
       ).rejects.toBeInstanceOf(TemporalMutationIneligibleError);
 
       expect(handle.query).not.toHaveBeenCalled();
     });
-
-    test("fires then queries through store input", async () => {
-      const handle = createMockHandle();
-      const input = createMockStoreInput(handle);
-      handle.query.mockResolvedValue({ fresh: true });
-
-      const result = await fireSignalAndQuery(
-        input,
-        "chg-456",
-        { name: "taskCompleted" },
-        [{ taskId: "tk-1" }],
-        { name: "getState" },
-      );
-
-      expect(handle.signal).toHaveBeenCalledWith(
-        { name: "taskCompleted" },
-        { taskId: "tk-1" },
-      );
-      expect(handle.query).toHaveBeenCalledWith({ name: "getState" });
-      expect(result).toEqual({ fresh: true });
-    });
   });
 
   describe("fireSignalAndRefresh", () => {
-    test("fires signal then refreshes cache (handle form)", async () => {
+    test("fires signal then refreshes cache", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       const store = createMockStore();
       const signalDef = { name: "taskAdded" };
       const payload = { taskId: "tk-1" };
 
       await fireSignalAndRefresh(
-        handle,
-
+        proxy,
         store as any,
         "chg-456",
         signalDef,
@@ -434,29 +516,9 @@ describe("_adapters", () => {
       expect(signalOrder).toBeLessThan(refreshOrder);
     });
 
-    test("fires signal then refreshes cache (input form)", async () => {
-      const handle = createMockHandle();
-      const input = createMockStoreInput(handle);
-      const store = createMockStore();
-      const signalDef = { name: "wisdomAdded" };
-      const payload = { content: "lesson" };
-
-      await fireSignalAndRefresh(
-        input,
-
-        store as any,
-        "chg-789",
-        signalDef,
-        payload,
-      );
-
-      expect(input.legacy.changes.get).toHaveBeenCalledWith("chg-789");
-      expect(handle.signal).toHaveBeenCalledWith(signalDef, payload);
-      expect(store.changes.refresh).toHaveBeenCalledWith("chg-789");
-    });
-
     test("does NOT refresh when signal fails", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       const store = createMockStore();
       // 'network reset' falls through to SC4 `unknown` → guard fires.
       handle.signal.mockRejectedValue(new Error("network reset"));
@@ -464,14 +526,7 @@ describe("_adapters", () => {
         await import("../temporal/mutation-safety");
 
       await expect(
-        fireSignalAndRefresh(
-          handle,
-
-          store as any,
-          "chg-1",
-          { name: "bad" },
-          {},
-        ),
+        fireSignalAndRefresh(proxy, store as any, "chg-1", { name: "bad" }, {}),
       ).rejects.toBeInstanceOf(TemporalMutationIneligibleError);
 
       expect(store.changes.refresh).not.toHaveBeenCalled();
@@ -482,20 +537,14 @@ describe("_adapters", () => {
       // throw in production. If it ever does (contract violation), the
       // helper propagates so callers can see the bug rather than swallowing.
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       const store = createMockStore();
       store.changes.refresh.mockRejectedValue(
         new Error("contract violation: refresh threw"),
       );
 
       await expect(
-        fireSignalAndRefresh(
-          handle,
-
-          store as any,
-          "chg-1",
-          { name: "ok" },
-          {},
-        ),
+        fireSignalAndRefresh(proxy, store as any, "chg-1", { name: "ok" }, {}),
       ).rejects.toThrow("contract violation: refresh threw");
 
       // Signal still fired before the refresh attempt
@@ -505,11 +554,11 @@ describe("_adapters", () => {
 
     test("passes through multiple signal args", async () => {
       const handle = createMockHandle();
+      const proxy = createMockProxy(handle);
       const store = createMockStore();
 
       await fireSignalAndRefresh(
-        handle,
-
+        proxy,
         store as any,
         "chg-2",
         { name: "multiArg" },
@@ -555,7 +604,11 @@ describe("_adapters", () => {
       let caught: unknown;
       try {
         await fireSignalAndRefresh(
-          handle as never,
+          createMockProxy(
+            handle,
+            "0000000000000000000000000000000000000000",
+            "chg-orphan",
+          ),
           store as any,
           "chg-orphan",
           { name: "taskAdded" },
@@ -581,7 +634,11 @@ describe("_adapters", () => {
       const ownStore = createMockStore();
 
       await fireSignalAndRefresh(
-        ownHandle as never,
+        createMockProxy(
+          ownHandle,
+          "0000000000000000000000000000000000000000",
+          "chg-own",
+        ),
         ownStore as any,
         "chg-own",
         { name: "taskAdded" },
@@ -609,7 +666,11 @@ describe("_adapters", () => {
       let caught: unknown;
       try {
         await fireSignalAndRefresh(
-          orphanHandle as never,
+          createMockProxy(
+            orphanHandle,
+            "0000000000000000000000000000000000000000",
+            "chg-orphan",
+          ),
           orphanStore as any,
           "chg-orphan",
           { name: "taskAdded" },
@@ -642,7 +703,11 @@ describe("_adapters", () => {
 
       try {
         await fireSignalAndRefresh(
-          handle as never,
+          createMockProxy(
+            handle,
+            "0000000000000000000000000000000000000000",
+            "chg-bypass",
+          ),
           store as any,
           "chg-bypass",
           { name: "taskAdded" },
@@ -684,7 +749,11 @@ describe("_adapters", () => {
       let caught: unknown;
       try {
         await fireSignalAndRefresh(
-          handle as never,
+          createMockProxy(
+            handle,
+            "0000000000000000000000000000000000000000",
+            "chg-bypass-true",
+          ),
           store as any,
           "chg-bypass-true",
           { name: "taskAdded" },
@@ -711,47 +780,65 @@ describe("_adapters", () => {
     test("builds correct workflowId and returns handle", () => {
       const handle = createMockHandle();
       const client = createMockClient(handle);
+      const owner = createMockOwnerFromClient(client);
 
-      const result = getChangeHandle(client, "proj-123", "chg-456");
+      const result = getChangeHandle(
+        owner,
+        "0000000000000000000000000000000000000000",
+        "chg-456",
+      );
 
       expect(client.workflow.getHandle).toHaveBeenCalledTimes(1);
       expect(client.workflow.getHandle).toHaveBeenCalledWith(
-        "adv/change/proj-123/chg-456",
+        "adv/change/0000000000000000000000000000000000000000/chg-456",
+        undefined,
       );
-      expect(result).toBe(handle);
+      expect(result.workflowId).toBe(
+        "adv/change/0000000000000000000000000000000000000000/chg-456",
+      );
     });
   });
 
   describe("startChangeWorkflow", () => {
     test("delegates to ensureChangeWorkflowStarted", async () => {
-      const handle = createMockHandle();
+      const handle = {
+        ...createMockHandle(),
+        workflowId:
+          "adv/change/0000000000000000000000000000000000000000/chg-def",
+      };
       const client = createMockClient(handle);
+      const owner = createMockOwnerFromClient(client);
       vi.mocked(ensureChangeWorkflowStarted).mockResolvedValue(handle);
 
       const input = {
-        projectId: "proj-abc",
+        projectId: "0000000000000000000000000000000000000000",
         changeId: "chg-def",
         title: "Test Change",
         initializedAt: new Date().toISOString(),
       };
 
-      const result = await startChangeWorkflow(client, input);
+      const result = await startChangeWorkflow(owner, input);
 
       expect(ensureChangeWorkflowStarted).toHaveBeenCalledTimes(1);
-      expect(result).toBe(handle);
+      expect(result.workflowId).toBe(
+        "adv/change/0000000000000000000000000000000000000000/chg-def",
+      );
     });
 
-    test("throws when client lacks workflow.start", async () => {
-      const client = {
+    test("throws when owner does not expose workflow.start", async () => {
+      const owner = createMockOwnerFromClient({
         workflow: {
           getHandle: vi.fn(),
           // start is intentionally missing
         },
-      } as unknown as Parameters<typeof startChangeWorkflow>[0];
+      });
+      vi.mocked(ensureChangeWorkflowStarted).mockRejectedValue(
+        new Error("does not expose workflow.start"),
+      );
 
       await expect(
-        startChangeWorkflow(client, {
-          projectId: "p",
+        startChangeWorkflow(owner, {
+          projectId: "0000000000000000000000000000000000000000",
           changeId: "c",
           title: "t",
           initializedAt: "now",
@@ -763,10 +850,11 @@ describe("_adapters", () => {
       vi.mocked(evaluateTargetReadiness).mockClear();
       const handle = createMockHandle();
       const client = createMockClient(handle);
+      const owner = createMockOwnerFromClient(client);
       vi.mocked(ensureChangeWorkflowStarted).mockResolvedValue(handle);
 
-      await startChangeWorkflow(client, {
-        projectId: "proj-abc",
+      await startChangeWorkflow(owner, {
+        projectId: "0000000000000000000000000000000000000000",
         changeId: "chg-def",
         title: "Test Change",
         initializedAt: new Date().toISOString(),
@@ -801,7 +889,7 @@ describe("isChangeReachable", () => {
     });
 
     const result = await isChangeReachable(
-      "proj-123",
+      "0000000000000000000000000000000000000000",
       "chg-456",
       deps,
       changesDir,
@@ -809,7 +897,7 @@ describe("isChangeReachable", () => {
 
     expect(result).toBe(true);
     expect(deps.visibilityLister).toHaveBeenCalledExactlyOnceWith(
-      "proj-123",
+      "0000000000000000000000000000000000000000",
       "chg-456",
     );
     expect(deps.diskChecker).not.toHaveBeenCalled();
@@ -823,7 +911,7 @@ describe("isChangeReachable", () => {
     });
 
     const result = await isChangeReachable(
-      "proj-123",
+      "0000000000000000000000000000000000000000",
       "chg-456",
       deps,
       changesDir,
@@ -846,7 +934,7 @@ describe("isChangeReachable", () => {
     });
 
     const result = await isChangeReachable(
-      "proj-123",
+      "0000000000000000000000000000000000000000",
       "chg-456",
       deps,
       changesDir,
@@ -862,7 +950,7 @@ describe("isChangeReachable", () => {
     const deps = createDeps();
 
     const result = await isChangeReachable(
-      "proj-123",
+      "0000000000000000000000000000000000000000",
       "chg-456",
       deps,
       changesDir,
@@ -881,7 +969,7 @@ describe("isChangeReachable", () => {
     });
 
     const result = await isChangeReachable(
-      "proj-123",
+      "0000000000000000000000000000000000000000",
       "chg-new",
       deps,
       changesDir,
@@ -905,7 +993,7 @@ describe("isChangeReachable", () => {
     });
 
     const result = await isChangeReachable(
-      "proj-123",
+      "0000000000000000000000000000000000000000",
       "chg-456",
       deps,
       changesDir,
@@ -930,7 +1018,12 @@ describe("isChangeReachable", () => {
     });
 
     await expect(
-      isChangeReachable("proj-123", "chg-456", deps, changesDir),
+      isChangeReachable(
+        "0000000000000000000000000000000000000000",
+        "chg-456",
+        deps,
+        changesDir,
+      ),
     ).resolves.toBe(false);
   });
 });
@@ -953,7 +1046,7 @@ describe("probeChangePhantomStatus (tri-state)", () => {
   test("all tiers report absent → confirmed_absent", async () => {
     const deps = createDeps();
     const result = await probeChangePhantomStatus(
-      "proj-1",
+      "0000000000000000000000000000000000000000",
       "chg-1",
       deps,
       changesDir,
@@ -967,7 +1060,7 @@ describe("probeChangePhantomStatus (tri-state)", () => {
       visibilityLister: vi.fn(async () => true),
     });
     const result = await probeChangePhantomStatus(
-      "proj-1",
+      "0000000000000000000000000000000000000000",
       "chg-1",
       deps,
       changesDir,
@@ -983,7 +1076,7 @@ describe("probeChangePhantomStatus (tri-state)", () => {
       diskChecker: vi.fn(async () => true),
     });
     const result = await probeChangePhantomStatus(
-      "proj-1",
+      "0000000000000000000000000000000000000000",
       "chg-1",
       deps,
       changesDir,
@@ -999,7 +1092,7 @@ describe("probeChangePhantomStatus (tri-state)", () => {
       }),
     });
     const result = await probeChangePhantomStatus(
-      "proj-1",
+      "0000000000000000000000000000000000000000",
       "chg-1",
       deps,
       changesDir,
@@ -1019,7 +1112,7 @@ describe("probeChangePhantomStatus (tri-state)", () => {
       }),
     });
     const result = await probeChangePhantomStatus(
-      "proj-1",
+      "0000000000000000000000000000000000000000",
       "chg-1",
       deps,
       changesDir,
@@ -1035,7 +1128,7 @@ describe("probeChangePhantomStatus (tri-state)", () => {
       }),
     });
     const result = await probeChangePhantomStatus(
-      "proj-1",
+      "0000000000000000000000000000000000000000",
       "chg-1",
       deps,
       changesDir,
@@ -1052,9 +1145,13 @@ describe("waitForGateCompletion (STRUCT-003 shared poll helper)", () => {
       .mockResolvedValueOnce({ status: "pending" })
       .mockResolvedValueOnce({ status: "done" });
 
-    const result = await waitForGateCompletion(handle as never, "release", {
-      delayMs: 0,
-    });
+    const result = await waitForGateCompletion(
+      createMockProxy(handle),
+      "release",
+      {
+        delayMs: 0,
+      },
+    );
 
     expect(result).toEqual({ status: "done" });
     expect(handle.query).toHaveBeenCalledTimes(2);
@@ -1064,9 +1161,13 @@ describe("waitForGateCompletion (STRUCT-003 shared poll helper)", () => {
     const handle = createMockHandle();
     handle.query.mockResolvedValueOnce({ status: "stuck" });
 
-    const result = await waitForGateCompletion(handle as never, "release", {
-      delayMs: 0,
-    });
+    const result = await waitForGateCompletion(
+      createMockProxy(handle),
+      "release",
+      {
+        delayMs: 0,
+      },
+    );
 
     expect(result).toEqual({ status: "stuck" });
     expect(handle.query).toHaveBeenCalledTimes(1);
@@ -1076,10 +1177,14 @@ describe("waitForGateCompletion (STRUCT-003 shared poll helper)", () => {
     const handle = createMockHandle();
     handle.query.mockResolvedValue({ status: "pending" });
 
-    const result = await waitForGateCompletion(handle as never, "release", {
-      attempts: 3,
-      delayMs: 0,
-    });
+    const result = await waitForGateCompletion(
+      createMockProxy(handle),
+      "release",
+      {
+        attempts: 3,
+        delayMs: 0,
+      },
+    );
 
     expect(result).toEqual({ status: "pending" });
     expect(handle.query).toHaveBeenCalledTimes(3);

--- a/plugin/src/tools/_adapters.ts
+++ b/plugin/src/tools/_adapters.ts
@@ -1,7 +1,7 @@
 /**
  * Tool Adapter Helpers — Signal/Query Surface
  *
- * Thin wrappers around Temporal workflow handle operations.
+ * Thin wrappers around the closed TemporalOperations owner API.
  * Used by tool-layer code to fire signals and run queries against
  * change workflows, replacing the old executeUpdate-based mutation path.
  *
@@ -11,13 +11,20 @@
 import { buildChangeWorkflowId } from "../temporal/client";
 import type { ChangeWorkflowInput } from "../temporal/contracts";
 import { ensureChangeWorkflowStarted } from "../temporal/workflow-start";
+import type { QueryDefinition, SignalDefinition } from "@temporalio/workflow";
 import {
-  getGuardedChangeHandle,
-  type TemporalStoreBackendInput,
-  type WorkflowHandleLike,
   runTemporal,
   runTemporalQuery,
 } from "../storage/store-temporal/shared";
+import {
+  makeTemporalOperationContext,
+  type TemporalOperations,
+  type TemporalWorkflowHandle,
+} from "../temporal/operations";
+import type {
+  TemporalWorkflowHandleProxy,
+  TemporalWorkflowHandleQueryProxy,
+} from "./change-mutation-coordinator";
 import type { Store } from "../storage/store";
 import {
   changeStateQuery,
@@ -46,21 +53,125 @@ import {
   type TemporalWorkflowDiagnostic,
 } from "../temporal/mutation-safety";
 import { createAdvSessionNotReadyEnvelope } from "../temporal/readiness-types";
+import {
+  TemporalMutationOutcomeError,
+  TemporalReadOutcomeError,
+  isTemporalMutationOutcomeError,
+  isTemporalReadOutcomeError,
+} from "../temporal/outcome-errors";
+
+export {
+  TemporalMutationOutcomeError,
+  TemporalReadOutcomeError,
+  isTemporalMutationOutcomeError,
+  isTemporalReadOutcomeError,
+};
 
 // Temporal signal processing + projection can take several seconds under load.
 // 60 attempts × 500ms = 30s total gives adequate headroom for CI and local dev.
 export const GATE_COMPLETION_POLL_ATTEMPTS = 60;
 export const GATE_COMPLETION_POLL_DELAY_MS = 500;
 
+/**
+ * Owner-bound workflow handle proxy. The only production-safe way to perform
+ * query/signal/describe on a workflow: the owner stays the single RPC authority,
+ * and the handle is the opaque workflow reference.
+ */
+function buildProxy(
+  owner: TemporalOperations,
+  handle: TemporalWorkflowHandle,
+  projectId: string,
+): TemporalWorkflowHandleProxy {
+  return {
+    owner,
+    handle,
+    workflowId: handle.workflowId,
+    projectId,
+    signal: async (signal: unknown, ...args: unknown[]) => {
+      const ctx = makeTemporalOperationContext(
+        projectId,
+        handle.workflowId,
+        "signal",
+        typeof signal === "object" && signal !== null && "name" in signal
+          ? String((signal as { name: string }).name)
+          : "signal",
+        10_000,
+      );
+      const outcome = await owner.signal(
+        ctx,
+        handle,
+        signal as SignalDefinition<unknown[], string>,
+        args,
+      );
+      if (outcome.kind === "confirmed") return;
+      throw new TemporalMutationOutcomeError(outcome);
+    },
+    query: async <T>(query: unknown, ...args: unknown[]): Promise<T> => {
+      const ctx = makeTemporalOperationContext(
+        projectId,
+        handle.workflowId,
+        "query",
+        typeof query === "object" && query !== null && "name" in query
+          ? String((query as { name: string }).name)
+          : "query",
+        5_000,
+      );
+      const outcome = await owner.query(
+        ctx,
+        handle,
+        query as QueryDefinition<T, unknown[], string>,
+        ...args,
+      );
+      if (outcome.kind === "complete") return outcome.value as T;
+      throw new TemporalReadOutcomeError(outcome);
+    },
+    describe: async () => {
+      const ctx = makeTemporalOperationContext(
+        projectId,
+        handle.workflowId,
+        "describe",
+        "describe",
+        5_000,
+      );
+      const outcome = await owner.describe(ctx, handle);
+      if (outcome.kind === "complete") return outcome.value;
+      throw new TemporalReadOutcomeError(outcome);
+    },
+    terminate: async (reason?: string) => {
+      const ctx = makeTemporalOperationContext(
+        projectId,
+        handle.workflowId,
+        "terminate",
+        "terminate",
+        10_000,
+      );
+      const outcome = await owner.terminate(ctx, handle, reason ?? "");
+      if (outcome.kind === "confirmed") return outcome.value;
+      throw new TemporalMutationOutcomeError(outcome);
+    },
+    cancel: async () => {
+      const ctx = makeTemporalOperationContext(
+        projectId,
+        handle.workflowId,
+        "cancel",
+        "cancel",
+        10_000,
+      );
+      const outcome = await owner.cancel(ctx, handle);
+      if (outcome.kind === "confirmed") return outcome.value;
+      throw new TemporalMutationOutcomeError(outcome);
+    },
+  };
+}
+
 export async function waitForAppliedReceipt(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleProxy,
   receiptId: string,
   opts: { attempts?: number; delayMs?: number } = {},
 ): Promise<MutationReceipt | undefined> {
   return waitForQueryPredicate(
     () =>
-      querySignal<MutationReceipt | undefined>(
-        handle,
+      proxy.query<MutationReceipt | undefined>(
         getMutationReceiptQuery,
         receiptId,
       ),
@@ -76,41 +187,19 @@ export async function waitForAppliedReceipt(
  * release-gate-completion paths (STRUCT-003).
  */
 export async function waitForGateCompletion(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleQueryProxy,
   gateId: GateId,
   opts: { attempts?: number; delayMs?: number } = {},
 ): Promise<GateCompletion | undefined> {
   return waitForQueryPredicate(
-    () => querySignal<GateCompletion>(handle, getGateStatusQuery, gateId),
+    () => proxy.query<GateCompletion>(getGateStatusQuery, gateId),
     (gate) => gate?.status === "done" || gate?.status === "stuck",
     opts,
   );
 }
 
-type SignalTarget = WorkflowHandleLike | TemporalStoreBackendInput;
-
-function isWorkflowHandleLike(
-  target: SignalTarget,
-): target is WorkflowHandleLike {
-  return (
-    typeof (target as WorkflowHandleLike).signal === "function" &&
-    typeof (target as WorkflowHandleLike).query === "function"
-  );
-}
-
-async function resolveChangeHandle(
-  target: SignalTarget,
-  changeId?: string,
-): Promise<WorkflowHandleLike> {
-  if (isWorkflowHandleLike(target)) return target;
-  if (!changeId) {
-    throw new Error("changeId is required when resolving a workflow handle");
-  }
-  return getGuardedChangeHandle(target, changeId);
-}
-
 /**
- * Fire-and-forget signal to a change workflow handle.
+ * Fire-and-forget signal to a change workflow.
  * Wrapped with Temporal retry (transient failures are retried).
  *
  * SC4 mutation-eligibility guard (rq-temporalMutationSafety01): if the
@@ -125,43 +214,26 @@ async function resolveChangeHandle(
  * by `evaluateDestructiveWorkflowRecoveryPreconditions`.
  */
 export async function fireSignal<Args extends unknown[]>(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleProxy,
   signal: unknown,
-  ...args: Args
-): Promise<void>;
-export async function fireSignal<Args extends unknown[]>(
-  input: TemporalStoreBackendInput,
-  changeId: string,
-  signal: unknown,
-  ...args: Args
-): Promise<void>;
-export async function fireSignal<Args extends unknown[]>(
-  target: SignalTarget,
-  signalOrChangeId: unknown,
   ...args: Args
 ): Promise<void> {
-  const handle = await resolveChangeHandle(
-    target,
-    isWorkflowHandleLike(target) ? undefined : String(signalOrChangeId),
-  );
-  const signal = isWorkflowHandleLike(target) ? signalOrChangeId : args[0];
-  const signalArgs = isWorkflowHandleLike(target) ? args : args.slice(1);
   let error: unknown;
   try {
-    await runTemporal(() => handle.signal(signal, ...signalArgs));
+    await runTemporal(() => proxy.signal(signal, ...args));
     return;
   } catch (err) {
     error = err;
   }
-  // SC4: classify-and-rethrow. classifyTemporalWorkflowFailure maps known
-  // Temporal gRPC and JS errors to a `TemporalWorkflowDiagnostic`; the SC4
-  // guard then ensures mutation-ineligible classes never reach the caller.
+  if (isTemporalMutationOutcomeError(error)) {
+    // The owner has already classified the outcome. Enforce SC4 mutation
+    // eligibility on the diagnostic; if it is ineligible, surface the typed
+    // TemporalMutationIneligibleError. Otherwise preserve the outcome error.
+    requireMutationEligible(error.outcome.diagnostic);
+    throw error;
+  }
   const diagnostic: TemporalWorkflowDiagnostic =
     enforceMutationEligibilityForError(error);
-  // diagnostic.class is `reachable` only when the error is null/undefined,
-  // which we already handled above by short-circuiting on success. Any
-  // remaining path here means the diagnostic was SC4-pass (not_found /
-  // poisoned_history) — surface the original error so the caller can decide.
   if (diagnostic.class === "reachable") {
     throw new Error(
       `fireSignal: unexpected reachable diagnostic after error: ${
@@ -173,34 +245,15 @@ export async function fireSignal<Args extends unknown[]>(
 }
 
 /**
- * Synchronous query against a change workflow handle.
+ * Synchronous query against a change workflow.
  * Wrapped with a 5-second per-attempt timeout to avoid hanging on dead workers.
  */
 export async function querySignal<T>(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleProxy,
   query: unknown,
-  ...args: unknown[]
-): Promise<T>;
-export async function querySignal<T>(
-  input: TemporalStoreBackendInput,
-  changeId: string,
-  query: unknown,
-  ...args: unknown[]
-): Promise<T>;
-export async function querySignal<T>(
-  target: SignalTarget,
-  queryOrChangeId: unknown,
   ...args: unknown[]
 ): Promise<T> {
-  const handle = await resolveChangeHandle(
-    target,
-    isWorkflowHandleLike(target) ? undefined : String(queryOrChangeId),
-  );
-  const query = isWorkflowHandleLike(target) ? queryOrChangeId : args[0];
-  const queryArgs = isWorkflowHandleLike(target) ? args : args.slice(1);
-  return runTemporalQuery(() =>
-    handle.query(query, ...queryArgs),
-  ) as Promise<T>;
+  return runTemporalQuery(() => proxy.query<T>(query, ...args));
 }
 
 /**
@@ -210,41 +263,14 @@ export async function querySignal<T>(
  * (including any signal handlers that have completed).
  */
 export async function fireSignalAndQuery<T, SArgs extends unknown[]>(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleProxy,
   signal: unknown,
   signalArgs: SArgs,
   query: unknown,
   ...queryArgs: unknown[]
-): Promise<T>;
-export async function fireSignalAndQuery<T, SArgs extends unknown[]>(
-  input: TemporalStoreBackendInput,
-  changeId: string,
-  signal: unknown,
-  signalArgs: SArgs,
-  query: unknown,
-  ...queryArgs: unknown[]
-): Promise<T>;
-export async function fireSignalAndQuery<T, SArgs extends unknown[]>(
-  target: SignalTarget,
-  signalOrChangeId: unknown,
-  signalArgsOrSignal: unknown,
-  queryOrSignalArgs: SArgs | unknown,
-  ...queryAndArgs: unknown[]
 ): Promise<T> {
-  if (isWorkflowHandleLike(target)) {
-    const signal = signalOrChangeId;
-    const signalArgs = signalArgsOrSignal as SArgs;
-    const query = queryOrSignalArgs;
-    await fireSignal(target, signal, ...signalArgs);
-    return querySignal<T>(target, query, ...queryAndArgs);
-  }
-
-  const changeId = String(signalOrChangeId);
-  const signal = signalArgsOrSignal;
-  const signalArgs = queryOrSignalArgs as SArgs;
-  const [query, ...queryArgs] = queryAndArgs;
-  await fireSignal(target, changeId, signal, ...signalArgs);
-  return querySignal<T>(target, changeId, query, ...queryArgs);
+  await fireSignal(proxy, signal, ...signalArgs);
+  return querySignal<T>(proxy, query, ...queryArgs);
 }
 
 /**
@@ -266,19 +292,15 @@ interface WorkflowHandleDescription {
 }
 
 async function resolveTargetQueue(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleProxy,
 ): Promise<string | undefined> {
-  const workflowId = (handle as { workflowId?: string }).workflowId;
+  const workflowId = proxy.workflowId;
   if (workflowId && workflowTaskQueueCache.has(workflowId)) {
     return workflowTaskQueueCache.get(workflowId);
   }
 
-  if (typeof handle.describe !== "function") {
-    return undefined;
-  }
-
   try {
-    const description = (await handle.describe()) as WorkflowHandleDescription;
+    const description = (await proxy.describe()) as WorkflowHandleDescription;
     if (typeof description.taskQueue === "string" && description.taskQueue) {
       if (workflowId) {
         workflowTaskQueueCache.set(workflowId, description.taskQueue);
@@ -292,11 +314,11 @@ async function resolveTargetQueue(
 }
 
 function makeHandleQueryProbe(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleProxy,
 ): (targetQueue: string) => Promise<QueryProbeResult> {
   return async () => {
     try {
-      await handle.query(changeStateQuery);
+      await proxy.query(changeStateQuery);
       return { ok: true };
     } catch (error) {
       return {
@@ -339,35 +361,19 @@ function makeHandleQueryProbe(
  *      not advanced).
  */
 export async function fireSignalAndRefresh<Args extends unknown[]>(
-  handle: WorkflowHandleLike,
-  store: Store,
-  changeId: string,
-  signal: unknown,
-  ...args: Args
-): Promise<void>;
-export async function fireSignalAndRefresh<Args extends unknown[]>(
-  input: TemporalStoreBackendInput,
-  store: Store,
-  changeId: string,
-  signal: unknown,
-  ...args: Args
-): Promise<void>;
-export async function fireSignalAndRefresh<Args extends unknown[]>(
-  target: SignalTarget,
+  proxy: TemporalWorkflowHandleProxy,
   store: Store,
   changeId: string,
   signal: unknown,
   ...args: Args
 ): Promise<void> {
-  const handle = await resolveChangeHandle(target, changeId);
-
   if (!isSessionReadinessBypassActive()) {
-    const targetQueue = await resolveTargetQueue(handle);
+    const targetQueue = await resolveTargetQueue(proxy);
     if (targetQueue) {
       const readiness = await evaluateTargetReadiness({
         targetQueue,
         hasWorkflow: true,
-        queryProbe: makeHandleQueryProbe(handle),
+        queryProbe: makeHandleQueryProbe(proxy),
         cacheTtlMs: 10_000,
         probeBudgetMs: 2_000,
       });
@@ -375,19 +381,15 @@ export async function fireSignalAndRefresh<Args extends unknown[]>(
         throw createAdvSessionNotReadyEnvelope(readiness.blockers);
       }
     }
-    // If the target queue cannot be resolved, the handle is too degraded to
-    // even identify the queue; proceed only in bypass mode so tests with
-    // minimal mocks can still exercise the signal/refresh path. Production
-    // handles always expose describe() and therefore always enforce the gate.
   }
 
-  await fireSignal(handle, signal, ...args);
+  await fireSignal(proxy, signal, ...args);
   const receiptId =
     args[0] && typeof args[0] === "object"
       ? (args[0] as { mutationReceiptId?: unknown }).mutationReceiptId
       : undefined;
   if (typeof receiptId === "string" && receiptId) {
-    const receipt = await waitForAppliedReceipt(handle, receiptId);
+    const receipt = await waitForAppliedReceipt(proxy, receiptId);
     if (!receipt) throw new MutationApplicationUnconfirmedError(receiptId);
   }
   await store.changes.refresh(changeId);
@@ -409,34 +411,13 @@ export async function fireSignalAndRefresh<Args extends unknown[]>(
  * `mutation-safety`) when the diagnostic is mutation-ineligible.
  */
 export async function fireSignalGuarded<Args extends unknown[]>(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleProxy,
   eligibility: TemporalWorkflowDiagnostic,
   signal: unknown,
-  ...args: Args
-): Promise<void>;
-export async function fireSignalGuarded<Args extends unknown[]>(
-  input: TemporalStoreBackendInput,
-  changeId: string,
-  eligibility: TemporalWorkflowDiagnostic,
-  signal: unknown,
-  ...args: Args
-): Promise<void>;
-export async function fireSignalGuarded<Args extends unknown[]>(
-  target: SignalTarget,
-  eligibilityOrChangeId: TemporalWorkflowDiagnostic | string,
-  signalOrEligibility: unknown,
   ...args: Args
 ): Promise<void> {
-  if (isWorkflowHandleLike(target)) {
-    const eligibility = eligibilityOrChangeId as TemporalWorkflowDiagnostic;
-    requireMutationEligible(eligibility);
-    await fireSignal(target, signalOrEligibility, ...args);
-    return;
-  }
-  const changeId = String(eligibilityOrChangeId);
-  const eligibility = signalOrEligibility as TemporalWorkflowDiagnostic;
   requireMutationEligible(eligibility);
-  await fireSignal(target, changeId, args[0], ...args.slice(1));
+  await fireSignal(proxy, signal, ...args);
 }
 
 /**
@@ -446,49 +427,15 @@ export async function fireSignalGuarded<Args extends unknown[]>(
  * gate the whole sequence.
  */
 export async function fireSignalAndRefreshGuarded<Args extends unknown[]>(
-  handle: WorkflowHandleLike,
+  proxy: TemporalWorkflowHandleProxy,
   store: Store,
   changeId: string,
   eligibility: TemporalWorkflowDiagnostic,
   signal: unknown,
-  ...args: Args
-): Promise<void>;
-export async function fireSignalAndRefreshGuarded<Args extends unknown[]>(
-  input: TemporalStoreBackendInput,
-  store: Store,
-  changeId: string,
-  eligibility: TemporalWorkflowDiagnostic,
-  signal: unknown,
-  ...args: Args
-): Promise<void>;
-export async function fireSignalAndRefreshGuarded<Args extends unknown[]>(
-  target: SignalTarget,
-  store: Store,
-  changeId: string,
-  eligibilityOrSignal: TemporalWorkflowDiagnostic | unknown,
   ...args: Args
 ): Promise<void> {
-  if (isWorkflowHandleLike(target)) {
-    const eligibility = eligibilityOrSignal as TemporalWorkflowDiagnostic;
-    requireMutationEligible(eligibility);
-    await fireSignalAndRefresh(
-      target,
-      store,
-      changeId,
-      args[0],
-      ...args.slice(1),
-    );
-    return;
-  }
-  const eligibility = eligibilityOrSignal as TemporalWorkflowDiagnostic;
   requireMutationEligible(eligibility);
-  await fireSignalAndRefresh(
-    target,
-    store,
-    changeId,
-    args[0],
-    ...args.slice(1),
-  );
+  await fireSignalAndRefresh(proxy, store, changeId, signal, ...args);
 }
 
 /**
@@ -540,60 +487,44 @@ export async function runPostSignalReadback<T>(
  * assessed via describe — never on a different run of the same workflowId.
  */
 export function getChangeHandle(
-  client: {
-    workflow: { getHandle: (workflowId: string, runId?: string) => unknown };
-  },
+  owner: TemporalOperations,
   projectId: string,
   changeId: string,
   runId?: string,
-): WorkflowHandleLike {
+): TemporalWorkflowHandleProxy {
   const workflowId = buildChangeWorkflowId(projectId, changeId);
-  // Unpinned callers keep the exact legacy single-arg call shape; the runId
-  // argument is only passed when a run is explicitly pinned.
-  return (
-    runId
-      ? client.workflow.getHandle(workflowId, runId)
-      : client.workflow.getHandle(workflowId)
-  ) as WorkflowHandleLike;
+  const handle = owner.getHandle(
+    makeTemporalOperationContext(
+      projectId,
+      workflowId,
+      runId ? "describe" : "query",
+      "getChangeHandle",
+      5_000,
+    ),
+    runId,
+  );
+  return buildProxy(owner, handle, projectId);
 }
 
 /**
  * Start a change workflow (idempotent — returns existing handle if already running).
- * Requires the client to expose `workflow.start`.
  */
 export async function startChangeWorkflow(
-  client: {
-    workflow: {
-      start?: (...args: unknown[]) => Promise<unknown>;
-      getHandle: (workflowId: string) => unknown;
-    };
-  },
+  owner: TemporalOperations,
   input: ChangeWorkflowInput,
-): Promise<WorkflowHandleLike> {
-  if (typeof client.workflow.start !== "function") {
-    throw new Error(
-      "Temporal client does not expose workflow.start; cannot start change workflows",
-    );
-  }
-
-  const handle = await ensureChangeWorkflowStarted(
-    {
-      workflow: client.workflow as unknown as {
-        start: (
-          workflow: unknown,
-          options: {
-            workflowId: string;
-            taskQueue: string;
-            args: [unknown];
-            searchAttributes?: Record<string, unknown[]>;
-          },
-        ) => Promise<WorkflowHandleLike>;
-        getHandle: (workflowId: string) => WorkflowHandleLike;
-      },
-    },
-    input,
+): Promise<TemporalWorkflowHandleProxy> {
+  const workflowId = buildChangeWorkflowId(input.projectId, input.changeId);
+  makeTemporalOperationContext(
+    input.projectId,
+    workflowId,
+    "start",
+    "startChangeWorkflow",
+    30_000,
   );
-  return handle as WorkflowHandleLike;
+  const handle = await ensureChangeWorkflowStarted(owner, input, {
+    workflowQueueMode: input.sessionId ? "session" : "project",
+  });
+  return buildProxy(owner, handle, input.projectId);
 }
 
 /**
@@ -655,7 +586,7 @@ export async function isChangeReachable(
 // rq-activeChangePointer01 / rq-doctorConsolidation01 (option B):
 /**
  * Tri-state phantom probe result. Unlike {@link isChangeReachable} which
- * collapses "confirmed absent" and "probe failed" into `false`, this type
+ * collapses "confirmed absent" and "probe failed" into `false`, this
  * preserves the distinction so the doctor can clear a phantom pointer ONLY
  * on confirmed-absent evidence and refuse on indeterminate.
  */
@@ -675,7 +606,8 @@ export type PhantomProbeResult =
  * Short-circuits to `confirmed_present` on the first tier that finds the
  * change.
  *
- * Pure: all I/O is injected via `deps`.
+ * Pure: all I/O is performed by the caller-supplied functions so the helper
+ * stays pure and fully testable.
  */
 export async function probeChangePhantomStatus(
   projectId: string,

--- a/plugin/src/tools/acceptance-reconciliation.ts
+++ b/plugin/src/tools/acceptance-reconciliation.ts
@@ -21,10 +21,12 @@ import {
   designConcernDispositionedSignal,
   verificationEvidenceDispositionedSignal,
 } from "../temporal/messages";
-import { coordinateChangeMutation } from "./change-mutation-coordinator";
+import {
+  coordinateChangeMutation,
+  type TemporalWorkflowHandleProxy,
+  type MutationOutcome,
+} from "./change-mutation-coordinator";
 import type { ChangeWorkflowState } from "../temporal/contracts";
-import type { WorkflowHandleLike } from "./change-mutation-coordinator";
-import type { MutationOutcome } from "./change-mutation-coordinator";
 
 export interface ReconciledAcceptanceRemediation {
   kind: "reconciled";
@@ -214,7 +216,7 @@ function matchesPendingRecoveredMatrix(
 }
 
 async function redeliverDisposition(
-  handle: WorkflowHandleLike,
+  handle: TemporalWorkflowHandleProxy,
   changeId: string,
   item: Extract<
     PendingReconciliationItem,
@@ -254,7 +256,7 @@ async function redeliverDisposition(
 }
 
 async function redeliverMatrix(
-  handle: WorkflowHandleLike,
+  handle: TemporalWorkflowHandleProxy,
   changeId: string,
   item: Extract<
     PendingReconciliationItem,
@@ -453,7 +455,7 @@ function itemFailureDetail(
 export async function reconcileRecoveredAcceptanceRemediation(input: {
   store: Store;
   changeId: string;
-  handle: WorkflowHandleLike;
+  handle: TemporalWorkflowHandleProxy;
 }): Promise<ReconcileRecoveredAcceptanceRemediationResult> {
   const { store, changeId, handle } = input;
 

--- a/plugin/src/tools/adv-worktree.archived-branches.test.ts
+++ b/plugin/src/tools/adv-worktree.archived-branches.test.ts
@@ -174,7 +174,7 @@ describe("adv_worktree_cleanup mode=archived_branches", () => {
         fn({
           context: {
             root: "/target",
-            projectId: "target-project",
+            projectId: "0a00e00000ec0000000000000000000000000000",
             externalRoot: "/external/target-project",
             trusted: false,
             trustSource: "explicit",
@@ -685,7 +685,7 @@ describe("adv_worktree_cleanup mode=archived_branches", () => {
     expect(parsed.mode).toBe("archived_branches");
     expect(parsed._projectContext).toMatchObject({
       root: "/target",
-      projectId: "target-project",
+      projectId: "0a00e00000ec0000000000000000000000000000",
     });
     expect(mocks.detectArchivedMergedBranches).toHaveBeenCalledWith(
       {

--- a/plugin/src/tools/adv-worktree.test.ts
+++ b/plugin/src/tools/adv-worktree.test.ts
@@ -73,7 +73,7 @@ describe("advWorktreeTools", () => {
         fn({
           context: {
             root: "/target",
-            projectId: "target-project",
+            projectId: "0a00e00000ec0000000000000000000000000000",
             externalRoot: "/external/target-project",
             trusted: false,
             trustSource: "explicit",
@@ -85,7 +85,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create delegates to advWorktreeCreate", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({ ok: true, path: "/wt" });
 
@@ -106,7 +109,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create warps the current OpenCode session when runtime context is available", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.loadWorktreeConfig.mockResolvedValue({ mode: "warp" });
     worktreeMock.advWorktreeCreate.mockResolvedValue({
@@ -156,7 +162,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create emits downgrade_reason: missing_server when runtime.serverUrl is absent", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -176,7 +185,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create emits downgrade_reason: missing_session when sessionID is unavailable", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.loadWorktreeConfig.mockResolvedValue({ mode: "warp" });
     worktreeMock.advWorktreeCreate.mockResolvedValue({
@@ -200,7 +212,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create emits downgrade_reason: missing_client when client is absent", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -223,7 +238,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create downgrades to terminal mode before endpoint probing when the workspace flag is off", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.loadWorktreeConfig.mockResolvedValue({ mode: "warp" });
     worktreeMock.advWorktreeCreate.mockResolvedValue({
@@ -251,7 +269,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create blocks already-warped sessions before endpoint probing", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     workspaceWarpMock.warpFlagEnabled.mockReturnValue(true);
     workspaceWarpMock.getSessionWorkspaceID.mockResolvedValue({
@@ -278,7 +299,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create emits downgrade_reason: lookup_failed when session lookup tuple is { ok: false }", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -310,7 +334,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create emits downgrade_reason: lookup_failed (no status) on network error tuple", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -340,7 +367,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create emits downgrade_reason: endpoint_unreachable when workspace endpoint is unavailable", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -375,7 +405,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create emits downgrade_reason: warp_failed after post-create warp failure", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -415,7 +448,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create reports cleanupFailed=true when orphan workspace cleanup also fails", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -452,7 +488,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create preserves legacy warning string alongside downgrade_reason", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -476,7 +515,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_create constructs WarpDeps with directory and client", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCreate.mockResolvedValue({
       ok: true,
@@ -525,7 +567,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_resume passes store for cache refresh on materialization", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeResume.mockResolvedValue({ ok: true, path: "/wt" });
 
@@ -542,7 +587,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_resume routes target_path materialization through target store", async () => {
-    const database = { projectDir: "/target", projectId: "target-project" };
+    const database = {
+      projectDir: "/target",
+      projectId: "0a00e00000ec0000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeResume.mockResolvedValue({
       ok: true,
@@ -584,12 +632,15 @@ describe("advWorktreeTools", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed._projectContext).toMatchObject({
       root: "/target",
-      projectId: "target-project",
+      projectId: "0a00e00000ec0000000000000000000000000000",
     });
   });
 
   it("adv_worktree_delete delegates to advWorktreeDelete", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDelete.mockResolvedValue({
       ok: true,
@@ -616,7 +667,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_delete passes dryRun to advWorktreeDelete", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDelete.mockResolvedValue({
       ok: true,
@@ -639,7 +693,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_delete routes target_path mutations through target store", async () => {
-    const database = { projectDir: "/target", projectId: "target-project" };
+    const database = {
+      projectDir: "/target",
+      projectId: "0a00e00000ec0000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDelete.mockResolvedValue({
       ok: true,
@@ -694,7 +751,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_cleanup formats removed and retained branches", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCleanup.mockResolvedValue({
       removed: ["change/done"],
@@ -725,7 +785,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_cleanup passes dryRun to advWorktreeCleanup", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCleanup.mockResolvedValue({
       removed: 0,
@@ -751,7 +814,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_cleanup routes target_path mutations through target store", async () => {
-    const database = { projectDir: "/target", projectId: "target-project" };
+    const database = {
+      projectDir: "/target",
+      projectId: "0a00e00000ec0000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCleanup.mockResolvedValue({
       removed: ["change/done"],
@@ -798,7 +864,10 @@ describe("advWorktreeTools", () => {
   // cleanup hangs (e.g. workflow query on a poisoned workflow) so it
   // doesn't exceed the SDK's 10s tool-execution timeout.
   it("adv_worktree_cleanup returns a timeout response instead of hanging", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCleanup.mockImplementation(
       () => new Promise(() => {}),
@@ -823,7 +892,10 @@ describe("advWorktreeTools", () => {
 
   // rq-worktreeBoundedCleanup02 AC2: oversize timeoutMs is clamped to safe budget
   it("adv_worktree_cleanup clamps oversize timeoutMs to safe budget and reports effectiveTimeoutMs", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCleanup.mockResolvedValue({
       removed: 0,
@@ -843,7 +915,10 @@ describe("advWorktreeTools", () => {
 
   // rq-worktreeBoundedCleanup02 AC4: default timeout is the safe budget (8000ms)
   it("adv_worktree_cleanup uses safe budget default when no timeoutMs provided", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCleanup.mockResolvedValue({
       removed: 1,
@@ -861,7 +936,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_cleanup passes an internal cleanup item timeout below the wrapper budget", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeCleanup.mockResolvedValue({
       removed: 0,
@@ -887,7 +965,10 @@ describe("advWorktreeTools", () => {
 
   // rq-worktreeBoundedCleanup02 AC1: delete tool also uses safe budget
   it("adv_worktree_delete returns a timeout response instead of hanging", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDelete.mockImplementation(
       () => new Promise(() => {}),
@@ -955,7 +1036,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_detach delegates to advWorktreeDetachBatch", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDetachBatch.mockResolvedValue({
       ok: true,
@@ -999,7 +1083,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_detach routes target_path mutations through target store", async () => {
-    const database = { projectDir: "/target", projectId: "target-project" };
+    const database = {
+      projectDir: "/target",
+      projectId: "0a00e00000ec0000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDetachBatch.mockResolvedValue({
       ok: true,
@@ -1062,7 +1149,10 @@ describe("advWorktreeTools", () => {
   });
 
   it("adv_worktree_detach returns a timeout response instead of hanging", async () => {
-    const database = { projectDir: "/repo", projectId: "p" };
+    const database = {
+      projectDir: "/repo",
+      projectId: "0000000000000000000000000000000000000000",
+    };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDetachBatch.mockImplementation(
       () => new Promise(() => {}),

--- a/plugin/src/tools/change-mutation-coordinator.ts
+++ b/plugin/src/tools/change-mutation-coordinator.ts
@@ -28,6 +28,10 @@ import {
   type ProjectionCommitVerifyResult,
 } from "../storage/change-projection-transaction";
 import type { Change, ProjectionCommitAuditEntry } from "../types";
+import type {
+  TemporalOperations,
+  TemporalWorkflowHandle,
+} from "../temporal/operations";
 
 export type { RecoveryReason };
 
@@ -37,18 +41,36 @@ export interface RecoveryEvidence {
 }
 
 /**
- * Minimal workflow-handle surface used by the coordinator. Keeps the coordinator
- * decoupled from the full Temporal SDK WorkflowHandle type so tests can pass
- * lightweight mocks.
+ * Query-only workflow handle proxy. The narrowest surface needed for
+ * polling helpers; full signal/describe operations still require the owner-bound
+ * proxy so they cannot be issued without the owning TemporalOperations.
  */
-export interface WorkflowHandleLike {
-  describe?: () => Promise<unknown>;
-  query(definition: unknown, ...args: unknown[]): Promise<unknown>;
+export interface TemporalWorkflowHandleQueryProxy {
+  readonly workflowId: string;
+  query<T>(definition: unknown, ...args: unknown[]): Promise<T>;
+}
+
+/**
+ * Owner-bound workflow handle proxy. The only production-safe way to perform
+ * query/signal/describe on a workflow: the owner stays the single RPC authority,
+ * and the handle is the opaque workflow reference.
+ */
+export interface TemporalWorkflowHandleProxy extends TemporalWorkflowHandleQueryProxy {
+  readonly owner: TemporalOperations;
+  readonly handle: TemporalWorkflowHandle;
+  readonly projectId: string;
   signal(definition: unknown, ...args: unknown[]): Promise<void>;
+  describe(): Promise<unknown>;
+  terminate(reason?: string): Promise<void>;
+  cancel(): Promise<void>;
 }
 
 export type ChangeAuthority =
-  | { kind: "temporal_live"; handle: WorkflowHandleLike; changeId: string }
+  | {
+      kind: "temporal_live";
+      handle: TemporalWorkflowHandleProxy;
+      changeId: string;
+    }
   | { kind: "workflow_completed"; evidence: RecoveryEvidence }
   | { kind: "workflow_missing"; evidence: RecoveryEvidence }
   | { kind: "workflow_poisoned"; evidence: RecoveryEvidence }
@@ -78,11 +100,11 @@ export interface MutationIntent<T> {
    * mutation receipt id and the full signal payload; callers must use both.
    */
   sendSignal: (
-    handle: WorkflowHandleLike,
+    handle: TemporalWorkflowHandleProxy,
     payload: Record<string, unknown>,
   ) => Promise<void>;
   /** Refresh authoritative state from Temporal after the signal is applied. */
-  refresh: (handle: WorkflowHandleLike) => Promise<T>;
+  refresh: (handle: TemporalWorkflowHandleProxy) => Promise<T>;
   /** Verify the intended postcondition against the refreshed Temporal state. */
   verifyTemporal: (value: T) => ProjectionCommitVerifyResult;
   /**
@@ -304,7 +326,7 @@ function failureToMutationOutcome<T>(
 export async function resolveChangeAuthority(args: {
   changeId?: string;
   signalError?: unknown;
-  handle?: WorkflowHandleLike;
+  handle?: TemporalWorkflowHandleProxy;
   skipProbe?: boolean;
 }): Promise<ChangeAuthority> {
   const { signalError, handle, skipProbe, changeId } = args;
@@ -313,7 +335,7 @@ export async function resolveChangeAuthority(args: {
     return failureToAuthority(normalizeWorkflowFailure(signalError));
   }
 
-  if (skipProbe || !handle || typeof handle.describe !== "function") {
+  if (skipProbe || !handle) {
     if (handle) {
       return {
         kind: "temporal_live",

--- a/plugin/src/tools/change-projection-quarantine.ts
+++ b/plugin/src/tools/change-projection-quarantine.ts
@@ -44,6 +44,7 @@ interface QuarantineSuccess {
   success: true;
   code: "QUARANTINED";
   change_id: string;
+  project_id: string;
   source_path: string;
   quarantine_path: string;
   reason: ChangeProjectionQuarantineReason;
@@ -141,7 +142,7 @@ export const changeProjectionQuarantineTools = {
       store: Store,
     ) => {
       const gitRoot = store.paths.root;
-      const stateRoot = store.paths.external ?? store.paths.root;
+      const projectDir = store.paths.external ?? store.paths.root;
       const projectId = await getProjectId(gitRoot);
 
       if (!projectId) {
@@ -156,7 +157,8 @@ export const changeProjectionQuarantineTools = {
         approvedByUser: args.approvedByUser ?? false,
         approvalEvidence: args.approvalEvidence ?? "",
         dryRun: args.dryRun ?? false,
-        stateRoot,
+        projectId,
+        projectDir,
         changesDir: store.paths.changes,
       });
 
@@ -174,7 +176,8 @@ interface QuarantineExecuteInput {
   approvedByUser: boolean;
   approvalEvidence: string;
   dryRun: boolean;
-  stateRoot: string;
+  projectId: string;
+  projectDir: string;
   changesDir: string;
 }
 
@@ -186,7 +189,8 @@ export async function executeQuarantine(
     approvedByUser,
     approvalEvidence,
     dryRun,
-    stateRoot,
+    projectId,
+    projectDir,
     changesDir,
   } = input;
 
@@ -202,7 +206,7 @@ export async function executeQuarantine(
 
   const sourcePath = join(changesDir, changeId, "change.json");
   const quarantineDir = join(
-    stateRoot,
+    projectDir,
     ".adv",
     "quarantine",
     "changes",
@@ -250,6 +254,7 @@ export async function executeQuarantine(
       success: true,
       code: "QUARANTINED",
       change_id: changeId,
+      project_id: projectId,
       source_path: sourcePath,
       quarantine_path: quarantinePath,
       reason,
@@ -349,7 +354,8 @@ export async function executeQuarantine(
 
     let auditId: string;
     try {
-      const audit = await appendChangeProjectionQuarantineAudit(stateRoot, {
+      const audit = await appendChangeProjectionQuarantineAudit(projectDir, {
+        project_id: projectId,
         change_id: changeId,
         reason: lockedDiagnosis.reason,
         action: "quarantine",
@@ -407,6 +413,7 @@ export async function executeQuarantine(
       success: true,
       code: "QUARANTINED",
       change_id: changeId,
+      project_id: projectId,
       source_path: sourcePath,
       quarantine_path: quarantinePath,
       reason: lockedDiagnosis.reason,

--- a/plugin/src/tools/change.archive-phase9.test.ts
+++ b/plugin/src/tools/change.archive-phase9.test.ts
@@ -24,6 +24,9 @@ import { opsFollowupResolutionUpsertedSignal } from "../temporal/messages";
 import * as storageJson from "../storage/json";
 import * as worktree from "./worktree";
 import * as gitFinalize from "./archive-helpers/git-finalize";
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
+
+const PROJECT_ID = "0".repeat(40);
 
 const mocks = vi.hoisted(() => {
   const workflow = {
@@ -122,14 +125,16 @@ const mocks = vi.hoisted(() => {
     loadSpecsMap: vi.fn(() => Promise.resolve(new Map())),
     findArchiveBundle: vi.fn(() => Promise.resolve(null)),
     fireSignalAndRefresh: vi.fn(async () => {}),
-    getProjectId: vi.fn(() => Promise.resolve("test-project")),
-    getService: vi.fn(() => ({
-      client: {
-        workflow: {
-          getHandle: vi.fn(() => workflow.handle),
+    getProjectId: vi.fn(() => Promise.resolve(PROJECT_ID)),
+    getService: vi.fn(() =>
+      createMockOwnerFromClient({
+        client: {
+          workflow: {
+            getHandle: vi.fn(() => workflow.handle),
+          },
         },
-      },
-    })),
+      }),
+    ),
     saveRecoveredGateCompletion: vi.fn(
       async (input: {
         change: Change;

--- a/plugin/src/tools/change.test.ts
+++ b/plugin/src/tools/change.test.ts
@@ -34,6 +34,9 @@ import * as worktree from "./worktree";
 import { gateTools } from "./gate";
 import { overlayOpsResolutionsForRead } from "./ops-followup-reconciliation";
 
+const PROJECT_ID = "0".repeat(40);
+const TARGET_PROJECT_ID = "0".repeat(39) + "1";
+
 const mocks = vi.hoisted(() => {
   const signalMock = vi.fn();
   const queryMock = vi.fn();
@@ -83,7 +86,7 @@ const mocks = vi.hoisted(() => {
     return callback({
       context: {
         root: "/tmp/target",
-        projectId: "target-project-id",
+        projectId: TARGET_PROJECT_ID,
         externalRoot: "/tmp/target-external",
         trusted: false,
         trustSource: "explicit",
@@ -107,7 +110,7 @@ const mocks = vi.hoisted(() => {
     getHandleMock,
     temporalBundle,
     getService: vi.fn(() => temporalBundle),
-    getProjectId: vi.fn(async () => "test-project-id"),
+    getProjectId: vi.fn(async () => PROJECT_ID),
     fireSignal: vi.fn(async () => {}),
     fireSignalAndRefresh: vi.fn(async () => {}),
     querySignal: vi.fn(),
@@ -2132,7 +2135,7 @@ describe("change tools — signal-driven lifecycle", () => {
       expect(parsed._phasePlan).toEqual(
         derivePhasePlanSafe(
           changeToDirectiveState({
-            projectId: "test-project-id",
+            projectId: PROJECT_ID,
             change,
             gates: row.state.gates,
           }),
@@ -2236,7 +2239,7 @@ describe("change tools — signal-driven lifecycle", () => {
         // resolved target project, not the source project.
         expect(parsed._projectContext).toMatchObject({
           root: "/tmp/target",
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
           stateMode: "temporal",
         });
         expect(mocks.withTargetPathStore).toHaveBeenCalledWith(
@@ -2525,8 +2528,8 @@ describe("change tools — signal-driven lifecycle", () => {
         const parsed = JSON.parse(result);
         expect(parsed._recoveryMutation).toBe(true);
         expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-          mocks.temporalBundle.client,
-          "test-project-id",
+          mocks.temporalBundle,
+          PROJECT_ID,
           "test-change",
         );
         // Probe-first recovery should skip the signal path entirely.
@@ -3015,8 +3018,8 @@ describe("change tools — signal-driven lifecycle", () => {
       expect(parsed.success).toBe(true);
       expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
       expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-        mocks.temporalBundle.client,
-        "test-project-id",
+        mocks.temporalBundle,
+        PROJECT_ID,
         "test-change",
       );
       const signalCall = mocks.fireSignalAndRefresh.mock.calls[0];
@@ -3261,7 +3264,7 @@ describe("change tools — signal-driven lifecycle", () => {
       expect(mocks.handleMock.describe).toBeUndefined();
       expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
       expect(mocks.markPoisonedWorkflowForChange).toHaveBeenCalledWith(
-        "test-project-id",
+        PROJECT_ID,
         "test-change",
       );
       expect(mocks.saveRecoveredChangeStatus).toHaveBeenCalledWith(
@@ -3309,7 +3312,7 @@ describe("change tools — signal-driven lifecycle", () => {
         // target project, not the source project.
         expect(parsed._projectContext).toMatchObject({
           root: "/tmp/target",
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
           stateMode: "temporal",
         });
         expect(mocks.withTargetPathStore).toHaveBeenCalledWith(
@@ -3325,15 +3328,15 @@ describe("change tools — signal-driven lifecycle", () => {
         expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
         // Workflow identity: the close signal addresses the resolved target
         // project's workflow, never the source project identity
-        // (mocks.getProjectId returns "test-project-id").
+        // (mocks.getProjectId returns PROJECT_ID).
         expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-          mocks.temporalBundle.client,
-          "target-project-id",
+          mocks.temporalBundle,
+          TARGET_PROJECT_ID,
           "test-change",
         );
         expect(mocks.getChangeHandle).not.toHaveBeenCalledWith(
-          mocks.temporalBundle.client,
-          "test-project-id",
+          mocks.temporalBundle,
+          PROJECT_ID,
           "test-change",
         );
         const signalCall = mocks.fireSignalAndRefresh.mock.calls[0];
@@ -3380,7 +3383,7 @@ describe("change tools — signal-driven lifecycle", () => {
         expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
         expect(mocks.removeChangeDir).not.toHaveBeenCalled();
         expect(parsed._projectContext).toMatchObject({
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
           stateMode: "temporal",
         });
       });
@@ -3449,7 +3452,7 @@ describe("change tools — signal-driven lifecycle", () => {
         );
         expect(mocks.removeChangeDir).not.toHaveBeenCalled();
         expect(parsed._projectContext).toMatchObject({
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
         });
       });
 
@@ -3457,7 +3460,7 @@ describe("change tools — signal-driven lifecycle", () => {
         const store = createMockStore();
         mocks.withTargetPathStore.mockRejectedValueOnce(
           new Error(
-            "Target project Temporal queue is not serviceable for target_path mutation: advance-target-project-id; status=unavailable; blockers=server_poller_probe_unavailable; action=open or restart the target project ADV worker, then retry the target_path mutation",
+            `Target project Temporal queue is not serviceable for target_path mutation: advance-${TARGET_PROJECT_ID}; status=unavailable; blockers=server_poller_probe_unavailable; action=open or restart the target project ADV worker, then retry the target_path mutation`,
           ),
         );
 
@@ -3535,13 +3538,13 @@ describe("change tools — signal-driven lifecycle", () => {
       expect(parsed.closed).toBe(2);
       expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(2);
       expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-        mocks.temporalBundle.client,
-        "test-project-id",
+        mocks.temporalBundle,
+        PROJECT_ID,
         "chg-1",
       );
       expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-        mocks.temporalBundle.client,
-        "test-project-id",
+        mocks.temporalBundle,
+        PROJECT_ID,
         "chg-2",
       );
     });
@@ -3862,7 +3865,7 @@ describe("change tools — signal-driven lifecycle", () => {
         // resolved target project, not the source project.
         expect(parsed._projectContext).toMatchObject({
           root: "/tmp/target",
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
           stateMode: "temporal",
         });
         expect(mocks.withTargetPathStore).toHaveBeenCalledWith(
@@ -3880,20 +3883,20 @@ describe("change tools — signal-driven lifecycle", () => {
         expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(2);
         // Workflow identity: every close signal addresses the resolved target
         // project's workflow, never the source project identity
-        // (mocks.getProjectId returns "test-project-id").
+        // (mocks.getProjectId returns PROJECT_ID).
         expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-          mocks.temporalBundle.client,
-          "target-project-id",
+          mocks.temporalBundle,
+          TARGET_PROJECT_ID,
           "chg-t1",
         );
         expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-          mocks.temporalBundle.client,
-          "target-project-id",
+          mocks.temporalBundle,
+          TARGET_PROJECT_ID,
           "chg-t2",
         );
         expect(mocks.getChangeHandle).not.toHaveBeenCalledWith(
-          mocks.temporalBundle.client,
-          "test-project-id",
+          mocks.temporalBundle,
+          PROJECT_ID,
           expect.anything(),
         );
         const signalCall = mocks.fireSignalAndRefresh.mock.calls[0];
@@ -3965,7 +3968,7 @@ describe("change tools — signal-driven lifecycle", () => {
         expect(mocks.fireSignalAndRefresh).not.toHaveBeenCalled();
         expect(mocks.sweepClosedChangesFromDisk).not.toHaveBeenCalled();
         expect(parsed._projectContext).toMatchObject({
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
           stateMode: "temporal",
         });
       });
@@ -4019,7 +4022,7 @@ describe("change tools — signal-driven lifecycle", () => {
           mocks.targetStore.paths.changes,
         );
         expect(parsed._projectContext).toMatchObject({
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
         });
       });
 
@@ -4027,7 +4030,7 @@ describe("change tools — signal-driven lifecycle", () => {
         const store = createMockStore();
         mocks.withTargetPathStore.mockRejectedValueOnce(
           new Error(
-            "Target project Temporal queue is not serviceable for target_path mutation: advance-target-project-id; status=unavailable; blockers=server_poller_probe_unavailable; action=open or restart the target project ADV worker, then retry the target_path mutation",
+            `Target project Temporal queue is not serviceable for target_path mutation: advance-${TARGET_PROJECT_ID}; status=unavailable; blockers=server_poller_probe_unavailable; action=open or restart the target project ADV worker, then retry the target_path mutation`,
           ),
         );
 
@@ -4726,7 +4729,7 @@ describe("change tools — signal-driven lifecycle", () => {
       );
       expect(parsed._projectContext).toEqual({
         root: "/tmp/target",
-        projectId: "target-project-id",
+        projectId: TARGET_PROJECT_ID,
         trusted: false,
         trustSource: "explicit",
         stateMode: "temporal",
@@ -5322,7 +5325,7 @@ describe("change tools — signal-driven lifecycle", () => {
         id: "ofl-target",
         changeId: "child-target",
         target_path: "/tmp/target",
-        target_project_id: "target-project-id",
+        target_project_id: TARGET_PROJECT_ID,
       });
       const store = createMockStore(parent);
       const getMock = store.changes.get as ReturnType<typeof vi.fn>;
@@ -5356,7 +5359,7 @@ describe("change tools — signal-driven lifecycle", () => {
         id: "ofl-target",
         changeId: "child-target",
         target_path: "/tmp/target",
-        target_project_id: "target-project-id",
+        target_project_id: TARGET_PROJECT_ID,
       });
       const store = createMockStore(parent);
       const getMock = store.changes.get as ReturnType<typeof vi.fn>;
@@ -5795,8 +5798,8 @@ describe("change tools — signal-driven lifecycle", () => {
       expect(parsed.success).toBe(true);
       expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
       expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-        mocks.temporalBundle.client,
-        "test-project-id",
+        mocks.temporalBundle,
+        PROJECT_ID,
         "test-change",
       );
       const signalCall = mocks.fireSignalAndRefresh.mock.calls[0];
@@ -5812,7 +5815,7 @@ describe("change tools — signal-driven lifecycle", () => {
       const store = createMockStore();
       mocks.getProjectId.mockImplementationOnce(async (root: string) => {
         expect(root).toBe("/tmp/target");
-        return "target-project-id";
+        return TARGET_PROJECT_ID;
       });
 
       const result = await changeTools.adv_change_reenter.execute(
@@ -5832,7 +5835,7 @@ describe("change tools — signal-driven lifecycle", () => {
       expect(parsed.success).toBe(true);
       expect(parsed._projectContext).toMatchObject({
         root: "/tmp/target",
-        projectId: "target-project-id",
+        projectId: TARGET_PROJECT_ID,
         stateMode: "temporal",
       });
       expect(mocks.withTargetPathStore).toHaveBeenCalledWith(
@@ -5846,8 +5849,8 @@ describe("change tools — signal-driven lifecycle", () => {
         expect.any(Function),
       );
       expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-        mocks.temporalBundle.client,
-        "target-project-id",
+        mocks.temporalBundle,
+        TARGET_PROJECT_ID,
         "test-change",
       );
       expect(mocks.fireSignalAndRefresh).toHaveBeenCalledWith(

--- a/plugin/src/tools/change.ts
+++ b/plugin/src/tools/change.ts
@@ -760,7 +760,7 @@ async function getChangeWorkflowHandleForStore(store: Store, changeId: string) {
   const projectId = service ? await getProjectId(store.paths.root) : null;
   if (!service || !projectId) return undefined;
   const { getChangeHandle } = await import("./_adapters");
-  return getChangeHandle(service.client, projectId, changeId);
+  return getChangeHandle(service, projectId, changeId);
 }
 
 function subagentReportTaskId(
@@ -2701,7 +2701,7 @@ export const changeTools = {
         return formatToolOutput({ error: "Temporal service not available" });
       }
 
-      const handle = getChangeHandle(bundle.client, projectId, changeId);
+      const handle = getChangeHandle(bundle, projectId, changeId);
       const recordedAt = new Date().toISOString();
       await fireSignalAndRefresh(
         handle,
@@ -2807,7 +2807,7 @@ export const changeTools = {
         if (!bundle) {
           return formatToolOutput({ error: "Temporal service not available" });
         }
-        const handle = getChangeHandle(bundle.client, projectId, changeId);
+        const handle = getChangeHandle(bundle, projectId, changeId);
         await fireSignalAndRefresh(
           handle,
           activeStore,
@@ -3105,7 +3105,7 @@ export const changeTools = {
             changeId,
           });
         }
-        const handle = getChangeHandle(bundle.client, projectId, changeId);
+        const handle = getChangeHandle(bundle, projectId, changeId);
         const closeInput = {
           approvalEvidence,
           reason,
@@ -3444,7 +3444,7 @@ export const changeTools = {
           let closed = 0;
           for (const id of selection.changeIds) {
             try {
-              const handle = getChangeHandle(bundle.client, projectId, id);
+              const handle = getChangeHandle(bundle, projectId, id);
               const closeInput = {
                 approvalEvidence,
                 reason,
@@ -3582,7 +3582,7 @@ export const changeTools = {
                 // D4 internal classification (rq-internalMonotonicRecovery01 / AC5):
                 // signal-error recovery is classified internally from the signal error +
                 // describe() evidence via the unified classifier.
-                const handle = getChangeHandle(bundle.client, projectId, id);
+                const handle = getChangeHandle(bundle, projectId, id);
                 const decision = await classifyMutationRecoveryDecision({
                   signalError: err,
                   handle,
@@ -5353,7 +5353,7 @@ export const changeTools = {
           });
         }
         const { getChangeHandle } = await import("./_adapters");
-        const handle = getChangeHandle(service.client, projectId, changeId);
+        const handle = getChangeHandle(service, projectId, changeId);
         const { isWorkflowCompletedError } =
           await import("../temporal/recovery-classification");
 
@@ -5431,7 +5431,7 @@ export const changeTools = {
         });
       }
       const { getChangeHandle } = await import("./_adapters");
-      const handle = getChangeHandle(service.client, projectId, changeId);
+      const handle = getChangeHandle(service, projectId, changeId);
 
       // Idempotent completed/not-found handling — reachable here, AFTER
       // approval + existence + archived status eligibility.
@@ -5760,19 +5760,10 @@ export const changeTools = {
 
       // Terminate the EXACT pinned run: a handle bound to (workflowId, runId)
       // can never kill a different run of the same workflow.
-      const pinnedHandle = getChangeHandle(
-        service.client,
-        projectId,
-        changeId,
-        runId,
-      );
+      const pinnedHandle = getChangeHandle(service, projectId, changeId, runId);
       let alreadyTerminated = false;
       try {
-        await (
-          pinnedHandle as unknown as {
-            terminate: (reason?: string) => Promise<unknown>;
-          }
-        ).terminate(
+        await pinnedHandle.terminate(
           `adv_change_workflow_terminate: operator-approved termination of ${eligibilityClass} shipped change workflow ${changeId} (run ${runId})`,
         );
       } catch (error) {
@@ -6068,7 +6059,7 @@ export const changeTools = {
           });
         }
         const projectId = (await getProjectId(activeStore.paths.root)) ?? "";
-        const handle = getChangeHandle(bundle.client, projectId, changeId);
+        const handle = getChangeHandle(bundle, projectId, changeId);
         await fireSignalAndRefresh(
           handle,
           activeStore,
@@ -6354,7 +6345,7 @@ export const changeTools = {
               changeId,
             });
           }
-          const handle = getChangeHandle(bundle.client, projectId, changeId);
+          const handle = getChangeHandle(bundle, projectId, changeId);
           // rq-cacheRefresh01: refresh after reenter so buildReentryResult
           // reads the reset-gates state from a fresh cache, not stale gates.
           await fireSignalAndRefresh(

--- a/plugin/src/tools/change/archive-gate.test.ts
+++ b/plugin/src/tools/change/archive-gate.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./archive-gate";
 import * as gitFinalize from "../archive-helpers/git-finalize";
 import { getService, reinitStsl } from "../../temporal/service";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { TemporalQueryTimeoutError } from "../../temporal/retry-wrapper";
 import { getGateStatusQuery } from "../../temporal/messages";
 import { getProjectId } from "../../utils/project-id";
@@ -382,7 +383,7 @@ describe("preservePhase9Evidence", () => {
   });
 });
 
-function fakeClientWithHandle(handle: {
+function fakeOwnerWithHandle(handle: {
   query: ReturnType<typeof vi.fn>;
   describe?: ReturnType<typeof vi.fn>;
   signal?: ReturnType<typeof vi.fn>;
@@ -393,33 +394,35 @@ function fakeClientWithHandle(handle: {
     query: handle.query,
     signal: handle.signal ?? vi.fn(),
   };
-  return { workflow: { getHandle: vi.fn(() => fullHandle) } };
+  return createMockOwnerFromClient({
+    workflow: { getHandle: vi.fn(() => fullHandle) },
+  });
 }
 
 describe("runReacquiringChangeQuery", () => {
   // rq-reapOrphanAdvWorkers T2: a handle captured before a mid-op reconnect
   // keeps the closed client. The reacquiring query must rebuild the handle
   // from getService() inside every retry attempt.
-  it("reacquires the client via getService() on retry after a reconnectable transport failure", async () => {
+  it("reacquires the owner via getService() on retry after a reconnectable transport failure", async () => {
     const doneGate = { status: "done" };
     const secondHandle = { query: vi.fn(async () => doneGate) };
-    const secondClient = fakeClientWithHandle(secondHandle);
-    const bundle: { client: unknown } = { client: undefined };
+    const secondOwner = fakeOwnerWithHandle(secondHandle);
+    let owner = secondOwner;
     const firstHandle = {
       query: vi.fn(async () => {
-        // Simulate reinitStsl mutating the cached bundle in place.
-        bundle.client = secondClient;
+        // Simulate reinitStsl replacing the cached owner.
+        owner = secondOwner;
         throw new Error("Channel has been shut down");
       }),
     };
-    const firstClient = fakeClientWithHandle(firstHandle);
-    bundle.client = firstClient;
+    const firstOwner = fakeOwnerWithHandle(firstHandle);
+    owner = firstOwner;
     vi.mocked(getService).mockImplementation(
-      () => bundle as unknown as ReturnType<typeof getService>,
+      () => owner as unknown as ReturnType<typeof getService>,
     );
 
     const result = await runReacquiringChangeQuery(
-      "project-a",
+      "0000000000000000000000000000000000000000",
       "change-a",
       getGateStatusQuery,
       "release",
@@ -428,9 +431,9 @@ describe("runReacquiringChangeQuery", () => {
     expect(result).toEqual(doneGate);
     expect(firstHandle.query).toHaveBeenCalledTimes(1);
     expect(secondHandle.query).toHaveBeenCalledTimes(1);
-    // The retried attempt rebuilt its handle from the swapped-in client,
+    // The retried attempt rebuilt its handle from the swapped-in owner,
     // not the closed one.
-    expect(secondClient.workflow.getHandle).toHaveBeenCalledTimes(1);
+    expect(secondOwner.getHandle).toHaveBeenCalledTimes(1);
     expect(vi.mocked(getService).mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
@@ -450,12 +453,12 @@ describe("runReacquiringChangeQuery", () => {
         .mockRejectedValueOnce(saturationError)
         .mockResolvedValueOnce(doneGate),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
     vi.mocked(reinitStsl).mockClear();
 
     const result = await runReacquiringChangeQuery(
-      "project-a",
+      "0000000000000000000000000000000000000000",
       "change-a",
       getGateStatusQuery,
       "release",
@@ -479,11 +482,11 @@ describe("waitForArchiveReleaseGateCompletion", () => {
         .mockResolvedValueOnce(pendingGate)
         .mockResolvedValueOnce(doneGate),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const result = await waitForArchiveReleaseGateCompletion(
-      "project-a",
+      "0000000000000000000000000000000000000000",
       "change-a",
       { delayMs: 1 },
     );
@@ -491,7 +494,7 @@ describe("waitForArchiveReleaseGateCompletion", () => {
     expect(result).toEqual(doneGate);
     expect(handle.query).toHaveBeenCalledTimes(2);
     expect(vi.mocked(getService).mock.calls.length).toBeGreaterThanOrEqual(2);
-    expect(client.workflow.getHandle).toHaveBeenCalledTimes(2);
+    expect(client.getHandle).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -523,7 +526,9 @@ describe("completeReleaseGateAfterFinalization — T3 ambiguous signal reconcile
   }
 
   beforeEach(() => {
-    vi.mocked(getProjectId).mockResolvedValue("project-test");
+    vi.mocked(getProjectId).mockResolvedValue(
+      "0000000000000000000000000000000000000000",
+    );
     recoveryWriterMocks.saveRecoveredGateCompletion.mockReset();
     recoveryWriterMocks.saveRecoveredGateCompletion.mockImplementation(
       async (input: {
@@ -548,8 +553,8 @@ describe("completeReleaseGateAfterFinalization — T3 ambiguous signal reconcile
         .mockResolvedValueOnce(doneGate), // the single bounded reconcile read
       signal: vi.fn().mockRejectedValue(saturationError()),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const result = await completeReleaseGateAfterFinalization({
       store: createStore("/repo"),
@@ -571,8 +576,8 @@ describe("completeReleaseGateAfterFinalization — T3 ambiguous signal reconcile
       query: vi.fn().mockResolvedValue(pendingGate),
       signal: vi.fn().mockRejectedValue(saturationError()),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const result = await completeReleaseGateAfterFinalization({
       store: createStore("/repo"),
@@ -598,8 +603,8 @@ describe("completeReleaseGateAfterFinalization — T3 ambiguous signal reconcile
         .fn()
         .mockRejectedValue(new Error("Cannot signal a completed workflow")),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const result = await completeReleaseGateAfterFinalization({
       store: createStore("/repo"),
@@ -636,7 +641,9 @@ describe("completeReleaseGateAfterFinalization — bounded release-gate query (A
   };
 
   beforeEach(() => {
-    vi.mocked(getProjectId).mockResolvedValue("project-test");
+    vi.mocked(getProjectId).mockResolvedValue(
+      "0000000000000000000000000000000000000000",
+    );
     recoveryWriterMocks.saveRecoveredGateCompletion.mockReset();
     recoveryWriterMocks.saveRecoveredGateCompletion.mockImplementation(
       async (input: {
@@ -659,8 +666,8 @@ describe("completeReleaseGateAfterFinalization — bounded release-gate query (A
       describe: vi.fn(async () => ({ status: { name: "TERMINATED" } })),
       signal: vi.fn(),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const result = await completeReleaseGateAfterFinalization({
       store: createStore("/repo"),
@@ -686,8 +693,8 @@ describe("completeReleaseGateAfterFinalization — bounded release-gate query (A
       describe: vi.fn(async () => ({ status: { name: "RUNNING" } })),
       signal: vi.fn(),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const result = await completeReleaseGateAfterFinalization({
       store: createStore("/repo"),
@@ -729,7 +736,9 @@ describe("completeReleaseGateAfterFinalization — refresh-after-poll race fix (
   };
 
   beforeEach(() => {
-    vi.mocked(getProjectId).mockResolvedValue("project-test");
+    vi.mocked(getProjectId).mockResolvedValue(
+      "0000000000000000000000000000000000000000",
+    );
   });
 
   it("calls store.changes.invalidate AFTER waitForArchiveReleaseGateCompletion observes done, not refresh", async () => {
@@ -765,8 +774,8 @@ describe("completeReleaseGateAfterFinalization — refresh-after-poll race fix (
         // Signal accepted by the server; workflow will process asynchronously.
       }),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const refreshMock = vi.fn(async () => {
       // Refresh should NOT be called on the confirmed-done branch after #305.
@@ -823,8 +832,8 @@ describe("completeReleaseGateAfterFinalization — refresh-after-poll race fix (
       query: vi.fn(async () => doneGate),
       signal: vi.fn(async () => {}),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const store = {
       ...createStore("/repo"),
@@ -873,7 +882,9 @@ describe("completeReleaseGateAfterFinalization — #305 residual cache-poisoning
   };
 
   beforeEach(() => {
-    vi.mocked(getProjectId).mockResolvedValue("project-test");
+    vi.mocked(getProjectId).mockResolvedValue(
+      "0000000000000000000000000000000000000000",
+    );
   });
 
   it("invalidate (not refresh) lets verifyReleaseGateDurableForArchive observe release done from the store", async () => {
@@ -908,8 +919,8 @@ describe("completeReleaseGateAfterFinalization — #305 residual cache-poisoning
         // Signal accepted by the server; workflow will process asynchronously.
       }),
     };
-    const client = fakeClientWithHandle(handle);
-    vi.mocked(getService).mockReturnValue({ client } as never);
+    const client = fakeOwnerWithHandle(handle);
+    vi.mocked(getService).mockReturnValue(client);
 
     const refreshMock = vi.fn(async () => {
       // Model refresh's state readback re-caching stale pre-signal state.

--- a/plugin/src/tools/change/archive-gate.ts
+++ b/plugin/src/tools/change/archive-gate.ts
@@ -25,17 +25,14 @@ import {
   TemporalQueryTimeoutError,
 } from "../../temporal/retry-wrapper";
 import { getService } from "../../temporal/service";
+import { buildChangeWorkflowId } from "../../temporal/client";
 import {
   fireSignalAndRefresh,
   getChangeHandle,
   waitForGateCompletion,
 } from "../_adapters";
-import {
-  createTemporalReadContext,
-  runTemporalQuery,
-  runTemporalRead,
-  type WorkflowHandleLike,
-} from "../../storage/store-temporal/shared";
+import { runTemporalQuery } from "../../storage/store-temporal/shared";
+import type { TemporalWorkflowHandleQueryProxy } from "../change-mutation-coordinator";
 import { isWorkflowCompletedError } from "../../temporal/recovery-classification";
 import {
   gateCompletedSignal,
@@ -188,10 +185,7 @@ function queryWithFreshChangeHandle(
   if (!bundle) {
     throw new Error("STSL not initialized for change query");
   }
-  return getChangeHandle(bundle.client, projectId, changeId).query(
-    query,
-    ...args,
-  );
+  return getChangeHandle(bundle, projectId, changeId).query(query, ...args);
 }
 export function runReacquiringChangeQuery<T>(
   projectId: string,
@@ -212,22 +206,18 @@ export function runReacquiringChangeQuery<T>(
 function reacquiringChangeQueryHandle(
   projectId: string,
   changeId: string,
-): WorkflowHandleLike {
+): TemporalWorkflowHandleQueryProxy {
   return {
-    query: (definition: unknown, ...args: unknown[]) =>
-      queryWithFreshChangeHandle(projectId, changeId, definition, args),
-    executeUpdate: () =>
-      Promise.reject(
-        new Error("reacquiring query handle does not support executeUpdate"),
-      ),
-    signal: () =>
-      Promise.reject(
-        new Error("reacquiring query handle does not support signal"),
-      ),
+    workflowId: buildChangeWorkflowId(projectId, changeId),
+    query: <T>(definition: unknown, ...args: unknown[]) =>
+      queryWithFreshChangeHandle(
+        projectId,
+        changeId,
+        definition,
+        args,
+      ) as Promise<T>,
   };
 }
-
-const RELEASE_GATE_PRE_QUERY_BUDGET_MS = 3_000;
 
 const TERMINAL_WORKFLOW_STATUS_NAMES = new Set([
   "COMPLETED",
@@ -250,61 +240,15 @@ function isUnresponsiveWorkflowError(error: unknown): boolean {
   );
 }
 
-async function describeChangeHandleWithDeadline(
-  bundle: NonNullable<ReturnType<typeof getService>>,
-  projectId: string,
-  changeId: string,
-): Promise<unknown> {
-  const handle = getChangeHandle(bundle.client, projectId, changeId);
-  // Fallback for environments without native deadline support (test mocks):
-  // use the direct describe() call. Production uses runTemporalRead for a
-  // bounded 3s deadline + AbortController that cancels the gRPC call cleanly.
-  if (
-    !bundle.connection ||
-    typeof (bundle.connection as unknown as { withDeadline?: unknown })
-      .withDeadline !== "function"
-  ) {
-    return handle.describe?.();
-  }
-  const ctx = createTemporalReadContext(RELEASE_GATE_PRE_QUERY_BUDGET_MS);
-  const result = await runTemporalRead(
-    bundle.connection,
-    () =>
-      handle.describe?.() ??
-      Promise.reject(new Error("Workflow handle has no describe() method")),
-    ctx,
-    { timeoutMs: RELEASE_GATE_PRE_QUERY_BUDGET_MS },
-  );
-  if (result.error) throw result.error;
-  return result.data;
-}
-
 async function runBoundedReacquiringChangeQuery<T>(
-  bundle: NonNullable<ReturnType<typeof getService>>,
   projectId: string,
   changeId: string,
   query: unknown,
   ...args: unknown[]
 ): Promise<T> {
-  // Fallback for environments without native deadline support (test mocks):
-  // use the original unbounded query path. Production uses runTemporalRead
-  // for a bounded 3s deadline + AbortController.
-  if (
-    !bundle.connection ||
-    typeof (bundle.connection as unknown as { withDeadline?: unknown })
-      .withDeadline !== "function"
-  ) {
-    return runReacquiringChangeQuery<T>(projectId, changeId, query, ...args);
-  }
-  const ctx = createTemporalReadContext(RELEASE_GATE_PRE_QUERY_BUDGET_MS);
-  const result = await runTemporalRead(
-    bundle.connection,
-    () => queryWithFreshChangeHandle(projectId, changeId, query, args),
-    ctx,
-    { timeoutMs: RELEASE_GATE_PRE_QUERY_BUDGET_MS },
-  );
-  if (result.error) throw result.error;
-  return result.data as T;
+  return runTemporalQuery(() =>
+    queryWithFreshChangeHandle(projectId, changeId, query, args),
+  ) as Promise<T>;
 }
 
 export async function waitForArchiveReleaseGateCompletion(
@@ -696,7 +640,7 @@ export async function recordPhase9Status(input: {
   if (!projectId) {
     throw new Error("Could not resolve project ID for phase9 status update");
   }
-  const handle = getChangeHandle(bundle.client, projectId, input.changeId);
+  const handle = getChangeHandle(bundle, projectId, input.changeId);
   await fireSignalAndRefresh(
     handle,
     input.store,
@@ -1391,11 +1335,11 @@ export async function completeReleaseGateAfterFinalization(input: {
   const evidence = buildReleaseCompletionEvidence(input.finalization);
   let currentGate: GateCompletion | undefined;
   try {
-    const description = await describeChangeHandleWithDeadline(
+    const description = await getChangeHandle(
       bundle,
       projectId,
       input.changeId,
-    );
+    ).describe();
     if (isTerminalWorkflowStatus(description)) {
       return recoverReleaseGateViaDiskProjection({
         store: input.store,
@@ -1408,7 +1352,6 @@ export async function completeReleaseGateAfterFinalization(input: {
     }
 
     currentGate = await runBoundedReacquiringChangeQuery<GateCompletion>(
-      bundle,
       projectId,
       input.changeId,
       getGateStatusQuery,
@@ -1442,11 +1385,7 @@ export async function completeReleaseGateAfterFinalization(input: {
   // the bounded reconcile read in the catch — never via re-fire. The handle is
   // built here, after the pre-signal query, so a mid-query reconnect
   // (reinitStsl swaps bundle.client in place) cannot pin a closed client (T2).
-  const signalHandle = getChangeHandle(
-    bundle.client,
-    projectId,
-    input.changeId,
-  );
+  const signalHandle = getChangeHandle(bundle, projectId, input.changeId);
   try {
     await signalHandle.signal(gateCompletedSignal, {
       gateId: "release",

--- a/plugin/src/tools/change/create-clarify.test.ts
+++ b/plugin/src/tools/change/create-clarify.test.ts
@@ -440,7 +440,7 @@ describe("checkActiveDuplicateChange poisoned-workflow handling", () => {
   test("returns undefined when no active duplicate exists", async () => {
     const store = createMockStore({ peers: [] });
     const result = await checkActiveDuplicateChange(store, "Add user auth", {
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
     expect(result).toBeUndefined();
   });
@@ -450,7 +450,7 @@ describe("checkActiveDuplicateChange poisoned-workflow handling", () => {
       peers: [{ id: "addUserAuth", title: "Add user auth", status: "active" }],
     });
     const result = await checkActiveDuplicateChange(store, "Add user auth", {
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
     expect(result).toBeDefined();
     expect(result?.code).toBe("DUPLICATE_ACTIVE_CHANGE");
@@ -461,9 +461,12 @@ describe("checkActiveDuplicateChange poisoned-workflow handling", () => {
     const store = createMockStore({
       peers: [{ id: "addUserAuth", title: "Add user auth", status: "active" }],
     });
-    markPoisonedWorkflowForChange("project-1", "addUserAuth");
+    markPoisonedWorkflowForChange(
+      "0000ec0100000000000000000000000000000000",
+      "addUserAuth",
+    );
     const result = await checkActiveDuplicateChange(store, "Add user auth", {
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
     expect(result).toBeDefined();
     expect(result?.code).toBe("DUPLICATE_ACTIVE_CHANGE_POISONED");
@@ -477,7 +480,7 @@ describe("checkActiveDuplicateChange poisoned-workflow handling", () => {
     });
     const result = await checkActiveDuplicateChange(store, "Add user auth", {
       forceRecreate: true,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
     expect(result).toBeDefined();
     expect(result?.code).toBe("DUPLICATE_ACTIVE_CHANGE");
@@ -490,10 +493,13 @@ describe("checkActiveDuplicateChange poisoned-workflow handling", () => {
     const store = createMockStore({
       peers: [{ id: "addUserAuth", title: "Add user auth", status: "active" }],
     });
-    markPoisonedWorkflowForChange("project-1", "addUserAuth");
+    markPoisonedWorkflowForChange(
+      "0000ec0100000000000000000000000000000000",
+      "addUserAuth",
+    );
     const result = await checkActiveDuplicateChange(store, "Add user auth", {
       forceRecreate: true,
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
     });
     expect(result).toBeUndefined();
   });

--- a/plugin/src/tools/change/create-clarify.ts
+++ b/plugin/src/tools/change/create-clarify.ts
@@ -20,7 +20,9 @@ import type { ConflictInventory } from "../../validator/types";
 import { generateChangeId } from "../../utils/change-id";
 import { isSyntheticValidationDraftPattern } from "../../utils/synthetic-fixture-detector";
 import { createLogger } from "../../utils/debug-log";
-import { queryClaimsByIssueNumber } from "../../temporal/visibility-claim-queries";
+import { buildClaimVisibilityQuery } from "../../temporal/visibility-claim-queries";
+import { CHANGE_WORKFLOW_PREFIX } from "../../temporal/contracts";
+import { makeTemporalOperationContext } from "../../temporal/operations";
 import { runClarifyReadinessChecks } from "../../validator/clarify-readiness";
 import { formatToolOutput } from "../../utils/tool-output";
 import {
@@ -29,6 +31,7 @@ import {
   withTargetPathStore,
 } from "../target-project";
 import { getService } from "../../temporal/service";
+import { buildChangeWorkflowId } from "../../temporal/client";
 import { loadProposalForContext } from "../change/artifacts";
 import {
   loadValidationInventory,
@@ -138,18 +141,36 @@ export async function defaultClaimChecker(
     status: string;
   }>
 > {
-  const bundle = getService();
-  if (!bundle) return [];
-  const client = bundle.client as unknown as Parameters<
-    typeof queryClaimsByIssueNumber
-  >[0];
-  if (!client.workflow?.list) return [];
-  const results = await queryClaimsByIssueNumber(
-    client,
-    projectId,
-    issueNumber,
-  );
-  return results.map((r) => ({ changeId: r.changeId, status: "active" }));
+  const owner = getService();
+  if (!owner) return [];
+  const query = buildClaimVisibilityQuery({ projectId, issueNumber });
+  const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
+  const results: { changeId: string; status: string }[] = [];
+  try {
+    const outcome = await owner.list<{ workflowId: string }>(
+      makeTemporalOperationContext(
+        projectId,
+        buildChangeWorkflowId(projectId, "issue-claim-check"),
+        "list",
+        "queryClaimsByIssueNumber",
+        5_000,
+      ),
+      query,
+    );
+    if (outcome.kind !== "complete") {
+      return [];
+    }
+    for (const wf of outcome.value) {
+      const wfid = wf.workflowId;
+      if (!wfid.startsWith(projectPrefix)) continue;
+      const changeId = wfid.slice(projectPrefix.length);
+      if (changeId.length === 0) continue;
+      results.push({ changeId, status: "active" });
+    }
+  } catch {
+    return [];
+  }
+  return results;
 }
 /**
  * Extract structured context-mismatch fields from an error, if it's an

--- a/plugin/src/tools/checkpoint.ts
+++ b/plugin/src/tools/checkpoint.ts
@@ -425,7 +425,7 @@ async function getHandleForChangeId(
   if (!projectId) {
     throw new Error("Could not resolve project ID");
   }
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 async function fireTaskCompletedFromCheckpoint(

--- a/plugin/src/tools/command-family-inventory.test.ts
+++ b/plugin/src/tools/command-family-inventory.test.ts
@@ -118,14 +118,6 @@ export const CHANGE_WORKFLOW_COMMAND_ADAPTERS: readonly ChangeWorkflowAdapterRow
       migrated: true,
       core: true,
     },
-    {
-      module: "index.ts",
-      exportedFn: "createTemporalStoreBackend",
-      methods: ["fireWorktreeAutoManagedMigrationIfNeeded"],
-      signals: ["worktreeAutoManagedSignal"],
-      migrated: false,
-      core: false,
-    },
   ];
 
 /**
@@ -144,6 +136,7 @@ const CHANGE_WORKFLOW_NON_ADAPTER_ALLOWLIST = new Set([
   "hydrate-documents.ts",
   "read-context.ts",
   "creation-hash.ts",
+  "index.ts",
 ]);
 
 const EXPECTED_CHANGE_COMMAND_TOKENS = [
@@ -212,12 +205,7 @@ describe("ChangeWorkflow command adapter inventory", () => {
     async (row) => {
       const source = await readAdapterSource(row.module);
       for (const method of row.methods) {
-        // The worktree marker is a local function, not an aggregate method.
-        if (row.module === "index.ts") {
-          expect(source).toContain(method);
-        } else {
-          expect(source).toContain(`${method}: async`);
-        }
+        expect(source).toContain(`${method}: async`);
       }
     },
   );

--- a/plugin/src/tools/conformance.test.ts
+++ b/plugin/src/tools/conformance.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "os";
 
 import { conformanceTools } from "./conformance";
 import { loadConformanceState } from "../storage/conformance";
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
 
 const mocks = vi.hoisted(() => {
   const signal = vi.fn(async () => {});
@@ -20,17 +21,19 @@ const mocks = vi.hoisted(() => {
   return {
     signal,
     query,
-    getService: vi.fn(() => ({
-      connection: { close: vi.fn(async () => {}) },
-      client: {
-        workflow: {
-          // Mock workflow handle must include both signal AND query so
-          // _adapters.isWorkflowHandleLike() recognizes it as a handle
-          // and routes fireSignal() through the direct-handle path.
-          getHandle: vi.fn(() => ({ signal, query })),
+    getService: vi.fn(() =>
+      createMockOwnerFromClient({
+        connection: { close: vi.fn(async () => {}) },
+        client: {
+          workflow: {
+            // Mock workflow handle must include both signal AND query so
+            // _adapters.isWorkflowHandleLike() recognizes it as a handle
+            // and routes fireSignal() through the direct-handle path.
+            getHandle: vi.fn(() => ({ signal, query })),
+          },
         },
-      },
-    })),
+      }),
+    ),
   };
 });
 
@@ -50,7 +53,7 @@ vi.mock("../utils/project-id", async () => {
   );
   return {
     ...actual,
-    getProjectId: vi.fn(async () => "proj123"),
+    getProjectId: vi.fn(async () => "0000000000000000000000000000000000000000"),
   };
 });
 
@@ -168,7 +171,11 @@ describe("adv_conformance action: init", () => {
 
   test("mode=sibling records the sibling path (does not require git availability)", async () => {
     const result = await tool.execute(
-      { action: "init", mode: "sibling", projectId: "abc123" },
+      {
+        action: "init",
+        mode: "sibling",
+        projectId: "abc1230000000000000000000000000000000000",
+      },
       makeStore(),
     );
     const parsed = JSON.parse(result);

--- a/plugin/src/tools/conformance.ts
+++ b/plugin/src/tools/conformance.ts
@@ -144,7 +144,7 @@ async function getChangeHandleForProjectDir(
   if (!bundle) return null;
   const projectId = await getProjectId(projectDir);
   if (!projectId) return null;
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 async function fireConformanceSignal(

--- a/plugin/src/tools/contract.test.ts
+++ b/plugin/src/tools/contract.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../temporal/messages";
 import { CHANGE_WORKFLOW_QUERY_NAMES } from "../temporal/contracts";
 import { loadChange } from "../storage/json";
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
 
 const fireSignalAndRefresh = vi.hoisted(() => vi.fn());
 const workflowHandle = vi.hoisted(() => ({
@@ -24,13 +25,16 @@ vi.mock("./_adapters", async (importOriginal) => ({
 }));
 
 vi.mock("../temporal/service", () => ({
-  getService: () => ({
-    client: { workflow: { getHandle: () => workflowHandle } },
-  }),
+  getService: () =>
+    createMockOwnerFromClient({
+      client: { workflow: { getHandle: () => workflowHandle } },
+    }),
 }));
 
+const PROJECT_ID = "0".repeat(40);
+
 vi.mock("../utils/project-id", () => ({
-  getProjectId: async () => "project-1",
+  getProjectId: async () => PROJECT_ID,
 }));
 
 import { contractTools } from "./contract";

--- a/plugin/src/tools/contract.ts
+++ b/plugin/src/tools/contract.ts
@@ -158,7 +158,7 @@ async function healthySignalHandle(store: Store, changeId: string) {
   if (!bundle) throw new Error("Temporal service not available");
   const projectId = await getProjectId(store.paths.root);
   if (!projectId) throw new Error("Could not resolve project ID");
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 async function saveRecoveredContract(input: {

--- a/plugin/src/tools/design-concern.ts
+++ b/plugin/src/tools/design-concern.ts
@@ -76,7 +76,7 @@ async function getChangeHandleForChangeId(store: Store, changeId: string) {
     store.productContext?.productProjectId ??
     (await getProjectId(store.paths.root));
   if (!projectId) throw new Error("Could not resolve project ID");
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 async function loadChange(store: Store, changeId: string): Promise<Change> {

--- a/plugin/src/tools/doctor.test.ts
+++ b/plugin/src/tools/doctor.test.ts
@@ -13,6 +13,7 @@
  */
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 import { doctorTools, setDoctorPointerRepairProvider } from "./doctor";
+import { createMockOwner } from "../temporal/__tests__/mock-owner";
 import type { Store } from "../storage/store";
 
 // ── Primitive mocks ──────────────────────────────────────────────────────
@@ -71,27 +72,35 @@ vi.mock("./_adapters", () => ({
   ReachabilityDeps: {},
 }));
 
+const PROJECT_ID = "0000000000000000000000000000000000000000";
+
 function makeStore(): Store {
   return {
     paths: {
       root: "/tmp/project",
       changes: "/tmp/changes",
-      external: "/tmp/x",
+      external: `/tmp/${PROJECT_ID}`,
     },
   } as unknown as Store;
 }
 
 function setHealthy() {
-  getServiceMock.mockReturnValue({
-    client: { workflow: { getHandle: vi.fn() } },
-    connection: {},
-    namespace: "default",
-  });
+  getServiceMock.mockReturnValue(
+    createMockOwner({
+      checkSearchAttributes: vi.fn().mockResolvedValue({
+        ok: true,
+        present: [{ name: "AdvChangeId" }, { name: "AdvChangeStatus" }],
+        missing: [],
+        wrongType: [],
+      }),
+      registerSearchAttributes: vi.fn().mockResolvedValue(undefined),
+    }),
+  );
   getTemporalHealthMock.mockResolvedValue({
     server_alive: true,
     worker_alive: true,
     worker_process_alive: true,
-    registered_queues: ["advance-pid"],
+    registered_queues: ["advance-" + PROJECT_ID],
     last_op_at: "2026-07-22T00:00:00.000Z",
     last_error: null,
     fallback_counts: {},
@@ -108,7 +117,7 @@ function setHealthy() {
     },
     queues: [
       {
-        queueName: "advance-pid",
+        queueName: "advance-" + PROJECT_ID,
         queueType: "project",
         serviceable: true,
         pollerCount: 2,
@@ -119,12 +128,12 @@ function setHealthy() {
   getTemporalWorkerDiagnosticsMock.mockReturnValue([
     {
       kind: "out_of_process",
-      queues: ["advance-pid"],
+      queues: ["advance-" + PROJECT_ID],
       failedQueues: [],
       alive: true,
       diagnostics: [
         {
-          queue: "advance-pid",
+          queue: "advance-" + PROJECT_ID,
           dead: false,
           restartCount: 0,
           childExitCode: null,
@@ -140,17 +149,11 @@ function setHealthy() {
     reason: "no_worker_attached",
   });
   getTemporalWorkerAlivenessMock.mockReturnValue(false);
-  checkAdvSearchAttributesMock.mockResolvedValue({
-    ok: true,
-    present: [{ name: "AdvChangeId" }, { name: "AdvChangeStatus" }],
-    missing: [],
-    wrongType: [],
-  });
   getStslStatsMock.mockReturnValue({
     reconnectCount: 0,
     reconnectFailureCount: 0,
   });
-  getProjectIdMock.mockReturnValue("pid");
+  getProjectIdMock.mockReturnValue(PROJECT_ID);
   probeTaskQueuePollersMock.mockResolvedValue({
     status: "fresh",
     pollerCount: 2,
@@ -451,23 +454,42 @@ describe("adv_doctor", () => {
   });
 
   test("missing search attributes: registered via the safe subset (missing-only, no wrong-type mutation)", async () => {
-    checkAdvSearchAttributesMock.mockResolvedValueOnce({
-      ok: false,
-      present: [{ name: "AdvChangeId" }],
-      missing: [{ name: "AdvChangeStatus" }],
-      wrongType: [],
+    let checkCalls = 0;
+    const checkSearchAttributes = vi.fn(async () => {
+      checkCalls++;
+      if (checkCalls === 1) {
+        return {
+          ok: false,
+          present: [{ name: "AdvChangeId" }],
+          missing: [{ name: "AdvChangeStatus" }],
+          wrongType: [],
+        };
+      }
+      return {
+        ok: true,
+        present: [{ name: "AdvChangeId" }, { name: "AdvChangeStatus" }],
+        missing: [],
+        wrongType: [],
+      };
     });
-    registerMissingAdvSearchAttributesMock.mockResolvedValueOnce({
-      ok: true,
-      created: [{ name: "AdvChangeStatus" }],
-      error: null,
-      verificationStatus: "verified",
-    });
+    const registerSearchAttributes = vi.fn().mockResolvedValue(undefined);
+    getServiceMock.mockReturnValue(
+      createMockOwner({
+        checkSearchAttributes,
+        registerSearchAttributes,
+      }),
+    );
 
     const result = await doctorTools.adv_doctor.execute({}, makeStore());
     const parsed = JSON.parse(result);
 
-    expect(registerMissingAdvSearchAttributesMock).toHaveBeenCalledTimes(1);
+    expect(registerSearchAttributes).toHaveBeenCalledTimes(1);
+    expect(registerSearchAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        opType: "adv_doctor.registerSearchAttributes",
+      }),
+    );
+    expect(checkSearchAttributes).toHaveBeenCalledTimes(3);
     expect(parsed.fixes_applied).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -504,20 +526,20 @@ describe("adv_doctor", () => {
       queues: [],
     });
     restartCurrentProjectTemporalWorkerMock.mockResolvedValue({
-      projectId: "pid",
-      expectedQueue: "advance-pid",
-      queues: ["advance-pid"],
+      projectId: PROJECT_ID,
+      expectedQueue: "advance-" + PROJECT_ID,
+      queues: ["advance-" + PROJECT_ID],
     });
     // Post-restart verification: worker is now alive.
     getTemporalWorkerDiagnosticsMock.mockReturnValue([
       {
         kind: "out_of_process",
-        queues: ["advance-pid"],
+        queues: ["advance-" + PROJECT_ID],
         failedQueues: [],
         alive: true,
         diagnostics: [
           {
-            queue: "advance-pid",
+            queue: "advance-" + PROJECT_ID,
             dead: false,
             restartCount: 0,
             childExitCode: null,
@@ -547,19 +569,29 @@ describe("adv_doctor", () => {
   });
 
   test("wrong-type search attributes: REFUSED with typed approval-required proposal (never auto-mutates)", async () => {
-    checkAdvSearchAttributesMock.mockResolvedValue({
-      ok: false,
-      present: [{ name: "AdvChangeId" }],
-      missing: [],
-      wrongType: [
-        { name: "AdvChangeStatus", expectedType: "Keyword", actualType: "Int" },
-      ],
-    });
+    const registerMissing = vi.fn();
+    getServiceMock.mockReturnValue(
+      createMockOwner({
+        checkSearchAttributes: vi.fn().mockResolvedValue({
+          ok: false,
+          present: [{ name: "AdvChangeId" }],
+          missing: [],
+          wrongType: [
+            {
+              name: "AdvChangeStatus",
+              expectedType: "Keyword",
+              actualType: "Int",
+            },
+          ],
+        }),
+        registerMissingSearchAttributes: registerMissing,
+      }),
+    );
 
     const result = await doctorTools.adv_doctor.execute({}, makeStore());
     const parsed = JSON.parse(result);
 
-    expect(registerMissingAdvSearchAttributesMock).not.toHaveBeenCalled();
+    expect(registerMissing).not.toHaveBeenCalled();
     expect(parsed.fixes_refused).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -624,14 +656,22 @@ describe("adv_doctor", () => {
   });
 
   test("refusal carries a typed proposal pointing to the specific operator action", async () => {
-    checkAdvSearchAttributesMock.mockResolvedValue({
-      ok: false,
-      present: [],
-      missing: [],
-      wrongType: [
-        { name: "AdvChangeId", expectedType: "Keyword", actualType: "Text" },
-      ],
-    });
+    getServiceMock.mockReturnValue(
+      createMockOwner({
+        checkSearchAttributes: vi.fn().mockResolvedValue({
+          ok: false,
+          present: [],
+          missing: [],
+          wrongType: [
+            {
+              name: "AdvChangeId",
+              expectedType: "Keyword",
+              actualType: "Text",
+            },
+          ],
+        }),
+      }),
+    );
 
     const result = await doctorTools.adv_doctor.execute({}, makeStore());
     const parsed = JSON.parse(result);

--- a/plugin/src/tools/doctor.ts
+++ b/plugin/src/tools/doctor.ts
@@ -30,10 +30,8 @@ import { z } from "zod";
 import type { Store } from "../storage/store";
 import { getService, getStslStats, reinitStsl } from "../temporal/service";
 import { getTemporalHealth } from "../temporal/health-probe";
-import {
-  checkAdvSearchAttributes,
-  registerMissingAdvSearchAttributes,
-} from "../temporal/observability";
+import { makeTemporalLifecycleContext } from "../temporal/operations";
+
 import {
   getOrphanQueueAdoptionStatus,
   getTemporalWorkerAliveness,
@@ -44,13 +42,9 @@ import { probeTaskQueuePollers } from "../temporal/queue-serviceability";
 import { evaluateOrphanAdoptionHealth } from "../temporal/orphan-queue-adopter";
 import {
   reconcileTerminalWorkflows,
-  type TerminalReconcileClient,
   type TerminalReconcileResult,
 } from "../temporal/reconcile-terminal-workflows";
-import {
-  buildTerminalReconcileDeps,
-  type TerminalSignalClient,
-} from "../temporal/reconcile-terminal-deps";
+import { buildTerminalReconcileDeps } from "../temporal/reconcile-terminal-deps";
 import { buildProjectTaskQueue } from "../temporal/client";
 import { basename, join } from "path";
 import { existsSync } from "fs";
@@ -209,13 +203,6 @@ interface SearchAttributeCheck {
   }>;
 }
 
-interface SearchAttributeRegisterResult {
-  ok: boolean;
-  created: Array<{ name: string }>;
-  error: string | null;
-  verificationStatus: string;
-}
-
 interface WorkerDiagnosticsEntry {
   kind: string;
   queues: string[];
@@ -239,10 +226,8 @@ async function probeQueue(
   if (!bundle) return false;
   try {
     const probe = await probeTaskQueuePollers({
-      connection: bundle.connection as unknown as Parameters<
-        typeof probeTaskQueuePollers
-      >[0]["connection"],
-      namespace: bundle.namespace,
+      owner: bundle,
+      projectId,
       taskQueue: buildProjectTaskQueue(projectId),
     });
     return probe.status === "fresh";
@@ -335,11 +320,14 @@ export const doctorTools = {
 
       // Search attributes probe (cheap; cheap to fail too).
       let searchAttrs: SearchAttributeCheck | null = null;
-      if (bundle) {
+      if (bundle && projectId) {
         try {
-          searchAttrs = (await checkAdvSearchAttributes(
-            bundle.connection,
-            bundle.namespace,
+          searchAttrs = (await bundle.checkSearchAttributes(
+            makeTemporalLifecycleContext(
+              projectId,
+              "adv_doctor.checkSearchAttributes",
+              5_000,
+            ),
           )) as SearchAttributeCheck;
         } catch {
           searchAttrs = null;
@@ -458,17 +446,16 @@ export const doctorTools = {
       // active sweep is required. Idempotent, and gated on positive archive
       // evidence plus an active-change veto.
       let terminalReconcile: TerminalReconcileResult | null = null;
-      const reconcileClient = bundle?.client as unknown;
-      if (reconcileClient && projectId) {
+      if (bundle && projectId) {
         try {
           terminalReconcile = await reconcileTerminalWorkflows(
-            reconcileClient as TerminalReconcileClient,
+            bundle,
             projectId,
             buildTerminalReconcileDeps({
               projectId,
               archiveDir: store.paths.archive,
               changesDir: store.paths.changes,
-              client: reconcileClient as TerminalSignalClient,
+              owner: bundle,
             }),
           );
           if (terminalReconcile.reconciled.length > 0) {
@@ -600,28 +587,47 @@ export const doctorTools = {
               });
               break;
             }
-            try {
-              const result = (await registerMissingAdvSearchAttributes(
-                bundle.connection,
-                bundle.namespace,
-              )) as SearchAttributeRegisterResult;
-              fixesApplied.push({
+            if (bundle && projectId) {
+              try {
+                const ctx = makeTemporalLifecycleContext(
+                  projectId,
+                  "adv_doctor.registerSearchAttributes",
+                  5_000,
+                );
+                const before = searchAttrs?.missing.map((a) => a.name) ?? [];
+                await bundle.registerSearchAttributes(ctx);
+                const recheck = (await bundle.checkSearchAttributes(
+                  ctx,
+                )) as SearchAttributeCheck;
+                const after = recheck.missing.map((a) => a.name);
+                const created = before.filter((n) => !after.includes(n));
+                fixesApplied.push({
+                  class: "missing_search_attributes",
+                  action: "register_missing",
+                  outcome: created.length > 0 ? "applied" : "no_op",
+                  before,
+                  after: created,
+                  evidence: `Registered ${created.length} missing attribute(s); remainingMissing=${after.length}`,
+                });
+              } catch (err) {
+                fixesApplied.push({
+                  class: "missing_search_attributes",
+                  action: "register_missing",
+                  outcome: "failed",
+                  evidence: `registerSearchAttributes threw: ${
+                    err instanceof Error ? err.message : String(err)
+                  }`,
+                });
+              }
+            } else {
+              fixesRefused.push({
                 class: "missing_search_attributes",
-                action: "register_missing",
-                outcome:
-                  result.ok && result.created.length > 0 ? "applied" : "no_op",
-                before: searchAttrs?.missing.map((a) => a.name) ?? [],
-                after: result.created.map((a) => a.name),
-                evidence: `Registered ${result.created.length} missing attribute(s); verificationStatus=${result.verificationStatus}`,
-              });
-            } catch (err) {
-              fixesApplied.push({
-                class: "missing_search_attributes",
-                action: "register_missing",
-                outcome: "failed",
-                evidence: `registerMissingAdvSearchAttributes threw: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
+                outcome: "approval_required",
+                operator_action:
+                  "Provide a valid project id so search attributes can be registered.",
+                proposal:
+                  "Cannot register search attributes without a project id. Ensure the store exposes a valid ADV project id.",
+                evidence: "projectId is undefined",
               });
             }
             break;
@@ -759,11 +765,14 @@ export const doctorTools = {
           ? await probeQueue(projectId, recheckBundle)
           : false;
         let recheckSAs = true;
-        if (recheckBundle) {
+        if (recheckBundle && projectId) {
           try {
-            const sa = (await checkAdvSearchAttributes(
-              recheckBundle.connection,
-              recheckBundle.namespace,
+            const sa = (await recheckBundle.checkSearchAttributes(
+              makeTemporalLifecycleContext(
+                projectId,
+                "adv_doctor.verify.checkSearchAttributes",
+                5_000,
+              ),
             )) as SearchAttributeCheck;
             recheckSAs = sa.ok;
           } catch {

--- a/plugin/src/tools/followup.ts
+++ b/plugin/src/tools/followup.ts
@@ -175,7 +175,7 @@ async function getChangeHandleForChangeId(
     store.productContext?.productProjectId ??
     (await getProjectId(store.paths.root));
   if (!projectId) throw new Error("Could not resolve project ID");
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 async function loadSourceChange(

--- a/plugin/src/tools/gate.test.ts
+++ b/plugin/src/tools/gate.test.ts
@@ -21,6 +21,9 @@ import {
 import { changeToDirectiveState } from "../temporal/change-state";
 import { deriveWorkflowDirective } from "../utils/workflow-directive";
 
+const PROJECT_ID = "0".repeat(40);
+const TARGET_PROJECT_ID = "0".repeat(39) + "1";
+
 const mocks = vi.hoisted(() => {
   const signalMock = vi.fn();
   const queryMock = vi.fn();
@@ -38,7 +41,7 @@ const mocks = vi.hoisted(() => {
     getHandleMock,
     temporalBundle,
     getService: vi.fn(() => temporalBundle),
-    getProjectId: vi.fn(async () => "test-project-id"),
+    getProjectId: vi.fn(async () => PROJECT_ID),
     fireSignal: vi.fn(async () => {}),
     fireSignalAndRefresh: vi.fn(async () => {}),
     querySignal: vi.fn(),
@@ -48,7 +51,7 @@ const mocks = vi.hoisted(() => {
       fn({
         context: {
           root: input.target_path,
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
           externalRoot: "/tmp/target-external",
           trusted: false,
           trustSource: "explicit",
@@ -273,8 +276,8 @@ describe("gate tools — signal-driven lifecycle", () => {
       expect(parsed.success).toBe(true);
       expect(mocks.fireSignalAndRefresh).toHaveBeenCalledTimes(1);
       expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-        mocks.temporalBundle.client,
-        "test-project-id",
+        mocks.temporalBundle,
+        PROJECT_ID,
         "test-change",
       );
       const signalCall = mocks.fireSignalAndRefresh.mock.calls[0];
@@ -2451,7 +2454,7 @@ describe("gate tools — signal-driven lifecycle", () => {
       expect(parsed._directive).toEqual(
         deriveWorkflowDirective(
           changeToDirectiveState({
-            projectId: "test-project-id",
+            projectId: PROJECT_ID,
             change,
             gates: row.state.gates,
           }),

--- a/plugin/src/tools/gate.ts
+++ b/plugin/src/tools/gate.ts
@@ -72,7 +72,7 @@ import {
   resolveReleaseReachability,
   verifyChangeBranchPushed,
 } from "./archive-helpers/git-finalize";
-import type { WorkflowHandleLike } from "../storage/store-temporal/shared";
+import type { TemporalWorkflowHandleProxy } from "./change-mutation-coordinator";
 import {
   evaluateGateReadiness,
   renderAcceptanceProjection,
@@ -283,7 +283,7 @@ async function recordLightweightProfileBoundaryFailure(
       : undefined,
   };
 
-  const handle = getChangeHandle(bundle.client, projectId, changeId);
+  const handle = getChangeHandle(bundle, projectId, changeId);
   try {
     await fireSignalAndRefresh(
       handle,
@@ -378,7 +378,7 @@ export async function reconcileRecoveredGates(input: {
 }
 
 async function waitForGateCompletionResult(
-  handle: WorkflowHandleLike,
+  handle: TemporalWorkflowHandleProxy,
   gateId: GateId,
 ): Promise<GateCompletion | undefined> {
   return waitForGateCompletion(handle, gateId);
@@ -1226,7 +1226,7 @@ async function handlePlanningGateCompletion({
       gateId,
     });
   }
-  const handle = getChangeHandle(bundle.client, projectId, changeId);
+  const handle = getChangeHandle(bundle, projectId, changeId);
   // rq-cacheRefresh01: helper fires signal AND refreshes cache so the
   // subsequent completeGateAndBuildResponse builds its response from
   // fresh state (no parallel inline refresh in the helper anymore).
@@ -1617,7 +1617,7 @@ export const gateTools = {
             gateId,
           });
         }
-        const handle = getChangeHandle(bundle.client, projectId, changeId);
+        const handle = getChangeHandle(bundle, projectId, changeId);
 
         // D4 internal classification (rq-internalMonotonicRecovery01):
         // acceptance/release gate recovery is classified from machine

--- a/plugin/src/tools/gate.worktree-isolation.test.ts
+++ b/plugin/src/tools/gate.worktree-isolation.test.ts
@@ -225,7 +225,10 @@ describe("evaluateGateWorktreeIsolation — existing-worktree ALLOW (rq-worktree
       worktreeExists,
       resumeRuntime: {
         projectRoot: "/repo/main",
-        database: { projectDir: "/repo/main", projectId: "proj-1" },
+        database: {
+          projectDir: "/repo/main",
+          projectId: "0000100000000000000000000000000000000000",
+        },
         log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       } as never,
     };

--- a/plugin/src/tools/health-probe-cache.test.ts
+++ b/plugin/src/tools/health-probe-cache.test.ts
@@ -213,11 +213,11 @@ describe("legacy createProbeCache", () => {
 describe("queue serviceability input isolation", () => {
   test("concurrent queue requests cannot overwrite each other's input", async () => {
     const projectA = {
-      projectId: "project-a",
+      projectId: "0000ec0a00000000000000000000000000000000",
       health: buildUsableTemporalHealth(),
     };
     const projectB = {
-      projectId: "project-b",
+      projectId: "0000ec0b00000000000000000000000000000000",
       health: buildUsableTemporalHealth(),
     };
 
@@ -226,16 +226,16 @@ describe("queue serviceability input isolation", () => {
       getQueueServiceability(projectB),
     ]);
 
-    expect(resultA.value?.expectedQueue).toContain("project-a");
-    expect(resultB.value?.expectedQueue).toContain("project-b");
+    expect(resultA.value?.expectedQueue).toContain("ec0a");
+    expect(resultB.value?.expectedQueue).toContain("ec0b");
     // Neither result should be polluted by the other project's input.
-    expect(resultA.value?.expectedQueue).not.toContain("project-b");
-    expect(resultB.value?.expectedQueue).not.toContain("project-a");
+    expect(resultA.value?.expectedQueue).not.toContain("ec0b");
+    expect(resultB.value?.expectedQueue).not.toContain("ec0a");
   });
 
   test("unusable Temporal dependency immediately yields queue not_admitted", async () => {
     const result = await getQueueServiceability({
-      projectId: "project-a",
+      projectId: "0000ec0a00000000000000000000000000000000",
       health: buildUnusableTemporalHealth(),
     });
 
@@ -245,7 +245,7 @@ describe("queue serviceability input isolation", () => {
 
   test("degraded Temporal health is still usable for queue serviceability", async () => {
     const result = await getQueueServiceability({
-      projectId: "project-a",
+      projectId: "0000ec0a00000000000000000000000000000000",
       health: {
         ...buildUnusableTemporalHealth(),
         server_alive: false,

--- a/plugin/src/tools/incident-pair-migration.test.ts
+++ b/plugin/src/tools/incident-pair-migration.test.ts
@@ -9,6 +9,9 @@ import { CHANGE_WORKFLOW_QUERY_NAMES } from "../temporal/contracts";
 import { evaluateGateReadiness } from "../temporal/gate-readiness";
 import { changeToWorkflowState } from "../temporal/change-state";
 import { loadChange } from "../storage/json";
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
+
+const PROJECT_ID = "0".repeat(40);
 
 const workflowHandle = vi.hoisted(() => ({
   signal: vi.fn(),
@@ -17,13 +20,14 @@ const workflowHandle = vi.hoisted(() => ({
 }));
 
 vi.mock("../temporal/service", () => ({
-  getService: () => ({
-    client: { workflow: { getHandle: () => workflowHandle } },
-  }),
+  getService: () =>
+    createMockOwnerFromClient({
+      client: { workflow: { getHandle: () => workflowHandle } },
+    }),
 }));
 
 vi.mock("../utils/project-id", () => ({
-  getProjectId: async () => "project-1",
+  getProjectId: async () => PROJECT_ID,
 }));
 
 import { contractTools } from "./contract";
@@ -168,7 +172,7 @@ async function seedProjection(
 
 function makeGetState(change: Change): ChangeWorkflowState {
   return changeToWorkflowState({
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     change,
   });
 }

--- a/plugin/src/tools/lightweight-profile.ts
+++ b/plugin/src/tools/lightweight-profile.ts
@@ -24,19 +24,19 @@ import { getProjectId } from "../utils/project-id";
 import { formatToolOutput } from "../utils/tool-output";
 import { getService } from "../temporal/service";
 import { getChangeHandle, fireSignalAndRefresh } from "./_adapters";
-import type { WorkflowHandleLike } from "../storage/store-temporal/shared";
+import type { TemporalWorkflowHandleProxy } from "./change-mutation-coordinator";
 import { lightweightProfileEvaluatedSignal } from "../temporal/messages";
 
 export interface EvaluateLightweightProfileDeps {
   getProjectId: (root: string) => Promise<string | null>;
   getService: () => ReturnType<typeof getService>;
   getChangeHandle: (
-    client: NonNullable<ReturnType<typeof getService>>["client"],
+    owner: NonNullable<ReturnType<typeof getService>>,
     projectId: string,
     changeId: string,
-  ) => WorkflowHandleLike;
+  ) => TemporalWorkflowHandleProxy;
   fireSignalAndRefresh: (
-    handle: WorkflowHandleLike,
+    handle: TemporalWorkflowHandleProxy,
     store: Store,
     changeId: string,
     signal: typeof lightweightProfileEvaluatedSignal,
@@ -143,7 +143,7 @@ export async function evaluateLightweightProfileAndSignal(input: {
     evaluationKey,
   });
 
-  const handle = deps.getChangeHandle(bundle.client, projectId, input.changeId);
+  const handle = deps.getChangeHandle(bundle, projectId, input.changeId);
   await deps.fireSignalAndRefresh(
     handle,
     input.store,

--- a/plugin/src/tools/ops-evidence.ts
+++ b/plugin/src/tools/ops-evidence.ts
@@ -247,7 +247,7 @@ async function getChangeHandleForChangeId(
     store.productContext?.productProjectId ??
     (await getProjectId(store.paths.root));
   if (!projectId) throw new Error("Could not resolve project ID");
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 export const opsEvidenceTools = {

--- a/plugin/src/tools/ops-followup-reconciliation.ts
+++ b/plugin/src/tools/ops-followup-reconciliation.ts
@@ -16,7 +16,7 @@ import type {
 } from "../types";
 import { opsFollowupResolutionUpsertedSignal } from "../temporal/messages";
 import { fireSignalAndRefresh, getChangeHandle } from "./_adapters";
-import type { WorkflowHandleLike } from "../storage/store-temporal/shared";
+import type { TemporalWorkflowHandleProxy } from "./change-mutation-coordinator";
 import {
   withTargetPathStore,
   type TargetStoreScope,
@@ -438,7 +438,7 @@ async function persistResolutionUpsert(input: {
 
   if (deps.fireSignalAndRefresh) {
     await deps.fireSignalAndRefresh(
-      {} as unknown as WorkflowHandleLike,
+      {} as unknown as TemporalWorkflowHandleProxy,
       store,
       changeId,
       opsFollowupResolutionUpsertedSignal,
@@ -461,13 +461,7 @@ async function persistResolutionUpsert(input: {
   if (!projectId) {
     throw new Error("Could not resolve project ID");
   }
-  const handle = getChangeHandleFn(
-    bundle.client as unknown as {
-      workflow: { getHandle: (workflowId: string) => WorkflowHandleLike };
-    },
-    projectId,
-    changeId,
-  );
+  const handle = getChangeHandleFn(bundle, projectId, changeId);
   await fireSignalAndRefresh(
     handle,
     store,

--- a/plugin/src/tools/reflection-target.test.ts
+++ b/plugin/src/tools/reflection-target.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
   withOptionalTargetPathStore: vi.fn(async (_input: unknown, fn: any) =>
     fn(mocks.targetStore, {
       root: "/target/project",
-      projectId: "a".repeat(40),
+      projectId: "a000000000000000000000000000000000000000".repeat(40),
       trusted: false,
       trustSource: "explicit",
       stateMode: "snapshot",

--- a/plugin/src/tools/reflection.ts
+++ b/plugin/src/tools/reflection.ts
@@ -932,7 +932,7 @@ export const reflectionTools = {
             store.productContext?.productProjectId ??
             (await getProjectId(store.paths.root));
           if (projectId) {
-            const handle = getChangeHandle(bundle.client, projectId, change.id);
+            const handle = getChangeHandle(bundle, projectId, change.id);
             await fireSignalAndRefresh(
               handle,
               store,

--- a/plugin/src/tools/report-followup.ts
+++ b/plugin/src/tools/report-followup.ts
@@ -68,7 +68,7 @@ async function getChangeHandleForChangeId(
     store.productContext?.productProjectId ??
     (await getProjectId(store.paths.root));
   if (!projectId) throw new Error("Could not resolve project ID");
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 async function loadSourceChange(

--- a/plugin/src/tools/session/index.test.ts
+++ b/plugin/src/tools/session/index.test.ts
@@ -12,7 +12,7 @@ import { execFileSync } from "node:child_process";
 vi.mock("../worktree/state", () => ({
   initStateDb: vi.fn(async () => ({
     projectDir: "/test",
-    projectId: "test-id",
+    projectId: "0e000d0000000000000000000000000000000000",
   })),
   listSessions: vi.fn(async () => []),
   getSessionRecord: vi.fn(async () => null),

--- a/plugin/src/tools/status-health-integration-blockers.test.ts
+++ b/plugin/src/tools/status-health-integration-blockers.test.ts
@@ -37,12 +37,14 @@ import {
   parseToolOutput,
 } from "../__tests__/setup";
 import { createDiskStore } from "../storage/store-disk";
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
 import { createTemporalStoreBackend } from "../storage/store-temporal";
 import type { Store } from "../storage/store";
 import { statusTools } from "./status";
 import { _statusProbeCaches } from "./status-health";
 import { _healthRequestProbeCaches } from "./status-health-plan";
 import { createDefaultGates, type Change } from "../types";
+const PROJECT_ID = "0000000000000000000000000000000000000000";
 import * as worktree from "./worktree";
 
 const sleep = (ms: number): Promise<void> =>
@@ -242,7 +244,7 @@ function buildWorkflowState(id: string, createdAt: string): any {
     lifecycleState: "open",
     createdAt,
     initializedAt: createdAt,
-    projectId: "project-1",
+    projectId: PROJECT_ID,
     tasks: [],
     deltas: {},
     wisdom: [],
@@ -286,7 +288,7 @@ function makeTemporalClient(options: {
         list: async function* () {
           mockListConfig.listCalls++;
           if (mockListConfig.delayMs > 0) await sleep(mockListConfig.delayMs);
-          const prefix = `adv/change/project-1/`;
+          const prefix = `adv/change/${PROJECT_ID}/`;
           for (const r of options.listRecords ?? []) {
             const searchAttributes: Record<string, unknown> = {};
             if (r.lastSignalAt !== undefined) {
@@ -325,8 +327,10 @@ async function setupStores(options: {
   }
   const store = createTemporalStoreBackend({
     legacy,
-    temporal: makeTemporalClient({ listRecords: options.visibilityRecords }),
-    projectId: "project-1",
+    temporal: createMockOwnerFromClient(
+      makeTemporalClient({ listRecords: options.visibilityRecords }),
+    ),
+    projectId: PROJECT_ID,
   });
   return { legacy, store };
 }

--- a/plugin/src/tools/status-health.session-queue.test.ts
+++ b/plugin/src/tools/status-health.session-queue.test.ts
@@ -73,6 +73,7 @@ vi.mock("../utils/worker-process-probe", () => ({
 vi.mock("./snapshot-scan", () => ({ scanSnapshotHealth: vi.fn() }));
 
 import { computeStatusQueueServiceability } from "./status-health";
+const PROJECT_ID = "0000000000000000000000000000000000000000";
 
 const HEALTH = {
   server_alive: true,
@@ -110,32 +111,32 @@ describe("computeStatusQueueServiceability multi-queue (rq-isolSessionTaskQueue0
     mockProbeTaskQueuePollers.mockResolvedValue({ status: "fresh" });
 
     const result = await computeStatusQueueServiceability({
-      projectId: "proj-status-test-001",
+      projectId: PROJECT_ID,
       health: { ...HEALTH },
     });
 
     expect(result).not.toBeNull();
     expect(result?.sessionQueue).toBe(
-      "advance-proj-status-test-001-sess_StatusHealth1",
+      "advance-" + PROJECT_ID + "-sess_StatusHealth1",
     );
     expect(result?.sessionQueueServiceability).toBeDefined();
     expect(result?.sessionQueueServiceability?.status).toBe("serviceable");
     // Project queue still probed alongside
-    expect(result?.expectedQueue).toBe("advance-proj-status-test-001");
+    expect(result?.expectedQueue).toBe("advance-" + PROJECT_ID);
     expect(result?.serviceability).toBeDefined();
   });
 
   it("omits sessionQueueServiceability when getCurrentSessionId is undefined (backward compat)", async () => {
     // sessionId unset (default mock state)
     const result = await computeStatusQueueServiceability({
-      projectId: "proj-status-test-002",
+      projectId: PROJECT_ID,
       health: { ...HEALTH },
     });
 
     expect(result).not.toBeNull();
     expect(result?.sessionQueue).toBeUndefined();
     expect(result?.sessionQueueServiceability).toBeUndefined();
-    expect(result?.expectedQueue).toBe("advance-proj-status-test-002");
+    expect(result?.expectedQueue).toBe("advance-" + PROJECT_ID);
   });
 
   it("exposes sessionQueue name but omits serviceability when bundle is unavailable", async () => {
@@ -143,7 +144,7 @@ describe("computeStatusQueueServiceability multi-queue (rq-isolSessionTaskQueue0
     // bundle stays null (default mock)
 
     const result = await computeStatusQueueServiceability({
-      projectId: "proj-status-test-003",
+      projectId: PROJECT_ID,
       health: { ...HEALTH },
     });
 
@@ -151,7 +152,7 @@ describe("computeStatusQueueServiceability multi-queue (rq-isolSessionTaskQueue0
     // sessionQueue is still exposed (operator visibility into what
     // session routing would target) even when the probe couldn't run.
     expect(result?.sessionQueue).toBe(
-      "advance-proj-status-test-003-sess_NoBundle",
+      "advance-" + PROJECT_ID + "-sess_NoBundle",
     );
     // Serviceability is omitted because probeTaskQueuePollers needs a
     // service bundle to call describeTaskQueue.
@@ -174,7 +175,7 @@ describe("computeStatusQueueServiceability multi-queue (rq-isolSessionTaskQueue0
     });
 
     const result = await computeStatusQueueServiceability({
-      projectId: "proj-status-test-004",
+      projectId: PROJECT_ID,
       health: { ...HEALTH },
     });
 
@@ -203,7 +204,7 @@ describe("computeStatusQueueServiceability multi-queue (rq-isolSessionTaskQueue0
     });
 
     const result = await computeStatusQueueServiceability({
-      projectId: "proj-status-test-004b",
+      projectId: PROJECT_ID,
       health: { ...HEALTH },
     });
 
@@ -217,7 +218,7 @@ describe("computeStatusQueueServiceability multi-queue (rq-isolSessionTaskQueue0
 
   it("reports no orphan-queue adoption summary when no adopter is active", async () => {
     const result = await computeStatusQueueServiceability({
-      projectId: "proj-status-test-005",
+      projectId: PROJECT_ID,
       health: { ...HEALTH },
     });
 

--- a/plugin/src/tools/status-health.ts
+++ b/plugin/src/tools/status-health.ts
@@ -401,10 +401,8 @@ export async function computeStatusQueueServiceability(input: {
   const bundle = getService();
   const serverPollerProbe = bundle
     ? await probeTaskQueuePollers({
-        connection: bundle.connection as unknown as Parameters<
-          typeof probeTaskQueuePollers
-        >[0]["connection"],
-        namespace: bundle.namespace,
+        owner: bundle,
+        projectId: input.projectId,
         taskQueue: expectedQueue,
       })
     : {
@@ -436,10 +434,8 @@ export async function computeStatusQueueServiceability(input: {
   let sessionQueueServiceability: QueueServiceability | undefined;
   if (bundle && sessionQueue) {
     const sessionPollerProbe = await probeTaskQueuePollers({
-      connection: bundle.connection as unknown as Parameters<
-        typeof probeTaskQueuePollers
-      >[0]["connection"],
-      namespace: bundle.namespace,
+      owner: bundle,
+      projectId: input.projectId,
       taskQueue: sessionQueue,
     });
     const sessionStaleCount = input.health.stale_queues

--- a/plugin/src/tools/store-consolidate.lifecycle.test.ts
+++ b/plugin/src/tools/store-consolidate.lifecycle.test.ts
@@ -28,22 +28,33 @@ import {
   ConsolidationLedgerRowSchema,
   type ConsolidationLedgerRow,
 } from "./store-consolidate";
-import {
-  createTemporalClientBundle,
-  buildEpicWorkflowId,
-} from "../temporal/client";
+import { buildEpicWorkflowId } from "../temporal/client";
 import {
   ensureChangeWorkflowStarted,
   ensureEpicWorkflowStarted,
 } from "../temporal/workflow-start";
 import type { EpicWorkflowState } from "../temporal/contracts";
 
-vi.mock("../temporal/client", async () => {
-  const actual =
-    await vi.importActual<typeof import("../temporal/client")>(
-      "../temporal/client",
-    );
-  return { ...actual, createTemporalClientBundle: vi.fn() };
+const createBundleMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../temporal/operations", async () => {
+  const actual = await vi.importActual<typeof import("../temporal/operations")>(
+    "../temporal/operations",
+  );
+  return {
+    ...actual,
+    TemporalOperationsOwner: class extends actual.TemporalOperationsOwner {
+      static async fromEnv(
+        projectId: string,
+        _env?: NodeJS.ProcessEnv,
+      ): Promise<actual.TemporalOperationsOwner> {
+        return new actual.TemporalOperationsOwner(
+          await createBundleMock(),
+          projectId,
+        );
+      }
+    },
+  };
 });
 
 vi.mock("../temporal/workflow-start", () => ({
@@ -51,7 +62,6 @@ vi.mock("../temporal/workflow-start", () => ({
   ensureEpicWorkflowStarted: vi.fn(async () => undefined),
 }));
 
-const createBundleMock = vi.mocked(createTemporalClientBundle);
 const ensureChangeStartedMock = vi.mocked(ensureChangeWorkflowStarted);
 const ensureEpicStartedMock = vi.mocked(ensureEpicWorkflowStarted);
 
@@ -172,7 +182,15 @@ function makeBundle(opts: {
   return {
     address: "mock:7233",
     namespace: "mock",
-    connection: { close: vi.fn(opts.close) },
+    connection: {
+      withDeadline: vi.fn(
+        async (_deadline: number, fn: () => Promise<unknown>) => fn(),
+      ),
+      withAbortSignal: vi.fn(
+        async (_signal: AbortSignal, fn: () => Promise<unknown>) => fn(),
+      ),
+      close: vi.fn(opts.close),
+    },
     client: { workflow: { getHandle, start: vi.fn() } },
   };
 }
@@ -216,9 +234,11 @@ describe("executeConsolidation — Temporal bundle lifecycle (default path)", ()
         listLiveEpicIds: listSourceLiveEpics,
       });
 
-      // The finally block must close the bundle exactly once.
+      // The finally block must close both owners. In this test both owners
+      // receive the same mocked bundle, so the shared connection close is
+      // awaited twice.
       await vi.waitFor(() =>
-        expect(bundle.connection.close).toHaveBeenCalledTimes(1),
+        expect(bundle.connection.close).toHaveBeenCalledTimes(2),
       );
 
       // While the close is still pending the report promise must NOT have
@@ -234,9 +254,12 @@ describe("executeConsolidation — Temporal bundle lifecycle (default path)", ()
       const report = await execPromise;
       expect(closeSettled).toBe(true);
 
-      // One bundle shared by the live-change recreate AND the Epic query.
-      expect(createBundleMock).toHaveBeenCalledTimes(1);
-      expect(bundle.connection.close).toHaveBeenCalledTimes(1);
+      // Two bundles are created: one bound to the source project for the live
+      // Epic query, and one bound to the target project for live recreation.
+      // Because the test uses a single mocked bundle object, the shared close
+      // is awaited twice.
+      expect(createBundleMock).toHaveBeenCalledTimes(2);
+      expect(bundle.connection.close).toHaveBeenCalledTimes(2);
       expect(ensureChangeStartedMock).toHaveBeenCalledTimes(1);
       expect(ensureEpicStartedMock).toHaveBeenCalledTimes(1);
       expect(bundle.client.workflow.getHandle).toHaveBeenCalledWith(

--- a/plugin/src/tools/store-consolidate.ts
+++ b/plugin/src/tools/store-consolidate.ts
@@ -49,10 +49,11 @@ import { getDataHome, resolveProjectIdentity } from "../utils/project-id";
 import { execFileGitAsync } from "../utils/git-binary";
 import { isProcessAlive } from "../utils/process-liveness";
 import { WORKER_LOCK_FILENAME } from "../temporal/worker-lock";
+import { buildEpicWorkflowId } from "../temporal/client";
 import {
-  buildEpicWorkflowId,
-  createTemporalClientBundle,
-} from "../temporal/client";
+  TemporalOperationsOwner,
+  makeTemporalOperationContext,
+} from "../temporal/operations";
 import { listEpicWorkflows } from "../temporal/list-epic-workflows";
 import { loadChange } from "../storage/json";
 import { changeSeedStateFromChange } from "../temporal/change-state";
@@ -62,6 +63,7 @@ import {
   ensureEpicWorkflowStarted,
 } from "../temporal/workflow-start";
 import { getEpicStateQuery } from "../temporal/messages";
+import { TemporalReadOutcomeError } from "../temporal/outcome-errors";
 import type {
   ChangeWorkflowInput,
   EpicWorkflowInput,
@@ -778,15 +780,19 @@ export interface BuildPlanOptions {
 }
 
 async function defaultListLiveEpicIds(projectId: string): Promise<string[]> {
-  const bundle = await createTemporalClientBundle();
+  let owner: TemporalOperationsOwner | undefined;
   try {
-    const entries = await listEpicWorkflows(bundle.client, {
+    owner = await TemporalOperationsOwner.fromEnv(projectId);
+    const entries = await listEpicWorkflows(owner, {
       projectId,
       status: "active",
     });
-    return entries.map((e) => e.id);
+    if (entries.kind !== "complete") {
+      throw entries.error;
+    }
+    return entries.value.map((e) => e.id);
   } finally {
-    await bundle.connection.close();
+    await owner?.close();
   }
 }
 
@@ -1435,11 +1441,27 @@ export async function executeConsolidation(
   }
 
   // --- Phase 2: live recreation under the true identity --------------------
-  type TemporalBundle = Awaited<ReturnType<typeof createTemporalClientBundle>>;
-  let bundle: TemporalBundle | null = null;
-  const getClient = async (): Promise<TemporalBundle["client"]> => {
-    if (!bundle) bundle = await createTemporalClientBundle();
-    return bundle.client;
+  const ownerRef: { current: TemporalOperationsOwner | null } = {
+    current: null,
+  };
+  const sourceOwnerRef: { current: TemporalOperationsOwner | null } = {
+    current: null,
+  };
+  const getOwner = async (): Promise<TemporalOperationsOwner> => {
+    if (!ownerRef.current) {
+      ownerRef.current = await TemporalOperationsOwner.fromEnv(
+        options.targetProjectId,
+      );
+    }
+    return ownerRef.current;
+  };
+  const getSourceOwner = async (): Promise<TemporalOperationsOwner> => {
+    if (!sourceOwnerRef.current) {
+      sourceOwnerRef.current = await TemporalOperationsOwner.fromEnv(
+        options.sourceProjectId,
+      );
+    }
+    return sourceOwnerRef.current;
   };
 
   const deps = options.deps ?? {};
@@ -1448,13 +1470,7 @@ export async function executeConsolidation(
   const recreateLiveChange =
     deps.recreateLiveChange ??
     (async (input: ChangeWorkflowInput): Promise<void> => {
-      const client = {
-        workflow: (await getClient()).workflow as unknown as {
-          start: (...args: unknown[]) => Promise<unknown>;
-          getHandle: (workflowId: string) => unknown;
-        },
-      };
-      await ensureChangeWorkflowStarted(client as never, input);
+      await ensureChangeWorkflowStarted(await getOwner(), input);
     });
   const queryLiveEpicState =
     deps.queryLiveEpicState ??
@@ -1462,27 +1478,26 @@ export async function executeConsolidation(
       projectId: string,
       epicId: string,
     ): Promise<EpicWorkflowState | null> => {
-      const client = await getClient();
-      const handle = client.workflow.getHandle(
-        buildEpicWorkflowId(projectId, epicId),
+      const o = await getSourceOwner();
+      const workflowId = buildEpicWorkflowId(projectId, epicId);
+      const ctx = makeTemporalOperationContext(
+        projectId,
+        workflowId,
+        "query",
+        "storeConsolidate.queryLiveEpicState",
+        epicQueryTimeoutMs,
       );
-      try {
-        return (await handle.query(getEpicStateQuery)) as EpicWorkflowState;
-      } catch (error) {
-        if (/not found/i.test(errorMessage(error))) return null;
-        throw error;
-      }
+      const handle = o.getHandle(ctx);
+      const outcome = await o.query(ctx, handle, getEpicStateQuery);
+      if (outcome.kind === "complete")
+        return outcome.value as EpicWorkflowState;
+      if (outcome.kind === "not_found") return null;
+      throw new TemporalReadOutcomeError(outcome);
     });
   const recreateLiveEpic =
     deps.recreateLiveEpic ??
     (async (input: EpicWorkflowInput): Promise<void> => {
-      const client = {
-        workflow: (await getClient()).workflow as unknown as {
-          start: (...args: unknown[]) => Promise<unknown>;
-          getHandle: (workflowId: string) => unknown;
-        },
-      };
-      await ensureEpicWorkflowStarted(client as never, input);
+      await ensureEpicWorkflowStarted(await getOwner(), input);
     });
 
   try {
@@ -1604,10 +1619,10 @@ export async function executeConsolidation(
       }
     }
   } finally {
-    // Cast defeats TS closure-narrowing (`bundle` is assigned inside the
-    // getClient closure, which the control-flow analysis cannot see).
-    const opened = bundle as TemporalBundle | null;
-    await opened?.connection.close();
+    await Promise.all([
+      sourceOwnerRef.current?.close(),
+      ownerRef.current?.close(),
+    ]);
   }
 
   // --- Phase 3: jsonl appends with content-hash dedupe ---------------------

--- a/plugin/src/tools/subagent-report.test.ts
+++ b/plugin/src/tools/subagent-report.test.ts
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => {
     fn({
       context: {
         root: "/target",
-        projectId: "target-project",
+        projectId: "0a00e00000ec0000000000000000000000000000",
         externalRoot: "/target-state",
         trusted: true,
         trustSource: "explicit",
@@ -2505,7 +2505,7 @@ describe("subagentReportTools", () => {
       fn({
         context: {
           root: "/target",
-          projectId: "target-project",
+          projectId: "0a00e00000ec0000000000000000000000000000",
           externalRoot: "/target-state",
           trusted: true,
           trustSource: "explicit",

--- a/plugin/src/tools/subagent-report.ts
+++ b/plugin/src/tools/subagent-report.ts
@@ -125,7 +125,7 @@ async function getChangeHandleForChangeId(store: Store, changeId: string) {
     store.productContext?.productProjectId ??
     (await getProjectId(store.paths.root));
   if (!projectId) throw new Error("Could not resolve project ID");
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 async function loadChange(store: Store, changeId: string): Promise<Change> {

--- a/plugin/src/tools/target-project.test.ts
+++ b/plugin/src/tools/target-project.test.ts
@@ -360,7 +360,8 @@ describe("withTargetPathStore", () => {
     expect(result.store).toBe(mocks.temporalStore);
     expect(mocks.probeTaskQueuePollers).toHaveBeenCalledWith(
       expect.objectContaining({
-        namespace: "default",
+        owner: mocks.temporalBundle,
+        projectId: TARGET_PROJECT_ID,
         taskQueue: `advance-${TARGET_PROJECT_ID}`,
         freshPollerMs: 60_000,
       }),

--- a/plugin/src/tools/target-project.ts
+++ b/plugin/src/tools/target-project.ts
@@ -266,10 +266,8 @@ export async function ensureTargetMutationQueueReady(input: {
   // Bounded fresh server poller evidence is conservative admission evidence
   // only: it admits the mutation without proving local worker liveness.
   const serverPollerProbe = await probeTaskQueuePollers({
-    connection: input.temporalBundle.connection as Parameters<
-      typeof probeTaskQueuePollers
-    >[0]["connection"],
-    namespace: input.temporalBundle.namespace,
+    owner: input.temporalBundle,
+    projectId: input.projectId,
     taskQueue: expectedQueue,
     freshPollerMs: input.freshPollerMs ?? TARGET_MUTATION_FRESH_POLLER_MS,
   });

--- a/plugin/src/tools/task.test.ts
+++ b/plugin/src/tools/task.test.ts
@@ -12,6 +12,9 @@ import type { Store } from "../storage/store";
 import { ContractEvidencePolicySchema, TaskTypeSchema } from "../types";
 import { taskUpdatedSignal } from "../temporal/messages";
 
+const PROJECT_ID = "0".repeat(40);
+const TARGET_PROJECT_ID = "0".repeat(39) + "1";
+
 async function seedProjection(
   change: import("../types").Change,
 ): Promise<void> {
@@ -48,7 +51,7 @@ const mocks = vi.hoisted(() => {
     getHandleMock,
     temporalBundle,
     getService: vi.fn(() => temporalBundle),
-    getProjectId: vi.fn(async () => "test-project-id"),
+    getProjectId: vi.fn(async () => PROJECT_ID),
     fireSignal: vi.fn(async () => {}),
     fireSignalAndRefresh: vi.fn(async () => {}),
     querySignal: vi.fn(),
@@ -77,7 +80,7 @@ const mocks = vi.hoisted(() => {
       fn({
         context: {
           root: "/tmp/target",
-          projectId: "target-project-id",
+          projectId: TARGET_PROJECT_ID,
           externalRoot: "/tmp/target-external",
           trusted: false,
           trustSource: "explicit",
@@ -323,8 +326,8 @@ describe("task tools — signal/query adapters", () => {
       expect(parsed.changeId).toBe("test-change");
       expect(mocks.querySignal).toHaveBeenCalledTimes(1);
       expect(mocks.getChangeHandle).toHaveBeenCalledWith(
-        mocks.temporalBundle.client,
-        "test-project-id",
+        mocks.temporalBundle,
+        PROJECT_ID,
         "test-change",
       );
     });

--- a/plugin/src/tools/task.ts
+++ b/plugin/src/tools/task.ts
@@ -420,7 +420,7 @@ async function getHandleForChangeId(
   if (!projectId) {
     throw new Error("Could not resolve project ID");
   }
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 // =============================================================================

--- a/plugin/src/tools/test.ts
+++ b/plugin/src/tools/test.ts
@@ -516,7 +516,7 @@ export const testTools = {
             const projectId = await getProjectId(store.paths.root);
             if (projectId) {
               const handle = getChangeHandle(
-                bundle.client,
+                bundle,
                 projectId,
                 taskInfo.changeId,
               );

--- a/plugin/src/tools/verification-evidence.test.ts
+++ b/plugin/src/tools/verification-evidence.test.ts
@@ -424,7 +424,7 @@ describe("adv_verification_evidence_disposition", () => {
       fn({
         context: {
           root: targetDir,
-          projectId: "target-project-id",
+          projectId: "0a00e00000ec00d0000000000000000000000000",
           trusted: true,
           trustSource: "explicit",
           stateMode: "temporal",

--- a/plugin/src/tools/verification-evidence.ts
+++ b/plugin/src/tools/verification-evidence.ts
@@ -76,7 +76,7 @@ async function getChangeHandleForChangeId(store: Store, changeId: string) {
     store.productContext?.productProjectId ??
     (await getProjectId(store.paths.root));
   if (!projectId) throw new Error("Could not resolve project ID");
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 async function loadChange(store: Store, changeId: string): Promise<Change> {

--- a/plugin/src/tools/wisdom-derived-export.test.ts
+++ b/plugin/src/tools/wisdom-derived-export.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
+import { buildProjectTaskQueue } from "../temporal/client";
+
+const PROJECT_ID = "0".repeat(40);
+const PROJECT_QUEUE = buildProjectTaskQueue(PROJECT_ID);
+
 const mocks = vi.hoisted(() => {
   const signal = vi.fn(async () => {});
   const executeUpdate = vi.fn(async () => ({
@@ -38,19 +44,20 @@ const mocks = vi.hoisted(() => {
     close,
     canReachTemporalAddress: vi.fn(async () => true),
     getTemporalWorkerAliveness: vi.fn(() => true),
-    getRegisteredTemporalWorkerQueues: vi.fn(() => ["advance-proj123"]),
+    getRegisteredTemporalWorkerQueues: vi.fn(() => [PROJECT_QUEUE]),
     addProjectWisdom,
     compactProjectWisdom,
     listProjectWisdom,
-    getService: vi.fn(() => ({
-      connection: { close },
-      client: {
-        workflow: {
-          getHandle: vi.fn(() => ({ executeUpdate, query, signal })),
-          start: vi.fn(async () => ({ executeUpdate, query, signal })),
+    getService: vi.fn(() =>
+      createMockOwnerFromClient({
+        client: {
+          workflow: {
+            getHandle: vi.fn(() => ({ executeUpdate, query, signal })),
+            start: vi.fn(async () => ({ executeUpdate, query, signal })),
+          },
         },
-      },
-    })),
+      }),
+    ),
     writeJsonlAtomic: vi.fn(async () => {}),
   };
 });
@@ -101,7 +108,7 @@ vi.mock("../utils/project-id", async () => {
   );
   return {
     ...actual,
-    getProjectId: vi.fn(async () => "proj123"),
+    getProjectId: vi.fn(async () => PROJECT_ID),
   };
 });
 
@@ -113,9 +120,7 @@ describe("adv_wisdom_add signal-driven path", () => {
     mocks.listProjectWisdom.mockResolvedValue([]);
     mocks.canReachTemporalAddress.mockResolvedValue(true);
     mocks.getTemporalWorkerAliveness.mockReturnValue(true);
-    mocks.getRegisteredTemporalWorkerQueues.mockReturnValue([
-      "advance-proj123",
-    ]);
+    mocks.getRegisteredTemporalWorkerQueues.mockReturnValue([PROJECT_QUEUE]);
   });
 
   afterEach(() => {

--- a/plugin/src/tools/wisdom-target.test.ts
+++ b/plugin/src/tools/wisdom-target.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   withOptionalTargetPathStore: vi.fn(async (_input: unknown, fn: any) =>
     fn(mocks.targetStore, {
       root: "/target/project",
-      projectId: "a".repeat(40),
+      projectId: "a000000000000000000000000000000000000000".repeat(40),
       trusted: false,
       trustSource: "explicit",
       stateMode: "snapshot",

--- a/plugin/src/tools/wisdom.ts
+++ b/plugin/src/tools/wisdom.ts
@@ -48,7 +48,7 @@ async function getChangeHandleForChangeId(
     store.productContext?.productProjectId ??
     (await getProjectId(store.paths.root));
   if (!projectId) return null;
-  return getChangeHandle(bundle.client, projectId, changeId);
+  return getChangeHandle(bundle, projectId, changeId);
 }
 
 function getProductOriginTags(store: Store): ProductOriginTags | undefined {

--- a/plugin/src/tools/worktree-auto-manage.test.ts
+++ b/plugin/src/tools/worktree-auto-manage.test.ts
@@ -389,7 +389,7 @@ describe("ensureWorktreeForMutation — existing-worktree ALLOW (marker-independ
     worktreeExistsForChangeSpy.mockResolvedValue(true);
     const targetAccess = {
       projectDir: "/target/repo",
-      projectId: "target-pid",
+      projectId: "0a00e000d0000000000000000000000000000000",
     };
     const result = await ensureWorktreeForMutation({
       change: legacyChange({ worktree_auto_managed: false }),

--- a/plugin/src/tools/worktree/detach.test.ts
+++ b/plugin/src/tools/worktree/detach.test.ts
@@ -70,7 +70,10 @@ import { worktreeDematerializedSignal } from "../../temporal/messages";
 import type { ChangeWorkflowState } from "../../temporal/contracts";
 import { WorktreeDematerializedSignalPayloadSchema } from "../../types";
 
-const access = { projectDir: "/repo", projectId: "proj-123" };
+const access = {
+  projectDir: "/repo",
+  projectId: "0000123000000000000000000000000000000000",
+};
 const repoRoot = "/repo";
 const TEN_DAYS_MS = 10 * 24 * 60 * 60 * 1000;
 

--- a/plugin/src/tools/worktree/detach.ts
+++ b/plugin/src/tools/worktree/detach.ts
@@ -239,19 +239,12 @@ async function getChangeWorkflowState(
   access: WorktreeStateAccess,
   changeId: string,
 ): Promise<ChangeWorkflowState | null> {
-  const bundle = getService();
-  if (!bundle) return null;
-  const workflowApi = bundle.client.workflow as {
-    getHandle?: (workflowId: string) => {
-      query: (def: unknown) => Promise<unknown>;
-    };
-  };
-  if (!workflowApi?.getHandle) return null;
+  const owner = getService();
+  if (!owner) return null;
 
-  const workflowId = `adv/change/${access.projectId}/${changeId}`;
   try {
-    const handle = workflowApi.getHandle(workflowId);
-    const state = (await handle.query(getStateQuery)) as ChangeWorkflowState;
+    const proxy = getChangeHandle(owner, access.projectId, changeId);
+    const state = await proxy.query<ChangeWorkflowState>(getStateQuery);
     if (!state || typeof state !== "object") return null;
     return state;
   } catch {
@@ -292,7 +285,7 @@ async function fireDetachSignal(
     };
   }
 
-  const handle = getChangeHandle(bundle.client, projectId, changeId);
+  const handle = getChangeHandle(bundle, projectId, changeId);
 
   try {
     if (store) {
@@ -557,11 +550,8 @@ export async function advWorktreeDetachBatch(
   try {
     // Fail closed when the mutation path cannot record durable receipts.
     if (args.mode === "apply") {
-      const bundle = getService();
-      const workflowApi = bundle?.client.workflow as {
-        getHandle?: (workflowId: string) => unknown;
-      };
-      if (!bundle || !workflowApi?.getHandle) {
+      const owner = getService();
+      if (!owner) {
         return {
           ok: false,
           reason:

--- a/plugin/src/tools/worktree/index-create.test.ts
+++ b/plugin/src/tools/worktree/index-create.test.ts
@@ -22,6 +22,7 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 import { execSync } from "child_process";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 
 const workflowExecuteUpdate = vi.hoisted(() => vi.fn(async () => undefined));
 const workflowQuery = vi.hoisted(() =>
@@ -54,18 +55,19 @@ vi.mock("../project-workflow-helper", () => ({
 
 // Mock temporal/service so fireWorktreeSignal can reach a handle.
 vi.mock("../../temporal/service", () => ({
-  getService: vi.fn(() => ({
-    connection: { close: vi.fn() },
-    client: {
-      workflow: {
-        getHandle: vi.fn(() => ({
-          signal: workflowSignal,
-          query: workflowQuery,
-        })),
-        list: workflowList,
+  getService: vi.fn(() =>
+    createMockOwnerFromClient({
+      client: {
+        workflow: {
+          getHandle: vi.fn(() => ({
+            signal: workflowSignal,
+            query: workflowQuery,
+          })),
+          list: workflowList,
+        },
       },
-    },
-  })),
+    }),
+  ),
 }));
 
 // Mock debug-log to capture audit trail.
@@ -119,7 +121,10 @@ function createGitRepo(): string {
 function createMockDeps(repoRoot: string): AdvWorktreeCreateDeps {
   return {
     projectRoot: repoRoot,
-    database: { projectDir: repoRoot, projectId: "test-id" },
+    database: {
+      projectDir: repoRoot,
+      projectId: "0e000d0000000000000000000000000000000000",
+    },
     log: {
       debug: vi.fn(),
       info: vi.fn(),
@@ -363,7 +368,8 @@ describe.skipIf(!isLinux)(
       workflowList.mockImplementationOnce(() =>
         (async function* () {
           yield {
-            workflowId: "adv/change/test-id/other-change",
+            workflowId:
+              "adv/change/0e000d0000000000000000000000000000000000/other-change",
           };
         })(),
       );
@@ -1006,7 +1012,8 @@ describe.skipIf(!isLinux)(
       workflowList.mockImplementationOnce(() =>
         (async function* () {
           yield {
-            workflowId: "adv/change/test-id/other-change",
+            workflowId:
+              "adv/change/0e000d0000000000000000000000000000000000/other-change",
           };
         })(),
       );
@@ -1025,7 +1032,7 @@ describe.skipIf(!isLinux)(
       });
       expect(workflowList).toHaveBeenCalledWith({
         query:
-          'AdvAffectedProjects = "test-id" AND AdvWorktreeBranches = "change/feature" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"',
+          'AdvAffectedProjects = "0e000d0000000000000000000000000000000000" AND AdvWorktreeBranches = "change/feature" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running"',
       });
       const list = execSync("git worktree list", { cwd: repoRoot }).toString();
       expect(list).not.toContain("change/feature");

--- a/plugin/src/tools/worktree/index-delete.test.ts
+++ b/plugin/src/tools/worktree/index-delete.test.ts
@@ -36,14 +36,18 @@ vi.mock("../project-workflow-helper", () => ({
 
 // Mock temporal/service so fireWorktreeSignal can reach a handle.
 vi.mock("../../temporal/service", () => ({
-  getService: vi.fn(() => ({
-    connection: { close: vi.fn() },
-    client: {
-      workflow: {
-        getHandle: vi.fn(() => ({ signal: workflowSignal, query: vi.fn() })),
+  getService: vi.fn(() =>
+    createMockOwnerFromClient({
+      client: {
+        workflow: {
+          getHandle: vi.fn(() => ({
+            signal: workflowSignal,
+            query: vi.fn(),
+          })),
+        },
       },
-    },
-  })),
+    }),
+  ),
 }));
 
 // Mock debug-log to capture audit trail.
@@ -76,6 +80,7 @@ import {
 import { appendDebugLog } from "../../utils/debug-log";
 import { runHooksWithSafety } from "./hooks";
 import { worktreeDeletedSignal } from "../../temporal/messages";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import {
   clearPendingDelete,
   getPendingDeletes,

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -182,7 +182,7 @@ async function fireWorktreeSignal(
       appendDebugLog("worktree", warning);
       return { ok: false, warning };
     }
-    const handle = getChangeHandle(bundle.client, projectId, changeId);
+    const handle = getChangeHandle(bundle, projectId, changeId);
     if (store) {
       // rq-cacheRefresh01: invalidate the cache after firing the signal
       // so subsequent reads see the worktree-create/delete state change.

--- a/plugin/src/tools/worktree/state-record-probe.test.ts
+++ b/plugin/src/tools/worktree/state-record-probe.test.ts
@@ -11,13 +11,16 @@
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
+
 const queryFn = vi.hoisted(() => vi.fn());
 const getHandleFn = vi.hoisted(() => vi.fn(() => ({ query: queryFn })));
 const getServiceFn = vi.hoisted(() =>
-  vi.fn(() => ({
-    connection: { close: vi.fn() },
-    client: { workflow: { getHandle: getHandleFn } },
-  })),
+  vi.fn(() =>
+    createMockOwnerFromClient({
+      client: { workflow: { getHandle: getHandleFn } },
+    }),
+  ),
 );
 
 vi.mock("../../temporal/service", () => ({
@@ -32,7 +35,7 @@ import {
 
 const access: WorktreeStateAccess = {
   projectDir: "/repo",
-  projectId: "proj-123",
+  projectId: "0000123000000000000000000000000000000000",
 };
 
 function stateWithWorktree(
@@ -76,7 +79,10 @@ describe("getWorktreeRecord", () => {
     expect(record?.setupReady).toBe(true);
     expect(record?.materialized).toBe(true);
     expect(record?.changeId).toBe("myChange");
-    expect(getHandleFn).toHaveBeenCalledWith("adv/change/proj-123/myChange");
+    expect(getHandleFn).toHaveBeenCalledWith(
+      "adv/change/0000123000000000000000000000000000000000/myChange",
+      undefined,
+    );
   });
 
   it("calls getHandle bound to client.workflow (regression: unbound `this` throws in the real SDK)", async () => {
@@ -109,10 +115,9 @@ describe("getWorktreeRecord", () => {
         };
       },
     };
-    getServiceFn.mockReturnValueOnce({
-      connection: { close: vi.fn() },
-      client: { workflow },
-    } as never);
+    getServiceFn.mockReturnValueOnce(
+      createMockOwnerFromClient({ client: { workflow } } as never),
+    );
 
     const record = await getWorktreeRecord(access, "change/myChange");
     expect(record).not.toBeNull();

--- a/plugin/src/tools/worktree/state-session-lifecycle.test.ts
+++ b/plugin/src/tools/worktree/state-session-lifecycle.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 
 // Note: do NOT mock ./state here — the test needs the real implementation.
 // Mocking it with importOriginal causes module-resolution ordering issues
@@ -31,14 +32,16 @@ const workflowGetHandle = vi.hoisted(() =>
 );
 
 vi.mock("../../temporal/service", () => ({
-  getService: vi.fn(() => ({
-    client: {
-      workflow: {
-        list: workflowList,
-        getHandle: workflowGetHandle,
+  getService: vi.fn(() =>
+    createMockOwnerFromClient({
+      client: {
+        workflow: {
+          list: workflowList,
+          getHandle: workflowGetHandle,
+        },
       },
-    },
-  })),
+    }),
+  ),
 }));
 
 import {
@@ -69,7 +72,7 @@ import { synthesizeTestProjectId } from "../../utils/project-id";
 
 const access: WorktreeStateAccess = {
   projectDir: "/test/project",
-  projectId: "test-id",
+  projectId: "0e000d0000000000000000000000000000000000",
 };
 
 describe("session lifecycle helpers (T21)", () => {
@@ -181,8 +184,14 @@ describe("cross-change worktree visibility helpers (T22)", () => {
   it("lists active owner change ids for a worktree branch and excludes current change", async () => {
     workflowList.mockImplementationOnce(() =>
       (async function* () {
-        yield { workflowId: "adv/change/test-id/current" };
-        yield { workflowId: "adv/change/test-id/other" };
+        yield {
+          workflowId:
+            "adv/change/0e000d0000000000000000000000000000000000/current",
+        };
+        yield {
+          workflowId:
+            "adv/change/0e000d0000000000000000000000000000000000/other",
+        };
         yield { workflowId: "adv/project/test-id" };
       })(),
     );
@@ -201,7 +210,10 @@ describe("cross-change worktree visibility helpers (T22)", () => {
   it("uses the active worktree owner query so non-owner workflows are not queried", async () => {
     workflowList.mockImplementationOnce(() =>
       (async function* () {
-        yield { workflowId: "adv/change/test-id/owner" };
+        yield {
+          workflowId:
+            "adv/change/0e000d0000000000000000000000000000000000/owner",
+        };
       })(),
     );
     changeWorkflowQuery.mockResolvedValueOnce({
@@ -224,16 +236,22 @@ describe("cross-change worktree visibility helpers (T22)", () => {
 
     expect(workflowList).toHaveBeenCalledWith({
       query:
-        'AdvAffectedProjects = "test-id" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running" AND AdvWorktreeBranches IS NOT NULL',
+        'AdvAffectedProjects = "0e000d0000000000000000000000000000000000" AND AdvLifecycleState = "open" AND ExecutionStatus = "Running" AND AdvWorktreeBranches IS NOT NULL',
     });
     expect(workflowGetHandle).toHaveBeenCalledTimes(1);
-    expect(workflowGetHandle).toHaveBeenCalledWith("adv/change/test-id/owner");
+    expect(workflowGetHandle).toHaveBeenCalledWith(
+      "adv/change/0e000d0000000000000000000000000000000000/owner",
+      undefined,
+    );
   });
 
   it("aggregates materialized worktrees from active change workflow search results", async () => {
     workflowList.mockImplementationOnce(() =>
       (async function* () {
-        yield { workflowId: "adv/change/test-id/change-a" };
+        yield {
+          workflowId:
+            "adv/change/0e000d0000000000000000000000000000000000/change-a",
+        };
       })(),
     );
     changeWorkflowQuery.mockResolvedValueOnce({
@@ -274,7 +292,10 @@ describe("cross-change worktree visibility helpers (T22)", () => {
   it("exposes an authoritative registry snapshot and compatibility views", async () => {
     workflowList.mockImplementation(() =>
       (async function* () {
-        yield { workflowId: "adv/change/test-id/change-a" };
+        yield {
+          workflowId:
+            "adv/change/0e000d0000000000000000000000000000000000/change-a",
+        };
       })(),
     );
     changeWorkflowQuery.mockResolvedValue({
@@ -339,8 +360,14 @@ describe("cross-change worktree visibility helpers (T22)", () => {
   it("isolates a poisoned workflow query and keeps healthy worktrees", async () => {
     workflowList.mockImplementationOnce(() =>
       (async function* () {
-        yield { workflowId: "adv/change/test-id/healthy" };
-        yield { workflowId: "adv/change/test-id/poisoned" };
+        yield {
+          workflowId:
+            "adv/change/0e000d0000000000000000000000000000000000/healthy",
+        };
+        yield {
+          workflowId:
+            "adv/change/0e000d0000000000000000000000000000000000/poisoned",
+        };
       })(),
     );
     changeWorkflowQuery
@@ -390,7 +417,8 @@ describe("cross-change worktree visibility helpers (T22)", () => {
       expect.objectContaining({
         source: "worktree_workflow",
         changeId: "poisoned",
-        workflowId: "adv/change/test-id/poisoned",
+        workflowId:
+          "adv/change/0e000d0000000000000000000000000000000000/poisoned",
         recoveryReason: "poisoned_history",
         evidenceSummary: expect.stringContaining("TMPRL1100"),
       }),
@@ -398,7 +426,8 @@ describe("cross-change worktree visibility helpers (T22)", () => {
     expect(result.poisonedWorkflows).toEqual([
       expect.objectContaining({
         changeId: "poisoned",
-        workflowId: "adv/change/test-id/poisoned",
+        workflowId:
+          "adv/change/0e000d0000000000000000000000000000000000/poisoned",
         recoveryReason: "poisoned_history",
         evidenceSummary: expect.stringContaining("TMPRL1100"),
       }),
@@ -412,7 +441,10 @@ describe("cross-change worktree visibility helpers (T22)", () => {
     // poisoned markers — error class is the sole authority.
     workflowList.mockImplementationOnce(() =>
       (async function* () {
-        yield { workflowId: "adv/change/test-id/generic-error" };
+        yield {
+          workflowId:
+            "adv/change/0e000d0000000000000000000000000000000000/generic-error",
+        };
       })(),
     );
     changeWorkflowQuery.mockRejectedValueOnce(
@@ -449,7 +481,9 @@ describe("cross-change worktree visibility helpers (T22)", () => {
     workflowList.mockImplementationOnce(() =>
       (async function* () {
         for (const id of [...healthyIds, "poisoned-scale"]) {
-          yield { workflowId: `adv/change/test-id/${id}` };
+          yield {
+            workflowId: `adv/change/0e000d0000000000000000000000000000000000/${id}`,
+          };
         }
       })(),
     );

--- a/plugin/src/tools/worktree/state-snapshot-budget.test.ts
+++ b/plugin/src/tools/worktree/state-snapshot-budget.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createMockOwnerFromClient } from "../../temporal/__tests__/mock-owner";
 import { getWorktreeRegistrySnapshot, type WorktreeStateAccess } from "./state";
 import {
   createInventoryBudget,
@@ -13,15 +14,11 @@ const queryFn = vi.fn();
 const getHandleFn = vi.hoisted(() => vi.fn(() => ({ query: queryFn })));
 const listFn = vi.hoisted(() => vi.fn());
 const getServiceFn = vi.hoisted(() =>
-  vi.fn(() => ({
-    connection: { close: vi.fn() },
-    client: {
-      workflow: {
-        list: listFn,
-        getHandle: getHandleFn,
-      },
-    },
-  })),
+  vi.fn(() =>
+    createMockOwnerFromClient({
+      client: { workflow: { list: listFn, getHandle: getHandleFn } },
+    }),
+  ),
 );
 
 vi.mock("../../temporal/service", () => ({
@@ -30,7 +27,7 @@ vi.mock("../../temporal/service", () => ({
 
 const access: WorktreeStateAccess = {
   projectDir: "/repo",
-  projectId: "proj-123",
+  projectId: "0000123000000000000000000000000000000000",
 };
 
 function stateWithWorktree(
@@ -67,7 +64,9 @@ beforeEach(() => {
 function mockListChangeIds(ids: string[]) {
   listFn.mockImplementation(async function* () {
     for (const id of ids) {
-      yield { workflowId: `adv/change/proj-123/${id}` };
+      yield {
+        workflowId: `adv/change/0000123000000000000000000000000000000000/${id}`,
+      };
     }
   });
 }

--- a/plugin/src/tools/worktree/state.ts
+++ b/plugin/src/tools/worktree/state.ts
@@ -39,6 +39,13 @@ import { appendDebugLog } from "../../utils/debug-log";
 import { getProjectId as getProjectIdRaw } from "../../utils/project-id";
 import { getStateQuery, worktreeDeletedSignal } from "../../temporal/messages";
 import { getService } from "../../temporal/service";
+import type { TemporalOperations } from "../../temporal/operations";
+import { makeTemporalOperationContext } from "../../temporal/operations";
+import {
+  getChangeHandle,
+  fireSignal,
+  fireSignalAndRefresh,
+} from "../_adapters";
 import type { Store } from "../../storage/store";
 import { acquireFileLock, atomicWriteFile } from "../../utils/fs";
 import { collectErrorText } from "../../temporal/error-text";
@@ -369,12 +376,6 @@ async function withPendingDeleteLock<T>(
   }
 }
 
-interface WorkflowListClient {
-  workflow: {
-    list?: (opts: { query: string }) => AsyncIterable<{ workflowId: string }>;
-  };
-}
-
 // =============================================================================
 // ACCESS RESOLUTION (retired — returns local-only)
 // =============================================================================
@@ -602,34 +603,33 @@ export async function removeWorktree(
     return { ok: false, reason: "not_a_change_branch" };
   }
 
-  const bundle = getService();
-  if (!bundle) {
-    return { ok: false, reason: "temporal_unavailable" };
-  }
-  const workflowApi = bundle.client.workflow as {
-    getHandle?: (workflowId: string) => ChangeWorkflowWorktreeHandle;
-  };
-  if (!workflowApi?.getHandle) {
+  const owner = getService();
+  if (!owner) {
     return { ok: false, reason: "temporal_unavailable" };
   }
 
-  const workflowId = `${CHANGE_WORKFLOW_PREFIX}${access.projectId}/${changeId}`;
-  let handle: ChangeWorkflowWorktreeHandle;
-  try {
-    handle = workflowApi.getHandle(workflowId);
-  } catch (error) {
-    return {
-      ok: false,
-      reason: `workflow_unreachable: ${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
+  const proxy = getChangeHandle(owner, access.projectId, changeId);
 
   try {
-    await handle.signal?.(worktreeDeletedSignal, {
-      branch,
-      reason: "missing_from_disk_cleanup",
-      deletedAt: new Date().toISOString(),
-    });
+    if (store) {
+      await fireSignalAndRefresh(
+        proxy,
+        store,
+        changeId,
+        worktreeDeletedSignal,
+        {
+          branch,
+          reason: "missing_from_disk_cleanup",
+          deletedAt: new Date().toISOString(),
+        },
+      );
+    } else {
+      await fireSignal(proxy, worktreeDeletedSignal, {
+        branch,
+        reason: "missing_from_disk_cleanup",
+        deletedAt: new Date().toISOString(),
+      });
+    }
   } catch (error) {
     return {
       ok: false,
@@ -691,21 +691,36 @@ export function buildWorktreeBranchVisibilityQuery(
 }
 
 export async function listChangeIdsByWorktreeBranch(
-  client: WorkflowListClient,
+  owner: TemporalOperations,
   projectId: string,
   branch: string,
 ): Promise<string[]> {
   const query = buildWorktreeBranchVisibilityQuery(projectId, branch);
-  const list = client.workflow.list;
-  if (!list) return [];
-
   const ids: string[] = [];
   const prefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
-  for await (const wf of list.call(client.workflow, { query })) {
-    if (!wf.workflowId.startsWith(prefix)) continue;
-    const changeId = wf.workflowId.slice(prefix.length);
-    if (!changeId) continue;
-    ids.push(changeId);
+  const placeholderWorkflowId = `${prefix}worktree-branch-owners`;
+  try {
+    const outcome = await owner.list<{ workflowId: string }>(
+      makeTemporalOperationContext(
+        projectId,
+        placeholderWorkflowId,
+        "list",
+        "listChangeIdsByWorktreeBranch",
+        10_000,
+      ),
+      query,
+    );
+    if (outcome.kind !== "complete") {
+      return [];
+    }
+    for (const wf of outcome.value) {
+      if (!wf.workflowId.startsWith(prefix)) continue;
+      const changeId = wf.workflowId.slice(prefix.length);
+      if (!changeId) continue;
+      ids.push(changeId);
+    }
+  } catch {
+    return [];
   }
   return ids;
 }
@@ -715,10 +730,10 @@ export async function findBranchOwnersAcrossChanges(
   branch: string,
   excludeChangeId?: string,
 ): Promise<string[]> {
-  const bundle = getService();
-  if (!bundle) return [];
+  const owner = getService();
+  if (!owner) return [];
   const owners = await listChangeIdsByWorktreeBranch(
-    bundle.client as WorkflowListClient,
+    owner,
     access.projectId,
     branch,
   );
@@ -736,18 +751,34 @@ export function buildActiveWorktreeChangesVisibilityQuery(
 }
 
 async function listChangeIdsWithActiveWorktrees(
-  client: WorkflowListClient,
+  owner: TemporalOperations,
   projectId: string,
 ): Promise<string[]> {
-  const list = client.workflow.list;
-  if (!list) return [];
   const query = buildActiveWorktreeChangesVisibilityQuery(projectId);
   const prefix = `${CHANGE_WORKFLOW_PREFIX}${projectId}/`;
+  const placeholderWorkflowId = `${prefix}active-worktrees`;
   const ids: string[] = [];
-  for await (const wf of list.call(client.workflow, { query })) {
-    if (!wf.workflowId.startsWith(prefix)) continue;
-    const changeId = wf.workflowId.slice(prefix.length);
-    if (changeId) ids.push(changeId);
+  try {
+    const outcome = await owner.list<{ workflowId: string }>(
+      makeTemporalOperationContext(
+        projectId,
+        placeholderWorkflowId,
+        "list",
+        "listChangeIdsWithActiveWorktrees",
+        10_000,
+      ),
+      query,
+    );
+    if (outcome.kind !== "complete") {
+      return [];
+    }
+    for (const wf of outcome.value) {
+      if (!wf.workflowId.startsWith(prefix)) continue;
+      const changeId = wf.workflowId.slice(prefix.length);
+      if (changeId) ids.push(changeId);
+    }
+  } catch {
+    return [];
   }
   return ids;
 }
@@ -921,19 +952,12 @@ export async function getWorktreeRegistrySnapshot(
 
   const bundle = getService();
   if (!bundle) return unavailable("Temporal service unavailable");
-  const client = bundle.client as WorkflowListClient & {
-    workflow: WorkflowListClient["workflow"] & {
-      getHandle?: (workflowId: string) => ChangeWorkflowWorktreeHandle;
-    };
-  };
+  const owner = bundle;
 
   if (!admit("client_check")) {
     return unavailable(
       "Inventory budget exhausted before Temporal client check",
     );
-  }
-  if (!client.workflow.list || !client.workflow.getHandle) {
-    return unavailable("Temporal workflow list/getHandle unavailable");
   }
 
   if (!admit("list_active_worktrees")) {
@@ -944,10 +968,7 @@ export async function getWorktreeRegistrySnapshot(
 
   let changeIds: string[];
   try {
-    changeIds = await listChangeIdsWithActiveWorktrees(
-      client,
-      access.projectId,
-    );
+    changeIds = await listChangeIdsWithActiveWorktrees(owner, access.projectId);
   } catch (error) {
     return unavailable("Unable to list active worktree workflows", error);
   }
@@ -982,13 +1003,13 @@ export async function getWorktreeRegistrySnapshot(
 
     inspectedCount += 1;
     const workflowId = `${CHANGE_WORKFLOW_PREFIX}${access.projectId}/${changeId}`;
-    const handle = client.workflow.getHandle!(workflowId);
+    const handle = getChangeHandle(owner, access.projectId, changeId);
     let state: ChangeWorkflowState;
     try {
-      state = (await awaitInventoryQuery(
-        handle.query(getStateQuery),
+      state = await awaitInventoryQuery(
+        handle.query<ChangeWorkflowState>(getStateQuery),
         budget,
-      )) as ChangeWorkflowState;
+      );
     } catch (error) {
       if (error instanceof InventoryInspectionStoppedError) {
         omitted.push({
@@ -1130,27 +1151,11 @@ export async function getWorktreeRecord(
 
   const bundle = getService();
   if (!bundle) return null;
-  const client = bundle.client as {
-    workflow?: {
-      getHandle?: (workflowId: string) => ChangeWorkflowWorktreeHandle;
-    };
-  };
-  // Call getHandle BOUND to client.workflow. The Temporal SDK's
-  // WorkflowClient.getHandle relies on `this` (it calls
-  // this.getOrMakeInterceptors()); extracting it into a bare variable and
-  // invoking it unbound throws `Cannot read properties of undefined (reading
-  // 'getOrMakeInterceptors')`, which the catch below would swallow to null —
-  // making worktreeExistsForChange always false and blocking every
-  // main-checkout mutation. Match the bound call pattern used elsewhere
-  // (e.g. getChangeSummaries/getWorktreeRegistrySnapshot in this file).
-  const workflowApi = client.workflow;
-  if (!workflowApi?.getHandle) return null;
 
-  const workflowId = `${CHANGE_WORKFLOW_PREFIX}${access.projectId}/${changeId}`;
+  const handle = getChangeHandle(bundle, access.projectId, changeId);
   let state: ChangeWorkflowState | undefined;
   try {
-    const handle = workflowApi.getHandle(workflowId);
-    state = (await handle.query(getStateQuery)) as ChangeWorkflowState;
+    state = await handle.query<ChangeWorkflowState>(getStateQuery);
   } catch {
     // Unknown existence (poisoned/unreachable workflow): do not assert a worktree.
     return null;

--- a/plugin/src/tools/worktree/triage.test.ts
+++ b/plugin/src/tools/worktree/triage.test.ts
@@ -20,7 +20,7 @@ import { execFileSync } from "child_process";
 vi.mock("./state", () => ({
   initStateDb: vi.fn(async () => ({
     projectDir: "/test",
-    projectId: "test-id",
+    projectId: "0e000d0000000000000000000000000000000000",
   })),
   getWorktreeRegistrySnapshot: vi.fn(async () => ({
     records: [],

--- a/plugin/src/types/lightweight-change-profile.state.test.ts
+++ b/plugin/src/types/lightweight-change-profile.state.test.ts
@@ -36,7 +36,7 @@ function makeProfileRequest(): Omit<LightweightChangeProfile, "evaluations"> {
 function makeEvaluation() {
   return evaluateLightweightProfile({
     snapshot: {
-      projectId: "project-1",
+      projectId: "0000ec0100000000000000000000000000000000",
       baselineRevision: "base-abc",
       observedRevision: "head-abc",
       fingerprint: "fp-1",

--- a/plugin/src/utils/manifest-frontmatter.ts
+++ b/plugin/src/utils/manifest-frontmatter.ts
@@ -251,7 +251,7 @@ export function runtimeFrontmatterCheck(
         const result = parseFrontmatter(fullPath);
         if (!result.ok) {
           failures++;
-          // eslint-disable-next-line no-console
+
           console.warn(`[ADV] frontmatter: ${fullPath} — ${result.error}`);
         }
       }
@@ -266,13 +266,11 @@ export function runtimeFrontmatterCheck(
   const budgetExceeded = elapsedMs > budgetMs;
 
   if (failures > 0) {
-    // eslint-disable-next-line no-console
     console.warn(
       `[ADV] frontmatter: ${failures} unparseable manifest(s) in ${checked} checked (${elapsedMs.toFixed(0)}ms)`,
     );
   }
   if (budgetExceeded) {
-    // eslint-disable-next-line no-console
     console.warn(
       `[ADV] frontmatter: scan budget exceeded (${elapsedMs.toFixed(0)}ms > ${budgetMs}ms), some files not checked`,
     );

--- a/plugin/src/utils/phase-plan.test.ts
+++ b/plugin/src/utils/phase-plan.test.ts
@@ -38,7 +38,7 @@ function makeState(
   overrides: Partial<ChangeWorkflowState> = {},
 ): ChangeWorkflowState {
   return {
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     changeId: "change-1",
     title: "Test change",
     initializedAt: FRESH,

--- a/plugin/src/utils/workflow-directive.test.ts
+++ b/plugin/src/utils/workflow-directive.test.ts
@@ -18,7 +18,7 @@ function makeState(
   overrides: Partial<ChangeWorkflowState> = {},
 ): ChangeWorkflowState {
   return {
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     changeId: "change-1",
     title: "Test change",
     initializedAt: FRESH,

--- a/plugin/src/validator/contract-variant-authority.test.ts
+++ b/plugin/src/validator/contract-variant-authority.test.ts
@@ -209,7 +209,7 @@ function makeState(
   overrides: Partial<ChangeWorkflowState> = {},
 ): ChangeWorkflowState {
   return {
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     changeId: change.id,
     title: change.title,
     initializedAt: createdAt,

--- a/plugin/src/validator/required-obligation-regression.test.ts
+++ b/plugin/src/validator/required-obligation-regression.test.ts
@@ -69,7 +69,7 @@ function makeChangeWorkflowState(
   overrides: Partial<ChangeWorkflowState> = {},
 ): ChangeWorkflowState {
   return {
-    projectId: "project-1",
+    projectId: "0000ec0100000000000000000000000000000000",
     changeId: "change-1",
     title: "Test change",
     initializedAt: "2026-05-20T00:00:00.000Z",


### PR DESCRIPTION
## Summary
- centralize all client-to-Temporal operations behind one typed owner
- require canonical project identity, bounded operation contexts, and typed timeout/effect-uncertainty outcomes
- keep routine reads projection-only and move mutation/recovery behavior to explicit command paths
- migrate plugin, CLI, build scripts, storage, and tools away from raw clients/handles
- enforce the boundary structurally across shipped source roots

## Verification
- pnpm run check: pass
- pnpm run build: pass
- bin/oc-test full: 8,212 passed, 0 failed
- bun test bin/: 381 passed, 0 failed
- independent root-invariant review: PASS

## Root cause removed
Reliability policy is no longer optional or bypassable at call sites. Raw Temporal access is structurally confined to the owner module.