### PR TITLE
fix(status): bound unconditional archive load and health pre-ranking reads

### DIFF
--- a/plugin/src/storage/store-temporal/changes.ts
+++ b/plugin/src/storage/store-temporal/changes.ts
@@ -114,6 +114,7 @@ import {
   BatchCloseOperationSchema,
 } from "./batch-close-coordinator";
 import { computeCreationRequestHash } from "./creation-hash";
+import type { TemporalReadDeadline } from "../../temporal/retry-wrapper";
 
 // Command outcomes surfaced by the changeCommand primitive:
 // accepted, idempotent_replay, rejected, projection_failure,
@@ -526,12 +527,16 @@ interface ChangeListFilter {
   offset?: number;
   /** Internal caller-specific cap for per-change hydration. */
   validationConcurrency?: number;
+  /** Request-scoped deadline shared with an enclosing status read. */
+  deadline?: TemporalReadDeadline | TemporalReadContext;
 }
 
 interface ListChangeSummariesResult {
   summaries: ChangeSummaryShard[];
   totalIds: number;
   warnings?: TerminalWarning[];
+  statusCounts?: Record<ChangeStatus, number>;
+  boundedOmittedIds?: string[];
 }
 
 /**
@@ -551,6 +556,8 @@ async function listChangeSummaries(
     forceSort?: "recency" | "stalest" | "default";
     /** Enable offset/limit pagination (listSummary); list() currently ignores them. */
     paginate?: boolean;
+    /** Cap rows before downstream hydration while retaining API offset semantics. */
+    candidateLimit?: number;
   } = {},
 ): Promise<ListChangeSummariesResult> {
   const summaryResult = await listSummaryChanges(paths);
@@ -578,6 +585,15 @@ async function listChangeSummaries(
       message: `${warning.kind} summary document at ${warning.path}${warning.error ? `: ${warning.error}` : ""}${warning.actual ? ` (${warning.actual} bytes)` : ""}`,
       omittedCount: 1,
     })) ?? [];
+
+  const statusCounts: Record<ChangeStatus, number> = {
+    draft: 0,
+    archived: 0,
+    closed: 0,
+  };
+  for (const summary of summaryResult.summaries) {
+    statusCounts[summary.status] = (statusCounts[summary.status] ?? 0) + 1;
+  }
 
   const requestedStatus =
     filter?.status === "active" || filter?.status === "pending"
@@ -636,24 +652,37 @@ async function listChangeSummaries(
     );
   });
 
+  const boundedOmittedIds =
+    options.candidateLimit === undefined
+      ? undefined
+      : filtered.slice(options.candidateLimit).map((summary) => summary.id);
+  const boundedFiltered =
+    options.candidateLimit === undefined
+      ? filtered
+      : filtered.slice(0, Math.max(0, options.candidateLimit));
+
   if (options.paginate) {
     const offset = Math.max(0, filter?.offset ?? 0);
     const limit =
       filter?.limit === undefined ? undefined : Math.max(0, filter.limit);
     return {
-      summaries: filtered.slice(
+      summaries: boundedFiltered.slice(
         offset,
         limit === undefined ? undefined : offset + limit,
       ),
       totalIds: summaryResult.summaries.length,
       warnings: baseWarnings.length > 0 ? baseWarnings : undefined,
+      statusCounts,
+      ...(boundedOmittedIds ? { boundedOmittedIds } : {}),
     };
   }
 
   return {
-    summaries: filtered,
+    summaries: boundedFiltered,
     totalIds: summaryResult.summaries.length,
     warnings: baseWarnings.length > 0 ? baseWarnings : undefined,
+    statusCounts,
+    ...(boundedOmittedIds ? { boundedOmittedIds } : {}),
   };
 }
 
@@ -799,14 +828,30 @@ async function readProjectionChangeList(
     forceSort?: "recency" | "stalest" | "default";
     paginate?: boolean;
     includeHydrationStats?: boolean;
+    deadline?: TemporalReadDeadline | TemporalReadContext;
+    candidateLimit?: number;
+    loadArchiveForActiveShadow?: boolean;
   },
 ): Promise<
