### PR TITLE
fix(scripts): assert live:true in deploy CLI liveness check

### DIFF
--- a/plugin/src/deploy-local.test.ts
+++ b/plugin/src/deploy-local.test.ts
@@ -142,7 +142,9 @@ describe("deploy-local.sh", () => {
       // from the fail-closed live:false payload. A blanket schema_version:1
       // ban false-fails on the always-emitted resume_projection_state field.
       expect(content).toContain('"live"[[:space:]]*:[[:space:]]*true');
-      expect(content).not.toContain('"schema_version"[[:space:]]*:[[:space:]]*1');
+      expect(content).not.toContain(
+        '"schema_version"[[:space:]]*:[[:space:]]*1',
+      );
     });
 
     test("removes stale adv commands from global", () => {

--- a/plugin/src/deploy-local.test.ts
+++ b/plugin/src/deploy-local.test.ts
@@ -137,7 +137,12 @@ describe("deploy-local.sh", () => {
       expect(content).toContain("is_recognized_adv_cli_target");
       expect(content).toContain("PATH shadow");
       expect(content).toContain('"source"[[:space:]]*:[[:space:]]*"temporal"');
-      expect(content).toContain('"schema_version"[[:space:]]*:[[:space:]]*1');
+      // Liveness contract (rq-statusCliWorkerFree01.2): the live-only CLI
+      // always emits source:"temporal"; "live":true distinguishes success
+      // from the fail-closed live:false payload. A blanket schema_version:1
+      // ban false-fails on the always-emitted resume_projection_state field.
+      expect(content).toContain('"live"[[:space:]]*:[[:space:]]*true');
+      expect(content).not.toContain('"schema_version"[[:space:]]*:[[:space:]]*1');
     });
 
     test("removes stale adv commands from global", () => {

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -957,9 +957,11 @@ verify_adv_cli_live_json() {
 	esac
 
 	printf '%s' "$output" | grep -q '"source"[[:space:]]*:[[:space:]]*"temporal"' || return 1
-	if printf '%s' "$output" | grep -q '"schema_version"[[:space:]]*:[[:space:]]*1'; then
-		return 1
-	fi
+	# Liveness contract (rq-statusCliWorkerFree01.2): the live-only CLI always
+	# emits source:"temporal" — even its fail-closed payload does — so the
+	# discriminator is "live":true. Do NOT ban schema_version:1 here: the
+	# always-emitted resume_projection_state field carries it legitimately.
+	printf '%s' "$output" | grep -q '"live"[[:space:]]*:[[:space:]]*true' || return 1
 	return 0
 }
 
@@ -1039,8 +1041,8 @@ check_adv_cli_install() {
 		if verify_adv_cli_live_json; then
 			echo "    ✓  status JSON: live Temporal metadata"
 		else
-			echo "    ✗  status JSON: installed adv did not emit live Temporal metadata"
-			echo "       Expected source:\"temporal\" and no disk-only schema_version:1 readiness"
+		echo "    ✗  status JSON: installed adv did not emit live Temporal metadata"
+		echo "       Expected source:\"temporal\" with live:true (rq-statusCliWorkerFree01.2 live-only contract)"
 			((cli_issues++)) || true
 		fi
 	fi


### PR DESCRIPTION
## Problem

`verify_adv_cli_live_json` in `scripts/deploy-local.sh` false-fails on **every** deploy:

```
✗  status JSON: installed adv did not emit live Temporal metadata
   Expected source:"temporal" and no disk-only schema_version:1 readiness
```

## Root cause

The check bans any `"schema_version": 1` in `adv status --json` output — a retired disk-fallback readiness shape. The current CLI is live-only and fail-closed (`rq-statusCliWorkerFree01.2`): no disk fallback payload exists, and `resume_projection_state.schema_version: 1` is **always** emitted (`bin/lib/resume-projection-state.ts:54`). The blanket grep can never pass.

## Fix

Assert `"live": true` — the actual liveness discriminator. Both success and the fail-closed failure payload emit `"source": "temporal"`; `live` distinguishes them. Failure message updated to cite the live-only contract.

## Verification

- `plugin/src/deploy-local.test.ts` updated (was pinning the buggy grep): 72/72 pass via `bin/oc-test targeted`.
- Extracted function exercised against three payloads:
  - real live CLI → PASS
  - synthetic `live:false` → correctly rejected
  - `live:true` + `resume_projection_state.schema_version:1` → PASS (the former false-negative)
- `bash -n` clean.