### PR TITLE
fix(adv-cli): report source "disk" + disk fallbacks for epic list and resume projection

### DIFF
--- a/bin/adv
+++ b/bin/adv
@@ -112,7 +112,7 @@ async function runStatus(noColor: boolean, json: boolean): Promise<number> {
     if (json) {
       process.stdout.write(
         emitJson({
-          source: "temporal",
+          source: "disk",
           live: false,
           stale: false,
           generated_at: new Date().toISOString(),

--- a/bin/adv.test.ts
+++ b/bin/adv.test.ts
@@ -181,7 +181,7 @@ describe("adv epic list dispatcher", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.source).toBe("temporal");
+    expect(parsed.source).toBe("disk");
     expect(parsed.live).toBe(true);
     expect(parsed.stale).toBe(false);
     expect(typeof parsed.project_id).toBe("string");
@@ -206,7 +206,7 @@ describe("adv epic list dispatcher", () => {
 
     expect(exitCode).not.toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.source).toBe("temporal");
+    expect(parsed.source).toBe("disk");
     expect(parsed.live).toBe(false);
     expect(parsed.stale).toBe(false);
     expect(parsed.project_id).toBeNull();
@@ -233,7 +233,7 @@ describe("adv status live default", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("status --json failure reports live Temporal error without disk fallback", async () => {
+  test("status --json reports zero changes for a repo with no ADV state", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "adv-dispatch-"));
     const initProc = Bun.spawn(
       ["git", "-c", "init.defaultBranch=trunk", "init", "--quiet"],
@@ -260,12 +260,16 @@ describe("adv status live default", () => {
     const stdout = await new Response(proc.stdout).text();
     const exitCode = await proc.exited;
 
-    expect(exitCode).toBe(2);
+    // A git repo with no ADV state has zero changes — that is a truthful
+    // result, not an error. Temporal is unreachable here by construction
+    // (ADV_TEMPORAL_ADDRESS points at a dead port) and it no longer matters:
+    // disk projections are the sole read authority.
+    expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.source).toBe("temporal");
-    expect(parsed.live).toBe(false);
+    expect(parsed.source).toBe("disk");
+    expect(parsed.live).toBe(true);
     expect(parsed.stale).toBe(false);
-    expect(parsed.remediation).toContain("Temporal");
+    expect(parsed.counts.active).toBe(0);
     expect(parsed.changes).toEqual([]);
   });
 });

--- a/bin/deploy-local-cli-check.test.ts
+++ b/bin/deploy-local-cli-check.test.ts
@@ -114,7 +114,7 @@ function runCheck(payload: string): number {
 /** Healthy live payload — the shape that broke the original check. */
 const HEALTHY_LIVE_PAYLOAD = JSON.stringify(
   {
-    source: "temporal",
+    source: "disk",
     live: true,
     stale: false,
     generated_at: "2026-08-05T00:00:00.000Z",
@@ -141,7 +141,7 @@ const HEALTHY_LIVE_PAYLOAD = JSON.stringify(
  */
 const LIVE_ERROR_PAYLOAD = JSON.stringify(
   {
-    source: "temporal",
+    source: "disk",
     live: false,
     stale: false,
     generated_at: "2026-08-05T00:00:00.000Z",
@@ -188,9 +188,9 @@ describe("verify_adv_cli_live_json", () => {
     expect(runCheck(DISK_ONLY_PAYLOAD)).not.toBe(0);
   });
 
-  test("rejects a payload whose source is not temporal", () => {
+  test("rejects a payload whose source is not disk", () => {
     expect(
-      runCheck(JSON.stringify({ source: "disk", live: false }, null, 2)),
+      runCheck(JSON.stringify({ source: "temporal", live: false }, null, 2)),
     ).not.toBe(0);
   });
 
@@ -204,13 +204,13 @@ describe("verify_adv_cli_live_json", () => {
     // string and never said what it actually saw. Report observed values so the
     // next divergence is legible in one run.
 
-    test("reports the observed source when it is not temporal", () => {
+    test("reports the observed source when it is not disk", () => {
       const { exitCode, diagnostic } = runCheckDetailed(
-        JSON.stringify({ source: "disk", live: false }),
+        JSON.stringify({ source: "temporal", live: false }),
       );
       expect(exitCode).not.toBe(0);
       expect(diagnostic).toContain("source");
-      expect(diagnostic).toContain("disk");
+      expect(diagnostic).toContain("temporal");
     });
 
     test("reports the observed top-level schema_version on a disk-only payload", () => {

--- a/bin/lib/adv-state-paths.ts
+++ b/bin/lib/adv-state-paths.ts
@@ -1,0 +1,52 @@
+/**
+ * adv CLI — ADV project state directory resolution
+ *
+ * Temporal was removed; disk projections are the sole read authority. The CLI
+ * must therefore locate a project's state directory itself.
+ *
+ * Two layouts exist:
+ *   canonical: {dataHome}/opencode/plugins/advance/{projectId}
+ *   oc shard:  ~/.local/share/opencode-projects/{projectId}/opencode/plugins/advance/{projectId}
+ *
+ * The shard layout is used for projects opened through the `oc` wrapper. Shard
+ * lookup deliberately uses the REAL home data dir rather than XDG_DATA_HOME:
+ * `oc` sets XDG_DATA_HOME to the *current* project's shard, so honouring it
+ * would nest one project's shard path inside another's.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { resolveExternalRoot } from "./project";
+
+/**
+ * Resolve a project's ADV state directory, preferring whichever layout
+ * actually contains the requested subdirectory.
+ *
+ * @param projectId ADV project id
+ * @param subdir subdirectory that must exist and be non-empty (e.g. "changes")
+ * @returns absolute path to `{stateDir}/{subdir}`
+ */
+export function resolveAdvStateSubdir(
+  projectId: string,
+  subdir: string,
+): string {
+  const canonical = join(resolveExternalRoot(projectId), subdir);
+  const shard = join(
+    homedir(),
+    ".local",
+    "share",
+    "opencode-projects",
+    projectId,
+    "opencode",
+    "plugins",
+    "advance",
+    projectId,
+    subdir,
+  );
+  try {
+    return readdirSync(canonical).length > 0 ? canonical : shard;
+  } catch {
+    return shard;
+  }
+}

--- a/bin/lib/epic-list.test.ts
+++ b/bin/lib/epic-list.test.ts
@@ -49,7 +49,7 @@ describe("epic list CLI helper", () => {
     );
 
     expect(payload).toEqual({
-      source: "temporal",
+      source: "disk",
       live: true,
       stale: false,
       generated_at: "2026-06-26T03:00:00.000Z",
@@ -83,7 +83,7 @@ describe("epic list CLI helper", () => {
       now,
     );
 
-    expect(payload.source).toBe("temporal");
+    expect(payload.source).toBe("disk");
     expect(payload.live).toBe(false);
     expect(payload.stale).toBe(false);
     expect(payload.project_id).toBe(PROJECT_ID);

--- a/bin/lib/epic-list.ts
+++ b/bin/lib/epic-list.ts
@@ -13,6 +13,9 @@ import {
   TemporalListOutcomeError,
 } from "../../plugin/src/cli/temporal-boundary";
 import { QUERY_TIMEOUT_MS } from "./live-status";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { resolveAdvStateSubdir } from "./adv-state-paths";
 
 export interface EpicListEntry {
   id: string;
@@ -20,7 +23,7 @@ export interface EpicListEntry {
 }
 
 export interface EpicListPayload {
-  source: "temporal";
+  source: "disk";
   live: boolean;
   stale: false;
   generated_at: string;
@@ -44,7 +47,7 @@ export function buildLiveEpicListPayload(
   },
 ): EpicListPayload {
   return {
-    source: "temporal",
+    source: "disk",
     live: true,
     stale: false,
     generated_at: options.now.toISOString(),
@@ -63,7 +66,7 @@ export function buildLiveEpicListFailure(
 ): EpicListPayload {
   const message = error instanceof Error ? error.message : String(error);
   return {
-    source: "temporal",
+    source: "disk",
     live: false,
     stale: false,
     generated_at: now.toISOString(),
@@ -95,15 +98,51 @@ export async function loadLiveEpics(
   projectId: string,
   timeoutMs = QUERY_TIMEOUT_MS,
 ): Promise<TemporalEpicWorkflowListEntry[]> {
-  return withTemporalOperations(
-    projectId,
-    (owner) =>
-      listEpicsFromVisibility(owner, {
-        projectId,
-        timeoutMs,
-        status: "active",
-      }),
-    undefined,
-    { connectTimeoutMs: timeoutMs },
-  );
+  try {
+    return await withTemporalOperations(
+      projectId,
+      (owner) =>
+        listEpicsFromVisibility(owner, {
+          projectId,
+          timeoutMs,
+          status: "active",
+        }),
+      undefined,
+      { connectTimeoutMs: timeoutMs },
+    );
+  } catch {
+    // Temporal removed: read epic projections from disk.
+    return loadEpicsFromDisk(projectId);
+  }
+}
+
+/**
+ * Disk-projection fallback for epic listing.
+ * Layout: {externalRoot}/active-epics/{epicId}/active-projection.json
+ */
+function loadEpicsFromDisk(
+  projectId: string,
+): TemporalEpicWorkflowListEntry[] {
+  try {
+    const root = resolveAdvStateSubdir(projectId, "active-epics");
+    const entries: TemporalEpicWorkflowListEntry[] = [];
+    for (const epicId of readdirSync(root)) {
+      try {
+        const raw = JSON.parse(
+          readFileSync(join(root, epicId, "active-projection.json"), "utf8"),
+        );
+        const state = raw.state ?? raw;
+        entries.push({
+          epicId: state.id ?? epicId,
+          title: state.title ?? epicId,
+          status: "active",
+        } as unknown as TemporalEpicWorkflowListEntry);
+      } catch {
+        // skip unreadable epic projections
+      }
+    }
+    return entries;
+  } catch {
+    return [];
+  }
 }

--- a/bin/lib/live-status.test.ts
+++ b/bin/lib/live-status.test.ts
@@ -108,7 +108,7 @@ describe("live status reader", () => {
       },
     );
 
-    expect(payload.source).toBe("temporal");
+    expect(payload.source).toBe("disk");
     expect(payload.live).toBe(true);
     expect(payload.stale).toBe(false);
     expect(payload.changes.map((change) => change.id)).toEqual(["liveChange"]);
@@ -348,7 +348,7 @@ describe("visibility search-attribute status reader", () => {
       { projectId: PROJECT_ID, archivedCount: 3, closedCount: 0, now },
     );
 
-    expect(payload.source).toBe("temporal");
+    expect(payload.source).toBe("disk");
     expect(payload.live).toBe(true);
     expect(payload.stale).toBe(false);
     expect(payload.changes.map((c) => c.id)).toEqual(["c1"]);

--- a/bin/lib/live-status.ts
+++ b/bin/lib/live-status.ts
@@ -27,8 +27,7 @@ import {
 } from "../../plugin/src/cli/temporal-boundary";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
-import { resolveExternalRoot } from "./project";
+import { resolveAdvStateSubdir } from "./adv-state-paths";
 
 export const QUERY_TIMEOUT_MS = 5_000;
 
@@ -333,18 +332,7 @@ export async function loadLiveSummaries(
  */
 function loadSummariesFromDisk(projectId: string): ChangeSummary[] {
   try {
-    const canonicalDir = join(resolveExternalRoot(projectId), "changes");
-    // Always use the real home data dir for shard lookup — XDG_DATA_HOME
-    // may be set to a per-project shard by the oc wrapper, causing nesting.
-    const realDataHome = join(homedir(), ".local", "share");
-    const shardDir = join(realDataHome, "opencode-projects", projectId, "opencode", "plugins", "advance", projectId, "changes");
-    let dir: string;
-    try {
-      const canonicalFiles = readdirSync(canonicalDir);
-      dir = canonicalFiles.length > 0 ? canonicalDir : shardDir;
-    } catch {
-      dir = shardDir;
-    }
+    const dir = resolveAdvStateSubdir(projectId, "changes");
     const files = readdirSync(dir).filter((f: string) => f.endsWith(".json"));
     const summaries: ChangeSummary[] = [];
     for (const f of files) {

--- a/bin/lib/resume-projection-live.ts
+++ b/bin/lib/resume-projection-live.ts
@@ -10,6 +10,9 @@
  */
 
 import { buildBinResumeProjection } from "./resume-projection";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { resolveAdvStateSubdir } from "./adv-state-paths";
 import type { ResumeProjection } from "../../plugin/src/cli/projection-boundary";
 import {
   buildChangeWorkflowId,
@@ -117,6 +120,87 @@ async function queryEpicState(
 }
 
 export async function loadLiveResumeProjection(
+  projectId: string,
+  timeoutMs = QUERY_TIMEOUT_MS,
+  epicIds?: string[],
+): Promise<LiveResumeProjectionResult> {
+  try {
+    return await loadResumeProjectionFromTemporal(projectId, timeoutMs, epicIds);
+  } catch {
+    // Temporal removed: build the projection from disk projections.
+    return loadResumeProjectionFromDisk(projectId, epicIds);
+  }
+}
+
+/**
+ * Disk-projection resume reader. Reads every change projection and every
+ * active epic projection, then builds the same projection shape the Temporal
+ * path produced.
+ */
+function loadResumeProjectionFromDisk(
+  projectId: string,
+  epicIds?: string[],
+): LiveResumeProjectionResult {
+  try {
+    const changeRecords: ChangeRecord[] = [];
+    const changesDir = resolveAdvStateSubdir(projectId, "changes");
+    let changeFiles: string[] = [];
+    try {
+      changeFiles = readdirSync(changesDir).filter((f) => f.endsWith(".json"));
+    } catch {
+      changeFiles = [];
+    }
+    for (const file of changeFiles) {
+      try {
+        const raw = JSON.parse(readFileSync(join(changesDir, file), "utf8"));
+        changeRecords.push(normalizeChangeRecord(raw.state ?? raw));
+      } catch {
+        // Skip unreadable change projections; projection is advisory.
+      }
+    }
+
+    const epicRecords: EpicRecord[] = [];
+    const epicsDir = resolveAdvStateSubdir(projectId, "active-epics");
+    let epicDirs: string[] = [];
+    try {
+      epicDirs = readdirSync(epicsDir);
+    } catch {
+      epicDirs = [];
+    }
+    const wanted = epicIds?.length ? new Set(epicIds) : null;
+    for (const epicId of epicDirs) {
+      if (wanted && !wanted.has(epicId)) continue;
+      try {
+        const raw = JSON.parse(
+          readFileSync(join(epicsDir, epicId, "active-projection.json"), "utf8"),
+        );
+        const epic = normalizeEpicRecord(raw.state ?? raw);
+        if (epic) epicRecords.push(epic);
+      } catch {
+        // Skip unreadable epic projections; projection is advisory.
+      }
+    }
+
+    return {
+      live: true,
+      resume_projection: buildBinResumeProjection(
+        changeRecords,
+        epicRecords,
+        projectId,
+        epicIds,
+      ),
+    };
+  } catch (err) {
+    return {
+      live: false,
+      error: err instanceof Error ? err.message : String(err),
+      remediation:
+        "ADV resume projection unavailable. Could not read change/epic projections from the project state directory.",
+    };
+  }
+}
+
+async function loadResumeProjectionFromTemporal(
   projectId: string,
   timeoutMs = QUERY_TIMEOUT_MS,
   epicIds?: string[],

--- a/plugin/src/deploy-local.test.ts
+++ b/plugin/src/deploy-local.test.ts
@@ -143,7 +143,7 @@ describe("deploy-local.sh", () => {
       // Pin the jq assertion that replaced it, not implementation tokens that
       // could regress to a substring heuristic.
       expect(content).toContain(
-        `jq -e '.source == "temporal" and (.schema_version != 1)'`,
+        `jq -e '.source == "disk" and (.schema_version != 1)'`,
       );
       // And guard against the old pattern creeping back in: a `grep -q`
       // referencing schema_version is the defect, not a valid implementation.

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -968,9 +968,13 @@ verify_adv_cli_live_json() {
 		;;
 	esac
 
-	# rq-advCliLocalInstall01: accept live-status metadata — `source: "temporal"`
-	# on success OR fail-closed live error metadata — and reject stale disk-only
+	# rq-advCliLocalInstall01: accept live-status metadata — `source: "disk"`
+	# on success OR fail-closed error metadata — and reject stale disk-only
 	# `schema_version: 1` output.
+	#
+	# Temporal was removed; disk projections are the sole read authority, so
+	# the CLI now reports `source: "disk"`. Asserting `"temporal"` here would
+	# require the CLI to report a source it no longer reads from.
 	#
 	# Assert structurally on the parsed document, not by substring. A previous
 	# whole-document grep for `"schema_version": 1` matched
@@ -996,7 +1000,7 @@ verify_adv_cli_live_json() {
 	fi
 
 	if printf '%s' "$output" |
-		jq -e '.source == "temporal" and (.schema_version != 1)' >/dev/null 2>&1; then
+		jq -e '.source == "disk" and (.schema_version != 1)' >/dev/null 2>&1; then
 		return 0
 	fi
 


### PR DESCRIPTION
Finishes the CLI side of the Temporal removal.

## Truthfulness
Several surfaces still claimed `source: "temporal"` for data read from disk:
- `bin/adv`, `bin/lib/live-status.ts`, `bin/lib/epic-list.ts`
- `scripts/deploy-local.sh` health check asserted `source == "temporal"` — it could never pass after the source became truthful
- failure remediation no longer tells users to check Temporal

## Disk fallbacks
Two CLI paths still read Temporal Visibility and failed:
- **epic list** → reads `active-epics/{epicId}/active-projection.json`
- **resume projection** → reads change + active epic projections; fixes the dashboard's `RESUME_PROJECTION_UNAVAILABLE` degradation

## Shared path resolution
New `bin/lib/adv-state-paths.ts` resolves canonical vs `oc`-shard state dirs in one place. `live-status`, `epic-list` and `resume-projection` now share it rather than each carrying a copy.

## Verification
- `bun test bin/`: **408 pass / 0 fail** (trunk baseline 402/6 — all 6 were stale Temporal-source assertions)
- `plugin deploy-local.test.ts`: 72/72
- tsc + check clean