### PR TITLE
docs: add RCAs for stale workflow reads and archive merge authority

### DIFF
--- a/docs/rca-archive-merge-authority-gap.md
+++ b/docs/rca-archive-merge-authority-gap.md
@@ -1,0 +1,132 @@
+# RCA — Archive Auto-Merge vs Orchestrator Merge Authority
+
+> **Status:** DRAFT — not yet an ADV change. Written from a pokeedge-web session because
+> cross-project change creation into this repo is currently broken (see the §7 note in
+> `rca-temporal-stale-projection-reads.md`).
+> Pick this up from an ADV session rooted at `/home/jon/dev/advance` and create the change.
+>
+> **Source:** pokeedge-web change `disableValueMetricSurfaces`, session of 2026-08-03.
+> **Suggested change summary:** `Align archive merge authority`
+> **Suggested origin:** `discovery`, source project `pokeedge-web`, source change `disableValueMetricSurfaces`.
+
+## 1. Summary
+
+Two rules govern whether a PR may be auto-merged, and they disagree.
+
+The ADV orchestrator prompt states that archive sign-off does **not** grant merge authority.
+`adv_change_archive` arms GitHub auto-merge as part of its normal release route.
+
+In the observed session the outcome was correct and desired, but it was reached by the tool
+doing something the orchestrator had been explicitly instructed not to do. Right result, wrong
+provenance — and the discrepancy means the documented authority model does not describe actual
+system behavior.
+
+## 2. The conflict
+
+### 2.1 What the orchestrator prompt says
+
+From the ADV orchestrator `PR Merge Authority` section:
+
+> An explicit user grant to merge the current change — for example `merge`, `merge and push`,
+> or equivalent — creates continuing merge authority [...] **Push-only permission, generic
+> Tier-A approval, or inferred archive approval does not authorize merge.**
+
+Tier B archive sign-off (`sign off` / `approve` / `ship it`) is explicitly *not* on the list of
+phrases that grant merge authority.
+
+### 2.2 What the tool did
+
+The user replied `approve` at the Tier B archive checkpoint. No merge grant was given at any
+point in the session. `adv_change_archive` returned:
+
+```json
+"finalization": {
+  "status": "pending_merge",
+  "route": "pr_auto_merge",
+  "prNumber": 692,
+  "autoMergeArmed": true,
+  "changeTipSha": "3aa03d3777de39593cdee9166b61f4dcc0b42498"
+}
+```
+
+Independently confirmed on the PR: `autoMergeRequest.enabledAt: 2026-08-03T04:29:22Z`,
+method `SQUASH`. The PR subsequently merged automatically once CI passed.
+
+### 2.3 Why this matters even though the outcome was right
+
+The orchestrator, following its instructions, did **not** arm auto-merge and would have
+refused to. Had the user wanted a manual merge gate — for example to inspect the squash
+result, coordinate a deploy window, or hold the change behind another merge — the documented
+authority model says they had one, and they did not.
+
+The gap is not "auto-merge is wrong". It is that **two components disagree about who owns the
+merge decision**, and the component with the weaker stated authority is the one that acted.
+
+## 3. Root cause
+
+`adv_change_archive`'s `pr_auto_merge` route treats archive sign-off as sufficient authority to
+arm auto-merge. The orchestrator prompt treats archive sign-off as explicitly insufficient.
+
+Neither is internally inconsistent; they were specified against different assumptions about
+what Tier B approval means. There is no shared, machine-checkable definition of merge
+authority that both the archive tool and the orchestrator consult — so the rule exists twice,
+in prose, with different content.
+
+This is a structural-correctness gap (P33): merge authority is currently enforced by two
+independent prose rules rather than one typed contract.
+
+## 4. Secondary finding — release gate does not close on archive success
+
+Related, surfaced in the same sequence.
+
+`adv_change_archive` returned `success: true` and wrote the archive bundle, but
+`adv_gate_status` still showed:
+
+```json
+"release": { "status": "pending" }
+```
+
+while `_directive` simultaneously reported `phase: "archived"`, `action: {"kind": "archived"}`.
+The release gate row required an explicit `adv_gate_complete gateId:"release"` after
+merge reachability was proven.
+
+So the change was simultaneously "archived" by directive and "release pending" by gate row.
+Either archive success should close the release gate once merge proof exists, or the
+`pending_merge` → `done` transition should be documented as an explicit orchestrator
+responsibility. Currently it is neither — an orchestrator that trusted `success: true` would
+leave the change permanently mid-release.
+
+## 5. Proposed scope
+
+1. **Single source of truth for merge authority.** Define it once, typed, consulted by both
+   `adv_change_archive` and the orchestrator prompt. Prose in two places with different content
+   is the defect.
+2. **Decide the intended semantics explicitly.** Either:
+   - Tier B archive sign-off *does* authorize auto-merge — then correct the orchestrator prompt
+     and stop describing archive approval as insufficient; or
+   - it does *not* — then `adv_change_archive` must not arm auto-merge without a merge grant,
+     and should expose a parameter for the orchestrator to pass one through.
+3. **Make the archive route's merge behavior visible at the sign-off checkpoint.** The user
+   approving archive should be told whether approving also merges. Currently the Tier B prompt
+   does not say so, and under the orchestrator's own rules it would be wrong to imply it.
+4. **Close the release-gate transition gap** described in §4.
+
+## 6. Success criteria (draft)
+
+1. Archive-time merge behavior is governed by one typed authority check, not two prose rules.
+2. An orchestrator following its prompt and the archive tool cannot reach different conclusions
+   about whether a given approval authorizes merge.
+3. The Tier B sign-off prompt accurately states whether approval will also merge the PR.
+4. After a successful archive with proven merge reachability, the release gate reaches `done`
+   without a separate undocumented step — or that step is documented.
+
+**Non-goals:** removing auto-merge; changing Tier B whitelist wording for archive sign-off
+itself.
+
+## 7. Provenance
+
+- Session: pokeedge-web, change `disableValueMetricSurfaces`, 2026-08-03.
+- PR #692, squash `de044101`, merged to `main` at `04:45:51Z`.
+- Auto-merge armed by the archive tool at `04:29:22Z`; no merge grant was issued by the user
+  at any point in the session.
+- Release gate closed manually at `04:48:03Z` after merge reachability was verified.

