### PR TITLE
refactor(commands): remove skill-duplicated methodology from 13 command files

### DIFF
--- a/.opencode/command/adv-arch-scan.md
+++ b/.opencode/command/adv-arch-scan.md
@@ -5,13 +5,13 @@ description: Scan architecture stack packs, coverage, and heuristic fallbacks
 # ADV Architecture Scan
 > **SUB-AGENT CONTEXT**: Return findings directly. Skip status markers.
 
-Orchestrate architecture inconsistency detection using three-phase strategy: Phase 1 (deterministic tools for known stacks) → Phase 2 (research fallback for unknown stacks) → Phase 3 (AI heuristic as universal fallback).
+Orchestrate architecture inconsistency detection. The `adv-arch-detection` skill owns the three detection passes: pass 1 (deterministic tools for known stacks) → pass 2 (research fallback for unknown stacks) → pass 3 (AI heuristic as universal fallback).
 
 ## Argument Parsing
 Parse `$ARGUMENTS`:
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--phase 1\|2\|3` | Run single phase | All |
+| `--phase 1\|2\|3` | Run a single detection pass (see skill) | All |
 | `--json` | JSON output | Text |
 | `--verbose` | Detailed progress | Off |
 | `--timeout N` | Sub-agent timeout (seconds) | 120 |
@@ -23,7 +23,9 @@ Parse `$ARGUMENTS`:
 
 ---
 ## Phase 0: Load Skill
-`skill("adv-arch-detection")` → three-phase detection strategy, Known-Stack Rule Matrix, Research Fallback, finding format, severity rubric, P33 boundaries. Unavailable → use embedded protocol.
+`skill("adv-arch-detection")` → three-phase detection strategy, Known-Stack Rule Matrix, Research Fallback, finding format, severity rubric, P33 boundaries.
+
+Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 
 ---
 ## Pre-flight
@@ -34,19 +36,6 @@ Parse `$ARGUMENTS`:
 
 ---
 ## Phase 1: Stack Packs (Known Stacks)
-
-Run stack-specific tools when stack is in the Stack Packs matrix before research fallback or generic AI heuristic fallback:
-
-| Stack Pack | Detection | Primary Tool | Fallback Tool | Checks |
-|------------|-----------|--------------|---------------|--------|
-| TypeScript/Node | `package.json` + `tsconfig.json` | `dependency-cruiser` | `madge` | Circular deps, layer violations, orphans |
-| ADV stack pack | TypeScript/Bun/OpenCode plugin/Temporal/spec-command-skill assets | existing structural enforcers | dependency graph tools | workflow bundle boundary, command/manifest symmetry, spec/asset anchors, command/skill methodology surfaces |
-| Capability Consistency <!-- rq-archcap01 --> | `package.json` + IaC files (`*.bicep`, `*.tf`) + source files | `bun run bin/arch-scan.ts` (typed adapter) | (none — typed pipeline is primary) | Config↔code↔deps inconsistencies: plumbed-but-unused env vars, present-but-inactive artifacts, deferred migrations, scaffold without tests |
-| Python | `pyproject.toml` / `setup.py` | `pydeps` | `import-deps` | Import cycles, module depth |
-| Go | `go.mod` | `go vet` | `gocyclo` | Shadowing, complexity, unused code |
-| Rust | `Cargo.toml` | `cargo-deps` | `cargo-modules` | Dependency graph, unused crates |
-
-If tools are absent → graceful fallback with `detectionMethod: degraded` and a note. If a relevant stack has no pack → list it in missing-pack coverage before Phase 2. Skip to Phase 2.
 
 If `--phase 1` only → skip to Report.
 
@@ -62,7 +51,7 @@ The typed pipeline is the primary detector for capability-consistency findings; 
 
 ### Structural Correctness Boundary Checks (P33)
 
-During Phase 1 or Phase 2, inspect architecture paths where correctness boundaries should be structural:
+During detection passes 1 and 2, inspect architecture paths where correctness boundaries should be structural:
 
 - Input boundaries: parser/schema/allowlist recognition and normalization before business logic
 - Workflow/state boundaries: state machines, typed events/signals, validators, or persisted schema contracts own transitions
@@ -74,75 +63,7 @@ Flag architectural findings when heuristic inference, prose convention, regex-on
 ADV stack pack findings must cite structural owners such as `plugin/src/temporal/workflow-bundle-boundary.test.ts`, manifest/command asset tests, spec/asset anchors, and context-snapshot purity tests instead of treating prose or one external tool as sole authority.
 
 ---
-## Phase 2: Research Fallback
-When stack is NOT in the Stack Packs matrix OR user requests `--phase 2`:
-
-1. **Detect stack** from project files (e.g., `Gemfile` → Ruby, `pom.xml` → Java)
-2. **Exa query** — search `"{stack} architecture linter"`, `"{stack} circular dependency detector"`
-3. **Context7 lookup** — find official docs for architecture analysis tools
-4. **Apply findings** — run discovered tools or rules inline
-5. **Cite sources** — every finding must include source URL or tool name
-
-If `--phase 2` only → skip to Phase 4: Report Generation.
-
-Timeout or research failure → keep Phase 1 findings, record the detector as degraded/skipped coverage, then continue to Phase 4: Report Generation or Phase 3 according to selected phases.
-
----
-## Phase 3: AI Heuristic
-Run Phase 3 when the user requests `--phase 3`, or during the default all-phases flow only when Phase 1 and Phase 2 produce no findings. `--phase 3` is a single-phase heuristic scan; it does not depend on prior Phase 1/2 results, and every uncorroborated finding remains low-confidence.
-
-- Analyze file structure and import patterns heuristically
-- Detect likely layer violations (e.g., UI importing DB directly)
-- Flag circular dependencies via import graph analysis
-- Detect suspected structural-correctness boundary violations (heuristic-owned persistence/gates/spec/security) only as low-confidence candidates unless corroborated by source evidence
-- Mark all findings with `detectionMethod: heuristic` and `confidence: low`
-
-Timeout or heuristic failure → keep deterministic/research findings, record the detector as degraded coverage, and continue to Phase 4: Report Generation.
-
-### Capability Sub-Phase (Phase 3 Heuristics)
-
-The capability-consistency pack runs Phase 3 rules (manifest-reference-vs-runtime-registration, scaffold-vs-test-green-path) in an **explicit sub-phase**, NOT subject to the default Phase 3 skip-on-no-prior-findings behavior above. Other Phase 3 categories (layer violations, circular deps, structural-correctness candidates) remain governed by the default Phase 3 trigger semantics — only the two capability Phase 3 rules run in this distinct sub-phase.
-
-Each Phase 3 capability rule declares an `intent_required` list (declaration strings searched repo-wide). The rule fires only when at least one declaration matches:
-
-- **intent gate closed** (no declaration matches) → rule is skipped, `coverage_entry.state: "skipped"` with reason mentioning "intent". False-positive protection for projects that intentionally omit a capability.
-- **intent gate open** (≥1 declaration matches) → rule produces a low-severity finding (intent declared but capability not honored at runtime).
-
-This sub-phase runs whenever the capability-consistency pack applies, regardless of whether Phase 1/2 produced findings. The default Phase 3 confidence `low` and `detectionMethod: heuristic` markers still apply to sub-phase findings unless corroborated by source evidence.
-
----
-## Phase 4: Report Generation
-
-### Rewrite Assessment (mandatory, derived)
-
-After all scan evidence (findings + coverage) is final and before report assembly, derive a rewrite assessment that explicitly labels and answers two questions:
-
-1. If the project/app were completely rewritten, what architecture would definitely change?
-2. If the project/app were completely rewritten, what would definitely not be carried over?
-
-Evidence rules:
-
-- Every definite answer MUST cite source/tool evidence or stable finding references (finding category + location) collected during the scan.
-- Heuristic-only content is tentative: label it tentative and keep it out of the definite answers.
-- A question with no evidence-backed answer yields the literal `No definite conclusion from scan evidence`.
-- Any degraded detector coverage sets `status: "indeterminate"`. Indeterminate is never a no-change conclusion; do not claim nothing would change.
-
-Advisory boundary: the assessment must not alter severity, confidence, coverage, or phase results, and must never authorize deletion or remediation by itself.
-
-Text output: a `REWRITE ASSESSMENT` section that answers both labeled questions, each definite entry followed by its evidence references.
-
-JSON output (command-level `rewriteAssessment`, when `--json`):
-
-```json
-"rewriteAssessment": {
-  "status": "complete" | "indeterminate",
-  "wouldChange": { "answer": "...", "evidence": ["..."], "confidence": "confirmed" | "tentative" },
-  "wouldNotCarryOver": { "answer": "...", "evidence": ["..."], "confidence": "confirmed" | "tentative" },
-  "tentative": [{ "statement": "...", "evidence": ["..."] }]
-}
-```
-
-`wouldChange` answers question 1; `wouldNotCarryOver` answers question 2. Each is one evidence-cited answer object. When no evidence-backed answer exists, use the literal `No definite conclusion from scan evidence` as `answer`, an empty `evidence` array, and `confidence: "tentative"`.
+## Report Generation
 
 ### Architecture Scanner Coverage Report
 
@@ -157,7 +78,7 @@ No findings → `[OK] No architecture issues detected.`
 Output JSON: `stack`, `phases`, `summary` (`bySeverity`, `byCategory`), `findings[]`, `coverage.detectedStacks`, `coverage.appliedPacks`, `coverage.missingPacks`, `coverage.skippedDetectors`, `coverage.degradedDetectors`, plus command-level `rewriteAssessment`. Severity: `blocker|major|minor|nit`. Heuristic-only findings stay low-confidence and non-blocking unless source/tool evidence corroborates.
 
 ---
-## Phase 5: Write Metadata
+## Write Metadata
 After report generation, call `adv_project_metadata action:"write"` with:
 - `key`: `"arch-scan"`
 - `count`: total findings count (0 if no findings)
@@ -170,4 +91,4 @@ Persists the scan result for display in `/adv-status`.
 
 ---
 ## Execution
-1. Parse arguments → 2. Pre-flight → 3. Phase 1 (if enabled) → 4. Phase 2 (if enabled) → 5. Phase 3 (if enabled) → 6. Rewrite Assessment → 7. Report → 8. Write Metadata
+1. Parse arguments → 2. Pre-flight → 3. Detection passes per skill (as enabled by `--phase`) → 4. Rewrite Assessment → 5. Report → 6. Write Metadata

--- a/.opencode/command/adv-audit.md
+++ b/.opencode/command/adv-audit.md
@@ -14,9 +14,7 @@ Multi-phase spec/implementation drift audit using sub-agents + quality gates; co
 
 ## Phase 0: Load Skill
 
-`skill("adv-audit")` → quality gates, audit dimensions, sub-agent roles, drift severity, report schema. If unavailable, use fallback below.
-
-Fallback: parse specs, map code, detect conflicts/drift/orphans, apply gates, report, write metadata.
+`skill("adv-audit")` → quality gates, audit dimensions, sub-agent roles, drift severity, report schema. Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 
 ## Target Resolution
 
@@ -27,17 +25,6 @@ Parse `$ARGUMENTS`: `capability` optional, `--json`, `--all` default, `--strict`
 1. `adv_spec action: "list"` → stop if no specs.
 2. `adv_change_list` → warn active changes may affect accuracy.
 3. Record `{workdir}` via `pwd`; include `WORKING DIRECTORY: {workdir}` in sub-agent prompts.
-
----
-
-## Quality Gates
-
-Use skill thresholds. Standard: HIGH drift 0, MEDIUM drift ≤3, orphaned code ≤3 files, conflicts 0, coverage ≥80%, CRITICAL ambiguity 0, HIGH ambiguity ≤3. `--strict`: all drift/conflict/orphan/ambiguity thresholds 0, coverage 100%.
-
-Ambiguity gates honor `clarify_enforcement` flag (read from project config or spec context):
-- `off` — skip ambiguity detection entirely
-- `advisory` — include findings in report; do not affect health status
-- `strict` — enforce ambiguity gates (CRITICAL and HIGH thresholds apply)
 
 ---
 
@@ -52,12 +39,6 @@ Execute stages:
 Each prompt includes `WORKING DIRECTORY: {workdir}` and expected JSON: `dimension`, `findings`, `summary`.
 
 > Ambiguity detection (B/F/S/Q/E taxonomy) runs inline during Phase 3 Synthesis using `runSpecAmbiguityChecks(markdown, capability)` — not a sub-agent stage.
-
----
-
-## Phase 2: Orphan Detection
-
-After Code Mapper, list source files not mapped to any spec (>50 lines; exclude config/types/generated/test utils). Categorize: undocumented feature, dead code, infrastructure.
 
 ---
 
@@ -103,37 +84,6 @@ If ALIGNED → report. If drift → report by default. Ask via `question` only w
 If ambiguity findings are present and `clarify_enforcement` is `advisory` or `strict`, include an informational handoff in the report:
 
 > Ambiguity findings can be resolved via `/adv-clarify`. Pass the structured findings list as context. Resolution writes back to the relevant spec file (not ADV change state).
-
----
-
-## Final Report
-
-Emit PROJECT AUDIT REPORT: scope, health, quality gate table, specs audited, requirement/scenario counts. If issues: findings by severity, spec text, actual, evidence, fix suggestion, conflicts, orphans, ambiguity findings, top 3 recommendations.
-
-JSON mode:
-
-```json
-{
-  "health": "ALIGNED|DRIFT_DETECTED|MAJOR_DRIFT",
-  "quality_gate": [],
-  "summary": {},
-  "drift": [],
-  "conflicts": [],
-  "orphans": [],
-  "ambiguity": [
-    {
-      "id": "...",
-      "category": "B|F|S|Q|E",
-      "severity": "CRITICAL|HIGH|MEDIUM|LOW",
-      "spec": "capability/rq-id",
-      "specText": "verbatim quote",
-      "issue": "...",
-      "fix": "..."
-    }
-  ],
-  "recommendations": []
-}
-```
 
 ---
 

--- a/.opencode/command/adv-clarify.md
+++ b/.opencode/command/adv-clarify.md
@@ -8,9 +8,7 @@ Resolve hidden assumptions, edge cases, acceptance criteria, and decision gaps a
 
 ## Phase 0: Load Skill
 
-`skill("adv-clarify")` → Socratic types, ambiguity categories, funnel technique, findings-driven mode, resolution log, output summary. Unavailable → use fallback below.
-
-Fallback: analyze context, summarize understanding, ask 1-2 neutral questions via `question`, update proposal only when findings-driven, then emit REQUIREMENTS DISCOVERY SUMMARY.
+`skill("adv-clarify")` → Socratic types, ambiguity categories, funnel technique, findings-driven mode, resolution log, output summary. Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 
 ## Stage Coverage
 
@@ -21,62 +19,9 @@ Use when ambiguity blocks:
 - `agree` — constraints, avoidances, acceptance criteria
 - `design` — architecture choices and operational implications
 
-## Findings-Driven Mode
-
-When invoked from `/adv-discover` Phase 2.5 mandatory trigger (CRITICAL ≥ 1 or HIGH ≥ 2), input is structured findings list in conversation context.
-
-Findings may also originate from `/adv-audit` ambiguity detection (Phase 3 inline scan). When the source is a spec audit, each finding includes `specCapability` context.
-
-Finding shape:
-
-```json
-[{"id":"B1","severity":"CRITICAL","category":"Boundaries","finding":"...","evidence":"...","reason":"...","specCapability":"advance-workflow"}]
-```
-
-Protocol:
-
-1. Convert each finding to Socratic question seeded by `reason`.
-2. Resolve by writing proposal.md section (for change findings) or spec file (for spec-law findings) via appropriate update tool.
-3. Add `## Clarify Resolution Log` to proposal.md or spec comments:
-   ```markdown
-   - B1 (resolved {ISO timestamp}): {resolution text}
-   ```
-4. Emit REQUIREMENTS DISCOVERY SUMMARY with cleared findings.
-5. End with `Next: rerun /adv-discover {change-id}` or `Next: rerun /adv-audit {capability}`.
-
-Return path same as `/adv-discover` AC Checkpoint Phase 4.5.1. `/adv-clarify` MUST NOT write `agreement.md` or call `adv_gate_complete`.
-
 ## Phase 1: Context Analysis
 
 Silently analyze stated/unstated assumptions, contradictions, knowledge gaps, specs, proposals, code, constraints.
