### PR TITLE
fix(adv_status): bound post-status enrichment, retry admission, and budget-to-cap invariant

### DIFF
--- a/.opencode/command/adv-coordinate.md
+++ b/.opencode/command/adv-coordinate.md
@@ -52,7 +52,7 @@ Use typed tools only:
 | Inspect linked changes when needed | `adv_change_show` |
 | Check relevant spec law | `adv_spec` |
 
-Report project-change inventory first. If no active Epics exist, report `No active Epics. No Epic-dependent coordination actions.` for Epic-dependent findings only, then continue change-scoped overlap, sequencing, and refactor-coverage analysis; this condition must not stop the run or suppress change-scoped analysis.
+Report project-change inventory first. If no active Epics exist, report `No active Epics. No Epic-dependent coordination actions.` for Epic-dependent findings only, then continue change-scoped overlap, sequencing, and refactor-coverage analysis; this condition must not stop the run or suppress change-scoped analysis. <!-- rq-epicCoordinateChangeCoverage01 -->
 
 Record:
 

--- a/ADV_INSTRUCTIONS.md
+++ b/ADV_INSTRUCTIONS.md
@@ -159,7 +159,7 @@ Each workflow command has a defined phase goal. Canonical in `manifest.ts` (`pha
 | `/adv-task`                 | Fast-track small changes: assess spec-law impact, prep, and hand off                                 |
 | `/adv-refactor [change-id]` | Refresh a stale proposal or batch-refresh the oldest 30% of active changes                           |
 | `/adv-cleanup`              | Triage stale changes, drifted worktrees, merged branches, and state leaks; delete approved candidates |
-| `/adv-coordinate`           | Audit project changes, Epic alignment, sequencing, and membership health                             |
+| `/adv-coordinate`           | Audit project changes, Epic alignment, sequencing, and membership health; includes Epic-unlinked in-flight changes                             |
 | `/adv-triage`               | Triage sources, coalesce issue links, assign bug priority, and balance portfolio |
 | `/adv-improve`              | Analyze improvements across existing specs, implementation, and external landscape                    |
 | `/adv-tron [target]`        | Investigate codebase structure, hotspots, risks, and suggest follow-up candidates             |

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ This also enables model comparison: run the same change on two models and compar
 | `/adv-comp-scan` | Scan competitor capabilities against this project for competitive intelligence                       |
 | `/adv-refactor`  | Refresh a stale proposal or batch-refresh the oldest 30% of active changes                           |
 | `/adv-cleanup`   | Triage stale changes, drifted worktrees, merged branches, and state leaks; delete approved candidates |
-| `/adv-coordinate` | Audit project changes, Epic alignment, sequencing, and membership health                          |
+| `/adv-coordinate` | Audit project changes, Epic alignment, sequencing, and membership health; includes Epic-unlinked in-flight changes                          |
 | `/adv-triage`    | Triage sources, coalesce issue links, assign bug priority, and balance portfolio |
 | `/adv-improve`   | Analyze improvements across existing specs, implementation, and external landscape                    |
 | `/adv-tron`      | Investigate codebase structure, hotspots, risks, and suggest follow-up candidates             |

--- a/plugin/src/manifest.ts
+++ b/plugin/src/manifest.ts
@@ -402,7 +402,7 @@ export const COMMAND_MANIFEST: Record<string, CommandDef> = {
   "adv-coordinate": {
     name: "adv-coordinate",
     description:
-      "Audit project changes, Epic alignment, sequencing, and membership health",
+      "Audit project changes, Epic alignment, sequencing, and membership health; includes Epic-unlinked in-flight changes",
     phase: "advanced",
     requiresChangeId: false,
     prerequisites: [],

--- a/plugin/src/mcp-server/health-field-scope.test.ts
+++ b/plugin/src/mcp-server/health-field-scope.test.ts
@@ -46,7 +46,14 @@ vi.mock("../temporal/service", () => ({
   getService: () => mockGetService(),
 }));
 
-vi.mock("../temporal/retry-wrapper", () => ({
+// Partial mock: the status read path consumes a growing surface of this module
+// (deadline construction, retry classification, gRPC status extraction). Listing
+// exports individually made this mock silently rot — a newly-imported export
+// threw "No <name> export is defined on the mock" at call time, which surfaced
+// as an error envelope instead of a status payload. Spread the real module and
+// override only the telemetry accessors this test actually stubs.
+vi.mock("../temporal/retry-wrapper", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../temporal/retry-wrapper")>()),
   getTemporalRetryTelemetry: () => mockGetTemporalRetryTelemetry(),
   getTemporalOpTelemetry: () => mockGetTemporalOpTelemetry(),
   getLastWorkerRunError: () => mockGetLastWorkerRunError(),

--- a/plugin/src/ops-follow-up-assets.test.ts
+++ b/plugin/src/ops-follow-up-assets.test.ts
@@ -163,7 +163,7 @@ describe("ops-follow-up spec versions bumped", () => {
 
   test("backlog-coordination version is at least 1.5.0", () => {
     const spec = loadSpec("backlog-coordination");
-    expect(spec.version).toBe("1.5.1");
+    expectVersionAtLeast(spec.version, "1.5.0");
   });
 });
 

--- a/plugin/src/storage/store-temporal/changes.ts
+++ b/plugin/src/storage/store-temporal/changes.ts
@@ -2,6 +2,7 @@ import type {
   Store,
   ChangeConflictAuthority,
   AuthorityDiagnostics,
+  DiskProjectionReadState,
 } from "../store-types";
 import { snapshotToLoadResult } from "./read-model";
 import {
@@ -529,6 +530,8 @@ interface ChangeListFilter {
   validationConcurrency?: number;
   /** Request-scoped deadline shared with an enclosing status read. */
   deadline?: TemporalReadDeadline | TemporalReadContext;
+  /** Request-scoped durable-projection marker owned by the status read. */
+  projectionState?: DiskProjectionReadState;
 }
 
 interface ListChangeSummariesResult {
@@ -558,6 +561,7 @@ async function listChangeSummaries(
     paginate?: boolean;
     /** Cap rows before downstream hydration while retaining API offset semantics. */
     candidateLimit?: number;
+    projectionState?: DiskProjectionReadState;
   } = {},
 ): Promise<ListChangeSummariesResult> {
   const summaryResult = await listSummaryChanges(paths);
@@ -831,6 +835,7 @@ async function readProjectionChangeList(
     deadline?: TemporalReadDeadline | TemporalReadContext;
     candidateLimit?: number;
     loadArchiveForActiveShadow?: boolean;
+    projectionState?: DiskProjectionReadState;
   },
 ): Promise<
   ChangeListResponse & {
@@ -882,12 +887,13 @@ async function readProjectionChangeList(
     // are applied before hydration without consuming the requested offset.
     paginate: false,
     candidateLimit: options.candidateLimit,
+    projectionState: options.projectionState,
   });
 
   const summaryRows = new Map<string, ChangeListResponse["changes"][number]>();
   if (summaryResult.summaries.length > 0) {
     for (const summary of summaryResult.summaries) {
-      markLoadedDiskProjection?.(summary.id);
+      markLoadedDiskProjection?.(summary.id, options.projectionState);
       summaryRows.set(summary.id, summaryToListRow(summary));
     }
   }
@@ -1047,7 +1053,7 @@ async function readProjectionChangeList(
     }
 
     if (diskResult?.success && diskResult.data) {
-      markLoadedDiskProjection?.(diskResult.data.id);
+      markLoadedDiskProjection?.(diskResult.data.id, options.projectionState);
       let change = diskResult.data;
       const terminalOnDisk =
         change.status === "archived" || change.status === "closed";
@@ -2074,7 +2080,7 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
     // never the primary list/status truth source for lifecycle/gate/task
     // state; warm rows served after deadline expiry stay degraded, and
     // completeness is never inferred from cache warmth or row count.
-    listSummary: async (filter) => {
+    listSummary: async (filter: ChangeListFilter | undefined) => {
       const projection = await readProjectionChangeList(
         filter,
         {
@@ -2094,6 +2100,7 @@ export function createChangeOps(deps: StoreDeps): Store["changes"] {
             filter?.limit === undefined
               ? undefined
               : Math.max(0, (filter.offset ?? 0) + filter.limit),
+          projectionState: filter?.projectionState,
         },
       );
       const { changes, warnings, hydrationStats } = projection;

--- a/plugin/src/storage/store-temporal/changes.ts
+++ b/plugin/src/storage/store-temporal/changes.ts
@@ -840,7 +840,13 @@ async function readProjectionChangeList(
     boundedOmittedIds?: string[];
   }
 > {
-  const { input: _input, legacy, memo, getTemporalChange } = deps;
+  const {
+    input: _input,
+    legacy,
+    memo,
+    getTemporalChange,
+    markLoadedDiskProjection,
+  } = deps;
 
   const suppliedRead = options.deadline;
   const ctx = suppliedRead
@@ -881,6 +887,7 @@ async function readProjectionChangeList(
   const summaryRows = new Map<string, ChangeListResponse["changes"][number]>();
   if (summaryResult.summaries.length > 0) {
     for (const summary of summaryResult.summaries) {
+      markLoadedDiskProjection?.(summary.id);
       summaryRows.set(summary.id, summaryToListRow(summary));
     }
   }
@@ -1040,6 +1047,7 @@ async function readProjectionChangeList(
     }
 
     if (diskResult?.success && diskResult.data) {
+      markLoadedDiskProjection?.(diskResult.data.id);
       let change = diskResult.data;
       const terminalOnDisk =
         change.status === "archived" || change.status === "closed";

--- a/plugin/src/storage/store-temporal/index.test.ts
+++ b/plugin/src/storage/store-temporal/index.test.ts
@@ -459,6 +459,31 @@ async function createPoisonedSignalStore(root: string, changeId: string) {
   return { store, signalCount: () => signalCount };
 }
 
+async function createDualWriteOutcomeStore(root: string, queryResult: unknown) {
+  const legacy = await createDiskStore(root);
+  const changeId = "dualWriteOutcome";
+  await legacy.changes.save(activeChange(changeId));
+  const handle = { query: async () => queryResult };
+  const temporal = createMockOwnerFromClient({
+    client: {
+      workflow: {
+        getHandle: () => handle,
+        start: async () => handle,
+      },
+    },
+  });
+  const store = createTemporalStoreBackend({
+    legacy,
+    temporal,
+    projectId: "0000ec0100000000000000000000000000000000",
+  });
+  return {
+    store,
+    projectionPath: join(root, ".adv", "changes", changeId, "change.json"),
+    changeId,
+  };
+}
+
 async function createMinimalPoisonedInput(root: string) {
   const legacy = await createDiskStore(root);
   const handle = {
@@ -1814,6 +1839,44 @@ describe("terminal aggregate degraded metadata (rq-terminalAggregateRead01)", ()
 });
 
 describe("createTemporalStoreBackend projection-only read enforcement", () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) await cleanupTempDir(tempDir);
+    tempDir = undefined;
+  });
+
+  it("does not write a projection for a non-confirmed readback outcome", async () => {
+    tempDir = await createTempDir();
+    const { store, projectionPath, changeId } =
+      await createDualWriteOutcomeStore(tempDir, {
+        kind: "degraded",
+        error: new Error("readback unavailable"),
+        diagnostic: { class: "transient" },
+      });
+    const before = await readFile(projectionPath, "utf8");
+
+    await store.changes.refresh(changeId);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(await readFile(projectionPath, "utf8")).toBe(before);
+  });
+
+  it("does not write a projection when confirmed readback has no value", async () => {
+    tempDir = await createTempDir();
+    const { store, projectionPath, changeId } =
+      await createDualWriteOutcomeStore(tempDir, {
+        kind: "complete",
+        value: undefined,
+      });
+    const before = await readFile(projectionPath, "utf8");
+
+    await store.changes.refresh(changeId);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(await readFile(projectionPath, "utf8")).toBe(before);
+  });
+
   it("guards the dual-write projection behind confirmed readback", async () => {
     const source = await readFile(
       new URL("./index.ts", import.meta.url),

--- a/plugin/src/storage/store-temporal/index.test.ts
+++ b/plugin/src/storage/store-temporal/index.test.ts
@@ -496,12 +496,14 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     await legacy.changes.save(archivedChange("poisonedDisk"));
 
     const store = await createPoisonedStore(tempDir);
+    expect(store.hasLoadedDiskProjection?.()).toBe(false);
     const result = await store.changes.get("poisonedDisk");
 
     expect(result.success).toBe(true);
     expect(result.data?.id).toBe("poisonedDisk");
     expect(result.data?.status).toBe("archived");
     expect((result.data as Change & { _source?: string })._source).toBe("disk");
+    expect(store.hasLoadedDiskProjection?.()).toBe(true);
   });
 
   it("returns an archive bundle projection when source disk snapshot is absent", async () => {
@@ -1812,6 +1814,25 @@ describe("terminal aggregate degraded metadata (rq-terminalAggregateRead01)", ()
 });
 
 describe("createTemporalStoreBackend projection-only read enforcement", () => {
+  it("guards the dual-write projection behind confirmed readback", async () => {
+    const source = await readFile(
+      new URL("./index.ts", import.meta.url),
+      "utf8",
+    );
+    const body = source.match(
+      /const dualWriteAfterMutation = async \([\s\S]*?\n\s{2}};\n\n\s{2}\/\*\*/,
+    )?.[0];
+    expect(body).toBeDefined();
+
+    const confirmedGuard = body!.indexOf('if (typed.outcome !== "confirmed")');
+    const valueGuard = body!.indexOf("if (!readbackValue)");
+    const projectionWrite = body!.indexOf("voidPersist(changeId, state)");
+
+    expect(confirmedGuard).toBeGreaterThanOrEqual(0);
+    expect(valueGuard).toBeGreaterThan(confirmedGuard);
+    expect(projectionWrite).toBeGreaterThan(valueGuard);
+  });
+
   it("getTemporalChange source never starts, signals, reseeds, or writes recovery state", async () => {
     const source = await readFile(
       new URL("./index.ts", import.meta.url),

--- a/plugin/src/storage/store-temporal/index.test.ts
+++ b/plugin/src/storage/store-temporal/index.test.ts
@@ -515,6 +515,50 @@ describe("createTemporalStoreBackend change projection fallback", () => {
     clearPoisonedWorkflowCache();
   });
 
+  it("does not mark a successful Temporal read as a disk projection", async () => {
+    tempDir = await createTempDir();
+    const legacy = await createDiskStore(tempDir);
+    const change = activeChange("temporalOnlyRead");
+    await mkdir(join(legacy.paths.changes, change.id), { recursive: true });
+    const temporal = createMockOwnerFromClient({
+      client: {
+        workflow: {
+          list: async function* () {
+            yield { workflowId: "adv/change/project-1/temporalOnlyRead" };
+          },
+          getHandle: () => ({
+            query: async () =>
+              changeToWorkflowState({
+                projectId: "0000ec0100000000000000000000000000000000",
+                change,
+              }),
+          }),
+          start: async () => {
+            throw new Error("start should not be called");
+          },
+        },
+      },
+    });
+    const store = createTemporalStoreBackend({
+      legacy,
+      temporal,
+      projectId: "0000ec0100000000000000000000000000000000",
+    });
+    const projectionState = { loaded: false };
+
+    const result = await store.status({
+      sourceRanked: true,
+      recentLimit: 1,
+      projectionState,
+    });
+
+    expect(result.changes.recent.map((entry) => entry.id)).toContain(
+      "temporalOnlyRead",
+    );
+    expect(projectionState.loaded).toBe(false);
+    expect(store.hasLoadedDiskProjection?.(projectionState)).toBe(false);
+  });
+
   it("returns a terminal disk projection when workflow history is poisoned", async () => {
     tempDir = await createTempDir();
     const legacy = await createDiskStore(tempDir);

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import type { Store } from "../store-types";
+import type { DiskProjectionReadState, Store } from "../store-types";
 import type { Change } from "../../types";
 import { createLogger } from "../../utils/debug-log";
 import { hasArchiveBundle } from "../json";
@@ -96,8 +96,12 @@ export function createTemporalStoreBackend(
   const changeOverlayCache = new Map<string, Partial<Change>>();
   const memo = new ChangeSummaryMemo();
   const loadedDiskProjectionIds = new Set<string>();
-  const markLoadedDiskProjection = (changeId: string): void => {
+  const markLoadedDiskProjection = (
+    changeId: string,
+    state?: DiskProjectionReadState,
+  ): void => {
     loadedDiskProjectionIds.add(changeId);
+    if (state) state.loaded = true;
   };
 
   // Reverse-lookup cache populated from any Temporal-observed tasks so
@@ -196,7 +200,10 @@ export function createTemporalStoreBackend(
   // Routine reads are disk/read-model authoritative. This closure has no
   // Temporal dependency and only populates advisory caches after validating a
   // fresh projection read.
-  const readProjectionSnapshot = async (changeId: string) => {
+  const readProjectionSnapshot = async (
+    changeId: string,
+    projectionState?: DiskProjectionReadState,
+  ) => {
     const readArchiveBundle = async (
       changeId: string,
     ): Promise<ChangeReadSnapshot | undefined> => {
@@ -238,13 +245,13 @@ export function createTemporalStoreBackend(
         ...archiveSnapshot.snapshot,
         status: "archived" as const,
       };
-      markLoadedDiskProjection(changeId);
+      markLoadedDiskProjection(changeId, projectionState);
       setCachedProjection(archived);
       return { ...archiveSnapshot, snapshot: archived };
     }
 
     if (diskSnapshot.found) {
-      markLoadedDiskProjection(changeId);
+      markLoadedDiskProjection(changeId, projectionState);
       setCachedProjection(diskSnapshot.snapshot);
       return diskSnapshot;
     }
@@ -664,7 +671,11 @@ export function createTemporalStoreBackend(
 
   const getTemporalChange = async (
     changeId: string,
-    opts?: { deadline?: TemporalReadDeadline; context?: TemporalReadContext },
+    opts?: {
+      deadline?: TemporalReadDeadline;
+      context?: TemporalReadContext;
+      projectionState?: DiskProjectionReadState;
+    },
   ): Promise<ReturnType<Store["changes"]["get"]>> => {
     const ctx =
       opts?.context ??
@@ -709,7 +720,10 @@ export function createTemporalStoreBackend(
     // and annotate the result so callers (e.g. adv_change_show) can surface the
     // poisoned state without paying a timeout.
     if (isPoisonedWorkflowForChange(input.projectId, changeId)) {
-      const snapshot = await readProjectionSnapshot(changeId);
+      const snapshot = await readProjectionSnapshot(
+        changeId,
+        opts?.projectionState,
+      );
       const result = snapshotToLoadResult(snapshot);
       if (result.success && result.data) {
         (result.data as Change & { _poisoned?: true })._poisoned = true;
@@ -916,6 +930,7 @@ export function createTemporalStoreBackend(
       candidateLimit?: number;
       hydrationConcurrency?: number;
       sourceRanked?: boolean;
+      projectionState?: DiskProjectionReadState;
     },
   ): Promise<import("../store-types").ResolvedChangeList> => {
     const ctx =
@@ -1427,7 +1442,10 @@ export function createTemporalStoreBackend(
 
       try {
         const result = await raceWithTemporalDeadline(
-          getTemporalChange(changeId, { context: ctx }),
+          getTemporalChange(changeId, {
+            context: ctx,
+            projectionState: options?.projectionState,
+          }),
           deadline,
         );
         if (isSchemaError(result)) {
@@ -1782,7 +1800,11 @@ export function createTemporalStoreBackend(
       const resolved = await listResolvedChanges(
         { includeArchived: false, includeClosed: false },
         options.deadline ?? createTemporalReadContext(),
-        { candidateLimit, sourceRanked: true },
+        {
+          candidateLimit,
+          sourceRanked: true,
+          projectionState: options.projectionState,
+        },
       );
 
       const changesById = new Map(
@@ -1854,6 +1876,9 @@ export function createTemporalStoreBackend(
         ? { limit: options.recentLimit }
         : {}),
       ...(options?.deadline ? { deadline: options.deadline } : {}),
+      ...(options?.projectionState
+        ? { projectionState: options.projectionState }
+        : {}),
     });
     const {
       changes,
@@ -2050,7 +2075,8 @@ export function createTemporalStoreBackend(
 
   const store: Store = {
     ...legacy,
-    hasLoadedDiskProjection: () => loadedDiskProjectionIds.size > 0,
+    hasLoadedDiskProjection: (state) =>
+      state?.loaded ?? loadedDiskProjectionIds.size > 0,
     specs: buildSpecsSurface(),
     changes: changeOps,
     tasks: createTaskOps(deps),

--- a/plugin/src/storage/store-temporal/index.ts
+++ b/plugin/src/storage/store-temporal/index.ts
@@ -95,6 +95,10 @@ export function createTemporalStoreBackend(
   const changeCache = new Map<string, Change>();
   const changeOverlayCache = new Map<string, Partial<Change>>();
   const memo = new ChangeSummaryMemo();
+  const loadedDiskProjectionIds = new Set<string>();
+  const markLoadedDiskProjection = (changeId: string): void => {
+    loadedDiskProjectionIds.add(changeId);
+  };
 
   // Reverse-lookup cache populated from any Temporal-observed tasks so
   // taskId-only methods can resolve the owning change without requiring the
@@ -234,11 +238,13 @@ export function createTemporalStoreBackend(
         ...archiveSnapshot.snapshot,
         status: "archived" as const,
       };
+      markLoadedDiskProjection(changeId);
       setCachedProjection(archived);
       return { ...archiveSnapshot, snapshot: archived };
     }
 
     if (diskSnapshot.found) {
+      markLoadedDiskProjection(changeId);
       setCachedProjection(diskSnapshot.snapshot);
       return diskSnapshot;
     }
@@ -2022,6 +2028,7 @@ export function createTemporalStoreBackend(
     changeOverlayCache,
     memo,
     taskChangeIndex,
+    markLoadedDiskProjection,
     buildSummary,
     setCachedChange,
     invalidateChange,
@@ -2043,6 +2050,7 @@ export function createTemporalStoreBackend(
 
   const store: Store = {
     ...legacy,
+    hasLoadedDiskProjection: () => loadedDiskProjectionIds.size > 0,
     specs: buildSpecsSurface(),
     changes: changeOps,
     tasks: createTaskOps(deps),

--- a/plugin/src/storage/store-temporal/shared.ts
+++ b/plugin/src/storage/store-temporal/shared.ts
@@ -1001,6 +1001,8 @@ export interface StoreDeps {
   changeOverlayCache: Map<string, Partial<Change>>;
   memo: ChangeSummaryMemo;
   taskChangeIndex: Map<string, string>;
+  /** Records disk projections observed by projection-only reads. */
+  markLoadedDiskProjection?: (changeId: string) => void;
 
   // Shared helpers (closures over the maps above)
   buildSummary: (state: ChangeWorkflowState) => ChangeSummary;

--- a/plugin/src/storage/store-temporal/shared.ts
+++ b/plugin/src/storage/store-temporal/shared.ts
@@ -30,7 +30,7 @@ import {
 import { reinitStsl } from "../../temporal/service";
 import { createLogger } from "../../utils/debug-log";
 import type { ChangeSummaryMemo, ChangeSummary } from "../store-temporal-memo";
-import type { Store } from "../store-types";
+import type { DiskProjectionReadState, Store } from "../store-types";
 import type { TemporalOperations } from "../../temporal/operations";
 import { makeTemporalOperationContext } from "../../temporal/operations";
 import {
@@ -1002,7 +1002,10 @@ export interface StoreDeps {
   memo: ChangeSummaryMemo;
   taskChangeIndex: Map<string, string>;
   /** Records disk projections observed by projection-only reads. */
-  markLoadedDiskProjection?: (changeId: string) => void;
+  markLoadedDiskProjection?: (
+    changeId: string,
+    state?: DiskProjectionReadState,
+  ) => void;
 
   // Shared helpers (closures over the maps above)
   buildSummary: (state: ChangeWorkflowState) => ChangeSummary;
@@ -1047,12 +1050,14 @@ export interface StoreDeps {
   /** Disk-only authoritative snapshot read for routine ReadStore methods. */
   readChangeSnapshot: (
     changeId: string,
+    state?: DiskProjectionReadState,
   ) => Promise<import("./read-model").ChangeReadSnapshot>;
   getTemporalChange: (
     changeId: string,
     opts?: {
       deadline?: TemporalReadDeadline;
       context?: import("./read-context").TemporalReadContext;
+      projectionState?: DiskProjectionReadState;
     },
   ) => Promise<ReturnType<Store["changes"]["get"]>>;
   listResolvedChanges: (
@@ -1061,6 +1066,11 @@ export interface StoreDeps {
       includeClosed?: boolean;
     },
     deadline?: TemporalReadDeadline,
-    options?: { candidateLimit?: number; hydrationConcurrency?: number },
+    options?: {
+      candidateLimit?: number;
+      hydrationConcurrency?: number;
+      sourceRanked?: boolean;
+      projectionState?: DiskProjectionReadState;
+    },
   ) => Promise<import("../store-types").ResolvedChangeList>;
 }

--- a/plugin/src/storage/store-types.ts
+++ b/plugin/src/storage/store-types.ts
@@ -143,6 +143,12 @@ export interface StatusReadOptions {
   deadline?: import("../temporal/retry-wrapper").TemporalReadDeadline;
   /** Use source-backed global recency before bounded hydration (health view). */
   sourceRanked?: boolean;
+  /** Mutable marker owned by one status request; never shared across calls. */
+  projectionState?: DiskProjectionReadState;
+}
+
+export interface DiskProjectionReadState {
+  loaded: boolean;
 }
 
 export interface ProductOriginTags {
@@ -262,8 +268,8 @@ export type ReadSnapshot<T> =
 interface StoreBase {
   paths: ProjectPaths;
   config: ProjectConfig | null;
-  /** True only when this store has already loaded a durable disk projection. */
-  hasLoadedDiskProjection?: () => boolean;
+  /** Request-scoped when a marker is supplied; no-arg calls retain legacy semantics. */
+  hasLoadedDiskProjection?: (state?: DiskProjectionReadState) => boolean;
   /** Product-link identity context. Omitted for legacy/mock stores. */
   productContext?: ProductContext;
 
@@ -318,6 +324,7 @@ export interface ReadStore extends StoreBase {
       limit?: number;
       offset?: number;
       deadline?: TemporalReadDeadline;
+      projectionState?: DiskProjectionReadState;
     }) => Promise<
       ChangeListResponse & {
         hydrationStats?: import("../types").HydrationStats;

--- a/plugin/src/storage/store-types.ts
+++ b/plugin/src/storage/store-types.ts
@@ -262,6 +262,8 @@ export type ReadSnapshot<T> =
 interface StoreBase {
   paths: ProjectPaths;
   config: ProjectConfig | null;
+  /** True only when this store has already loaded a durable disk projection. */
+  hasLoadedDiskProjection?: () => boolean;
   /** Product-link identity context. Omitted for legacy/mock stores. */
   productContext?: ProductContext;
 

--- a/plugin/src/temporal/diagnostics.test.ts
+++ b/plugin/src/temporal/diagnostics.test.ts
@@ -6,7 +6,7 @@ import {
   isWorkflowMutationIneligible,
   type TemporalServiceContext,
 } from "./diagnostics";
-import { TemporalQueryTimeoutError } from "./retry-wrapper";
+import { GRPC_NOT_FOUND, TemporalQueryTimeoutError } from "./retry-wrapper";
 
 /**
  * Build a validated @temporalio/client ServiceError-shaped error: a wrapper
@@ -127,9 +127,11 @@ describe("classifyTemporalWorkflowFailure", () => {
   });
 
   test("extracts nested gRPC cause", () => {
-    const d = classifyTemporalWorkflowFailure(grpcError(5, "workflow absent"));
+    const d = classifyTemporalWorkflowFailure(
+      grpcError(GRPC_NOT_FOUND, "workflow absent"),
+    );
     expect(d.cause).toEqual({
-      code: 5,
+      code: GRPC_NOT_FOUND,
       statusName: "NOT_FOUND",
       details: "workflow absent",
     });

--- a/plugin/src/temporal/retry-wrapper.ts
+++ b/plugin/src/temporal/retry-wrapper.ts
@@ -47,7 +47,7 @@ export const temporalOpLatency = {
 // classification. The Temporal client nests a raw @grpc/grpc-js ServiceError
 // as `ServiceError.cause`, where the numeric `code` lives.
 const GRPC_DEADLINE_EXCEEDED = 4;
-const GRPC_NOT_FOUND = 5;
+export const GRPC_NOT_FOUND = 5;
 const GRPC_ALREADY_EXISTS = 6;
 const GRPC_RESOURCE_EXHAUSTED = 8;
 const GRPC_ABORTED = 10;

--- a/plugin/src/tools/status-enrich.ts
+++ b/plugin/src/tools/status-enrich.ts
@@ -143,6 +143,19 @@ export interface StatusResolvedChangeContext {
   resolvedChanges?: ReadonlyMap<string, Change>;
 }
 
+export interface StatusEnrichmentOptions {
+  /** Absolute request cutoff shared by all non-health enrichment reads. */
+  cutoffAt?: number;
+  signal?: AbortSignal;
+}
+
+function enrichmentWithinBudget(options?: StatusEnrichmentOptions): boolean {
+  return (
+    !options?.signal?.aborted &&
+    (options?.cutoffAt === undefined || Date.now() < options?.cutoffAt)
+  );
+}
+
 export async function getFastFollowParentContext(
   store: Store,
   parentChangeId: string,
@@ -171,7 +184,9 @@ export async function enrichRecentChangeStatus(
   clarifyMode: string,
   isPrimary: boolean,
   resolved?: StatusResolvedChangeContext,
+  options?: StatusEnrichmentOptions,
 ): Promise<void> {
+  if (!enrichmentWithinBudget(options)) return;
   const changeId = String(rc.id);
   let changeData: Change;
   let proposalText: string;
@@ -183,6 +198,9 @@ export async function enrichRecentChangeStatus(
     proposalText = resolved.change.documents?.proposal ?? "";
   } else {
     const changeResult = await store.changes.get(changeId);
+    if (!enrichmentWithinBudget(options)) {
+      return;
+    }
     if (!changeResult.success || !changeResult.data) return;
     changeData = changeResult.data;
     // Temporal-first proposal read per KD-6. Falls back to disk/archive
@@ -190,6 +208,7 @@ export async function enrichRecentChangeStatus(
     // empty string for snapshot rendering (status output is read-only).
     proposalText =
       (await readArtifact(store, changeId, "proposal"))?.content ?? "";
+    if (!enrichmentWithinBudget(options)) return;
   }
 
   const gates = changeData.gates ?? createDefaultGates();
@@ -249,6 +268,7 @@ export async function enrichRecentChangeStatus(
     | undefined;
   if (isPrimary) {
     try {
+      if (!enrichmentWithinBudget(options)) return;
       // Prefer rc.lastActivityAt (already-enriched recency field); fall back to
       // changeData.lastActivityAt. If neither present, treat as fresh (no resolver).
       const lastActivityAt =
@@ -263,6 +283,7 @@ export async function enrichRecentChangeStatus(
             lastActivityAgeMinutes,
             lastActivityAt,
           });
+          if (!enrichmentWithinBudget(options)) return;
           resumeFreshnessInput = {
             findings: result.findings,
             skipped: result.skipped,
@@ -302,9 +323,11 @@ export async function enrichRecentChangeStatus(
     ...(failClosedPlan ? { _phasePlan: failClosedPlan } : {}),
   });
 
+  if (!enrichmentWithinBudget(options)) return;
   const dependencyStatus = await buildExternalDependencyStatus(
     changeData.external_dependencies,
   );
+  if (!enrichmentWithinBudget(options)) return;
   if (dependencyStatus) {
     (rc as unknown as Record<string, unknown>)._externalDependencyStatus =
       dependencyStatus.summary;
@@ -316,6 +339,7 @@ export async function enrichRecentChangeStatus(
       ? undefined
       : fallbackNextGate;
   if (directive && nextGate) {
+    if (!enrichmentWithinBudget(options)) return;
     const parentContext = changeData.fast_follow_of
       ? await getFastFollowParentContext(
           store,
@@ -323,6 +347,7 @@ export async function enrichRecentChangeStatus(
           resolved?.resolvedChanges,
         )
       : undefined;
+    if (!enrichmentWithinBudget(options)) return;
     const item = buildNextGateRecommendationFromDirective({
       directive,
       changeId,
@@ -742,6 +767,14 @@ export async function buildCandidateEnrichmentPatch(
               lastActivityAgeMinutes,
               lastActivityAt,
             });
+            if (signal?.aborted || Date.now() >= cutoffAt) {
+              return notAdmittedPatch(
+                changeId,
+                rank,
+                start,
+                "execution cutoff",
+              );
+            }
             candidateResumeFreshness = {
               findings: result.findings,
               skipped: result.skipped,
@@ -782,6 +815,9 @@ export async function buildCandidateEnrichmentPatch(
     const dependencyStatus = await buildExternalDependencyStatus(
       changeData.external_dependencies,
     );
+    if (signal?.aborted || Date.now() >= cutoffAt) {
+      return notAdmittedPatch(changeId, rank, start, "execution cutoff");
+    }
     if (dependencyStatus) {
       candidate._externalDependencyStatus = dependencyStatus.summary;
     }
@@ -814,6 +850,9 @@ export async function buildCandidateEnrichmentPatch(
             resolved?.resolvedChanges,
           )
         : undefined;
+      if (signal?.aborted || Date.now() >= cutoffAt) {
+        return notAdmittedPatch(changeId, rank, start, "execution cutoff");
+      }
       const item = buildNextGateRecommendationFromDirective({
         directive,
         changeId,

--- a/plugin/src/tools/status-health-integration-blockers.test.ts
+++ b/plugin/src/tools/status-health-integration-blockers.test.ts
@@ -1,17 +1,14 @@
 /**
  * status-health-integration-blockers.test.ts
  *
- * TDD RED only — acceptance-level end-to-end tests that prove the three
- * remaining integration blockers for `adv_status view:"health"`:
+ * GREEN regression suite — acceptance-level end-to-end tests that protect the
+ * integrated `adv_status view:"health"` deadline and source-ranking path:
  *
- *   A) status load → enrichment → specs read sit OUTSIDE a single request-
+ *   A) status load → enrichment → specs read stay inside the single request-
  *      owned 8s / 7.5s non-composition budget;
- *   B) `listSourceRankedCandidates` has no production caller — ranking
- *      still happens after per-change hydration;
- *   C) `createHealthProbeCache` has no production caller — the bounded
- *      plan still wraps the legacy coalesced `createProbeCache`, so
- *      concurrent same-key forceRefreshes are deduplicated and late /
- *      aborted older publications can clobber newer ones.
+ *   B) source-backed ranking stays bounded before per-change hydration;
+ *   C) health probe caches preserve request-local publication ordering under
+ *      concurrent same-key forceRefreshes.
  *
  * Tests use real production composition: real `createTemporalStoreBackend`,
  * real `store.status({ recentLimit, deadline })`, real `runHealthStatus`.

--- a/plugin/src/tools/status-host-cap.test.ts
+++ b/plugin/src/tools/status-host-cap.test.ts
@@ -484,9 +484,8 @@ describe("adv_status corpus-pressure mechanisms", () => {
       archiveParseCounts[view] = archiveLoadChangeCalls.length;
     }
 
-    // RED: current production loads every archived change even when terminal
-    // statuses are not requested. The implementation task must make all three
-    // routine status views avoid this work entirely.
+    // Routine active-status views must not parse archived bundles when terminal
+    // statuses are not requested.
     expect(archiveParseCounts).toEqual({ summary: 0, changes: 0, hygiene: 0 });
   }, 20_000);
 
@@ -499,8 +498,8 @@ describe("adv_status corpus-pressure mechanisms", () => {
       sourceRanked: true,
     });
 
-    // RED: current production reads every active disk candidate before applying
-    // candidateLimit. This must remain a mechanism count, not a wall-clock test.
+    // Source ranking must apply candidateLimit before active disk projection
+    // reads; keep this as a mechanism count rather than a wall-clock test.
     expect(sourceRankedProjectionReads.length).toBeLessThanOrEqual(10);
   }, 20_000);
 

--- a/plugin/src/tools/status-host-cap.test.ts
+++ b/plugin/src/tools/status-host-cap.test.ts
@@ -503,4 +503,60 @@ describe("adv_status corpus-pressure mechanisms", () => {
     // candidateLimit. This must remain a mechanism count, not a wall-clock test.
     expect(sourceRankedProjectionReads.length).toBeLessThanOrEqual(10);
   }, 20_000);
+
+  test("bounds cost injected inside the non-health enrichment loop", async () => {
+    store = await setupCorpusStore(tempDir);
+    const initialStatus = await store.status();
+    let delayedGets = 0;
+    let enrichmentStarted = false;
+    store.changes.get = async (changeId) => {
+      if (enrichmentStarted && delayedGets < 10) {
+        delayedGets += 1;
+        await sleep(1_200);
+      }
+      return {
+        success: true,
+        data: { ...SAMPLE_CHANGE, id: changeId, status: "draft" },
+      };
+    };
+
+    store.status = async () => {
+      const recent = Array.from({ length: 10 }, (_, index) => ({
+        ...(initialStatus.changes.recent[index] ??
+          initialStatus.changes.recent[0]),
+        id: `enrichment-${index}`,
+        status: "draft" as const,
+      }));
+      // Force the actual per-change fallback path after status loading. The
+      // seeded recent rows are synthetic only to isolate loop cost from the
+      // upstream resolver.
+      const result = {
+        ...initialStatus,
+        changes: { ...initialStatus.changes, recent },
+        resolvedChanges: new Map(),
+      };
+      enrichmentStarted = true;
+      return result;
+    };
+
+    const toolMap = createToolMap(store, tempDir, store.paths.agenda) as {
+      adv_status: {
+        execute: (args: Record<string, unknown>) => Promise<unknown>;
+      };
+    };
+    const parsed = parseBoundToolResult(
+      await toolMap.adv_status.execute({
+        view: "changes",
+        forceRefresh: true,
+      }),
+    );
+
+    expect(parsed.errorClass).not.toBe("ToolExecutionTimeout");
+    expect(
+      parsed.warnings?.some(
+        (warning: { code?: string }) =>
+          warning.code === "SOURCE_DEADLINE_EXCEEDED",
+      ),
+    ).toBe(true);
+  }, 20_000);
 });

--- a/plugin/src/tools/status.test.ts
+++ b/plugin/src/tools/status.test.ts
@@ -22,6 +22,8 @@ import {
 } from "../__tests__/setup";
 import { createLegacyStore } from "../storage/store";
 import type { Store } from "../storage/store";
+import { GRPC_NOT_FOUND } from "../temporal/retry-wrapper";
+import type { StatusReadOptions } from "../storage/store-types";
 import { GATE_ORDER, createDefaultGates } from "../types";
 import {
   initializeToolSchemaTelemetry,
@@ -306,7 +308,11 @@ describe("Status Tools", () => {
 
     test("does not retry a NOT_FOUND status when a disk projection is already loaded", async () => {
       const notFoundError = Object.assign(new Error("service response"), {
-        cause: { code: 5, details: "service response", metadata: {} },
+        cause: {
+          code: GRPC_NOT_FOUND,
+          details: "service response",
+          metadata: {},
+        },
       });
       const statusSpy = vi.fn().mockRejectedValue(notFoundError);
       store.status = statusSpy;
@@ -320,11 +326,27 @@ describe("Status Tools", () => {
       expect(statusSpy).toHaveBeenCalledTimes(1);
       expect(parsed.view).toBe("summary");
       expect(parsed.bootstrap_retry).toBeUndefined();
+      expect(parsed.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "SOURCE_WORKFLOW_DURABLY_ABSENT",
+            source: "workflow_query",
+          }),
+        ]),
+      );
+      expect(parsed.hydrationStats).toMatchObject({
+        durableAbsence: true,
+        omitted: 0,
+      });
     });
 
     test("admits NOT_FOUND retry when no disk projection is loaded", async () => {
       const notFoundError = Object.assign(new Error("service response"), {
-        cause: { code: 5, details: "service response", metadata: {} },
+        cause: {
+          code: GRPC_NOT_FOUND,
+          details: "service response",
+          metadata: {},
+        },
       });
       const originalStatus = store.status.bind(store);
       const statusSpy = vi
@@ -339,6 +361,67 @@ describe("Status Tools", () => {
       expect(statusSpy).toHaveBeenCalledTimes(2);
       expect(parsed.view).toBe("summary");
       expect(parsed.bootstrap_retry).toMatchObject({ recovered: true });
+    });
+
+    test("scopes disk projection admission to one status request", async () => {
+      const notFoundError = Object.assign(new Error("service response"), {
+        cause: {
+          code: GRPC_NOT_FOUND,
+          details: "service response",
+          metadata: {},
+        },
+      });
+      const originalStatus = store.status.bind(store);
+      let statusCalls = 0;
+      let durableProjectionWasLoaded = false;
+      store.status = vi.fn(async (options?: StatusReadOptions) => {
+        statusCalls += 1;
+        if (statusCalls === 1) {
+          durableProjectionWasLoaded = true;
+          if (options?.projectionState) options.projectionState.loaded = true;
+          return originalStatus(options);
+        }
+        throw notFoundError;
+      });
+      (
+        store as Store & {
+          hasLoadedDiskProjection?: (state?: { loaded: boolean }) => boolean;
+        }
+      ).hasLoadedDiskProjection = (state) =>
+        state?.loaded ?? durableProjectionWasLoaded;
+
+      await statusTools.adv_status.execute({}, store);
+      const result = await statusTools.adv_status.execute({}, store);
+      const parsed = parseToolOutput(result);
+
+      expect(statusCalls).toBe(4);
+      expect(parsed.bootstrap_retry).toMatchObject({
+        recovered: false,
+        lastErrorClass: "bootstrap_in_progress",
+      });
+    });
+
+    test("does not classify TMPRL1100 as durable absence even with projection signal", async () => {
+      const bootstrapError = new Error(
+        "[TMPRL1100] Nondeterminism error: No command scheduled for event HistoryEvent(id: 231, WorkflowExecutionUpdateAccepted)",
+      );
+      const statusSpy = vi.fn().mockRejectedValue(bootstrapError);
+      store.status = statusSpy;
+      (
+        store as Store & {
+          hasLoadedDiskProjection?: () => boolean;
+        }
+      ).hasLoadedDiskProjection = () => true;
+
+      const result = await statusTools.adv_status.execute({}, store);
+      const parsed = parseToolOutput(result);
+
+      expect(statusSpy).toHaveBeenCalledTimes(3);
+      expect(parsed.bootstrap_retry).toMatchObject({
+        recovered: false,
+        lastErrorClass: "bootstrap_in_progress",
+      });
+      expect(parsed.warnings).toBeUndefined();
     });
 
     test("shows retained terminal cleanup blocker counts without exact paths", async () => {

--- a/plugin/src/tools/status.test.ts
+++ b/plugin/src/tools/status.test.ts
@@ -304,6 +304,43 @@ describe("Status Tools", () => {
       );
     });
 
+    test("does not retry a NOT_FOUND status when a disk projection is already loaded", async () => {
+      const notFoundError = Object.assign(new Error("service response"), {
+        cause: { code: 5, details: "service response", metadata: {} },
+      });
+      const statusSpy = vi.fn().mockRejectedValue(notFoundError);
+      store.status = statusSpy;
+      (
+        store as Store & { hasLoadedDiskProjection?: () => boolean }
+      ).hasLoadedDiskProjection = () => true;
+
+      const result = await statusTools.adv_status.execute({}, store);
+      const parsed = parseToolOutput(result);
+
+      expect(statusSpy).toHaveBeenCalledTimes(1);
+      expect(parsed.view).toBe("summary");
+      expect(parsed.bootstrap_retry).toBeUndefined();
+    });
+
+    test("admits NOT_FOUND retry when no disk projection is loaded", async () => {
+      const notFoundError = Object.assign(new Error("service response"), {
+        cause: { code: 5, details: "service response", metadata: {} },
+      });
+      const originalStatus = store.status.bind(store);
+      const statusSpy = vi
+        .fn()
+        .mockRejectedValueOnce(notFoundError)
+        .mockImplementation(() => originalStatus());
+      store.status = statusSpy;
+
+      const result = await statusTools.adv_status.execute({}, store);
+      const parsed = parseToolOutput(result);
+
+      expect(statusSpy).toHaveBeenCalledTimes(2);
+      expect(parsed.view).toBe("summary");
+      expect(parsed.bootstrap_retry).toMatchObject({ recovered: true });
+    });
+
     test("shows retained terminal cleanup blocker counts without exact paths", async () => {
       const access = await initWorktreeStateDb(tempDir);
       const retainedPath = join(tempDir, "status-retained");

--- a/plugin/src/tools/status.ts
+++ b/plugin/src/tools/status.ts
@@ -15,6 +15,7 @@ import {
   type TemporalReadContext,
 } from "../storage/store-temporal/read-context";
 import { getTemporalWorkerRole } from "../plugin-init";
+import { STATUS_READ_DEADLINE_BUDGET_MS } from "../utils/tool-budgets";
 import {
   classifyTemporalError,
   extractGrpcStatus,
@@ -422,7 +423,12 @@ export const statusTools = {
           // Disk-backed target stores ignore this option, while Temporal-backed
           // stores use the absolute deadline for every source and hydration
           // stage rather than minting a fresh budget per view/call.
-          const temporalReadContext = createTemporalReadContext();
+          // AC5: the status-local budget is derived from the host tool cap
+          // minus a measured serialization headroom (tool-budgets.ts), so
+          // changing either source constant cannot silently erase the margin.
+          const temporalReadContext = createTemporalReadContext(
+            STATUS_READ_DEADLINE_BUDGET_MS,
+          );
           // Disk stores have no Temporal status path and intentionally retain
           // their legacy call shape; the deadline is meaningful only when the
           // Temporal backend exposes its summary projection reader.

--- a/plugin/src/tools/status.ts
+++ b/plugin/src/tools/status.ts
@@ -488,7 +488,7 @@ export const statusTools = {
           if (isTemporalReadExpired(temporalReadContext)) {
             status = buildDeadlineDegradedStatus(status);
           }
-          // Request-local resolved documents (AC4): extracted for
+          // Request-local resolved documents: extracted for
           // enrichment reuse and stripped before output serialization —
           // the map is transport-only, never response payload.
           const resolvedChanges = status.resolvedChanges;
@@ -509,7 +509,10 @@ export const statusTools = {
               message: `⚠️ Status read incomplete — ${warning.message}`,
             });
           }
-          let migrationStatus: unknown = null;
+          let migrationStatus:
+            | Awaited<ReturnType<typeof loadMigrationStatus>>
+            | null
+            | undefined = null;
 
           const projectId = activeStore.paths.external
             ? basename(activeStore.paths.external)
@@ -679,7 +682,6 @@ export const statusTools = {
               "recentChangeEnrichment",
               async () => {
                 let primaryAssigned = false;
-                let deadlineExceeded = false;
                 if (view === "health") {
                   const cutoffAt =
                     statusReadOptions?.deadline?.deadlineAt ??
@@ -688,7 +690,6 @@ export const statusTools = {
                   let rank = 0;
                   for (const rc of recentChanges) {
                     if (postStatusBudgetExceeded()) {
-                      deadlineExceeded = true;
                       break;
                     }
                     const isPrimary = !primaryAssigned && rc.status === "draft";
@@ -716,7 +717,6 @@ export const statusTools = {
                 } else {
                   for (const rc of recentChanges) {
                     if (postStatusBudgetExceeded()) {
-                      deadlineExceeded = true;
                       break;
                     }
                     const isPrimary = !primaryAssigned && rc.status === "draft";
@@ -743,13 +743,10 @@ export const statusTools = {
                       !enrichmentRead.complete ||
                       postStatusBudgetExceeded()
                     ) {
-                      deadlineExceeded = true;
                       break;
                     }
                   }
                 }
-                if (postStatusBudgetExceeded()) deadlineExceeded = true;
-                return deadlineExceeded;
               },
             );
             if (postStatusBudgetExceeded()) {
@@ -1212,7 +1209,11 @@ export const statusTools = {
                 temporalReadContext,
                 { maxAttempts: 1, opType: "status.snapshotHealth" },
               );
-              if (!snapshotHealthRead.complete || !snapshotHealthRead.data) {
+              if (
+                !snapshotHealthRead.complete ||
+                !snapshotHealthRead.data ||
+                postStatusBudgetExceeded()
+              ) {
                 status = buildDeadlineDegradedStatus(status);
                 return buildDegradedResponse();
               }
@@ -1228,7 +1229,11 @@ export const statusTools = {
                 temporalReadContext,
                 { maxAttempts: 1, opType: "status.specs" },
               );
-              if (!specsRead.complete || !specsRead.data) {
+              if (
+                !specsRead.complete ||
+                !specsRead.data ||
+                postStatusBudgetExceeded()
+              ) {
                 status = buildDeadlineDegradedStatus(status);
                 return buildDegradedResponse();
               }

--- a/plugin/src/tools/status.ts
+++ b/plugin/src/tools/status.ts
@@ -464,12 +464,7 @@ export const statusTools = {
               message: `⚠️ Status read incomplete — ${warning.message}`,
             });
           }
-          const migrationStatus =
-            view === "hygiene"
-              ? await withRecordedPhase("adv_status", "migrationStatus", () =>
-                  loadMigrationStatus(activeStore),
-                )
-              : null;
+          let migrationStatus: unknown = null;
 
           const projectId = activeStore.paths.external
             ? basename(activeStore.paths.external)
@@ -543,13 +538,63 @@ export const statusTools = {
             });
           };
 
+          const postStatusCutoffAt =
+            statusReadOptions?.deadline?.deadlineAt ??
+            temporalReadContext.deadline.deadlineAt;
+          const postStatusBudgetExceeded = () =>
+            isTemporalReadExpired(temporalReadContext) ||
+            Date.now() >= postStatusCutoffAt;
+          const degradeForDeadline = () => {
+            status = buildDeadlineDegradedStatus(status);
+            return buildDegradedResponse();
+          };
+          const runBoundedStatusPhase = async <T>(
+            opType: string,
+            operation: () => Promise<T>,
+          ): Promise<
+            | { kind: "complete"; data: T }
+            | { kind: "deadline" }
+            | { kind: "error"; error: unknown }
+          > => {
+            if (postStatusBudgetExceeded()) return { kind: "deadline" };
+            const phaseRead = await runTemporalRead(
+              undefined,
+              operation,
+              temporalReadContext,
+              { maxAttempts: 1, opType },
+            );
+            if (!phaseRead.complete) {
+              return postStatusBudgetExceeded()
+                ? { kind: "deadline" }
+                : { kind: "error", error: phaseRead.error };
+            }
+            if (postStatusBudgetExceeded()) return { kind: "deadline" };
+            return { kind: "complete", data: phaseRead.data as T };
+          };
+
+          if (view === "hygiene") {
+            const migrationRead = await runTemporalRead(
+              undefined,
+              () =>
+                withRecordedPhase("adv_status", "migrationStatus", () =>
+                  loadMigrationStatus(activeStore),
+                ),
+              temporalReadContext,
+              { maxAttempts: 1, opType: "status.migrationStatus" },
+            );
+            if (!migrationRead.complete || postStatusBudgetExceeded()) {
+              return degradeForDeadline();
+            }
+            migrationStatus = migrationRead.data;
+          }
+
           // A status read that consumed its aggregate budget is already a
           // useful typed result. Do not enter view-specific enrichment/probe
           // stages after expiry: those stages have independent best-effort
           // work and could outlive the host safety cap while the caller has
           // already been told the authoritative read is incomplete.
           if (isTemporalReadExpired(temporalReadContext)) {
-            return buildDegradedResponse();
+            return degradeForDeadline();
           }
 
           if (plan.recentEnrichment) {
@@ -564,6 +609,9 @@ export const statusTools = {
                   resolvedChanges,
                 ),
             );
+            if (postStatusBudgetExceeded()) {
+              return degradeForDeadline();
+            }
             if (
               view === "summary" &&
               recentChanges.length > STATUS_SUMMARY_RECENT_LIMIT
@@ -586,6 +634,7 @@ export const statusTools = {
               "recentChangeEnrichment",
               async () => {
                 let primaryAssigned = false;
+                let deadlineExceeded = false;
                 if (view === "health") {
                   const cutoffAt =
                     statusReadOptions?.deadline?.deadlineAt ??
@@ -593,6 +642,10 @@ export const statusTools = {
                   const patches: CandidateEnrichmentPatch[] = [];
                   let rank = 0;
                   for (const rc of recentChanges) {
+                    if (postStatusBudgetExceeded()) {
+                      deadlineExceeded = true;
+                      break;
+                    }
                     const isPrimary = !primaryAssigned && rc.status === "draft";
                     if (isPrimary) primaryAssigned = true;
                     const patch = await buildCandidateEnrichmentPatch({
@@ -617,32 +670,64 @@ export const statusTools = {
                   });
                 } else {
                   for (const rc of recentChanges) {
+                    if (postStatusBudgetExceeded()) {
+                      deadlineExceeded = true;
+                      break;
+                    }
                     const isPrimary = !primaryAssigned && rc.status === "draft";
                     if (isPrimary) primaryAssigned = true;
-                    await enrichRecentChangeStatus(
-                      rc,
-                      status,
-                      activeStore,
-                      clarifyMode,
-                      isPrimary,
-                      {
-                        change: resolvedChanges?.get(String(rc.id)),
-                        resolvedChanges,
-                      },
+                    const enrichmentRead = await runTemporalRead(
+                      undefined,
+                      () =>
+                        enrichRecentChangeStatus(
+                          rc,
+                          status,
+                          activeStore,
+                          clarifyMode,
+                          isPrimary,
+                          {
+                            change: resolvedChanges?.get(String(rc.id)),
+                            resolvedChanges,
+                          },
+                          { cutoffAt: postStatusCutoffAt },
+                        ),
+                      temporalReadContext,
+                      { maxAttempts: 1, opType: "status.recentEnrichment" },
                     );
+                    if (
+                      !enrichmentRead.complete ||
+                      postStatusBudgetExceeded()
+                    ) {
+                      deadlineExceeded = true;
+                      break;
+                    }
                   }
                 }
+                if (postStatusBudgetExceeded()) deadlineExceeded = true;
+                return deadlineExceeded;
               },
             );
+            if (postStatusBudgetExceeded()) {
+              return degradeForDeadline();
+            }
           }
 
           if (plan.resumeProjection) {
-            await withRecordedPhase("adv_status", "resumeProjection", () =>
-              appendResumeProjectionRecommendations(activeStore, status, {
-                projectId,
-                limit: 3,
-              }),
+            const resumeRead = await runTemporalRead(
+              undefined,
+              () =>
+                withRecordedPhase("adv_status", "resumeProjection", () =>
+                  appendResumeProjectionRecommendations(activeStore, status, {
+                    projectId,
+                    limit: 3,
+                  }),
+                ),
+              temporalReadContext,
+              { maxAttempts: 1, opType: "status.resumeProjection" },
             );
+            if (!resumeRead.complete || postStatusBudgetExceeded()) {
+              return degradeForDeadline();
+            }
           }
 
           let probeFreshness: Record<string, ProbeCacheFreshness> = {};
@@ -707,12 +792,20 @@ export const statusTools = {
           if (view !== "health") {
             if (plan.temporalHealth) {
               try {
-                const temporalProbe = await fetchStatusTemporalHealth(
-                  projectId,
-                  {
-                    forceRefresh,
-                  },
+                const temporalProbeRead = await runBoundedStatusPhase(
+                  "status.temporalHealth",
+                  () =>
+                    fetchStatusTemporalHealth(projectId, {
+                      forceRefresh,
+                    }),
                 );
+                if (temporalProbeRead.kind === "deadline") {
+                  return degradeForDeadline();
+                }
+                if (temporalProbeRead.kind === "error") {
+                  throw temporalProbeRead.error;
+                }
+                const temporalProbe = temporalProbeRead.data;
                 temporalHealth = temporalProbe.value;
                 probeFreshness.temporal_health = temporalProbe.freshness;
               } catch (err) {
@@ -731,14 +824,24 @@ export const statusTools = {
             }
 
             if (plan.queueServiceability && temporalHealth) {
-              const queueServiceabilityProbe =
-                await fetchStatusQueueServiceability(
-                  {
-                    projectId,
-                    health: temporalHealth,
-                  },
-                  { forceRefresh },
-                );
+              const queueServiceabilityRead = await runBoundedStatusPhase(
+                "status.queueServiceability",
+                () =>
+                  fetchStatusQueueServiceability(
+                    {
+                      projectId,
+                      health: temporalHealth!,
+                    },
+                    { forceRefresh },
+                  ),
+              );
+              if (queueServiceabilityRead.kind === "deadline") {
+                return degradeForDeadline();
+              }
+              if (queueServiceabilityRead.kind === "error") {
+                throw queueServiceabilityRead.error;
+              }
+              const queueServiceabilityProbe = queueServiceabilityRead.data;
               queueServiceability = queueServiceabilityProbe.value;
               probeFreshness.queue_serviceability =
                 queueServiceabilityProbe.freshness;
@@ -752,9 +855,17 @@ export const statusTools = {
 
             if (plan.workerProcesses) {
               try {
-                const workerProcessesProbe = await fetchStatusWorkerProcesses({
-                  forceRefresh,
-                });
+                const workerProcessesRead = await runBoundedStatusPhase(
+                  "status.workerProcesses",
+                  () => fetchStatusWorkerProcesses({ forceRefresh }),
+                );
+                if (workerProcessesRead.kind === "deadline") {
+                  return degradeForDeadline();
+                }
+                if (workerProcessesRead.kind === "error") {
+                  throw workerProcessesRead.error;
+                }
+                const workerProcessesProbe = workerProcessesRead.data;
                 workerProcesses = workerProcessesProbe.value;
                 probeFreshness.worker_processes =
                   workerProcessesProbe.freshness;
@@ -791,11 +902,21 @@ export const statusTools = {
             }
 
             if (plan.searchAttributes) {
-              const searchAttributesProbe =
-                await statusSearchAttributesProbeCache.fetch(
-                  projectId ?? MISSING_PROJECT_ID_CACHE_KEY,
-                  { forceRefresh },
-                );
+              const searchAttributesRead = await runBoundedStatusPhase(
+                "status.searchAttributes",
+                () =>
+                  statusSearchAttributesProbeCache.fetch(
+                    projectId ?? MISSING_PROJECT_ID_CACHE_KEY,
+                    { forceRefresh },
+                  ),
+              );
+              if (searchAttributesRead.kind === "deadline") {
+                return degradeForDeadline();
+              }
+              if (searchAttributesRead.kind === "error") {
+                throw searchAttributesRead.error;
+              }
+              const searchAttributesProbe = searchAttributesRead.data;
               searchAttributes = searchAttributesProbe.value;
               probeFreshness.search_attributes =
                 searchAttributesProbe.freshness;
@@ -818,9 +939,13 @@ export const statusTools = {
             }
 
             if (plan.projectConfig) {
-              const configResult = await loadProjectConfigWithDiagnostics(
-                activeStore.paths.root,
+              const configRead = await runBoundedStatusPhase(
+                "status.projectConfig",
+                () => loadProjectConfigWithDiagnostics(activeStore.paths.root),
               );
+              if (configRead.kind === "deadline") return degradeForDeadline();
+              if (configRead.kind === "error") throw configRead.error;
+              const configResult = configRead.data;
 
               if (!activeStore.paths.external) {
                 status.recommendations.unshift(
@@ -864,52 +989,76 @@ export const statusTools = {
             }
 
             if (plan.worktreeCleanup) {
-              await withRecordedPhase(
-                "adv_status",
-                "worktreeCleanup",
-                async () => {
-                  try {
-                    const worktreeAccess = await initWorktreeStateDb(
-                      activeStore.paths.root,
-                    );
-                    await advWorktreeCleanup("status", {
-                      projectRoot: activeStore.paths.root,
-                      database: worktreeAccess,
-                      log: {
-                        debug: () => undefined,
-                        info: () => undefined,
-                        warn: () => undefined,
-                        error: () => undefined,
-                      },
-                      store: activeStore,
-                      forceAttempts: false,
-                    });
-                    terminalCleanupRetained = summarizePendingDeletes(
-                      await getPendingDeletes(worktreeAccess),
-                    );
-                  } catch {
-                    // Status cleanup discovery is best-effort; status itself must remain available.
-                  }
-                },
+              const cleanupRead = await runBoundedStatusPhase(
+                "status.worktreeCleanup",
+                () =>
+                  withRecordedPhase(
+                    "adv_status",
+                    "worktreeCleanup",
+                    async () => {
+                      try {
+                        const worktreeAccess = await initWorktreeStateDb(
+                          activeStore.paths.root,
+                        );
+                        await advWorktreeCleanup("status", {
+                          projectRoot: activeStore.paths.root,
+                          database: worktreeAccess,
+                          log: {
+                            debug: () => undefined,
+                            info: () => undefined,
+                            warn: () => undefined,
+                            error: () => undefined,
+                          },
+                          store: activeStore,
+                          forceAttempts: false,
+                        });
+                        terminalCleanupRetained = summarizePendingDeletes(
+                          await getPendingDeletes(worktreeAccess),
+                        );
+                      } catch {
+                        // Status cleanup discovery is best-effort; status itself must remain available.
+                      }
+                    },
+                  ),
               );
+              if (cleanupRead.kind === "deadline") return degradeForDeadline();
+              if (cleanupRead.kind === "error") throw cleanupRead.error;
             }
 
             if (plan.worktreeCensus) {
-              const worktreeCensusProbe =
-                await statusWorktreeCensusProbeCache.fetch(
-                  activeStore.paths.root,
-                  { forceRefresh },
-                );
+              const worktreeCensusRead = await runBoundedStatusPhase(
+                "status.worktreeCensus",
+                () =>
+                  statusWorktreeCensusProbeCache.fetch(activeStore.paths.root, {
+                    forceRefresh,
+                  }),
+              );
+              if (worktreeCensusRead.kind === "deadline") {
+                return degradeForDeadline();
+              }
+              if (worktreeCensusRead.kind === "error") {
+                throw worktreeCensusRead.error;
+              }
+              const worktreeCensusProbe = worktreeCensusRead.data;
               worktreeCensus = worktreeCensusProbe.value;
               probeFreshness.worktree_census = worktreeCensusProbe.freshness;
             }
 
             if (plan.sessionDebt) {
-              opencodeSessionDebt = await withRecordedPhase(
-                "adv_status",
-                "sessionDebtScan",
-                () => scanOpenCodeSessionDebt(),
+              const sessionDebtRead = await runBoundedStatusPhase(
+                "status.sessionDebt",
+                () =>
+                  withRecordedPhase("adv_status", "sessionDebtScan", () =>
+                    scanOpenCodeSessionDebt(),
+                  ),
               );
+              if (sessionDebtRead.kind === "deadline") {
+                return degradeForDeadline();
+              }
+              if (sessionDebtRead.kind === "error") {
+                throw sessionDebtRead.error;
+              }
+              opencodeSessionDebt = sessionDebtRead.data;
               opencodeDebtCounts =
                 deriveOpencodeDebtCounts(opencodeSessionDebt);
               if (
@@ -933,11 +1082,20 @@ export const statusTools = {
             }
 
             if (plan.healthSnapshot) {
-              healthSnapshot = await withRecordedPhase(
-                "adv_status",
-                "healthSnapshot",
-                () => computeHealthSnapshot(activeStore),
+              const healthSnapshotRead = await runBoundedStatusPhase(
+                "status.healthSnapshot",
+                () =>
+                  withRecordedPhase("adv_status", "healthSnapshot", () =>
+                    computeHealthSnapshot(activeStore),
+                  ),
               );
+              if (healthSnapshotRead.kind === "deadline") {
+                return degradeForDeadline();
+              }
+              if (healthSnapshotRead.kind === "error") {
+                throw healthSnapshotRead.error;
+              }
+              healthSnapshot = healthSnapshotRead.data;
               if (healthSnapshot.closed_to_active_ratio > 5) {
                 const ratio = healthSnapshot.closed_to_active_ratio;
                 const message = `⚠️  Closed-change disk leak detected (ratio ${ratio}:1). Run \`adv_cleanup\` to inspect stale changes.`;
@@ -953,9 +1111,19 @@ export const statusTools = {
               }
             }
 
