### PR TITLE
fix(adv-tron): make adv-tron command-only, never agent-spawned

### DIFF
--- a/.opencode/agents/adv.md
+++ b/.opencode/agents/adv.md
@@ -246,7 +246,7 @@ Choose inline vs delegation for context continuity and progress tracking.
 - Context-shed delegation: delegate only when design decisions are made, task HOW does not feed downstream decisions, AC are defined, task is mechanical implementation, and floor ≈5 files or ≈50 lines. If unsure, inline.
 - Orchestrator operational delegation: shed authority-free ops work before context gets noisy: expected >5 reads/searches, repo/dependency/same-pattern scans, DB/log/status/usage audits, GitHub CI/check-run/status investigation, repeated verify/test bursts, and structured verification triage for local/CI failures.
 - Do not run a second primary recon, shell/test, status, CI-check, or verification triage digest cycle when mapped operational work can go to a worker; resume inline for synthesis, decisions, and ADV state mutation after the worker returns.
-- Worker routing: use `explore`/`adv-tron` for scans, `general` for generic ops/status work, `adv-verifier` for verify-only bursts and structured local verification triage (`general` fallback only when unavailable), `adv-engineer` for code edits, `adv-designer` for frontend edits, `adv-researcher` for sourced architecture, and `adv-temporal-repair` for Temporal/session-pointer/artifact-phantom triage.
+- Worker routing: use `explore` for scans (`adv-tron` is command-only via `/adv-tron`; never spawn it), `general` for generic ops/status work, `adv-verifier` for verify-only bursts and structured local verification triage (`general` fallback only when unavailable), `adv-engineer` for code edits, `adv-designer` for frontend edits, `adv-researcher` for sourced architecture, and `adv-temporal-repair` for Temporal/session-pointer/artifact-phantom triage.
 
 ### Worktree Isolation Routing
 