-
-## Phase 2: Question Loop
-
-Use skill question categories and funnel. Max 2-3 questions per response; lead open, add 1-2 clarifiers; summarize before asking; watch overwhelm signals.
-
-**ALWAYS use `question` tool** — never plain text questions.
-
-Flow: analyze → summarize → ask via `question` → process response → repeat until sufficient.
-
-## Phase 3: Output
-
-Emit REQUIREMENTS DISCOVERY SUMMARY:
-
-- confirmed requirements with acceptance criteria
-- assumptions to validate
-- edge cases identified
-- remaining questions
-- suggested next steps
-
-If invoked from `/adv-discover` Phase 2.5 or Phase 4.5.1, final line MUST be `Next: rerun /adv-discover {change-id}`.
-
-## Constraints
-
-- MUST use `question` tool for questions.
-- MUST NOT write `agreement.md`.
-- MUST NOT call `adv_gate_complete`.
-- Max 2-3 questions per response.
-- Neutral framing; no leading questions.
 
 ## Anti-Patterns
 

--- a/.opencode/command/adv-comp-scan.md
+++ b/.opencode/command/adv-comp-scan.md
@@ -23,7 +23,9 @@ Parse `$ARGUMENTS`:
 
 ---
 ## Phase 0: Load Skill
-`skill("adv-comp-research")` → two-mode strategy, auto-mode detection, comparison table format, evidence requirements. Unavailable → use embedded protocol.
+`skill("adv-comp-research")` → two-mode strategy, auto-mode detection, comparison table format, evidence requirements.
+
+Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 
 ---
 ## Pre-flight