--- a/docs/rca-temporal-stale-projection-reads.md
+++ b/docs/rca-temporal-stale-projection-reads.md
@@ -1,0 +1,177 @@
+# RCA — Stale Workflow Projections and Degraded Temporal Reads
+
+> **Status:** DRAFT — not yet an ADV change. Written from a pokeedge-web session because
+> cross-project change creation into this repo is currently broken (see §7).
+> Pick this up from an ADV session rooted at `/home/jon/dev/advance` and create the change.
+>
+> **Source:** pokeedge-web change `disableValueMetricSurfaces`, session of 2026-08-03.
+> **Suggested change summary:** `Fix stale workflow state reads`
+> **Suggested origin:** `discovery`, source project `pokeedge-web`, source change `disableValueMetricSurfaces`.
+
+## 1. Summary
+
+For the full duration of a multi-hour session, ADV's Temporal-backed read and write paths
+degraded while `adv_doctor` continuously reported the system fully healthy. The degradation
+silently disabled an entire agent lane, made approved contract text unreachable through the
+documented tool path, recorded genuine passing test evidence as missing, and blocked a gate
+against two remediations that had both been applied correctly.
+
+None of it was visible through the diagnostic surface an operator would consult.
+
+## 2. Observed symptoms
+
+| # | Symptom | Evidence |
+|---|---|---|
+| 1 | Artifact hydration failed permanently | `adv_change_show include:{agreement,design,artifactOnly:true}` returned the index with `readable: false` and `_artifactsError: "Temporal operation exceeded 1500ms timeout"` on every attempt, including solo calls with no parallel contention |
+| 2 | Briefing-packet generation failed permanently | `_briefingPacketError: "Temporal operation exceeded 8000ms timeout"` |
+| 3 | Writes reported timeout but landed | `adv_task_update` returned `ToolExecutionTimeout` at 10000ms on nearly every call; re-reading always showed the mutation applied |
+| 4 | Durable test evidence did not persist | `adv_run_test` returned run IDs but durable records were absent, yielding `consumer_warnings: [{kind: "verification_missing"}]` for runs that genuinely executed and passed |
+| 5 | Acceptance readiness projection froze | Gate refused with `VERIFICATION_EVIDENCE_MISSING` and did not clear after either documented remediation, though both returned `success: true` |
+| 6 | Worktree deletion timed out | `adv_worktree_delete` timed out at 8000ms on both dry-run and apply; cleanup completed with raw git |
+
+### 2.1 The lane-disabling consequence of symptom 2
+
+This one deserves separate billing because it is not merely slow — it is a **capability loss**.
+
+The `adv-designer` lane hard-requires an authoritative BRIEFING PACKET plus an
+`IMPLEMENTATION_RECEIPT` with active cycle provenance, and refuses to begin without them.
+Because briefing-packet hydration could not complete, the designer lane refused every
+dispatch with a packet defect:
+
+```
+packet_defect: required frontend follow-up implementation provenance is missing
+```
+
+All frontend UI work in the change had to be rerouted to `adv-engineer`. The work completed
+correctly, but a degraded *read* path silently removed the specialist lane that repo law
+(`AGENTS.md` UI Laws) points frontend work at. Nothing announced this; it surfaced only as a
+sub-agent refusal that looked like a packet-authoring mistake.
+
+## 3. Root cause
+
+The acceptance-gate failure is the most diagnostic instance and was traced across three
+`adv-temporal-repair` engagements.
+
+The acceptance readiness evaluator reads a **workflow-only projection that is not persisted
+in the durable change snapshot**. `adv_gate_status` surfaces this directly:
+
+```json
+"_unavailable": [
+  { "scope": "gateCriteria", "reason": "workflow-only projection; not persisted in durable change snapshot" },
+  { "scope": "acceptanceCriteriaProjection", "reason": "workflow-only projection; not persisted in durable change snapshot" }
+]
+```
+
+That projection was computed at gate-enter, `03:59:43Z`. The clean attempt-3 report and the
+typed verification disposition both landed at `04:00:19Z` — after gate-enter. Both were
+present in durable state (`adv_task_show` showed attempt 3 with no `consumer_warnings`), and
+both were invisible to the frozen evaluator.
+
+### 3.1 The decisive evidence — a signal asymmetry
+
+Within a single gate-completion sequence, two blockers behaved differently:
+
+| Signal | Blocker | Outcome |
+|---|---|---|
+| `contractReviewMatrixSetSignal` via `adv_contract_review_matrix_set` | `ACCEPTANCE_REVIEW_MATRIX_MISSING` | **Cleared** between retries |
+| report-submit + `adv_verification_evidence_disposition` | `VERIFICATION_EVIDENCE_MISSING` | **Did not clear**, both returned `success: true` |
+
+Same workflow, same gate, same retry window. The contract-review-matrix path refreshes its
+portion of the projection; the verification-evidence path does not. This rules out
+"the signal never arrived" as a general explanation and localizes the defect to
+signal→projection propagation for the verification-evidence channel.
+
+### 3.2 Contributing factor — queue contention
+
+`adv_doctor` reported 27+ tracked session queues active on the worker. Parallel Temporal
+reads reliably contended: the same `adv_task_show` call that timed out when issued alongside
+another read succeeded when issued alone. Confirmed twice.
+
+This does not explain symptoms 1, 2 and 5 (which failed solo), but it compounded everything.
+
+### 3.3 Why nothing caught it
+
+`adv_doctor` reported `healthy` throughout: `server_alive`, `worker_alive`,
+`queue_serviceable`, `search_attributes_ok` all true, `poisoned_workflows: []`,
+`can_conclude_clean: true`.
+
+Liveness checks do not measure read latency, projection freshness, or signal-to-projection
+propagation. The only surface an operator would consult gave positive assurance while six
+distinct read paths were failing.
+
+### 3.4 Ruled out
+
+- **Poisoned history** — `adv_wip_state` returned `poisoned_workflows: []`.
+- **Phantom / lost state** — change was real, `claim_inventory.completeness: "complete"`.
+- **Unhealthy worker** — `adv_doctor` healthy, and writes consistently landed.
+- **Wrong `concernKey`** — schema explicitly specifies `"verification"`; that value was used.
+- **Missing test evidence** — evidence existed and was durably recorded (`tr_mscp6lea_1c7946e5`, `evidenceRecording.status: "recorded"`).
+
+## 4. Impact
+
+- An entire agent lane (`adv-designer`) was silently disabled by a degraded read path.
+- Approved contract text (AC/constraints/avoidances) was unreachable through the documented
+  path, nearly forcing execution against inferred acceptance criteria. It was recovered only
+  because a `documents` field on the disk snapshot happened to carry the full artifact text.
+- Genuine passing test evidence was recorded as missing, then blocked a gate.
+- A correctly applied remediation appeared to fail, driving a repair engagement that
+  recommended an approval-gated `adv_change_reenter` the user would have had to approve.
+- Every write required a defensive verification read, roughly doubling tool calls.
+- `adv_doctor` gave false assurance throughout.
+
+## 5. Proposed scope
+
+1. **Refresh-on-signal.** Refresh or invalidate the acceptance/release readiness projection
+   when verification-evidence signals land, matching the behavior
+   `contractReviewMatrixSetSignal` already demonstrates.
+2. **Report "latest" resolution.** Determine whether it resolves per agent-lane. If it does,
+   a stale error report from a lane that never ran (the `adv-designer` attempt-1 error report
+   here) can block acceptance regardless of a clean report from the lane that did the work.
+   Either scope the check to lanes that produced work, or document the rule explicitly.
+3. **Revisit short internal deadlines.** Failing permanently at 1500ms for artifact hydration
+   is worse than taking 4000ms, especially when the fallback is "the agent cannot read the
+   approved contract".
+4. **Make degraded reads legible.** A caller receiving `readable: false` should be able to
+   distinguish transient contention from hard failure. `adv_doctor` should report read latency
+   and projection freshness, not liveness alone.
+5. **Decouple lane preconditions from fallible reads.** A degraded read path must not silently
+   disable an agent lane. Either decouple the `adv-designer` packet precondition, or give the
+   orchestrator a supported way to construct the packet when hydration is unavailable.
+
+## 6. Success criteria (draft)
+
+1. A verification-evidence disposition or warning-free report submitted after gate-enter is
+   reflected in readiness evaluation without re-entering the gate.
+2. Artifact and briefing-packet hydration either succeed under realistic worker load or
+   report a typed, actionable degraded state distinguishable from hard failure.
+3. `adv_doctor` surfaces read-latency and projection-staleness signals.
+4. A degraded read path cannot silently disable an agent lane.
+
+**Non-goals:** rewriting the Temporal integration wholesale; eliminating the workflow-only
+projection concept. The fix is refresh-on-signal plus legibility.
+
+## 7. Related — cross-project change creation is broken
+
+Filing this as a proper ADV change from the pokeedge-web session failed:
+
+```
+adv_change_create target_path:/home/jon/dev/advance
+→ Failed to create target project change at /home/jon/dev/advance:
+  TemporalOperationContext.projectId mismatch: context 'bdf259aa162ae192af5b18899ccdc653b085528d'
+  does not belong to owner '67fe3e95bc2afb49e94cada183986fa1712e47d5'
+```
+
+The target store resolved the Advance project's ID (`bdf259aa…`) but validated it against the
+**session** project's owner (`67fe3e95…` = pokeedge-web). This is a structural rejection, not a
+timeout, and it is plausibly the same project-context/target-store family as the above. Worth
+capturing as its own change — it is why this document exists as a file instead of an ADV change.
+
+## 8. Provenance
+
+- Session: pokeedge-web, change `disableValueMetricSurfaces`, 2026-08-03.
+- Shipped successfully despite the degradation: PR #692, squash `de044101`, merged to `main`.
+- Three `adv-temporal-repair` engagements; the third produced the projection-freeze diagnosis.
+- Resolution that finally cleared the gate: re-firing
+  `adv_verification_evidence_disposition` after `adv_doctor` confirmed worker health. The
+  second firing propagated where the first had not — consistent with a transient propagation
+  window rather than a permanent channel break.


