### PR TITLE
fix(adv-cleanup): shorten command description to satisfy voice-standard word limit

### DIFF
--- a/.opencode/command/adv-cleanup.md
+++ b/.opencode/command/adv-cleanup.md
@@ -1,6 +1,6 @@
 ---
 name: adv-cleanup
-description: Triage stale changes, drifted worktrees, merged archived branches, and archived/closed state leaks; delete approved safe worktrees/branches only with typed confirmation
+description: Triage stale changes, drifted worktrees, merged branches, and state leaks; delete approved candidates
 ---
 # ADV Cleanup — Hygiene Triage
 

--- a/ADV_INSTRUCTIONS.md
+++ b/ADV_INSTRUCTIONS.md
@@ -158,7 +158,7 @@ Each workflow command has a defined phase goal. Canonical in `manifest.ts` (`pha
 | --------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `/adv-task`                 | Fast-track small changes: assess spec-law impact, prep, and hand off                                 |
 | `/adv-refactor [change-id]` | Refresh a stale proposal or batch-refresh the oldest 30% of active changes                           |
-| `/adv-cleanup`              | Triage stale changes, drifted worktrees, merged archived branches, and archived/closed state leaks; delete approved safe worktrees/branches only with typed confirmation |
+| `/adv-cleanup`              | Triage stale changes, drifted worktrees, merged branches, and state leaks; delete approved candidates |
 | `/adv-coordinate`           | Audit project changes, Epic alignment, sequencing, and membership health                             |
 | `/adv-triage`               | Triage sources, coalesce issue links, assign bug priority, and balance portfolio |
 | `/adv-improve`              | Analyze improvements across existing specs, implementation, and external landscape                    |

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ This also enables model comparison: run the same change on two models and compar
 | `/adv-arch-scan` | Scan architecture stack packs, coverage, and heuristic fallbacks                                     |
 | `/adv-comp-scan` | Scan competitor capabilities against this project for competitive intelligence                       |
 | `/adv-refactor`  | Refresh a stale proposal or batch-refresh the oldest 30% of active changes                           |
-| `/adv-cleanup`   | Triage stale changes, drifted worktrees, merged archived branches, and archived/closed state leaks; delete approved safe worktrees/branches only with typed confirmation |
+| `/adv-cleanup`   | Triage stale changes, drifted worktrees, merged branches, and state leaks; delete approved candidates |
 | `/adv-coordinate` | Audit project changes, Epic alignment, sequencing, and membership health                          |
 | `/adv-triage`    | Triage sources, coalesce issue links, assign bug priority, and balance portfolio |
 | `/adv-improve`   | Analyze improvements across existing specs, implementation, and external landscape                    |

--- a/plugin/src/adv-cleanup-contract-assets.test.ts
+++ b/plugin/src/adv-cleanup-contract-assets.test.ts
@@ -177,7 +177,7 @@ describe("adv-cleanup hygiene triage contract", () => {
   describe("user-facing command description", () => {
     test("manifest, command frontmatter, README, and instructions stay synced", () => {
       const description =
-        "Triage stale changes, drifted worktrees, merged archived branches, and archived/closed state leaks; delete approved safe worktrees/branches only with typed confirmation";
+        "Triage stale changes, drifted worktrees, merged branches, and state leaks; delete approved candidates";
       const manifest = readRepoFile("plugin/src/manifest.ts");
       const readme = readRepoFile("README.md");
       const instructions = readRepoFile("ADV_INSTRUCTIONS.md");

--- a/plugin/src/manifest.ts
+++ b/plugin/src/manifest.ts
@@ -392,7 +392,7 @@ export const COMMAND_MANIFEST: Record<string, CommandDef> = {
   "adv-cleanup": {
     name: "adv-cleanup",
     description:
-      "Triage stale changes, drifted worktrees, merged archived branches, and archived/closed state leaks; delete approved safe worktrees/branches only with typed confirmation",
+      "Triage stale changes, drifted worktrees, merged branches, and state leaks; delete approved candidates",
     phase: "advanced",
     requiresChangeId: false,
     prerequisites: [],


### PR DESCRIPTION
## Problem

`extendCleanupHygieneCoverage` (merged in d30cbf75) shipped a 20-word `adv-cleanup` description, breaking two guards on trunk:

| Test | Assertion |
|---|---|
| `manifest.test.ts` | `adv-cleanup: description must be 5-14 words, got 20` |
| `manifest-doc-drift.test.ts` | `adv-cleanup.md: description must be 5-14 words, got 20` |

The long form was introduced while disclosing the command's new destructive capability. The disclosure is worth keeping — it just has to fit the limit.

## Fix

New description is 13 words and keeps both halves (what is triaged, and that deletion is limited to approved candidates):

`Triage stale changes, drifted worktrees, merged branches, and state leaks; delete approved candidates`

Updated in all five synced locations: `plugin/src/manifest.ts`, `.opencode/command/adv-cleanup.md` frontmatter, `README.md`, `ADV_INSTRUCTIONS.md`, and the sync-test constant.

## Verification

- `manifest.test.ts` + `manifest-doc-drift.test.ts` + `adv-cleanup-contract-assets.test.ts` — **127/127 pass**
- `pnpm run check` — **exit 0** (0 errors; 4 pre-existing warnings)
- Full suite — **8366 passed, 1 failed**

## Expected CI state

CI will report failure. The single remaining test failure is `src/mcp-server/health-field-scope.test.ts:99`, **pre-existing and unrelated** — introduced by trunk commit `da0344dd` (#365), which rewrote the `temporal_health` serialization path. Trunk has been red since 2026-08-04T02:17 (run 30871352061). That regression needs its own change.

`bounded-status.test.ts`, which timed out in the d30cbf75 run, passes here — it was a load-induced flake, not a regression.