@@ -45,34 +47,16 @@ All research MUST stay on public sources only.
 ## Phase 1: Source Mode (GitHub Repos)
 When mode is `source`:
 
-1. **Repo metadata** — Exa for candidate repos; searchcode file-tree, file-fetch, and repo-analysis capabilities for README, package manifests, main language
-2. **Feature surface** — analyze source structure, API endpoints, key modules
-3. **Tech stack** — identify dependencies, frameworks, runtime
-
 If repo is private or inaccessible → fallback to public mode with warning.
 
 ---
 ## Phase 1: Public Mode (Websites / Docs)
 When mode is `public`:
 
-1. **Firecrawl primary** — Firecrawl scrape for pricing, features, changelog pages
-2. **Exa fallback** — Exa web search for recent news, reviews, comparisons
-3. **Structured extraction** — identify feature list, pricing tiers, target audience
-
 If Firecrawl fails → use Exa search results as primary source.
 
 ---
-## Phase 2: Comparison Synthesis
-Align findings to comparison table:
-
-| Feature | This Project | Competitor | Notes |
-|---------|-------------|------------|-------|
-| {feature} | {our_status} | {their_status} | {observation} |
-
-Generate structured findings with `category`, `our_status`, `their_status`, `delta`, `source`.
-
----
-## Phase 3: Write Metadata
+## Write Metadata
 After successful completion, call `adv_project_metadata action:"write"` with:
 - `key`: `"comp-scan"`
 - `count`: number of comparison dimensions analyzed