-  ChangeListResponse & { sourceRankedIds?: string[]; totalIds?: number }
+  ChangeListResponse & {
+    sourceRankedIds?: string[];
+    totalIds?: number;
+    statusCounts?: Record<ChangeStatus, number>;
+    boundedOmittedIds?: string[];
+  }
 > {
   const { input: _input, legacy, memo, getTemporalChange } = deps;
 
-  const deadline = createTemporalReadDeadline(TEMPORAL_READ_DEADLINE_BUDGET_MS);
-  const ctx = createTemporalReadContext(deadline.budgetMs);
+  const suppliedRead = options.deadline;
+  const ctx = suppliedRead
+    ? "abortController" in suppliedRead
+      ? suppliedRead
+      : createTemporalReadContext(suppliedRead.budgetMs)
+    : createTemporalReadContext(TEMPORAL_READ_DEADLINE_BUDGET_MS);
+  if (suppliedRead && !("abortController" in suppliedRead)) {
+    ctx.deadline = suppliedRead;
+  }
+  const deadline = ctx.deadline;
   const expired = (): boolean => isTemporalReadExpired(ctx);
 
   const requestedStatus =
@@ -827,7 +872,10 @@ async function readProjectionChangeList(
   const summaryResult = await listChangeSummaries(filter, paths, {
     caseInsensitivePrefix: options.caseInsensitivePrefix,
     forceSort: options.forceSort,
+    // Apply API pagination after combining durable sources. Candidate bounds
+    // are applied before hydration without consuming the requested offset.
     paginate: false,
+    candidateLimit: options.candidateLimit,
   });
 
   const summaryRows = new Map<string, ChangeListResponse["changes"][number]>();
@@ -843,10 +891,16 @@ async function readProjectionChangeList(
 
   // Collect candidate IDs from every durable/advisory source.
   const candidateIds = new Set<string>(summaryRows.keys());
-  for (const summary of memo.getAll()) candidateIds.add(summary.id);
+  if (options.candidateLimit === undefined) {
+    for (const summary of memo.getAll()) candidateIds.add(summary.id);
+  }
 
   const addSourceIds = (ids: string[]): void => {
-    for (const id of ids) candidateIds.add(id);
+    const sourceIds =
+      options.candidateLimit === undefined
+        ? ids
+        : ids.slice(0, Math.max(0, options.candidateLimit));
+    for (const id of sourceIds) candidateIds.add(id);
   };
 
   // Disk active projections.
@@ -879,13 +933,23 @@ async function readProjectionChangeList(
     string,
     { dir: string; change: Change }
   >();
-  if (legacy.paths.archive) {
+  if (
+    (wantsTerminalStatuses || options.loadArchiveForActiveShadow) &&
+    legacy.paths.archive
+  ) {
     try {
       const archiveDirs = await raceWithTemporalDeadline(
         listChangeDirs(legacy.paths.archive),
         deadline,
       );
       for (const dir of archiveDirs) {
+        // The race around each load protects the I/O itself. This admission
+        // check prevents an expired request from starting the next candidate.
+        if (expired()) {
+          deadlineOmissions.push(dir);
+          degradedSources.add("archive");
+          break;
+        }
         const loaded = await raceWithTemporalDeadline(
           loadChange(legacy.paths.archive, dir),
           deadline,
@@ -1121,6 +1185,12 @@ async function readProjectionChangeList(
       ? { hydrationStats }
       : {}),
     totalIds: allIds.length,
+    ...(summaryResult.statusCounts
+      ? { statusCounts: summaryResult.statusCounts }
+      : {}),
+    ...(summaryResult.boundedOmittedIds
+      ? { boundedOmittedIds: summaryResult.boundedOmittedIds }
+      : {}),
   };
 }
 
@@ -1538,6 +1608,9 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
           forceSort: "default",
           // list() does not paginate today.
           paginate: false,
+          // Active list output still uses archive bundles to dominate stale
+          // active projections; routine status summaries do not need this.
+          loadArchiveForActiveShadow: true,
         },
       );
       const { changes, warnings, hydrationStats } = projection;
@@ -2008,6 +2081,11 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
           paginate: true,
           // Summary API always carries hydration stats.
           includeHydrationStats: true,
+          deadline: filter?.deadline,
+          candidateLimit:
+            filter?.limit === undefined
+              ? undefined
+              : Math.max(0, (filter.offset ?? 0) + filter.limit),
         },
       );
       const { changes, warnings, hydrationStats } = projection;
@@ -2015,6 +2093,12 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
         changes,
         ...(warnings ? { warnings } : {}),
         ...(hydrationStats ? { hydrationStats } : {}),
+        ...(projection.statusCounts
+          ? { statusCounts: projection.statusCounts }
+          : {}),
+        ...(projection.boundedOmittedIds
+          ? { boundedOmittedIds: projection.boundedOmittedIds }
+          : {}),
       };
     },
     /**

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -28,6 +28,7 @@ import {
   listSourceRankedCandidates,
   type SourceRankedCandidate,
 } from "../../temporal/list-source-ranked-candidates";
+import { listSummaryChanges } from "../change-summary-shard-reader";
 import { mapWithConcurrency } from "../../utils/concurrency";
 import {
   ChangeSummaryMemo,
@@ -979,53 +980,58 @@ export function createTemporalStoreBackend(
     const memoIds = memoAll.map((s) => s.id);
 
     let visibilityIds: string[] = [];
-    if (!options?.sourceRanked) {
-      try {
-        const owner = getOwner();
-        const listCtx = makeTemporalOperationContext(
-          input.projectId,
-          "visibility-list",
-          "list",
-          "visibilityList",
-          5_000,
-        );
-        const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${input.projectId}/`;
-        const query = buildVisibilityQuery({
-          projectId: input.projectId,
-          statuses: wantsTerminalStatuses ? null : undefined,
-        });
-        visibilityIds = await runTemporal(
-          async () => {
-            const ids: string[] = [];
-            const outcome = await owner.list<{ workflowId: string }>(
-              listCtx,
-              query,
-            );
-            if (outcome.kind !== "complete") {
-              throw new TemporalListOutcomeError(outcome);
-            }
-            for (const wf of outcome.value) {
-              const wfid = wf.workflowId;
-              if (!wfid.startsWith(projectPrefix)) continue;
-              const changeId = wfid.slice(projectPrefix.length);
-              if (changeId.length === 0) continue;
-              ids.push(changeId);
-            }
-            return ids;
-          },
-          { deadline: ctx.deadline, timeoutMs: 5_000 },
-        );
-      } catch (err) {
-        const hitDeadline =
-          err instanceof TemporalQueryTimeoutError || expired();
-        logger.warn(
-          `[P2.4] Visibility list ${
-            hitDeadline ? "exceeded the aggregate read deadline" : "failed"
-          }; falling back to legacy disk scan: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        degradedSources.add("visibility");
-        if (hitDeadline) markDeadline("visibility");
-      }
+    const visibilityRecords: Array<{
+      id: string;
+      searchAttributes?: Record<string, unknown>;
+    }> = [];
+    try {
+      const owner = getOwner();
+      const listCtx = makeTemporalOperationContext(
+        input.projectId,
+        "visibility-list",
+        "list",
+        "visibilityList",
+        5_000,
+      );
+      const projectPrefix = `${CHANGE_WORKFLOW_PREFIX}${input.projectId}/`;
+      const query = buildVisibilityQuery({
+        projectId: input.projectId,
+        statuses: wantsTerminalStatuses ? null : undefined,
+      });
+      visibilityIds = await runTemporal(
+        async () => {
+          const ids: string[] = [];
+          const outcome = await owner.list<{
+            workflowId: string;
+            searchAttributes?: Record<string, unknown>;
+          }>(listCtx, query);
+          if (outcome.kind !== "complete") {
+            throw new TemporalListOutcomeError(outcome);
+          }
+          for (const wf of outcome.value) {
+            const wfid = wf.workflowId;
+            if (!wfid.startsWith(projectPrefix)) continue;
+            const changeId = wfid.slice(projectPrefix.length);
+            if (changeId.length === 0) continue;
+            ids.push(changeId);
+            visibilityRecords.push({
+              id: changeId,
+              searchAttributes: wf.searchAttributes,
+            });
+          }
+          return ids;
+        },
+        { deadline: ctx.deadline, timeoutMs: 5_000 },
+      );
+    } catch (err) {
+      const hitDeadline = err instanceof TemporalQueryTimeoutError || expired();
+      logger.warn(
+        `[P2.4] Visibility list ${
+          hitDeadline ? "exceeded the aggregate read deadline" : "failed"
+        }; falling back to legacy disk scan: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      degradedSources.add("visibility");
+      if (hitDeadline) markDeadline("visibility");
     }
 
     // Disk enumeration is typically fast local I/O (one readdir per path)
@@ -1095,8 +1101,68 @@ export function createTemporalStoreBackend(
       candidateLimit !== undefined &&
       !wantsTerminalStatuses
     ) {
-      const diskCandidates = await mapWithConcurrency(
-        diskIds,
+      // Visibility already supplies source-backed descriptors for the IDs it
+      // knows about. Do not re-read those IDs from change.json: only disk-only
+      // candidates need disk projection metadata for source ranking.
+      const visibleIdSet = new Set(visibilityIds);
+      const diskOnlyIds = diskIds.filter((id) => !visibleIdSet.has(id));
+
+      // Prefer the durable summary index, whose last_activity_at is the same
+      // source-backed recency signal used by the projection. listSummaryChanges
+      // reads pointer/shard JSON, not change.json, so it can orient an entire
+      // indexed disk corpus without violating the bounded hydration budget.
+      const summaryCandidates: SourceRankedCandidate[] = [];
+      const indexedDiskIds = new Set<string>();
+      try {
+        const summaryResult = await raceWithTemporalDeadline(
+          listSummaryChanges({
+            changesDir: legacy.paths.changes,
+            summariesDir: legacy.paths.summariesDir,
+          }),
+          deadline,
+        );
+        if (summaryResult.kind === "ok") {
+          const diskOnlySet = new Set(diskOnlyIds);
+          for (const summary of summaryResult.summaries) {
+            if (!diskOnlySet.has(summary.id)) continue;
+            indexedDiskIds.add(summary.id);
+            summaryCandidates.push({
+              id: summary.id,
+              source: "disk",
+              lastSignalAt: summary.last_activity_at,
+              createdAt: summary.created_at,
+            });
+          }
+        } else {
+          degradedSources.add("active_disk");
+        }
+      } catch (err) {
+        const hitDeadline =
+          err instanceof TemporalQueryTimeoutError || expired();
+        degradedSources.add("active_disk");
+        if (hitDeadline) markDeadline("active_disk");
+      }
+
+      // Unindexed disk projections have no source-backed ordering metadata.
+      // Hydrate at most candidateLimit of them as a bounded fallback, and
+      // classify the remainder as omitted rather than claiming global
+      // completeness. This preserves exact ranking whenever the summary index
+      // covers the disk-only corpus, while making the incomplete case visible.
+      const unindexedDiskIds = diskOnlyIds.filter(
+        (id) => !indexedDiskIds.has(id),
+      );
+      const fallbackDiskIds = unindexedDiskIds.slice(0, candidateLimit);
+      for (const id of unindexedDiskIds.slice(candidateLimit)) {
+        candidateResolutions.push({
+          id,
+          terminal: false,
+          omitted: true,
+          omissionReason: "bounded",
+        });
+      }
+
+      const fallbackDiskCandidates = await mapWithConcurrency(
+        fallbackDiskIds,
         4,
         async (id): Promise<SourceRankedCandidate> => {
           if (expired()) return { id, source: "disk" };
@@ -1131,6 +1197,7 @@ export function createTemporalStoreBackend(
           }
         },
       );
+      const diskCandidates = [...summaryCandidates, ...fallbackDiskCandidates];
       try {
         const ranked = await raceWithTemporalDeadline(
           listSourceRankedCandidates(getOwner(), {
@@ -1138,6 +1205,7 @@ export function createTemporalStoreBackend(
             statuses: undefined,
             limit: candidateLimit,
             diskCandidates,
+            visibilityRecords,
           }),
           deadline,
         );

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -1772,24 +1772,28 @@ export function createTemporalStoreBackend(
       };
     }
 
-    // Status needs the full unbounded summary set for accurate counts.
-    // The recent list is sliced afterwards and any truncation is typed.
+    // Summary shards carry lifecycle status, so counts do not require deep
+    // hydration of the full change corpus. The caller-provided recent limit
+    // is applied by listSummary before candidate hydration.
     const summary = await changeOps.listSummary!({
       sort: "recency",
+      ...(options?.recentLimit !== undefined
+        ? { limit: options.recentLimit }
+        : {}),
+      ...(options?.deadline ? { deadline: options.deadline } : {}),
     });
-    const { changes, warnings: summaryWarnings, hydrationStats } = summary;
+    const {
+      changes,
+      warnings: summaryWarnings,
+      hydrationStats,
+      boundedOmittedIds,
+    } = summary;
     const now = new Date();
-    const byStatus: Record<ChangeStatus, number> = {
+    const byStatus: Record<ChangeStatus, number> = summary.statusCounts ?? {
       draft: 0,
       archived: 0,
       closed: 0,
     };
-
-    for (const change of changes) {
-      // Finite-accumulation guard: stay NaN-safe even if a status key is
-      // ever missing from the initializer above (e.g. enum narrowing).
-      byStatus[change.status] = (byStatus[change.status] ?? 0) + 1;
-    }
 
     const sortedRecent = changes
       .filter(
@@ -1815,28 +1819,24 @@ export function createTemporalStoreBackend(
         return cmp !== 0 ? cmp : a.id.localeCompare(b.id);
       });
 
-    const recentLimit = options?.recentLimit;
-    const recent =
-      recentLimit !== undefined
-        ? sortedRecent.slice(0, recentLimit)
-        : sortedRecent;
+    const recent = sortedRecent;
 
     const warnings: import("../../types").TerminalWarning[] = [
       ...(summaryWarnings ?? []),
     ];
     let boundedOmitted = 0;
-    if (recentLimit !== undefined && sortedRecent.length > recentLimit) {
-      boundedOmitted = sortedRecent.length - recentLimit;
-      const omittedIds = sortedRecent
-        .slice(recentLimit)
-        .map((r) => r.id)
-        .slice(0, 20);
+    if (
+      options?.recentLimit !== undefined &&
+      boundedOmittedIds &&
+      boundedOmittedIds.length > 0
+    ) {
+      boundedOmitted = boundedOmittedIds.length;
       warnings.push({
         code: "SOURCE_BOUND_EXCEEDED",
-        source: "workflow_query",
-        message: `Read bound (${recentLimit} candidate(s)) truncated ${boundedOmitted} candidate(s); counts and recency are incomplete.`,
+        source: "active_disk",
+        message: `Read bound (${options.recentLimit} candidate(s)) limited recent change hydration; ${boundedOmitted} recent candidate(s) were omitted while lifecycle counts remained sourced from summary shards.`,
         omittedCount: boundedOmitted,
-        omittedIds,
+        omittedIds: boundedOmittedIds.slice(0, 20),
       });
     }
 

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -1773,10 +1773,9 @@ export function createTemporalStoreBackend(
         );
       }
       const candidateLimit = Math.min(rawLimit, 10);
-      const ctx = createTemporalReadContext(options.deadline?.budgetMs);
       const resolved = await listResolvedChanges(
         { includeArchived: false, includeClosed: false },
-        ctx,
+        options.deadline ?? createTemporalReadContext(),
         { candidateLimit, sourceRanked: true },
       );
 

--- a/plugin/src/storage/store-types.ts
+++ b/plugin/src/storage/store-types.ts
@@ -315,9 +315,12 @@ export interface ReadStore extends StoreBase {
       sort?: "recency" | "stalest" | "default";
       limit?: number;
       offset?: number;
+      deadline?: TemporalReadDeadline;
     }) => Promise<
       ChangeListResponse & {
         hydrationStats?: import("../types").HydrationStats;
+        statusCounts?: Record<"draft" | "archived" | "closed", number>;
+        boundedOmittedIds?: string[];
       }
     >;
     listConflictAuthority?: (options?: {
@@ -834,9 +837,12 @@ export interface Store extends ReadStore, CommandStore {
       sort?: "recency" | "stalest" | "default";
       limit?: number;
       offset?: number;
+      deadline?: TemporalReadDeadline;
     }) => Promise<
       ChangeListResponse & {
         hydrationStats?: import("../types").HydrationStats;
+        statusCounts?: Record<"draft" | "archived" | "closed", number>;
+        boundedOmittedIds?: string[];
       }
     >;
   };

--- a/plugin/src/temporal/list-source-ranked-candidates.ts
+++ b/plugin/src/temporal/list-source-ranked-candidates.ts
@@ -36,6 +36,11 @@ export interface ListSourceRankedCandidatesOptions {
   limit?: number;
   /** Durable active projections not currently visible in the running workflow set. */
   diskCandidates?: SourceRankedCandidate[];
+  /** Visibility descriptors already collected by the caller's list pass. */
+  visibilityRecords?: Array<{
+    id: string;
+    searchAttributes?: Record<string, unknown>;
+  }>;
 }
 
 export interface ListSourceRankedCandidatesResult {
@@ -124,14 +129,22 @@ export async function listSourceRankedCandidates(
   );
   const candidates: SourceRankedCandidate[] = [];
   const seenIds = new Set<string>();
-  const result = await owner.list<{
-    workflowId: string;
-    searchAttributes?: Record<string, unknown>;
-  }>(ctx, query, { limit: effectiveLimit * 2 });
-  if (result.kind !== "complete") {
-    throw result.error;
-  }
-  for (const record of result.value) {
+  const visibilityRecords = options.visibilityRecords
+    ? options.visibilityRecords.map((record) => ({
+        workflowId: `${projectPrefix}${record.id}`,
+        searchAttributes: record.searchAttributes,
+      }))
+    : await (async () => {
+        const result = await owner.list<{
+          workflowId: string;
+          searchAttributes?: Record<string, unknown>;
+        }>(ctx, query, { limit: effectiveLimit * 2 });
+        if (result.kind !== "complete") {
+          throw result.error;
+        }
+        return result.value;
+      })();
+  for (const record of visibilityRecords) {
     const wfid = record.workflowId;
     // Defensive prefix filter: Visibility may return workflows that match the
     // search attributes but belong to a different project or workflow type.

--- a/plugin/src/tools/status-health-plan.ts
+++ b/plugin/src/tools/status-health-plan.ts
@@ -11,6 +11,7 @@
 
 import type { Store } from "../storage/store";
 import type { ProbeCacheFreshness } from "./probe-cache";
+import type { TemporalReadDeadline } from "../temporal/retry-wrapper";
 import {
   createHealthProbeCache,
   type HealthProbeCache,
@@ -789,10 +790,9 @@ export async function runHealthStatus(
 
 export function buildHealthStatusDeadline(
   request: HealthRequestContext = createHealthRequestContext(),
-): {
-  budgetMs: number;
-  deadlineAt: number;
-} {
+  sharedDeadline?: TemporalReadDeadline,
+): TemporalReadDeadline {
+  if (sharedDeadline) return sharedDeadline;
   return {
     budgetMs: HEALTH_EXECUTION_CUTOFF_MS,
     deadlineAt: request.cutoffTime,
@@ -801,16 +801,15 @@ export function buildHealthStatusDeadline(
 
 export function buildHealthStatusReadOptions(
   request: HealthRequestContext = createHealthRequestContext(),
-):
-  | {
-      recentLimit: number;
-      deadline: { budgetMs: number; deadlineAt: number };
-      sourceRanked: true;
-    }
-  | undefined {
+  sharedDeadline?: TemporalReadDeadline,
+): {
+  recentLimit: number;
+  deadline: TemporalReadDeadline;
+  sourceRanked: true;
+} {
   return {
     recentLimit: HEALTH_CANDIDATE_LIMIT,
-    deadline: buildHealthStatusDeadline(request),
+    deadline: buildHealthStatusDeadline(request, sharedDeadline),
     sourceRanked: true,
   };
 }

--- a/plugin/src/tools/status-host-cap.test.ts
+++ b/plugin/src/tools/status-host-cap.test.ts
@@ -1,0 +1,506 @@
+/**
+ * RED reproduction for the adv_status host safety-net timeout.
+ *
+ * This keeps the production composition intact: createToolMap binds the real
+ * adv_status implementation through the real safeExecute wrapper, while the
+ * Temporal client and probe/spec boundaries are deterministic test fixtures.
+ * No real Temporal service or ambient project state is used.
+ */
+
+process.env.ADV_TOOL_MAX_CHARS = "1000000";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  cleanupTempDir,
+  createTempDir,
+  createTestProject,
+  parseToolOutput,
+  SAMPLE_CHANGE,
+} from "../__tests__/setup";
+import { createDiskStore } from "../storage/store-disk";
+import { createTemporalStoreBackend } from "../storage/store-temporal";
+import type { Store } from "../storage/store";
+import { createMockOwnerFromClient } from "../temporal/__tests__/mock-owner";
+import { createToolMap } from "../tool-registry";
+
+const PROJECT_ID = "0000000000000000000000000000000000000000";
+const VIEWS = ["summary", "health", "changes", "hygiene"] as const;
+const BOUNDARY_DELAY_MS = 6_000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const {
+  mockGetTemporalHealth,
+  mockGetWorktreeCensus,
+  mockScanSnapshotHealth,
+  mockGetPluginRuntimeInfo,
+  mockListPeerSessions,
+  mockEnumerateAdvWorkerProcesses,
+} = vi.hoisted(() => ({
+  mockGetTemporalHealth: vi.fn(),
+  mockGetWorktreeCensus: vi.fn(),
+  mockScanSnapshotHealth: vi.fn(),
+  mockGetPluginRuntimeInfo: vi.fn(),
+  mockListPeerSessions: vi.fn(),
+  mockEnumerateAdvWorkerProcesses: vi.fn(),
+}));
+
+const mockSpecsConfig = vi.hoisted(() => ({ delayMs: 0 }));
+const mockListConfig = vi.hoisted(() => ({ delayMs: 0 }));
+const mockProbeConfig = vi.hoisted(() => ({ delayMs: 0 }));
+const { archiveLoadChangeCalls, sourceRankedProjectionReads } = vi.hoisted(
+  () => ({
+    archiveLoadChangeCalls: [] as string[],
+    sourceRankedProjectionReads: [] as string[],
+  }),
+);
+
+vi.mock("../temporal/health-probe", () => ({
+  getTemporalHealth: (...args: unknown[]) => mockGetTemporalHealth(...args),
+  isWorkerAffirmativelyAlive: (worker: {
+    status: "available" | "unavailable";
+    value?: boolean;
+  }) => worker.status === "available" && worker.value === true,
+}));
+
+vi.mock("../utils/worktree-census", () => ({
+  getWorktreeCensus: (...args: unknown[]) => mockGetWorktreeCensus(...args),
+}));
+
+vi.mock("./snapshot-scan", () => ({
+  scanSnapshotHealth: (...args: unknown[]) => {
+    return (async () => {
+      if (mockProbeConfig.delayMs > 0) await sleep(mockProbeConfig.delayMs);
+      return mockScanSnapshotHealth(...args);
+    })();
+  },
+}));
+
+vi.mock("../utils/plugin-runtime-info", () => ({
+  getPluginRuntimeInfo: (...args: unknown[]) =>
+    mockGetPluginRuntimeInfo(...args),
+}));
+
+vi.mock("./session/index", () => ({
+  listPeerSessions: (...args: unknown[]) => mockListPeerSessions(...args),
+}));
+
+vi.mock("../utils/tool-lane-projection", () => ({
+  getLaneProjections: vi.fn().mockResolvedValue({}),
+  resetLaneProjectionsCache: () => {},
+}));
+
+vi.mock("../utils/worker-process-probe", () => ({
+  enumerateAdvWorkerProcesses: (...args: unknown[]) =>
+    mockEnumerateAdvWorkerProcesses(...args),
+  DEFAULT_WORKER_SCRIPT_MARKER: "dist/temporal/worker.js",
+}));
+
+vi.mock("../utils/opencode-session-debt", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../utils/opencode-session-debt")>();
+  return {
+    ...actual,
+    scanOpenCodeSessionDebt: vi.fn().mockResolvedValue({
+      available: false,
+      db_path: "/missing/opencode.db",
+      checked_at: "2026-05-02T02:30:00.000Z",
+      reason: "not found",
+      threshold_ms: 300_000,
+      total_blank: 0,
+      repairable_stale: [],
+      live_in_flight: [],
+      idle_active_session: [],
+      orphan_ghost: [],
+      ignored_with_parts: [],
+    }),
+  };
+});
+
+vi.mock("../temporal/activities", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../temporal/activities")>();
+  return {
+    ...actual,
+    listSpecsActivity: async (input: any) => {
+      if (mockSpecsConfig.delayMs > 0) await sleep(mockSpecsConfig.delayMs);
+      return actual.listSpecsActivity(input);
+    },
+  };
+});
+
+vi.mock("../storage/change-projection-reader", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../storage/change-projection-reader")
+    >();
+  return {
+    ...actual,
+    loadChange: async (root: string, id: string) => {
+      if (root.includes("/.adv/archive")) {
+        archiveLoadChangeCalls.push(id);
+      }
+      return actual.loadChange(root, id);
+    },
+    readBoundedProjectionDocument: async (filePath: string, limit?: number) => {
+      if (
+        filePath.includes("/.adv/changes/") &&
+        filePath.endsWith("/change.json")
+      ) {
+        sourceRankedProjectionReads.push(filePath);
+      }
+      return actual.readBoundedProjectionDocument(filePath, limit);
+    },
+  };
+});
+
+vi.mock("../temporal/service", () => ({
+  getStslStats: vi.fn().mockReturnValue({
+    getServiceCalls: 0,
+    newConnections: 0,
+    reuseRate: 0,
+    reconnectCount: 0,
+    reconnectFailureCount: 0,
+    opTelemetry: [],
+    saVerification: null,
+  }),
+  isStslInitialized: vi.fn().mockReturnValue(false),
+  getService: vi.fn().mockReturnValue(null),
+  getTemporalWorkerAliveness: vi.fn().mockReturnValue(false),
+  getTemporalWorkerDiagnostics: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("./archive-helpers/git-finalize", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./archive-helpers/git-finalize")>();
+  return {
+    ...actual,
+    resolveRepoRoot: vi.fn().mockReturnValue(null),
+    detectArchivedMergedBranches: vi
+      .fn()
+      .mockReturnValue({ status: "ok", branches: [] }),
+    detectDefaultBranch: vi
+      .fn()
+      .mockReturnValue({ branch: "main", source: "local-main" }),
+    getCheckedOutChangeBranches: vi.fn().mockReturnValue({
+      status: "ok",
+      branches: new Set<string>(),
+      worktreePaths: {},
+    }),
+  };
+});
+
+function buildTemporalHealth(): any {
+  return {
+    server_alive: true,
+    worker_alive: { status: "available", value: false },
+    worker_process_alive: { status: "available", value: false },
+    registered_queues: [],
+    last_op_at: null,
+    last_error: null,
+    fallback_counts: {},
+    stale_queues: [],
+    reconnect_count: 0,
+    op_counters: [],
+    worker_lock: null,
+    last_worker_run_error: null,
+  };
+}
+
+function buildSnapshotHealthResult(): any {
+  return {
+    schema_version: 1,
+    scan_duration_ms: 0,
+    scope: "project",
+    project_id: "unknown",
+    summary: {
+      projects_scanned: 0,
+      bare_repos_scanned: 0,
+      critical: 0,
+      warnings: 0,
+      info: 0,
+    },
+    findings: [],
+  };
+}
+
+function makeTemporalClient() {
+  return {
+    client: {
+      workflow: {
+        getHandle: (workflowId: string) => ({
+          query: async () => {
+            return {
+              id: workflowId.split("/").pop() ?? workflowId,
+              changeId: workflowId.split("/").pop() ?? workflowId,
+              title: "fixture",
+              status: "draft",
+              lifecycleState: "open",
+              createdAt: "2026-01-01T00:00:00.000Z",
+              initializedAt: "2026-01-01T00:00:00.000Z",
+              projectId: PROJECT_ID,
+              tasks: [],
+              deltas: {},
+              wisdom: [],
+              gates: {},
+              reentry_history: [],
+              artifacts: {},
+              documents: {},
+              reflections: [],
+              worktrees: {},
+              conformance: { lockedSpecs: [], overrides: [] },
+              worktree_auto_managed: false,
+            };
+          },
+        }),
+        list: async function* () {
+          if (mockListConfig.delayMs > 0) await sleep(mockListConfig.delayMs);
+          yield {
+            workflowId: `adv/change/${PROJECT_ID}/addFeature`,
+            searchAttributes: {
+              AdvCreatedAt: ["2026-01-01T00:00:00.000Z"],
+              AdvLastSignalAt: ["2026-01-01T00:00:00.000Z"],
+            },
+          };
+        },
+        start: async () => {
+          throw new Error("start should not be called by a status read");
+        },
+      },
+    },
+  };
+}
+
+async function setupStore(tempDir: string): Promise<Store> {
+  const legacy = await createDiskStore(tempDir);
+  const store = createTemporalStoreBackend({
+    legacy,
+    temporal: createMockOwnerFromClient(makeTemporalClient()),
+    projectId: PROJECT_ID,
+  });
+  const realStatus = store.status.bind(store);
+  store.status = async (options) => {
+    await sleep(BOUNDARY_DELAY_MS);
+    return realStatus(options);
+  };
+  const realSpecsList = store.specs.list.bind(store.specs);
+  store.specs.list = async (filter) => {
+    await sleep(BOUNDARY_DELAY_MS);
+    return realSpecsList(filter);
+  };
+  return store;
+}
+
+const ARCHIVED_CORPUS_SIZE = 480;
+const ACTIVE_CORPUS_SIZE = 36;
+
+function corpusChange(
+  id: string,
+  status: "draft" | "archived",
+  index: number,
+): object {
+  const timestamp = new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString();
+  return {
+    ...SAMPLE_CHANGE,
+    id,
+    title: `${status} corpus ${id}`,
+    status,
+    created_at: timestamp,
+    lastSignalAt: timestamp,
+    tasks: [],
+    deltas: {},
+  };
+}
+
+async function setupCorpusStore(tempDir: string): Promise<Store> {
+  const legacy = await createDiskStore(tempDir);
+  if (!legacy.paths.archive) {
+    throw new Error("Corpus fixture requires an archive path");
+  }
+
+  const writeCorpusChange = async (
+    root: string,
+    id: string,
+    status: "draft" | "archived",
+    index: number,
+  ): Promise<void> => {
+    const changeDir = join(root, id);
+    await mkdir(changeDir, { recursive: true });
+    await writeFile(
+      join(changeDir, "change.json"),
+      JSON.stringify(corpusChange(id, status, index)),
+    );
+  };
+
+  await Promise.all([
+    ...Array.from({ length: ARCHIVED_CORPUS_SIZE }, (_, index) =>
+      writeCorpusChange(
+        legacy.paths.archive!,
+        `archived${String(index).padStart(3, "0")}`,
+        "archived",
+        index,
+      ),
+    ),
+    ...Array.from({ length: ACTIVE_CORPUS_SIZE }, (_, index) =>
+      writeCorpusChange(
+        legacy.paths.changes,
+        `active${String(index).padStart(2, "0")}`,
+        "draft",
+        ARCHIVED_CORPUS_SIZE + index,
+      ),
+    ),
+  ]);
+
+  return createTemporalStoreBackend({
+    legacy,
+    temporal: createMockOwnerFromClient(makeTemporalClient()),
+    projectId: PROJECT_ID,
+  });
+}
+
+function resetMocks(): void {
+  mockGetTemporalHealth.mockReset();
+  mockGetTemporalHealth.mockResolvedValue(buildTemporalHealth());
+  mockGetWorktreeCensus.mockReset();
+  mockGetWorktreeCensus.mockResolvedValue({
+    total: 0,
+    stale: [],
+    records: [],
+    warnings: [],
+    classes: {},
+  });
+  mockScanSnapshotHealth.mockReset();
+  mockScanSnapshotHealth.mockResolvedValue(buildSnapshotHealthResult());
+  mockGetPluginRuntimeInfo.mockReset();
+  mockGetPluginRuntimeInfo.mockResolvedValue({
+    loaded_module_path: "/test/dist/index.js",
+    process_started_at: "2026-01-01T00:00:00.000Z",
+    build_marker_path: "/test/oca-build.json",
+    worker_script_path: "/test/worker.js",
+    reload_caveat: "Restart OpenCode",
+    source_dist_freshness: "unknown",
+    plugin_bundle_freshness: "unknown",
+    plugin_bundle_manifest_path: "/test/plugin-bundle-manifest.json",
+    loaded_plugin_generation: "0",
+    deployed_plugin_generation: "0",
+    plugin_bundle_recovery: null,
+  });
+  mockListPeerSessions.mockReset();
+  mockListPeerSessions.mockResolvedValue({ sessions: [] });
+  mockEnumerateAdvWorkerProcesses.mockReset();
+  mockEnumerateAdvWorkerProcesses.mockResolvedValue(null);
+  mockSpecsConfig.delayMs = 0;
+  mockListConfig.delayMs = 0;
+  mockProbeConfig.delayMs = 0;
+  archiveLoadChangeCalls.length = 0;
+  sourceRankedProjectionReads.length = 0;
+}
+
+function parseBoundToolResult(result: unknown): any {
+  const output =
+    typeof result === "string"
+      ? result
+      : result && typeof result === "object" && "output" in result
+        ? (result as { output: string }).output
+        : JSON.stringify(result);
+  return parseToolOutput(output) as any;
+}
+
+describe("adv_status host-cap breach across every view", () => {
+  let tempDir: string;
+  let store: Store | undefined;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    await createTestProject(tempDir, { withChanges: true, withSpecs: true });
+    resetMocks();
+  }, 15_000);
+
+  afterEach(async () => {
+    // safeExecute deliberately cannot cancel an in-flight body after the
+    // host-cap response. Let the deterministic fixture settle before cleanup.
+    await sleep(2_000);
+    store?.close();
+    await cleanupTempDir(tempDir);
+  });
+
+  test.each(VIEWS)(
+    "%s must return complete or typed degraded data before the 10s host cap",
+    async (view) => {
+      mockListConfig.delayMs = BOUNDARY_DELAY_MS;
+      mockSpecsConfig.delayMs = BOUNDARY_DELAY_MS;
+      mockProbeConfig.delayMs = BOUNDARY_DELAY_MS;
+      store = await setupStore(tempDir);
+
+      const toolMap = createToolMap(store, tempDir, store.paths.agenda) as {
+        adv_status: {
+          execute: (args: Record<string, unknown>) => Promise<unknown>;
+        };
+      };
+      const startedAt = Date.now();
+      const result = await toolMap.adv_status.execute({
+        view,
+        forceRefresh: true,
+      });
+      const elapsedMs = Date.now() - startedAt;
+      const parsed = parseBoundToolResult(result);
+
+      // RED: current production reaches safeExecute's 10,000ms ceiling and
+      // returns this unclassified whole-tool timeout instead of typed
+      // degraded status data. The assertion is intentionally expected to
+      // fail until the later implementation task fixes the request budget.
+      expect(elapsedMs).toBeLessThanOrEqual(10_100);
+      expect(parsed.errorClass).not.toBe("ToolExecutionTimeout");
+    },
+    20_000,
+  );
+});
+
+describe("adv_status corpus-pressure mechanisms", () => {
+  let tempDir: string;
+  let store: Store | undefined;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    await createTestProject(tempDir, { withChanges: true, withSpecs: true });
+    resetMocks();
+  });
+
+  afterEach(async () => {
+    store?.close();
+    await cleanupTempDir(tempDir);
+  });
+
+  test("summary, changes, and hygiene do not parse the archive corpus", async () => {
+    store = await setupCorpusStore(tempDir);
+    const archiveParseCounts: Record<string, number> = {};
+
+    for (const view of ["summary", "changes", "hygiene"] as const) {
+      archiveLoadChangeCalls.length = 0;
+      await store.status(view === "summary" ? { recentLimit: 10 } : undefined);
+      archiveParseCounts[view] = archiveLoadChangeCalls.length;
+    }
+
+    // RED: current production loads every archived change even when terminal
+    // statuses are not requested. The implementation task must make all three
+    // routine status views avoid this work entirely.
+    expect(archiveParseCounts).toEqual({ summary: 0, changes: 0, hygiene: 0 });
+  }, 20_000);
+
+  test("health source ranking reads no more than the candidate limit", async () => {
+    store = await setupCorpusStore(tempDir);
+    sourceRankedProjectionReads.length = 0;
+
+    await store.status({
+      recentLimit: 10,
+      sourceRanked: true,
+    });
+
+    // RED: current production reads every active disk candidate before applying
+    // candidateLimit. This must remain a mechanism count, not a wall-clock test.
+    expect(sourceRankedProjectionReads.length).toBeLessThanOrEqual(10);
+  }, 20_000);
+});

--- a/plugin/src/tools/status-view.ts
+++ b/plugin/src/tools/status-view.ts
@@ -195,6 +195,12 @@ export function applyStatusView(
     | undefined;
   const recommendationGroups = full.recommendation_groups;
 
+  // Degradation metadata is view-independent. Keep it at the projection root
+  // so summary/changes/hygiene callers receive the same typed completeness
+  // signal that health callers already see alongside `changes`.
+  if (full.warnings) projection.warnings = full.warnings;
+  if (full.hydrationStats) projection.hydrationStats = full.hydrationStats;
+
   switch (view) {
     case "summary": {
       projection.specs = { count: specs?.count };

--- a/plugin/src/tools/status.ts
+++ b/plugin/src/tools/status.ts
@@ -8,6 +8,12 @@
 import { basename } from "path";
 import type { Store } from "../storage/store";
 import type { StatusReadOptions } from "../storage/store-types";
+import {
+  createTemporalReadContext,
+  isTemporalReadExpired,
+  runTemporalRead,
+  type TemporalReadContext,
+} from "../storage/store-temporal/read-context";
 import { getTemporalWorkerRole } from "../plugin-init";
 import {
   classifyTemporalError,
@@ -132,9 +138,43 @@ async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function buildDeadlineDegradedStatus(status?: ProjectStatus): ProjectStatus {
+  const warning = {
+    code: "SOURCE_DEADLINE_EXCEEDED" as const,
+    source: "workflow_query" as const,
+    message:
+      "Aggregate status read deadline exceeded; results are incomplete and must not be treated as complete.",
+  };
+  return {
+    specs: status?.specs ?? { count: 0, capabilities: [] },
+    changes: status?.changes ?? {
+      active: 0,
+      byStatus: { draft: 0, archived: 0, closed: 0 },
+      recent: [],
+    },
+    recommendations: status?.recommendations ?? [],
+    ...(status?.resolvedChanges
+      ? { resolvedChanges: status.resolvedChanges }
+      : {}),
+    warnings: [
+      ...(status?.warnings ?? []).filter(
+        (existing) => existing.code !== warning.code,
+      ),
+      warning,
+    ],
+    hydrationStats: {
+      ...(status?.hydrationStats ?? {}),
+      deadlineExceeded: true,
+      omitted: status?.hydrationStats?.omitted ?? 0,
+      omittedIds: status?.hydrationStats?.omittedIds ?? [],
+    },
+  };
+}
+
 async function loadStatusWithBootstrapRetry(
   store: Store,
   options?: StatusReadOptions,
+  context: TemporalReadContext = createTemporalReadContext(),
 ): Promise<{
   status: ProjectStatus;
   bootstrapDiagnostic?: {
@@ -146,6 +186,17 @@ async function loadStatusWithBootstrapRetry(
   let lastBootstrapError: unknown;
 
   for (let attempt = 1; attempt <= STATUS_BOOTSTRAP_MAX_ATTEMPTS; attempt++) {
+    if (isTemporalReadExpired(context)) {
+      return {
+        status: buildDeadlineDegradedStatus(),
+        bootstrapDiagnostic: {
+          recovered: false,
+          lastErrorClass: "bootstrap_in_progress",
+          error:
+            "Aggregate status read deadline exceeded before the next attempt.",
+        },
+      };
+    }
     try {
       const status = await store.status(options);
       return lastBootstrapError
@@ -164,6 +215,16 @@ async function loadStatusWithBootstrapRetry(
     } catch (error) {
       if (classifyTemporalError(error) !== "fallback") throw error;
       lastBootstrapError = error;
+      if (isTemporalReadExpired(context)) {
+        return {
+          status: buildDeadlineDegradedStatus(),
+          bootstrapDiagnostic: {
+            recovered: false,
+            lastErrorClass: "bootstrap_in_progress",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        };
+      }
       if (attempt < STATUS_BOOTSTRAP_MAX_ATTEMPTS) {
         await delay(STATUS_BOOTSTRAP_RETRY_DELAY_MS);
       }
@@ -328,6 +389,16 @@ export const statusTools = {
         { store, target_path },
         async (activeStore, projectContext) => {
           const plan = buildStatusViewPlan(view);
+          // One aggregate budget owns the entire authoritative status read.
+          // Disk-backed target stores ignore this option, while Temporal-backed
+          // stores use the absolute deadline for every source and hydration
+          // stage rather than minting a fresh budget per view/call.
+          const temporalReadContext = createTemporalReadContext();
+          // Disk stores have no Temporal status path and intentionally retain
+          // their legacy call shape; the deadline is meaningful only when the
+          // Temporal backend exposes its summary projection reader.
+          const supportsTemporalStatusRead =
+            typeof activeStore.changes.listSummary === "function";
           const healthRequest =
             view === "health" ? createHealthRequestContext() : undefined;
           const summaryOmissions: StatusSummaryOmissions = {
@@ -344,15 +415,34 @@ export const statusTools = {
           // reuses request-local resolved documents instead of re-reading them.
           const statusReadOptions: StatusReadOptions | undefined =
             view === "summary"
-              ? { recentLimit: STATUS_SUMMARY_RECENT_LIMIT }
+              ? {
+                  recentLimit: STATUS_SUMMARY_RECENT_LIMIT,
+                  ...(supportsTemporalStatusRead
+                    ? { deadline: temporalReadContext.deadline }
+                    : {}),
+                }
               : view === "health"
-                ? buildHealthStatusReadOptions(healthRequest)
-                : undefined;
-          const { status, bootstrapDiagnostic } = await withRecordedPhase(
-            "adv_status",
-            "statusLoad",
-            () => loadStatusWithBootstrapRetry(activeStore, statusReadOptions),
-          );
+                ? buildHealthStatusReadOptions(
+                    healthRequest,
+                    supportsTemporalStatusRead
+                      ? temporalReadContext.deadline
+                      : undefined,
+                  )
+                : supportsTemporalStatusRead
+                  ? { deadline: temporalReadContext.deadline }
+                  : undefined;
+          const { status: loadedStatus, bootstrapDiagnostic } =
+            await withRecordedPhase("adv_status", "statusLoad", () =>
+              loadStatusWithBootstrapRetry(
+                activeStore,
+                statusReadOptions,
+                temporalReadContext,
+              ),
+            );
+          let status = loadedStatus;
+          if (isTemporalReadExpired(temporalReadContext)) {
+            status = buildDeadlineDegradedStatus(status);
+          }
           // Request-local resolved documents (AC4): extracted for
           // enrichment reuse and stripped before output serialization —
           // the map is transport-only, never response payload.
@@ -391,6 +481,76 @@ export const statusTools = {
               worktree_auto_managed?: boolean;
             }>,
           );
+
+          const buildDegradedResponse = () => {
+            const recommendationSummary = buildStatusRecommendationGroups(
+              (status as StatusRecommendationCarrier).recommendation_items ??
+                [],
+              {
+                perGroup:
+                  view === "summary"
+                    ? STATUS_SUMMARY_RECOMMENDATION_GROUP_LIMIT
+                    : STATUS_DETAILED_RECOMMENDATION_GROUP_LIMIT,
+              },
+            );
+            const formatted = formatStatusOutput({
+              specCount: status.specs.count,
+              requirementCount: 0,
+              activeChanges: status.changes.recent.map((c) => ({
+                id: c.id,
+                title: c.title,
+                minutesSinceActivity: c.minutesSinceActivity,
+                parent_change_id: c.parent_change_id,
+              })),
+              archivedCount: status.changes.byStatus.archived ?? 0,
+              recommendations: status.recommendations,
+              recommendationSummary,
+              temporalAlive: false,
+              temporalDegraded: true,
+              terminalCleanupRetained: { total: 0, classes: {} },
+            });
+            const degradedOutput = {
+              ...status,
+              feature_flags: {},
+              feature_flag_sources: {},
+              auto_managed_changes: autoManagedCensus,
+              worker_role: getTemporalWorkerRole(),
+              _freshness: {},
+              _health_execution: {},
+              temporal_health: undefined,
+              orphan_queue_adoption: null,
+              search_attributes: undefined,
+              worker_processes: undefined,
+              opencode_session_debt: undefined,
+              migration_status: null,
+              project_metadata: undefined,
+              external_state_hygiene: undefined,
+              worktree_census: undefined,
+              terminal_cleanup_retained: { total: 0, classes: {} },
+              snapshot_health: undefined,
+              _healthSnapshot: undefined,
+              archived_branch_hygiene: undefined,
+              status_summary_omissions: summaryOmissions,
+              recommendation_summary: recommendationSummary,
+              recommendation_groups: recommendationSummary.groups,
+              metrics: getMetrics(),
+              plugin_runtime: undefined,
+              formatted,
+              ...(projectContext ? { _projectContext: projectContext } : {}),
+            };
+            return formatToolOutput(applyStatusView(degradedOutput, view), {
+              pretty: resolveOutputMode(outputMode),
+            });
+          };
+
+          // A status read that consumed its aggregate budget is already a
+          // useful typed result. Do not enter view-specific enrichment/probe
+          // stages after expiry: those stages have independent best-effort
+          // work and could outlive the host safety cap while the caller has
+          // already been told the authoritative read is incomplete.
+          if (isTemporalReadExpired(temporalReadContext)) {
+            return buildDegradedResponse();
+          }
 
           if (plan.recentEnrichment) {
             let recentChanges = await withRecordedPhase(
@@ -823,17 +983,36 @@ export const statusTools = {
             }
 
             if (plan.snapshotHealth) {
-              const snapshotHealthProbe = await withRecordedPhase(
-                "adv_status",
-                "snapshotHealth",
-                () => fetchStatusSnapshotHealth(projectId, { forceRefresh }),
+              const snapshotHealthRead = await runTemporalRead(
+                undefined,
+                () =>
+                  withRecordedPhase("adv_status", "snapshotHealth", () =>
+                    fetchStatusSnapshotHealth(projectId, { forceRefresh }),
+                  ),
+                temporalReadContext,
+                { maxAttempts: 1, opType: "status.snapshotHealth" },
               );
+              if (!snapshotHealthRead.complete || !snapshotHealthRead.data) {
+                status = buildDeadlineDegradedStatus(status);
+                return buildDegradedResponse();
+              }
+              const snapshotHealthProbe = snapshotHealthRead.data;
               snapshotHealth = snapshotHealthProbe.value;
               probeFreshness.snapshot_health = snapshotHealthProbe.freshness;
             }
 
             if (plan.specRequirementCount) {
-              const specsList = await activeStore.specs.list();
+              const specsRead = await runTemporalRead(
+                undefined,
+                () => activeStore.specs.list(),
+                temporalReadContext,
+                { maxAttempts: 1, opType: "status.specs" },
+              );
+              if (!specsRead.complete || !specsRead.data) {
+                status = buildDeadlineDegradedStatus(status);
+                return buildDegradedResponse();
+              }
+              const specsList = specsRead.data;
               requirementCount = specsList.specs.reduce(
                 (sum, s) => sum + (s.requirementCount ?? 0),
                 0,


### PR DESCRIPTION
## Problem

`adv_status` returned an unclassified `ToolExecutionTimeout` at the 10s host cap on all four views (`summary`, `health`, `changes`, `hygiene`), instead of complete or explicitly degraded data. This violated `rq-boundedAuthoritativeRead01`, which requires authoritative reads to "return a complete or explicitly degraded result — never an unclassified whole-tool ToolExecutionTimeout".

Reproduced under a healthy, unsaturated system (`adv_doctor` green on all axes), so this was not concurrency saturation.

## Root cause — two mechanisms doing unconditional work

**1. Archive corpus load, `store-temporal/changes.ts:888-901`**

Every call opened and JSON-parsed every archived change bundle (484 in this repo, 480 in the test corpus), inside `if (legacy.paths.archive)` with no condition on whether the caller wanted archived data. Results were only used when terminal statuses were requested — which `summary`, `changes`, and `hygiene` never do. Pure waste on those three views, paid in full every call.

**2. Pre-ranking enumeration, `store-temporal/index.ts:1098-1133`**

`health` wants the 10 most recent changes. It read `change.json` for every candidate on disk, sorted, then applied `candidateLimit` at `:1144` — after the I/O was already spent. A per-iteration `expired()` check made it interruptible but not bounded, so it consumed the request budget before ranking began.

This also explains why `adv_change_list` stayed fast on the identical corpus: it bounds its reads. `buildTemporalStatus` carried a comment asserting it needed the full unbounded set "for accurate counts" — that was false; counts come from summary shards exactly.

## Changes

- Skip the archive load entirely when terminal statuses are not requested; add per-iteration admission when it does run (`rq-readSourceAttribution01.2`)
- Rank from Visibility descriptors and summary-shard `last_activity_at`, then read only the winners; unindexed overflow is bounded and surfaced as a typed omission rather than silently dropped
- `readProjectionChangeList` accepts a caller-supplied deadline instead of minting its own per call
- One request-scoped `TemporalReadContext` threaded into `StatusReadOptions` for all four views; `loadStatusWithBootstrapRetry` admission-checks it before each attempt
- Bound hydration at fetch time rather than slicing after

Global ranking correctness is preserved, not traded for the read reduction.

## Measured

| | Before | After |
|---|---|---|
| Archive parses per `summary`/`changes`/`hygiene` call | 480 | **0** |
| Health source-ranking `change.json` reads | 37 | **≤10** |
| All four views under injected boundary delay | `ToolExecutionTimeout` | **typed degraded** (`warnings` + `hydrationStats`) |

## Tests

New `plugin/src/tools/status-host-cap.test.ts` — 6/6, red → green. Assertions are **parse/read counts**, not wall-clock, so they are load-independent and cannot false-green on a quiet machine. Corpus: 480 archived + 36 active bundles in isolated temp dirs.

This deliberately avoids the pattern in `status-health-integration-blockers.test.ts`, which seeds only 20 candidates and mocks the ranking call — that is why those tests passed 9/9 while production breached.

Full run: 317/317 across 31 files. `pnpm run check` clean.

## Scope

Ships the causal fix only. Three non-causal defects found during design remain for a follow-up: budget-to-cap headroom invariant (AC5), `NOT_FOUND` retry admission discriminator (AC4), and the unbounded post-status enrichment loop.