### PR TITLE
fix(adv-tron): deny task:adv-tron in agent frontmatter, not just host config

### DIFF
--- a/.opencode/agents/adv.md
+++ b/.opencode/agents/adv.md
@@ -74,6 +74,14 @@ tools:
   searchcode_*: true
   firecrawl_*: true
   webfetch: true
+permission:
+  # adv-tron is command-only (/adv-tron). A `task` deny removes the subagent
+  # from the Task tool description entirely, so no orchestrator can spawn it.
+  # Must live here: agent-file frontmatter overrides opencode.json agent
+  # permission, so a host-side config deny alone is silently ignored.
+  task:
+    "*": allow
+    "adv-tron": deny
 ---
 > **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 <!-- ADV_SYNC:START adv -->

--- a/.opencode/agents/build.md
+++ b/.opencode/agents/build.md
@@ -59,6 +59,14 @@ tools:
   # === ADV writes — task-level execution only ===
   # === BLOCKED: Orchestration and gate management ===
   # <<< ADV-GENERATED adv_* tools <<<
+permission:
+  # adv-tron is command-only (/adv-tron). A `task` deny removes the subagent
+  # from the Task tool description entirely, so no orchestrator can spawn it.
+  # Must live here: agent-file frontmatter overrides opencode.json agent
+  # permission, so a host-side config deny alone is silently ignored.
+  task:
+    "*": allow
+    "adv-tron": deny
 ---
 > **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 <!-- ADV_SYNC:START build -->

--- a/.opencode/agents/plan.md
+++ b/.opencode/agents/plan.md
@@ -55,6 +55,14 @@ tools:
   firecrawl_firecrawl_scrape: true
   firecrawl_firecrawl_crawl: true
   firecrawl_firecrawl_check_crawl_status: true
+permission:
+  # adv-tron is command-only (/adv-tron). A `task` deny removes the subagent
+  # from the Task tool description entirely, so no orchestrator can spawn it.
+  # Must live here: agent-file frontmatter overrides opencode.json agent
+  # permission, so a host-side config deny alone is silently ignored.
+  task:
+    "*": allow
+    "adv-tron": deny
 ---
 > **Invoke routing:** ADV tools referenced below but not in the manifest frontmatter above are Tier 3 (invoke-only). Dispatch them via `adv_tool_invoke({name, args})` — e.g., `adv_tool_invoke({name: "adv_subagent_report_submit", args: {report: ...}})`. Use `adv_tool_catalog` to discover all available tools and `adv_tool_describe` for schemas. Tier-4 reads (the catalog returned by `adv_tool_catalog`) also via `tools.adv.*`; all other adv_* tools are host-only.
 


### PR DESCRIPTION
Follow-up to #387.

## Problem

#387 made `/adv-tron` invocable without a Task spawn so operators could deny `task: adv-tron`. That deny was applied host-side in `opencode.json` `agent.<name>.permission.task` — and **silently did nothing**.

`adv.md`, `build.md`, and `plan.md` all declare `tools: task: true`, which flattens to `permission.task: "allow"`. Agent-file frontmatter overrides config-level agent permission, so the pattern object never applied.

Verified with `opencode debug config` after a restart:

| agent | agent-file `task` key | effective `permission.task` |
|---|---|---|
| `adv` | `tools: task: true` | `"allow"` ❌ |
| `build` | `tools: task: true` | `"allow"` ❌ |
| `plan` | `tools: task: true` | `"allow"` ❌ |
| `general` | *(none)* | `{"*":"allow","adv-tron":"deny"}` ✓ |

`general` is the control: the only orchestrator whose agent file declares no `task` key is the only one where the host config survived.

## Fix

Add a `permission:` block with `task: {"*": allow, "adv-tron": deny}` to the three orchestrator agent files. `tools: task: true` is retained — they still spawn every other subagent.

Frontmatter parse verified for all three files.