@@ -92,4 +76,4 @@ Output structured JSON: `competitor`, `mode`, `comparison`, `findings[]`, `takea
 
 ---
 ## Execution
-1. Parse arguments → 2. Pre-flight → 3. Phase 1 (mode-specific) → 4. Phase 2 (synthesis) → 5. Write Metadata → 6. Report
+1. Parse arguments → 2. Pre-flight → 3. Phase 1 (mode-specific) → 4. Comparison synthesis per skill → 5. Write Metadata → 6. Report

--- a/.opencode/command/adv-design.md
+++ b/.opencode/command/adv-design.md
@@ -70,26 +70,11 @@ Keep the design actionable for `/adv-prep`; it should explain why the plan is co
 
 ## Phase 2.5: Design Leverage Scout
 
-Run a mandatory bounded leverage-scout pass after draft design and before independent validation (Phase 3.5). The scout identifies leverage points: shortcuts, reusable components, parallelism opportunities, simplification paths, and cross-cutting improvements.
+`skill("adv-opportunity-scout")` → bounded scout methodology (modes, output schema, routing taxonomy, prompt templates, opt-out, degradation). Use `design` mode for this phase. If skill is unavailable, the scout phase is inconclusive and recorded in the phase output; do not auto-adopt or surface candidates without the skill's routing taxonomy.
 
-### Execution
+### Integration with Validator
 
-1. **Prepare split-load contract** — orchestrator owns ScoutCandidate schema, routing taxonomy, fallback/degradation, adoption, and all ADV mutations. Do not load scout methodology into main context unless worker loading is unavailable.
-2. **Prepare context** — assemble proposal summary, agreement objectives/AC/constraints/avoidances, draft design content (Phase 2 output), and prior-consideration data from discovery's conflict scan. Inject this content inline; do not pass external ADV artifact paths.
-3. **Spawn adv-researcher** — prompt worker to load `skill("adv-opportunity-scout")` in `design` mode when available; otherwise use the embedded schema/routing summary in this command. The researcher returns ≤5 structured candidates (8-field ScoutCandidate schema).
-4. **Sort candidates** — by payoff/risk ratio (highest first).
-5. **Route adoption** per the skill's routing taxonomy:
-   - **Auto-adopt** only when: contract-tied (not "untied"), low risk, `adopt_now`/`design_around` fate, no user-value tradeoff.
-   - **Surface to user** for all other candidates (untied, medium+ risk, or user-value tradeoff).
-6. **Integrate adopted findings** — auto-adopted candidates are incorporated into the design before the validator runs (Phase 3.5). The validator then validates the design including any adopted improvements.
-
-### Opt-Out
-
-The scout phase may be skipped with rationale for trivially scoped changes where the opportunity surface is likely zero. Record "Scout: skipped — {rationale}" in the phase output.
-
-### Degradation
-
-If worker skill-load is unavailable, adv-researcher spawn fails, returns empty/malformed output, or times out: record "Scout: inconclusive ({reason})" and proceed without blocking. Mandatory means "must attempt," not "must succeed."
+Auto-adopted candidates from the scout are incorporated into the design before the validator runs (Phase 3.5). The validator then validates the design including any adopted improvements.
 
 ### Output
 

--- a/.opencode/command/adv-discover.md
+++ b/.opencode/command/adv-discover.md
@@ -375,31 +375,11 @@ Update proposal artifact with the discovery findings so the sign-off flow can pr
 
 ## Phase 3.5: Discovery Opportunity Scout
 
-Run a trigger-based Discovery Opportunity Scout pass after current-state research and before agreement formation when Trigger Conditions apply. The scout identifies missed opportunities: alternative approaches, overlooked patterns, gaps in objectives/AC, and unconsidered edge cases.
+`skill("adv-opportunity-scout")` → bounded scout methodology (modes, output schema, routing taxonomy, prompt templates, opt-out, degradation). Use `discovery` mode for this phase. If skill is unavailable, the scout phase is inconclusive and recorded in the phase output; do not auto-adopt or surface candidates without the skill's routing taxonomy.
 
-### Trigger Conditions
+### Integration with Agreement
 
-Run the scout for strategic, architecture, product, ecosystem, external-option, or broad objective/AC changes. Skip for narrow low-opportunity changes where the opportunity surface is likely zero and record `Scout: skipped — {rationale}`.
-
-### Execution
-
-1. **Evaluate Trigger Conditions** — decide `run`, `skip`, or `inconclusive` before spawning. Record rationale in the phase output.
-2. **Prepare split-load contract** — orchestrator owns ScoutCandidate schema, routing taxonomy, fallback/degradation, adoption, and all ADV mutations. Do not load scout methodology into main context unless worker loading is unavailable.
-3. **Prepare context** — assemble proposal summary, agreement objectives/AC/constraints/avoidances, current-state findings (Phase 2–3), and prior-consideration data from Phase 1.6 conflict scan.
-4. **Spawn adv-researcher when triggered** — prompt worker to load `skill("adv-opportunity-scout")` in `discovery` mode when available; otherwise use the embedded schema/routing summary in this command. The researcher returns ≤5 structured candidates (8-field ScoutCandidate schema) and submits a compact `RESEARCHER_REPORT` before final response.
-5. **Sort candidates** — by payoff/risk ratio (highest first).
-6. **Route adoption** per the skill's routing taxonomy:
-   - **Auto-adopt** only when: contract-tied (not "untied"), low risk, `adopt_now`/`design_around` fate, no user-value tradeoff.
-   - **Surface to user** for all other candidates (untied, medium+ risk, or user-value tradeoff).
-7. **Integrate adopted findings** — auto-adopted candidates are incorporated into the agreement's objectives or AC before Phase 4 agreement presentation.
-
-### Opt-Out
-
-The scout phase may be skipped with rationale for narrow low-opportunity changes. Record `Scout: skipped — {rationale}` in the phase output.
-
-### Degradation
-
-If worker skill-load is unavailable, adv-researcher spawn fails, returns empty/malformed output, or times out: record `Scout: inconclusive ({reason})` and proceed without blocking. Triggered means must attempt when applicable, not must succeed.
+Auto-adopted candidates from the scout are incorporated into the agreement's objectives or AC before Phase 4 agreement presentation.
 
 ### Output
 

--- a/.opencode/command/adv-harden.md
+++ b/.opencode/command/adv-harden.md
@@ -304,7 +304,7 @@ Return JSON with: `dimension: "test_coverage"`, `files_with_tests`, `files_witho
 
 #### AI-Slop Detection Scanner
 
-Use the methodology from `adv-slop-detection` loaded in Phase 0 for this scanner dimension. Preserve same severity ladder as the dedicated slop-scan workflow: BLOCKER (security/data loss) > HIGH (silent failures) > MEDIUM (debt) > LOW (style).
+Use the methodology from `adv-slop-detection` loaded in Phase 0 for this scanner dimension.
 
 Return JSON with: `dimension: "ai_slop"`, `summary` (total, blockers, high, by_category), `issues` (severity, category, file, line, pattern, code_snippet, message, fix_suggestion), `debt_quadrant`.
 

--- a/.opencode/command/adv-improve.md
+++ b/.opencode/command/adv-improve.md
@@ -13,9 +13,7 @@ Evidence-backed improvement analysis across current-state gaps, LBP/reference ar
 
 ## Phase 0: Load Skill
 
-`skill("adv-improve")` → target resolution, scan categories, LBP comparison, external landscape, synthesis, research pack schema. Unavailable → use fallback below.
-
-Fallback: run phases in this file; cap findings; cite evidence; write only `docs/*-prep.md`; never create ADV changes/tasks/gates/specs.
+`skill("adv-improve")` → target resolution, scan categories, LBP comparison, external landscape, synthesis, research pack schema. Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 
 ## Command Boundary
 