@@ -265,7 +265,7 @@ Sub-agent nesting depth and parallelism are agent-self-enforced (no runtime guar
 | `adv-temporal-repair` | Temporal/workflow/session-pointer/target-path/artifact-phantom diagnosis; packet includes WORKING DIRECTORY, CHANGE if known, TARGET_PATH, SYMPTOM, RECENT_TOOL_ERROR, ATTEMPT | Classification + primary-ADV next actions |
 | `adv-verifier`   | Need verify-only bursts, local command classification, or structured verification triage | Strict Verification Triage Result JSON for orchestrator persistence |
 | `general`        | Need generic multi-step bursts or unavailable-runtime fallback for verify bursts | Completed changes or verify results (file:line refs) |
-| `adv-tron`       | Codebase reconnaissance, hotspots, risk mapping (repo-local)         | Structure + risk report               |
+| `adv-tron`       | **Never spawn.** Command-only via `/adv-tron` (repo-local)          | Structure + risk report               |
 
 | Constraint | Value |
 |---|---|

--- a/.opencode/command/adv-tron.md
+++ b/.opencode/command/adv-tron.md
@@ -1,6 +1,7 @@
 ---
 name: adv-tron
 description: Investigate codebase structure, hotspots, risks, and suggest follow-up candidates
+agent: adv-tron
 ---
 # ADV Tron — Codebase Reconnaissance
 Investigate codebase to map structure, identify hotspots, surface risks, suggest follow-up work. Read-only — × never modifies files or ADV state.
@@ -70,8 +71,8 @@ Combination routing examples:
 
 - `/adv-slop-scan <target> then /adv-optimizer <target>` — first classify slop/deletion-safety evidence, then synthesize simplification proposal.
 - `/adv-arch-scan <target> then /adv-slop-scan <target>` — first validate architecture/structural boundary, then scan quality smells if source evidence also suggests code-level slop.
-## Phase 4: Spawn Tron Sub-Agent
-Spawn `adv-tron` agent via Task tool. System prompt has behavioral instructions. Pass this packet plus mode-specific context:
+## Phase 4: Run as Tron Sub-Agent
+This command declares `agent: adv-tron` in frontmatter, so OpenCode invokes the `adv-tron` subagent directly — no Task-tool spawn. ADV orchestrator agents deny `task: adv-tron`, making `/adv-tron` the only entry point. The agent's system prompt carries behavioral instructions; establish this packet plus mode-specific context as the working scope:
 
 ```
 WORKING DIRECTORY: {workdir}
@@ -126,4 +127,4 @@ Validate findings (require file references, remove evidence-free, deduplicate). 
 | Skill | `skill("adv-tron")` |
 | Context | `adv_project_context`, `adv_change_list` |
 | Structure | lgrep file tree, lgrep repo outline |
-| Spawn | Task tool (`adv-tron` agent) |
+| Invocation | Command frontmatter `agent: adv-tron` (direct subagent invocation; not Task-spawned) |

--- a/ADV_INSTRUCTIONS.md
+++ b/ADV_INSTRUCTIONS.md
@@ -879,7 +879,7 @@ This table is session-level operational routing, distinct from task-level Step 4
 | Trigger | Worker |
 | --- | --- |
 | >5 file reads/searches expected | `explore` |
-| repo structure / dependency map / same-pattern scan | `explore` or `adv-tron` |
+| repo structure / dependency map / same-pattern scan | `explore` |
 | DB/log/status/usage audit | `general` |
 | GitHub CI / check-run / status investigation | `general` |
 | repeated verify/test bursts | `adv-verifier` |
@@ -932,7 +932,7 @@ Primary agents: `adv`, `plan`, `build` (not spawnable). Spawnable: global `explo
 | `adv-visual-review`  | Image analysis (screenshots, UI captures) for text-only model orchestrators                                                                                                                                            |
 | `adv-verifier`       | Verify-only bursts and structured local verification triage; returns strict Verification Triage Result JSON; no edits or ADV mutation                                                                                  |
 | `general`            | Generic multi-step work and unavailable-runtime fallback for verify bursts                                                                                                                                              |
-| `adv-tron`       | Recon + hotspots (repo-local)                                                                                                                                                                                           |
+| `adv-tron`       | Recon + hotspots (repo-local; **command-only** via `/adv-tron` — never agent-spawned)                                                                                                                                                                                           |
 
 `adv-tron` repo-local. `adv-researcher` / `adv-engineer` / `adv-reviewer` / `adv-designer` bundled global via `scripts/deploy-local.sh`. Research pattern: `adv-researcher` covers docs/API/examples + architecture in a single spawn. Apply routing: structural `metadata.frontend == "true"` starts with `adv-engineer` (or a risk-forced inline implementation), then dispatches matching-cycle `adv-designer` follow-up with an implementation receipt; `metadata.delegation_hint` cannot select designer as the initial classified frontend implementation route.
 


### PR DESCRIPTION
## Problem

`adv-tron` is repo-local (`.opencode/agents/adv-tron.md`, present only in this repo), but ADV orchestrator agents auto-spawn it via the Task tool in **any** repo. Where no repo-local definition exists, OpenCode still spawns an agent by that name from bare inline config — no prompt, no tool grants, no read-only boundary, tools defaulting to allow.

Session-log evidence (220 assistant messages, a repo with no `.opencode/agents/adv-tron.md`):

| lane | lgrep | bash | read | grep |
|---|---|---|---|---|
| `adv-tron` **with** repo-local definition | 20% | 0% | 32% | 34% |
| `adv-tron` **without** definition | 0% | 43% | 57% | 0% |

Without the file it falls back to raw `bash` and serial `read`, bypassing lgrep entirely and losing the `bash: false` read-only boundary.

## Fix

`adv-tron` should be command-only. Declaring `agent: adv-tron` in the command frontmatter makes OpenCode invoke the subagent directly ([docs](https://opencode.ai/docs/commands/): "If this is a subagent the command will trigger a subagent invocation by default"), so orchestrators can deny `task: adv-tron` without breaking `/adv-tron`.

Denying via `permission.task` removes the subagent from the Task tool description entirely, so the model never attempts it.

- `.opencode/command/adv-tron.md` — add `agent: adv-tron`; Phase 4 + Key Tools no longer describe a Task spawn
- `ADV_INSTRUCTIONS.md` — `explore` owns repo-structure scans; `adv-tron` marked command-only
- `.opencode/agents/adv.md` — worker-routing table marks `adv-tron` never-spawn

Host-side `permission.task` denies for `adv`/`plan`/`build`/`general` are configured separately in the operator's `opencode.jsonc`.

## Verification

Config-shape verified against `https://opencode.ai/config.json` (`permission.task` accepts pattern→action) and the OpenCode commands/agents/permissions docs. Behavioral verification requires an OpenCode restart.