-            externalStateHygiene = plan.externalStateHygiene
-              ? await computeExternalStateHygiene(activeStore)
-              : undefined;
+            if (plan.externalStateHygiene) {
+              const externalStateRead = await runBoundedStatusPhase(
+                "status.externalStateHygiene",
+                () => computeExternalStateHygiene(activeStore),
+              );
+              if (externalStateRead.kind === "deadline") {
+                return degradeForDeadline();
+              }
+              if (externalStateRead.kind === "error") {
+                throw externalStateRead.error;
+              }
+              externalStateHygiene = externalStateRead.data;
+            }
 
             if (plan.archivedBranchHygiene) {
               try {
@@ -967,11 +1135,18 @@ export const statusTools = {
                   recommendation_items: (status as StatusRecommendationCarrier)
                     .recommendation_items,
                 };
-                await appendArchivedBranchHygieneRecommendations(
-                  hygieneStatus,
-                  activeStore,
-                  repoRoot,
+                const archivedHygieneRead = await runBoundedStatusPhase(
+                  "status.archivedBranchHygiene",
+                  () =>
+                    appendArchivedBranchHygieneRecommendations(
+                      hygieneStatus,
+                      activeStore,
+                      repoRoot,
+                    ),
                 );
+                if (archivedHygieneRead.kind === "deadline") {
+                  return degradeForDeadline();
+                }
                 status.recommendations = hygieneStatus.recommendations;
                 (status as StatusRecommendationCarrier).recommendation_items =
                   hygieneStatus.recommendation_items;
@@ -1021,9 +1196,18 @@ export const statusTools = {
 
             if (plan.peerSessions) {
               try {
-                const peerResult = await listPeerSessions({
-                  projectRoot: activeStore.paths.root,
-                });
+                const peerRead = await runBoundedStatusPhase(
+                  "status.peerSessions",
+                  () =>
+                    listPeerSessions({
+                      projectRoot: activeStore.paths.root,
+                    }),
+                );
+                if (peerRead.kind === "deadline") {
+                  return degradeForDeadline();
+                }
+                if (peerRead.kind === "error") throw peerRead.error;
+                const peerResult = peerRead.data;
                 if (peerResult.unavailable) {
                   peerSessions = { unavailable: true };
                 } else {
@@ -1034,18 +1218,37 @@ export const statusTools = {
               }
             }
 
-            pluginRuntimeInfo = plan.pluginRuntime
-              ? await getPluginRuntimeInfo()
-              : undefined;
+            if (plan.pluginRuntime) {
+              const pluginRuntimeRead = await runBoundedStatusPhase(
+                "status.pluginRuntime",
+                () => getPluginRuntimeInfo(),
+              );
+              if (pluginRuntimeRead.kind === "deadline") {
+                return degradeForDeadline();
+              }
+              if (pluginRuntimeRead.kind === "error") {
+                throw pluginRuntimeRead.error;
+              }
+              pluginRuntimeInfo = pluginRuntimeRead.data;
+            }
           } else {
-            const healthResult = await runHealthStatus({
-              store: activeStore,
-              projectId,
-              forceRefresh,
-              autoManagedCensus,
-              request: healthRequest!,
-              loadMigrationStatus: () => loadMigrationStatus(activeStore),
-            });
+            const healthRead = await runBoundedStatusPhase(
+              "status.health",
+              () =>
+                runHealthStatus({
+                  store: activeStore,
+                  projectId,
+                  forceRefresh,
+                  autoManagedCensus,
+                  request: healthRequest!,
+                  loadMigrationStatus: () => loadMigrationStatus(activeStore),
+                }),
+            );
+            if (healthRead.kind === "deadline") {
+              return degradeForDeadline();
+            }
+            if (healthRead.kind === "error") throw healthRead.error;
+            const healthResult = healthRead.data;
 
             temporalHealth = healthResult.temporal_health;
             queueServiceability = healthResult.temporal_queue_serviceability
@@ -1239,19 +1442,40 @@ export const statusTools = {
             formatted.sessionDebtSection = "";
           }
 
-          const projectMetadata = plan.projectMetadata
-            ? await readProjectMetadata(
-                activeStore.paths.root,
-                activeStore.paths.projectMetadata,
-              )
-            : undefined;
+          let projectMetadata:
+            | Awaited<ReturnType<typeof readProjectMetadata>>
+            | undefined;
+          if (plan.projectMetadata) {
+            const projectMetadataRead = await runBoundedStatusPhase(
+              "status.projectMetadata",
+              () =>
+                readProjectMetadata(
+                  activeStore.paths.root,
+                  activeStore.paths.projectMetadata,
+                ),
+            );
+            if (projectMetadataRead.kind === "deadline") {
+              return degradeForDeadline();
+            }
+            if (projectMetadataRead.kind === "error") {
+              throw projectMetadataRead.error;
+            }
+            projectMetadata = projectMetadataRead.data;
+          }
 
           if (plan.futureWork) {
-            futureWorkProjection = await withRecordedPhase(
-              "adv_status",
-              "futureWorkProjection",
-              () => buildFutureWorkProjection(activeStore),
+            const futureWorkRead = await runBoundedStatusPhase(
+              "status.futureWorkProjection",
+              () =>
+                withRecordedPhase("adv_status", "futureWorkProjection", () =>
+                  buildFutureWorkProjection(activeStore),
+                ),
             );
+            if (futureWorkRead.kind === "deadline") {
+              return degradeForDeadline();
+            }
+            if (futureWorkRead.kind === "error") throw futureWorkRead.error;
+            futureWorkProjection = futureWorkRead.data;
           }
 
           // T4: tool-context telemetry is only required for the health view.

--- a/plugin/src/tools/status.ts
+++ b/plugin/src/tools/status.ts
@@ -586,9 +586,16 @@ export const statusTools = {
             });
           };
 
-          const postStatusCutoffAt =
-            statusReadOptions?.deadline?.deadlineAt ??
-            temporalReadContext.deadline.deadlineAt;
+          // The post-status cutoff is the REQUEST-SCOPED AGGREGATE deadline,
+          // never a view-specific sub-budget. `statusReadOptions.deadline` is
+          // not safe here: for the health view on a store without a Temporal
+          // summary reader, `buildHealthStatusDeadline` falls back to health's
+          // own 7.5s execution cutoff. Using that as the outer bound made the
+          // whole response degrade the moment health's INNER budget was spent,
+          // discarding the health payload that `runHealthStatus` had already
+          // legitimately degraded and returned. Inner sub-budgets are owned and
+          // enforced by their own executors.
+          const postStatusCutoffAt = temporalReadContext.deadline.deadlineAt;
           const postStatusBudgetExceeded = () =>
             isTemporalReadExpired(temporalReadContext) ||
             Date.now() >= postStatusCutoffAt;

--- a/plugin/src/tools/status.ts
+++ b/plugin/src/tools/status.ts
@@ -17,6 +17,7 @@ import {
 import { getTemporalWorkerRole } from "../plugin-init";
 import {
   classifyTemporalError,
+  extractGrpcStatus,
   getTemporalRetryTelemetry,
 } from "../temporal/retry-wrapper";
 import { isWorkerAffirmativelyAlive } from "../temporal/health-probe";
@@ -133,6 +134,7 @@ async function loadMigrationStatus(_store: Store) {
 
 const STATUS_BOOTSTRAP_RETRY_DELAY_MS = 50;
 const STATUS_BOOTSTRAP_MAX_ATTEMPTS = 3;
+const GRPC_NOT_FOUND = 5;
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -168,6 +170,24 @@ function buildDeadlineDegradedStatus(status?: ProjectStatus): ProjectStatus {
       omitted: status?.hydrationStats?.omitted ?? 0,
       omittedIds: status?.hydrationStats?.omittedIds ?? [],
     },
+  };
+}
+
+function buildDurableAbsenceStatus(): ProjectStatus {
+  return {
+    specs: { count: 0, capabilities: [] },
+    changes: {
+      active: 0,
+      byStatus: {
+        draft: 0,
+        archived: 0,
+        closed: 0,
+      },
+      recent: [],
+    },
+    recommendations: [
+      "⚠️ Temporal workflow is durably absent; status read stopped after the loaded disk projection was retained.",
+    ],
   };
 }
 
@@ -214,6 +234,15 @@ async function loadStatusWithBootstrapRetry(
         : { status };
     } catch (error) {
       if (classifyTemporalError(error) !== "fallback") throw error;
+      // A structurally identified gRPC NOT_FOUND is terminal once this store
+      // has already loaded a durable disk projection. Do not use error text:
+      // TMPRL1100 has no gRPC status and remains bootstrap-retry eligible.
+      if (
+        extractGrpcStatus(error) === GRPC_NOT_FOUND &&
+        store.hasLoadedDiskProjection?.() === true
+      ) {
+        return { status: buildDurableAbsenceStatus() };
+      }
       lastBootstrapError = error;
       if (isTemporalReadExpired(context)) {
         return {

--- a/plugin/src/tools/status.ts
+++ b/plugin/src/tools/status.ts
@@ -19,6 +19,7 @@ import { STATUS_READ_DEADLINE_BUDGET_MS } from "../utils/tool-budgets";
 import {
   classifyTemporalError,
   extractGrpcStatus,
+  GRPC_NOT_FOUND,
   getTemporalRetryTelemetry,
 } from "../temporal/retry-wrapper";
 import { isWorkerAffirmativelyAlive } from "../temporal/health-probe";
@@ -135,8 +136,6 @@ async function loadMigrationStatus(_store: Store) {
 
 const STATUS_BOOTSTRAP_RETRY_DELAY_MS = 50;
 const STATUS_BOOTSTRAP_MAX_ATTEMPTS = 3;
-const GRPC_NOT_FOUND = 5;
-
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -175,6 +174,12 @@ function buildDeadlineDegradedStatus(status?: ProjectStatus): ProjectStatus {
 }
 
 function buildDurableAbsenceStatus(): ProjectStatus {
+  const warning = {
+    code: "SOURCE_WORKFLOW_DURABLY_ABSENT" as const,
+    source: "workflow_query" as const,
+    message:
+      "Temporal workflow is durably absent after a retained disk projection; status read stopped without retrying the unreachable workflow.",
+  };
   return {
     specs: { count: 0, capabilities: [] },
     changes: {
@@ -186,9 +191,9 @@ function buildDurableAbsenceStatus(): ProjectStatus {
       },
       recent: [],
     },
-    recommendations: [
-      "⚠️ Temporal workflow is durably absent; status read stopped after the loaded disk projection was retained.",
-    ],
+    recommendations: [],
+    warnings: [warning],
+    hydrationStats: { durableAbsence: true, omitted: 0 },
   };
 }
 
@@ -205,6 +210,11 @@ async function loadStatusWithBootstrapRetry(
   };
 }> {
   let lastBootstrapError: unknown;
+  const projectionState = { loaded: false };
+  const readOptions: StatusReadOptions | undefined =
+    typeof store.hasLoadedDiskProjection === "function"
+      ? { ...(options ?? {}), projectionState }
+      : options;
 
   for (let attempt = 1; attempt <= STATUS_BOOTSTRAP_MAX_ATTEMPTS; attempt++) {
     if (isTemporalReadExpired(context)) {
@@ -219,7 +229,7 @@ async function loadStatusWithBootstrapRetry(
       };
     }
     try {
-      const status = await store.status(options);
+      const status = await store.status(readOptions);
       return lastBootstrapError
         ? {
             status,
@@ -240,7 +250,7 @@ async function loadStatusWithBootstrapRetry(
       // TMPRL1100 has no gRPC status and remains bootstrap-retry eligible.
       if (
         extractGrpcStatus(error) === GRPC_NOT_FOUND &&
-        store.hasLoadedDiskProjection?.() === true
+        store.hasLoadedDiskProjection?.(projectionState) === true
       ) {
         return { status: buildDurableAbsenceStatus() };
       }

--- a/plugin/src/types/responses.ts
+++ b/plugin/src/types/responses.ts
@@ -38,6 +38,7 @@ export type TerminalWarningCode =
   | "TERMINAL_SOURCE_DEGRADED"
   | "TERMINAL_CANDIDATE_OMITTED"
   | "SOURCE_DEADLINE_EXCEEDED"
+  | "SOURCE_WORKFLOW_DURABLY_ABSENT"
   | "SOURCE_BOUND_EXCEEDED"
   | "SOURCE_RANKING_DEGRADED";
 
@@ -87,6 +88,8 @@ export interface HydrationStats {
    * explicitly incomplete.
    */
   boundedOmitted?: number;
+  /** True when the workflow source is durably absent after a disk projection read. */
+  durableAbsence?: boolean;
   /**
    * Specific candidate IDs omitted because the aggregate read deadline
    * expired or the circuit breaker tripped. Present when callers need to

--- a/plugin/src/utils/safe-execute.ts
+++ b/plugin/src/utils/safe-execute.ts
@@ -22,6 +22,7 @@ import {
   isAdvSessionNotReady,
   ADV_SESSION_NOT_READY_KIND,
 } from "../temporal/readiness-types";
+import { DEFAULT_TOOL_TIMEOUT_MS } from "./tool-budgets";
 
 /**
  * Optional enrichment context. All fields are additive — no existing
@@ -243,23 +244,6 @@ export function formatErrorResponse(
 // =============================================================================
 
 const DEFAULT_TRUNCATION_LIMIT = 30000;
-
-/**
- * Default safety-net timeout for a single tool execute() call, in
- * milliseconds. Tools that exceed this budget are interrupted and an
- * agent-visible `ToolExecutionTimeout` error is returned.
- *
- * Rationale: covers SDK-side Zod parse hangs on missing required args
- * (the root cause of the zero-args `adv_change_update` hang reproduced
- * during /adv-design of completeTemporalOnlyMigration — see wisdom
- * ws-3550c245 and design.md KD-8), as well as any deadlocked workflow
- * Update / signal path where `runTemporal` itself has no timeout.
- *
- * 10s is deliberately more forgiving than the Temporal query timeout
- * (5s, P1.3.8) because legitimate tool bodies may invoke multiple
- * backend operations in sequence.
- */
-const DEFAULT_TOOL_TIMEOUT_MS = 10_000;
 
 /**
  * Optional safety-net timeout override. Accepted by `safeExecute` and

--- a/plugin/src/utils/tool-budgets.test.ts
+++ b/plugin/src/utils/tool-budgets.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { HEALTH_EXECUTION_CUTOFF_MS } from "../tools/status-health-plan";
 import {
   DEFAULT_TOOL_TIMEOUT_MS,
   STATUS_READ_DEADLINE_BUDGET_MS,
@@ -27,5 +28,14 @@ describe("status read/tool timeout budget contract", () => {
     // Headroom must be strictly positive — a zero/negative margin means
     // the degraded response has no time to serialize.
     expect(TOOL_RESPONSE_HEADROOM_MS).toBeGreaterThan(0);
+  });
+
+  test("health execution cutoff stays inside the status read budget", () => {
+    // The health executor has its own provider cutoff, but the outer status
+    // deadline is authoritative. Keep the inner cutoff strictly below it so
+    // the health guard can never outlive the remaining status-read budget.
+    expect(HEALTH_EXECUTION_CUTOFF_MS).toBeLessThan(
+      STATUS_READ_DEADLINE_BUDGET_MS,
+    );
   });
 });

--- a/plugin/src/utils/tool-budgets.test.ts
+++ b/plugin/src/utils/tool-budgets.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_TOOL_TIMEOUT_MS,
+  STATUS_READ_DEADLINE_BUDGET_MS,
+  TOOL_RESPONSE_HEADROOM_MS,
+} from "./tool-budgets";
+
+describe("status read/tool timeout budget contract", () => {
+  test("keeps the measured response headroom and derived status budget", () => {
+    // These fixed measurements make changing either source constant alone a
+    // deliberate CI decision instead of a silent erosion of the margin.
+    expect(DEFAULT_TOOL_TIMEOUT_MS).toBe(10_000);
+    expect(TOOL_RESPONSE_HEADROOM_MS).toBe(199);
+    expect(STATUS_READ_DEADLINE_BUDGET_MS).toBe(
+      DEFAULT_TOOL_TIMEOUT_MS - TOOL_RESPONSE_HEADROOM_MS,
+    );
+    expect(STATUS_READ_DEADLINE_BUDGET_MS).toBe(9_801);
+  });
+
+  test("AC5: budget + headroom never exceeds the host tool cap", () => {
+    // Machine-checked invariant: regardless of how the source constants
+    // change, the serialization headroom must always fit beneath the cap so
+    // degradation can be reached and serialized before the host fires.
+    expect(
+      STATUS_READ_DEADLINE_BUDGET_MS + TOOL_RESPONSE_HEADROOM_MS,
+    ).toBeLessThanOrEqual(DEFAULT_TOOL_TIMEOUT_MS);
+    // Headroom must be strictly positive — a zero/negative margin means
+    // the degraded response has no time to serialize.
+    expect(TOOL_RESPONSE_HEADROOM_MS).toBeGreaterThan(0);
+  });
+});

--- a/plugin/src/utils/tool-budgets.ts
+++ b/plugin/src/utils/tool-budgets.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared host-tool budget constants.
+ *
+ * The global TEMPORAL_READ_DEADLINE_BUDGET_MS remains unchanged because it is
+ * also used by non-status read paths (including callers whose outer tool cap
+ * is not the 10-second default). The status path gets its own budget below;
+ * its owner must pass this value when creating the request context.
+ */
+export const DEFAULT_TOOL_TIMEOUT_MS = 10_000;
+
+/**
+ * Reserve for assembling a degraded status result and serializing it.
+ *
+ * Measurement: 100 iterations of a synthetic 3,670,196-character health
+ * payload (1,000 changes, 8 tasks per change, 500 recommendations), including
+ * degraded-result assembly, health projection, and formatToolOutput with the
+ * production 21,000-character cap, had a 132.262634 ms maximum on 2026-08-04.
+ * The reserve is ceil(max * 1.5) = 199 ms; the factor covers normal scheduler
+ * variance without inventing a round-number margin.
+ *
+ * A larger reserve makes the status read degrade more often under load because
+ * it shortens the Temporal budget. That completeness trade is intentional:
+ * bounded typed failure is safer than letting an opaque host timeout win.
+ */
+export const TOOL_RESPONSE_HEADROOM_MS = 199;
+
+/**
+ * Status-local aggregate read budget. Keep this derived from the host cap so
+ * changing either source constant cannot silently erase the response margin.
+ */
+export const STATUS_READ_DEADLINE_BUDGET_MS =
+  DEFAULT_TOOL_TIMEOUT_MS - TOOL_RESPONSE_HEADROOM_MS;


### PR DESCRIPTION
## Problem

`adv_status` was returning `ToolExecutionTimeout` (unclassified 10s host-cap timeout) instead of a complete or explicitly degraded result. A previous attempt (PR #365) fixed the store layer and deployed, but the production symptom survived because the **tool layer** still had unbounded paths.

## What this change does

**D5 — Bounded the post-status enrichment loop** (the prime suspect for the post-deploy breach)
- Per-iteration deadline admission added to BOTH enrichment branches (the non-health branch serving summary/changes/hygiene previously had none)
- `cutoffAt`/`signal` threaded into `enrichRecentChangeStatus` via new `StatusEnrichmentOptions`
- All post-status phases (resume projection, probes, migration, snapshotHealth, specRequirementCount) bounded under the shared request budget

**D3 — Structural NOT_FOUND retry discriminator**
- A gRPC code-5 error (extracted structurally via cause-chain walk, not message text) + request-scoped disk-projection state refuses retry for durably-absent workflows after 1 attempt instead of 3
- Genuine bootstrap-in-progress (no projection loaded) still retries and recovers
- TMPRL1100 inherently excluded (no gRPC code); `classifyTemporalError` and `retry-wrapper.ts` unmodified

**D4 — Budget derived from host cap**
- `STATUS_READ_DEADLINE_BUDGET_MS = DEFAULT_TOOL_TIMEOUT_MS - TOOL_RESPONSE_HEADROOM_MS` (10,000 - 199 = 9,801), wired into `createTemporalReadContext` at the status handler
- Headroom reserve (199ms) measured, not guessed: 132ms max over 100 iterations of a 3.67MB degraded payload serialization
- CI-enforced invariant: `budget + headroom ≤ cap`

**Review-found fixes (acceptance stage)**
- **C7 violation fixed**: `buildDurableAbsenceStatus` now returns typed `SOURCE_WORKFLOW_DURABLY_ABSENT` warning + `hydrationStats` instead of a prose-only emoji string that was structurally indistinguishable from a legitimately empty project
- **C6/AC4 violation fixed**: the projection flag was session-lifetime (store created once, reused session-wide) so after any prior load, every subsequent NOT_FOUND — including genuine bootstrap — skipped retry. Now request-scoped via `DiskProjectionReadState`
- Behavioral `dualWriteAfterMutation` guard tests replaced the brittle regex source-ordering assertion
- TMPRL1100 negative test, centralized `GRPC_NOT_FOUND`, stale comment corrections

**Harden-found fixes**
- **postStatusCutoffAt regression fixed**: was derived from the health view's inner 7.5s sub-budget on disk-backed stores, making the whole response degrade the moment health's internal budget was spent. Now unconditionally the request-scoped aggregate deadline
- **MCP health-field-scope test mock fixed**: the `vi.mock` of `retry-wrapper` listed exports individually and silently rotted; converted to `importOriginal` partial mock
- **3 pre-existing trunk failures fixed** (from the archived `broadenCoordinateTriage` change): manifest-doc-drift (propagated the intentional 13-word description to manifest + 2 doc tables), ops-follow-up-assets (exact-equality → `expectVersionAtLeast` matching the test's own stated contract), spec-citation-invariant (cited `rq-epicCoordinateChangeCoverage01` at its real enforcement site)

## Verification

- Full suite: **544 files, 8406 tests, 0 failures** (trunk was 4 failed before this change)
- `pnpm run check`: 0 errors, 4 pre-existing warnings
- `bun test bin/`: 381 pass, 0 fail
- RED→GREEN independently verified by orchestrator for D5 (ToolExecutionTimeout at 10136ms reproduced), D3 (3 retries → 1), and both review blockers

## Contract

19 contract items (SC1-2, AC1-6, C1-7, DONT1-4): all pass/respected, 0 failing.