### PR DESCRIPTION
Two incident write-ups sourced from the pokeedge-web `disableValueMetricSurfaces` session of 2026-08-03. Both are **drafts intended to become ADV changes** — they are filed as documents because cross-project change creation into this repo currently fails (see below).

## `rca-temporal-stale-projection-reads.md`

Acceptance readiness evaluation reads a workflow-only projection computed at gate-enter and never refreshed. A clean report and a typed verification disposition, both submitted after gate-enter and both returning `success: true`, were invisible to it.

The decisive evidence is a signal asymmetry within a single gate-completion sequence: `contractReviewMatrixSetSignal` refreshed its portion of the projection and cleared its blocker, while the verification-evidence channel did not.

Also covers five other symptoms from the same session — artifact hydration failing permanently at a 1500ms internal deadline, briefing-packet hydration failing at 8000ms (which **silently disabled the `adv-designer` lane entirely**, forcing all frontend work to `adv-engineer`), writes reporting timeout while landing, durable `adv_run_test` evidence not persisting, and `adv_worktree_delete` timing out.

`adv_doctor` reported `healthy` throughout all of it.

## `rca-archive-merge-authority-gap.md`

`adv_change_archive` arms GitHub auto-merge on its `pr_auto_merge` route. The ADV orchestrator prompt states that archive sign-off does *not* grant merge authority. Both cannot be right.

In the observed session the outcome was correct and desired, but reached by the tool doing what the orchestrator had been explicitly instructed not to do. Also documents a secondary finding: the release gate stays `pending` after a successful archive and needs an explicit `adv_gate_complete` once merge reachability is proven.

## Why these are docs and not ADV changes

```
adv_change_create target_path:/home/jon/dev/advance
→ TemporalOperationContext.projectId mismatch: context 'bdf259aa…'
  does not belong to owner '67fe3e95…'
```

The target store resolved this project's ID but validated it against the session project's owner. Plausibly the same project-context family as the first RCA; worth its own change.

## Note

Docs-only. No code, no spec deltas, no behavior change.