@@ -28,17 +26,6 @@ Fallback: run phases in this file; cap findings; cite evidence; write only `docs
 **Persistence:** Deep research warrants disk persistence under `docs/{target-slug}-prep.md` for consequential deliverables.
 
 **Gate:** none. Read-only for ADV state.
-
-## Target Resolution
-
-`$ARGUMENTS` optional:
-
-| Invocation | Mode |
-|---|---|
-| No args | broad repo-wide scan |
-| With target | scoped scan of file / directory / capability / symbol / concept |
-
-Resolve in order: file path → read; directory → outline; symbol → lgrep symbol search; concept → lgrep semantic search. Ask via `question` only when interpretations materially differ.
 
 ## Exits
 
@@ -56,63 +43,6 @@ Resolve in order: file path → read; directory → outline; symbol → lgrep sy
 Load `adv_project_context`, `adv_change_list`, `adv_spec action: "list"`. Detect worktree, stack files, and source roots (`src/`, `lib/`, `app/`, `packages/`, `*.ts/*.js/*.py/*.go`). Exit cleanly if no source files.
 
 ---
-
-## Phase 2: Current-State Scan
-
-Analyze 6 categories from the loaded skill or embedded fallback; cap 5 findings each: Security, Reliability, Testing, Observability, Developer Experience, Code Quality.
-
-Every finding MUST have evidence: file path, searched path, or source citation.
-
----
-
-## Phase 3: LBP / Reference Comparison
-
-Use Context7 (resolve library, then query docs) for detected stack. Fallback to `webfetch` canonical docs. If unavailable, use local conventions and annotate `[Reference: local conventions — Context7/webfetch unavailable]`.
-
-Build deviation table: `SOUND` / `DRIFTED` / `ANTI-PATTERN`, source citation, wrong path, correct pattern, minimum viable fix, greenfield note.
-
----
-
-## Phase 4: External Landscape
-
-Use Exa web-search queries: `"{domain} alternatives comparison {current-year}"`, `"{domain} emerging tools trends {current-year}"`.
-
-Extract top-3 competitors + 2 emerging patterns max. Each entry needs source URL, one-sentence summary, relevance. If unavailable/no relevant results, state reason; do not fabricate.
-
----
-
-## Phase 5: Synthesis
-
-Deduplicate against active changes and existing follow-ups. Sort CRITICAL → HIGH → MEDIUM → LOW → GREENFIELD.
-
-Emit **IMPROVEMENT ANALYSIS** with Current State, Architecture, External Landscape, Summary, top 3 recommendations, health signal, and next commands: `/adv-proposal <summary>`, `/adv-task`, `/adv-audit`, `/adv-tron`.
-
-No significant issues → emit **PRODUCTION READY** with positive findings by category.
-
----
-
-## Phase 6: Persist Research Pack
-
-Write/update repo-local pack:
-
-- broad → `docs/repo-improve-prep.md`
-- scoped → `docs/{target-slug}-prep.md`
-- slug collision with different target → append `-2`, `-3`, …
-
-Required sections, in order: Header, Purpose & Scope, Current State, LBP / Reference Comparison, Competitors & Alternatives, Emerging Patterns, Applicability to This Repo, Open Questions for Research, Sources.
-
-If section cannot refresh, mark `⚠ not refreshed ({reason})` and preserve prior content below. Never fabricate sources. × Do NOT write outside `docs/*-prep.md`.
-
----
-
-## Constraints
-
-- No ADV state mutation.
-- Only write: research pack under `docs/*-prep.md`.
-- No change/follow-up creation; suggestions only.
-- Bounded: 5 findings/category, 3 competitors + 2 patterns.
-- Evidence required; reject evidence-free findings.
-- Fallback/unavailability notes MUST appear in report and pack.
 
 ## Key Tools
 

--- a/.opencode/command/adv-refactor.md
+++ b/.opencode/command/adv-refactor.md
@@ -14,9 +14,9 @@ Bidirectional reconciliation: update stale change proposals to match current cod
 
 ## Phase 0: Load Skill
 
-`skill("adv-refactor")` → batch selection, staleness analysis, drift/obsolescence/conflict scanners, intent verification, dry-run/execute report. If unavailable, use fallback below.
+`skill("adv-refactor")` → batch selection, staleness analysis, drift/obsolescence/conflict scanners, intent verification, dry-run/execute report.
 
-Fallback: select target(s), run three scanners, check deps inline, synthesize, ask on intent conflicts, optionally update under contract, validate.
+Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 
 ## Parse Flags
 
@@ -31,43 +31,6 @@ Batch mode: `adv_change_list({ sort: "stalest", excludeRecencyBands: ["hot"] })`
 ## Pre-flight
 
 `adv_change_show include: { proposal: true, problemStatement: true, agreement: true, design: true }` + `adv_task_list`; use returned `_proposal` / `_problemStatement` / `_agreement` / `_design` or other returned context only (× don't read artifact files directly; × don't dereference `artifacts.*.path`). Record `{workdir}` via `pwd`; include `WORKING DIRECTORY: {workdir}` in prompts.
-
----
-
-## Phase 1: Staleness Analysis
-
-Spawn `explore` × 3:
-
-1. Drift Scanner — EXACT, METADATA, FUZZY; task reference validation.
-2. Obsolescence Detector — implemented-elsewhere requirements; tests as evidence.
-3. Conflict Scanner — overlaps with recent archived changes.
-
-Inline dependency check: Context7 (resolve library → query docs) against changelogs/release notes; `webfetch` fallback.
-
----
-
-## Phase 2: Synthesis & Intent Verification
-
-> Anti-Loop: `>>> SYNTHESIS COMPLETE <<<` → aggregate immediately.
-
-Combine drift, deps, conflicts, tasks, obsolescence. If code contradicts requirement → `[ADV:ATTN]` → ask via `question`: `New requirement` (update spec) or `Bug in code` (keep spec, flag code).
-
----
-
-## Phase 3: Refactoring (Under Contract)
-
-Skip if dry-run. If `--execute`:
-
-1. Path alignment — update moved-file refs in proposal, deltas, tasks.
-2. Intent guard — add `> Refactored: aligned with implementation in {file}`.
-3. Obsolescence — mark `[OBSOLETE]` with implementation location; don't delete.
-4. Task derivation — `adv_task_add` validation tasks.
-
----
-
-## Phase 4: Validation
-
-`adv_change_validate strict: true` → fix formatting issues → retry once.
 
 ---
 

--- a/.opencode/command/adv-reflect.md
+++ b/.opencode/command/adv-reflect.md
@@ -14,9 +14,9 @@ Produce two-plane reflection for archived change: project execution + system fri
 
 ## Phase 0: Load Skill
 
-`skill("adv-reflect")` → two-plane dimensions, friction taxonomy, metric synthesis, REFLECTION.md template, persistence rules. If unavailable, use fallback below.
+`skill("adv-reflect")` → two-plane dimensions, friction taxonomy, metric synthesis, REFLECTION.md template, persistence rules.
 
-Fallback: load archived change, gather local task/gate metrics, synthesize Plane 1 + Plane 2, call `adv_reflect`, write REFLECTION.md, present summary.
+Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 
 ## Exits
 
@@ -40,33 +40,6 @@ Parse `$ARGUMENTS`: `change-id` required. If empty, use `adv_change_list` → au
 
 ---
 
-## Phase 2: Gather Metrics
-
-Use the loaded change state and `adv_reflect`'s local metric extraction. Capture task count, retry count, elapsed time, per-gate durations, and task-derived work-time metrics without calling a separate user-facing investment tool.
-
----
-
-## Phase 3: Assemble Plane 1 — Project Execution
-
-Use skill rubric:
-
-| Dimension | Source |
-|---|---|
-| Efficiency | task counts, elapsed, retry density, per-gate durations |
-| Quality | TDD compliance, review/harden findings |
-| Process | gate completion, TDD intent mix, delegation count, drift triggers |
-| Wisdom | captured/promoted entries, reuse hits |
-
----
-
-## Phase 4: Assemble Plane 2 — System Friction
-
-Map evidence to categories from skill: `docs_gap`, `missing_capability`, `tool_gap`, `workaround`, `ux_friction`, `provider_specific`.
-
-Use wisdom entries, error recovery logs, cancellations, and runtime-specific failures. Provider-specific only when issue depends on runtime/provider (Bun vs Node, API quirks, env mismatch), not generic logic/design bugs.
-
----
-
 ## Phase 5: Persist
 
 1. Call `adv_reflect changeId: <target>`; report persists to `reflections.jsonl`.
@@ -76,8 +49,6 @@ Use wisdom entries, error recovery logs, cancellations, and runtime-specific fai
 ---
 
 ## Phase 6: Present Report
-
-Emit REFLECTION COMPLETE banner with change ID/title, Plane 1 summary, Plane 2 friction count/top categories, archive path, persisted reflection ID.
 
 ### Archive-visible summary
 

--- a/.opencode/command/adv-slop-scan.md
+++ b/.opencode/command/adv-slop-scan.md
@@ -27,9 +27,7 @@ $ARGUMENTS
 </UserRequest>
 ## Phase 0: Load Skill
 
-`skill("adv-slop-detection")` → two-phase detection strategy, smell categories, thresholds, confidence, report schema. If unavailable, use fallback below.
-
-Fallback: run AST/regex checks from `slop-smells.yaml`, then first-level `explore` scanners for semantic smells. Preserve `WORKING DIRECTORY` in all prompts.
+`skill("adv-slop-detection")` → two-phase detection strategy, smell categories, thresholds, confidence, report schema. Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 ## Pre-flight
 
 1. Git repo check: `git rev-parse --is-inside-work-tree`; stop if false.
@@ -53,53 +51,10 @@ Runner adapters:
 
 Each finding MUST include `id`, `name`, `severity`, `file`, `line`, `description`, `fix`, `confidence`, `detectionMethod`, `grouping`, `actionability`, `phase: 1`; include `nestingDepth`/`complexity` where applicable.
 
-### Phase 1 Confidence Defaults
-
-- AST-backed structural findings default to `confidence: high`
-- Regex-only defensive-overkill findings default to `confidence: medium`
-- Required detector degraded/failed/timed-out/unavailable/applicable-skipped coverage fails the scan with `SLOP_SCAN_DEGRADED`; it is not converted into low-confidence fallback findings.
-- Assign `actionability` and `grouping` before severity sorting
-
-### Required Coverage Failure Boundary
-
-Applicable required detectors are detector registry entries with `important: true`. If Phase 1 records any required detector state as `degraded`, `failed`, `timed_out`, `unavailable`, or applicable-required `skipped`, stop the command as unsuccessful before Phase 2. Preserve the typed report and coverage details for diagnosis. Advisory/external coverage such as `external-ci-semgrep` (`important: false`) remains visible but does not fail the local scan.
-
-### Structural Correctness Bypass (QUAL-012)
-
-Heuristics used only for discovery/ranking/triage/advisory notes are not findings.
-
-### Deletion Candidate Taxonomy
-
-Deletion candidates are `MAINT-003 deletion_candidate` findings, not automatic deletion actions. Subtypes:
-
-- unused dependency
-- unused export
-- unused file
-- unreachable branch
-- uncallable private symbol
-- impossible feature-flag path
-
-Every deletion candidate must include source evidence, confidence, detectionMethod, grouping, actionability, and a verification-oriented fix. Public exports, generated files, tests, fixtures, command modules, plugin registration surfaces, prompt context, examples, and task summaries are protected false-positive surfaces unless target source evidence proves otherwise.
-
-### Deletion Safety / Actionability Boundary
-
-Do not auto-delete. A deletion candidate is actionable only when structural evidence exists: tool-backed symbol/file/dependency evidence, exact reachability proof, entrypoint/config checks, typed roots, or source citations. No single external tool is the sole correctness authority for deletion safety.
-
-Uncertain candidates go to `low-confidence / user-review`. Heuristic-only or text-only unused-code guesses are not actionable removal proof.
-
 If `--phase 1` only → Phase 3: Report Generation.
 ## Phase 2: Heuristic Detection
 
 AI-assisted semantic scan via first-level `explore` sub-agents only.
-
-### No Nested Scanner Delegation (CRITICAL)
-
-`/adv-slop-scan` may fan out to first-level `explore` scanners only.
-
-- Scanner workers MUST do analysis inline with their own tools.
-- Scanner workers must NOT spawn additional sub-agents, delegates, or worker agents.
-- Scanner workers must NOT invoke any `/adv-*` slash commands; if ADV context is needed they must use ADV tools directly.
-- Deeper-analysis need → return gap to orchestrator.
 
 ### Work Distribution
 
@@ -119,11 +74,6 @@ EXPECTED OUTPUT: JSON with findings array per dimension schema
 
 Also include smell definitions for category, file list, novelty check, and these bans: do all work inline; do NOT spawn sub-agents/delegates; do NOT invoke `/adv-*`.
 
-### Context Boundary (Non-Scannable)
-
-Context packet text is orientation only, not a finding location. Every finding must cite a target source file and line or scoped source evidence. Do NOT emit findings against CHANGE, AFFECTED FILES summaries, TASK EVIDENCE SUMMARY, examples, or fixture descriptions.
-
-Timeout → `TIMEOUT`; failure → `INCOMPLETE`; all fail → report Phase 1 findings only and suggest `--phase 1` or retry. If Phase 1 required coverage has `SLOP_SCAN_DEGRADED`, do not start Phase 2.
 ## Phase 3: Report Generation
 
 > Anti-Loop: after Phase 2 → aggregate directly.

--- a/.opencode/command/adv-triage.md
+++ b/.opencode/command/adv-triage.md
@@ -17,12 +17,12 @@ Reconcile backlog sources into GitHub issues, apply `priority:*` labels to bugs 
 
 ## Phase 0: Load Skill
 
-`skill("adv-triage")` → source enumeration, structural matching, cleanup validation, coalesce evidence tiers, approval parser, portfolio-balance schema, report template, and anti-patterns. If unavailable, continue with this embedded protocol.
+`skill("adv-triage")` → source enumeration, structural matching, cleanup validation, coalesce evidence tiers, approval parser, portfolio-balance schema, report template, and anti-patterns. Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 
 ## Parse Flags
 
 - `--dry-run` — preview only; skip GH/link/cleanup mutations + Tier B prompts
-- `--source <name>` — limit Phase 2 scan: `gh`/`wisdom`/`notes`/`changes`/`epics`/`todos`
+- `--source <name>` — limit the source scan (skill § Gather Sources): `gh`/`wisdom`/`notes`/`changes`/`epics`/`todos`
 
 Reject unknown flags: single-line error + valid list.
 
@@ -42,37 +42,6 @@ Any failure → `[ADV:BLOCKED]` + cause, stop. Resolve project handle, ensure cu
 
 ---
 
-## Phase 2: Gather Sources
-
-Inline parallel reads (I/O bound, no sub-agents). 7 sources: open GH issues, GH Projects items, active ADV changes, active ADV Epics, wisdom, cross-session notes, TODO/FIXMEs. Cap each 100; overflow → recency sort + `(N more not shown)`. Build inventory records with stable refs, linkage fields, optional Epic membership, and advisory `kind_hint`. `kind_hint` (`bug | feature | unknown`) classifies a **source item being promoted to a GitHub issue**; its consumers are the Phase 4a `reclassify N as bug|feature` reply, the `ADV Type` field set at issue creation, and the Phase 4c bug priority loop. It is advisory and never authorizes persistence.
-
-`kind_hint` is distinct from `defectHint`: `kind_hint` classifies a source item on its way to becoming an issue, while `defectHint` ranks an existing ADV change already tracked in ADV. For active changes, derive the optional advisory `defectHint` with `deriveDefectHint({ originKind, title })`: typed `origin.kind === 'triage'` yields source `origin_kind` and is the PRIMARY source; a `/^\s*fix\b/i` title prefix yields source `title_prefix` and is SECONDARY and weak. The hint always carries its evidence source and affects ordering only; it does not decide membership or authorize a mutation. Use `adv_change_list status:'in-flight'`, `adv_epic_list`, and bounded `adv_epic_show` only for plausible relevant Epics. See skill § Phase 1.
-
----
-
-## Phase 3: Match + Identify Gaps
-
-Structural-first match (stable ref → body excerpt → title similarity). Build `represented[]` + `unrepresented[]`. Title-similarity is heuristic-only — stays in user-confirmation list, never auto-suppresses. See skill § Phase 2.
-
-## Phase 3.5: Source Cleanup Validation (Tier B, batched)
-
-After `represented[]` / `unrepresented[]` are built and before any issue creation or bug priority assignment, validate the whole source pool for cleanup decisions. Build command-local `cleanup_decisions[]` with source, stable ref, classification, evidence, proposed action, survivor/source when applicable, and source/reason approval group. Classifications: `relevant`, `stale/already-addressed`, `duplicate/superseded`, `should-merge`, `unclear`.
-
-- `relevant` → may proceed to Phase 4 issue creation or bug priority assignment.
-- `stale/already-addressed` / `duplicate/superseded` / `should-merge` → surface source, reason, evidence, survivor/source, and proposed action; mutate/suppress only after explicit Tier B approval batched by source/reason.
-- `unclear` → ask focused relevance clarification before issue creation or priority assignment; unresolved items stay visible and are not silently suppressed.
-
-Source-specific actions after approval:
-
-- ADV changes: recommend `/adv-archive` for completed/ready work; close duplicate/superseded/not-planned/cancelled only through ADV close tools with approval evidence.
-- GitHub issues: capability-detect duplicate close support via `gh issue close --help`. If `--duplicate-of` is available, use native duplicate close. If unavailable, use documented `Duplicate of #N` comment semantics plus supported close reasons only.
-
-MUST NOT create or open issue candidates before cleanup validation completes for the source pool. MUST NOT apply bug priority labels before cleanup validation completes. Title similarity and agent inference are advisory only (P33): they may flag cleanup candidates, never mutate, close, suppress, or remove without structural evidence and explicit approval. See skill § Source cleanup validation.
-
-If `unrepresented[]` is empty, represented issues have required fields, and cleanup validation has completed with no unresolved cleanup/clarification actions: `No new issues, no label gaps.` Skip Phase 4a issue creation, then continue through Phase 5 coalesce and Phase 6 portfolio balance.
-
----
-
 ## Phase 4: User Assignments (Tier B, batched)
 
 ### 4a. Confirm new issues
@@ -81,7 +50,7 @@ When `unrepresented[]` non-empty: emit Tier B inline approval (skill § Phase 3a
 
 ### 4b. Relevance validation
 
-Thin late fallback only: if a field-gap candidate was not covered by Phase 3.5 cleanup validation or new evidence appears after issue creation, relevance-check before asking for bug context or applying priority. Evidence sources: issue body/comments/labels/project status, linked ADV change state, current source/docs/tests for implementation-gap claims, and user-provided context from the run. Classify each item as `relevant`, `stale/already-addressed`, `duplicate/superseded`, or `unclear`.
+Thin late fallback only: if a field-gap candidate was not covered by cleanup validation (skill § Source Cleanup Validation) or new evidence appears after issue creation, relevance-check before asking for bug context or applying priority. Evidence sources: issue body/comments/labels/project status, linked ADV change state, current source/docs/tests for implementation-gap claims, and user-provided context from the run. Classify each item as `relevant`, `stale/already-addressed`, `duplicate/superseded`, or `unclear`.
 
 - `relevant` → include in the Phase 4c bug priority loop.
 - `stale/already-addressed` or `duplicate/superseded` → surface evidence and get explicit user approval before closing/removing/deprioritizing.
@@ -139,57 +108,6 @@ Reply grammar (exact, no LLM fallback):
 - `stop` / `abort` — halt without linking
 
 Anything else → re-prompt. On approval, call `adv_change_update_issues changeId:<id> add:[<issue-url>]` per approved pair. Partial failure is safe: retain successful links, report failed pairs with exact retry calls, continue only when failure does not corrupt linkage authority. `--dry-run` emits candidates and proposed calls without prompting or mutating.
-
----
-
-## Phase 6: Portfolio-Balance Report
-
-Emit exactly three sections. Cap each section at 10 rows and append `(N more not shown)` when truncated. No chat popup and no file write.
-
-### Important to complete
-
-Represent every nonterminal ADV change with no linked GitHub issue in this same section; absence of an issue link MUST NOT exclude it. Build membership structurally from typed change state only: nonterminal state plus typed absence of issue linkage. Title similarity, title prefix inference, and agent inference MUST NOT decide whether an unlinked change appears. Keep this membership decision separate from ranking.
-
-Rank the resulting changes by existing structural signals plus the bounded advisory hint:
-1. linked issue priority (`critical` → `high` → `medium` → `low` → none),
-2. for an unlinked change only, optional `defectHint` ordering weight strictly between `priority:low` and `priority:medium`; it may lift defect work above the weakest structural triage signal but never above a deliberate medium-or-higher human triage decision,
-3. gate proximity to release (release/acceptance/execution before earlier gates),
-4. recent activity as deterministic tie-breaker.
-
-Each row includes change ID/title, current gate, task progress, last activity, linked issue + priority, optional Epic ID/title/order, and any advisory defect hint rendered with its evidence source (`source:origin_kind` or `source:title_prefix`). Epic order is advisory: warn when earlier entries remain incomplete, never block work solely due to order. Resume pointer: `→ /adv-apply {change-id}`.
-
-### Cleanup needed
-
-Report counts + top IDs for `/adv-cleanup` buckets: ready-to-archive, stuck-at-proposal, abandoned-mid-flight, duplicate/superseded. Include stale Epic-entry projection warnings when found, but route repair through typed Epic repair tools or `/adv-cleanup`; `/adv-triage` MUST NOT close/cancel/archive changes or mutate Epic membership in this section.
-
-Pointer: `→ /adv-cleanup`.
-
-### Open issues worth solving
-
-List open issues with no linked active ADV change after Phase 5, sorted by `priority:*` then recency. Annotate related Epic shell/entry context when structurally present. Pointer: `→ /adv-proposal #N` (new issue-linked changes use `origin_kind:'triage'`). Never silently suppress overflow or heuristic overlaps.
-
----
-
-## Phase 7: Final Report
-
-Emit: sources scanned, issues created, priorities assigned, coalesce pairs proposed/linked/rejected/failed, active Epics inspected, and three portfolio-balance counts. If `--dry-run`, append `Re-run without --dry-run to apply mutations.`
-
----
-
-## Constraints
-
-- × MUST NOT auto-create GH issues without Tier B approval
-- × MUST NOT auto-link a coalesce pair without approval covering that displayed pair
-- × MUST NOT let `approve all` authorize hidden overflow pairs
-- × MUST NOT use heuristic similarity as linkage, cleanup, gate, or suppression authority (P33)
-- × MUST NOT own change closure or Epic repair from the portfolio report; delegate to typed paths
-- × MUST NOT write feature scoring fields from this command
-- × MUST NOT write `priority:*` labels to non-bug issues
-- × MUST NOT let an advisory defect hint filter, suppress, close, deprioritize, or authorize any mutation
-- × MUST NOT write any `priority:*` label or parallel priority field to an ADV change; `priority:*` remains GitHub-issue-scoped
-- × MUST NOT generate, echo, stage, commit, or push ROADMAP.md or `.adv/roadmap-snapshot.json`
-- × MUST NOT post priority rationale as issue comments
-- × MUST NOT use `question` to confirm priority choice — only gather bounded context
 
 ---
 

--- a/.opencode/command/adv-tron.md
+++ b/.opencode/command/adv-tron.md
@@ -24,53 +24,14 @@ Target resolution: file path → read directly, directory → outline all, symbo
 
 ---
 ## Phase 1: Load Skill
-`skill("adv-tron")` → provides investigation protocol, search priorities, evidence requirements, report schema. If the skill is unavailable, continue with the embedded protocol in this command file.
+`skill("adv-tron")` → provides investigation protocol, search priorities, evidence requirements, report schema.
+
+Required — if the skill fails to load, stop and report a broken deploy (run scripts/deploy-local.sh --fix).
 ## Phase 2: Determine Mode
 Empty args → broad. Non-empty → scoped. Emit: `[ADV:WORK] Tron reconnaissance: {mode}`.
 ## Phase 3: Gather Context
 1. `adv_project_context` + `adv_change_list`
 2. Broad: lgrep file tree for structure. Scoped: resolve target to concrete files/symbols → if unresolved after semantic/symbol/text search, fall back to the closest concrete target or broad reconnaissance and state that choice. Ask via `question` only if multiple plausible interpretations would lead to materially different investigations.
-
-### Analysis Startup Sequence
-
-Before deep reads, establish baseline context in this order:
-
-1. **WORKING DIRECTORY / repo root** — record the actual workdir and resolved target path.
-2. **Project context** — load `adv_project_context`.
-3. **active ADV state** — inspect active changes plus relevant wisdom/spec context using ADV read tools.
-4. **repo tree/outline** — inspect repo tree/outline before target-local reads.
-5. **coverage gaps** — record unavailable tools, skipped dimensions, and unexamined areas.
-
-### Broad Scan
-
-Run a bounded broad scan with: structure map, hotspot/risk scan, related pattern/convention scan, active-change/spec overlap check, and coverage gaps. Cap findings at 10.
-
-### Scoped Scan
-
-Run a bounded scoped scan with: target normalization, deep read, dependency/usage trace, related/sibling code scan, active-change/spec overlap check, and coverage gaps. Cap findings at 15.
-
-### Degraded Execution
-
-If `lgrep` or outline tools fail, fallback to allowed read/search tools, report degraded coverage, and only emit findings backed by inspected source. Unsupported signals become coverage gaps/open questions, not findings.
-
-### Follow-up Routing Matrix
-
-Use these trigger criteria for suggested next commands. Tron recommends only; it must not invoke `/adv-*`, must not create agenda/change/task state, and must not edit files.
-
-| Trigger criteria | Recommend |
-| --- | --- |
-| Simplification, bloat, duplicated flow, verbose code, or long-term maintainability proposal needed | `/adv-optimizer <target>` |
-| Slop smell, dead-code/deletion-safety, detector coverage, defensive overkill, AI-code quality issue | `/adv-slop-scan <target>` |
-| Architecture boundary, stack-pack, structural-correctness, heuristic-owned state/spec/security/persistence concern | `/adv-arch-scan <target>` |
-| Explicit spec-vs-implementation drift | `/adv-audit <capability>` |
-| Follow-up already bounded and implementation-ready | `/adv-task` |
-| Durable change needs proposal/agreement/design | `/adv-proposal <summary>` |
-| More local reconnaissance needed before choosing owner | `/adv-tron <deeper-target>` |
-
-Combination routing examples:
-
-- `/adv-slop-scan <target> then /adv-optimizer <target>` — first classify slop/deletion-safety evidence, then synthesize simplification proposal.
-- `/adv-arch-scan <target> then /adv-slop-scan <target>` — first validate architecture/structural boundary, then scan quality smells if source evidence also suggests code-level slop.
 ## Phase 4: Run as Tron Sub-Agent
 This command declares `agent: adv-tron` in frontmatter, so OpenCode invokes the `adv-tron` subagent directly — no Task-tool spawn. ADV orchestrator agents deny `task: adv-tron`, making `/adv-tron` the only entry point. The agent's system prompt carries behavioral instructions; establish this packet plus mode-specific context as the working scope:
 
@@ -104,23 +65,6 @@ Pass only:
 **Scoped:** target, resolved files, repo root, project context, relevant ADV state. Task: deep-read target, trace dependencies, find related code, assess complexity/coverage/risk, check ADV overlap, suggest follow-ups. Cap: 15 findings.
 
 **Opt-scan candidates:** If validated static opt-scan candidates are available, pass them in the spawn packet under `OPTIMIZATION_CANDIDATES`. Tron consumes them read-only, preserves all source evidence, and includes them as advisory `optimization_candidates` in the `TRON_REPORT` with a recommended `/adv-optimizer` handoff. Do not run opt-scan automatically from this command if candidates are not already available; candidate generation is outside Tron's scope.
-## Phase 5: Synthesize
-Validate findings (require file references, remove evidence-free, deduplicate). Emit TRON RECONNAISSANCE REPORT:
-- Target/scope
-- Numbered findings (category, title, description, evidence, confidence)
-- Hotspots (file/module + why)
-- Risks (with file references)
-- Open questions
-- Possible follow-ups (title, rationale, priority — suggestions only, not auto-created)
-- Suggested next commands (command, target, trigger, rationale): `/adv-optimizer`, `/adv-slop-scan`, `/adv-arch-scan`, `/adv-proposal`, `/adv-task`, `/adv-tron`, and optional `/adv-audit` only for explicit spec-vs-implementation drift
-## Constraints
-- Read-only — × never writes files or mutates ADV state
-- Adjacent commands are recommendations only — must not invoke `/adv-*`, must not create agenda/change/task state, must not edit files
-- × No agenda creation — suggestions in human-readable form only
-- × No change creation — user decides follow-up
-- Bounded: 10 findings (broad), 15 (scoped)
-
----
 ## Key Tools
 | Purpose | Tool |
 |---------|------|


### PR DESCRIPTION
## What

Removes inline methodology from 13 `/adv-*` command files where that methodology already exists as a standalone skill loaded in Phase 0.

`.opencode/command`: **411,730 → 377,993 bytes (−33,737, −8%)**

## Why

Each affected command loads its skill in Phase 0 and then restated the same methodology inline as a fallback (`If unavailable, continue with this embedded protocol.`). Skills ship alongside commands via `deploy-local.sh`, so a command running without its skill is a broken deploy — not a normal degraded state.

The fallback is replaced with a loud failure: the agent is now told to stop and report a broken deploy rather than silently running a stale inline copy that drifts from the skill.

## Scope

Touched (13): `adv-triage` `adv-audit` `adv-clarify` `adv-improve` `adv-slop-scan` `adv-reflect` `adv-refactor` `adv-arch-scan` `adv-comp-scan` `adv-tron` `adv-discover` `adv-design` `adv-harden`

**Deliberately untouched** — no skill counterpart, inline methodology is canonical: `adv-prep` `adv-archive` `adv-apply` `adv-research` `adv-coordinate` `adv-optimizer`

## Beyond deletion

- `adv-arch-scan.md` conflated two numbering schemes: the skill's detection passes (1/2/3, still selectable via `--phase`) and the command's own sections (0/1/4/5). Command-local sections no longer carry Phase numbers; only the skill's passes do.
- Repaired dangling references to deleted sections in `adv-triage.md` and `adv-comp-scan.md`.

## Verification

- `pnpm run check` green (0 errors; 4 pre-existing warnings in `src/temporal/`, untouched)
- 114 tests pass across `adv-triage-phase4c-agent`, `consumer-integration`, `manifest`, `manifest-doc-drift`, `delegation-matrix`, `cli-surface-matrix`
- Every phase reference cross-checked against defined headings; no dangling refs remain

## Note

Deletions were applied under under-delete discipline: content was removed only where it could be positively matched against skill text. Several sections initially flagged as duplicate were kept because they carry command-local operational content (ADV tool calls, approval tiers, output formats).