### PR TITLE
docs(skills): remove Temporal references from ADV skills

### DIFF
--- a/skills/adv-arch-detection/SKILL.md
+++ b/skills/adv-arch-detection/SKILL.md
@@ -26,7 +26,7 @@ Detect stack from project files, then run stack-specific tools from the Stack Pa
 | Detected File | Stack Pack | Tools / Structural owners |
 |---------------|------------|---------------------------|
 | `package.json` + `tsconfig.json` | TypeScript/Node | `dependency-cruiser`, `madge` |
-| `package.json` + ADV command/spec/skill/Temporal assets | ADV stack pack | dependency graph tools; workflow bundle boundary tests; command/manifest symmetry tests; spec/asset anchors; command/skill methodology surfaces |
+| `package.json` + ADV command/spec/skill assets | ADV stack pack | dependency graph tools; plugin bundle boundary tests; command/manifest symmetry tests; spec/asset anchors; command/skill methodology surfaces |
 | `pyproject.toml` / `setup.py` | Python | `pydeps` |
 | `go.mod` | Go | `go vet`, `gocyclo` |
 | `Cargo.toml` | Rust | `cargo-deps` |
@@ -59,7 +59,7 @@ Run Phase 3 when the user requests `--phase 3`, after Phase 1/2 produce no findi
 | Stack Pack | Primary Tool / Structural Owner | Fallback Tool | Checks |
 |------------|----------------------------------|---------------|--------|
 | TypeScript/Node | `dependency-cruiser` | `madge` | Circular deps, layer violations, orphans |
-| ADV stack pack | existing structural enforcers | dependency graph tools | TypeScript/Bun/OpenCode plugin/Temporal workflow bundle boundary, command/manifest symmetry, spec/asset anchors, command/skill methodology surfaces |
+| ADV stack pack | existing structural enforcers | dependency graph tools | TypeScript/Bun/OpenCode plugin bundle boundary, command/manifest symmetry, spec/asset anchors, command/skill methodology surfaces |
 | Capability Consistency | `bun run bin/arch-scan.ts` (typed adapter) | (none — typed pipeline is primary) | Config↔code↔deps inconsistencies: plumbed-but-unused env vars, present-but-inactive artifacts, deferred migrations, scaffold without tests |
 | Python | `pydeps` | `import-deps` | Import cycles, module depth |
 | Go | `go vet` | `gocyclo` | Shadowing, complexity, unused code |

--- a/skills/adv-cleanup/SKILL.md
+++ b/skills/adv-cleanup/SKILL.md
@@ -110,8 +110,8 @@ The `adv_worktree_triage` classes map to these groups as follows:
 | `archived_not_cleaned` | safe | yes — owning change archived; delete tool enforces archived+merged+clean |
 | `missing_from_disk` | safe | yes — registry-only record, nothing on disk to lose |
 | `dirty_uncommitted_work` | dirty/in-use | **no** — force-deleting discards staged/modified/untracked work |
-| `missing_from_temporal_unmerged` | dirty/in-use | **no** — has commits ahead of the default branch |
-| `missing_from_temporal` | needs-investigation | no — may still be active; resume or inspect first |
+| `stale_head_unmerged` | dirty/in-use | **no** — has commits ahead of the default branch |
+| `stale_head` | needs-investigation | no — may still be active; resume or inspect first |
 | `registry_missing_change_id` | needs-investigation | no — repair registry metadata first |
 | `stale_head` | needs-investigation | no — classification ambiguous |
 | `terminal_cleanup_retained` | blocked | no — cleanup already attempted and blocked; resolve the blocker first |

--- a/skills/adv-triage/SKILL.md
+++ b/skills/adv-triage/SKILL.md
@@ -10,7 +10,7 @@ keywords: ["triage", "backlog", "portfolio", "github-projects", "prioritization"
 
 Methodology for `/adv-triage`: reconcile source items into GitHub issues, apply bug priorities autonomously, coalesce approved issue↔change overlaps, and report what to finish, clean up, or start across active changes, Epics, and open issues.
 
-GitHub Projects v2 owns issue/project membership. Temporal-backed ADV changes and Epics own work-in-progress state. Legacy roadmap files/readers are retired; this skill has no file-write or git-commit phase.
+GitHub Projects v2 owns issue/project membership. Disk-backed ADV changes and Epics own work-in-progress state. Legacy roadmap files/readers are retired; this skill has no file-write or git-commit phase.
 
 **Canonical source:** `.opencode/command/adv-triage.md` owns orchestration and mutation. This skill owns rubrics, prompt templates, schemas, and anti-patterns.
 

--- a/skills/adv-worktree/SKILL.md
+++ b/skills/adv-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adv-worktree
-description: "ADV worktree workflow — create, manage, triage, and clean up git worktrees with Temporal-coordinated state and per-worktree git isolation. Covers when to isolate, multi-session model, and merge-before-delete protocol."
+description: "ADV worktree workflow — create, manage, triage, and clean up git worktrees with disk-coordinated state and per-worktree git isolation. Covers when to isolate, multi-session model, and merge-before-delete protocol."
 keywords:
   [
     "worktree",
@@ -24,7 +24,7 @@ Load this skill when you need to **create, manage, triage, or clean up git workt
 
 ## Multi-Session Note
 
-This skill applies in single-session AND multi-session modes. **Concurrent worktrees per project are first-class and Temporal-coordinated** — no soft-locks, no warnings, no fallback framing. ADV serializes state writes via Temporal workflow updates; per-worktree git isolation eliminates working-tree races between sessions. See `ADV_INSTRUCTIONS.md § Multi-Session Coordination`.
+This skill applies in single-session AND multi-session modes. **Concurrent worktrees per project are first-class and disk-coordinated** — no soft-locks, no warnings, no fallback framing. ADV serializes state writes via per-change file locks in `commitChangeProjection`; per-worktree git isolation eliminates working-tree races between sessions. See `ADV_INSTRUCTIONS.md § Multi-Session Coordination`.
 
 ## When to Create a Worktree
 
@@ -51,7 +51,7 @@ Use `adv_worktree_create` when:
 - `mode: "spawn"` returns the worktree path for follow-up launch handling; do not assume a terminal was opened unless the calling workflow explicitly does so
 - Already-warped sessions cannot create another worktree; open a fresh OpenCode session from the trunk checkout
 - On delete, the change branch must be archived AND merged AND clean (3-condition gate); pre-delete and post-delete hooks run with safety bounds (timeout, env sanitization, exit-code surfaced)
-- Multiple worktrees per project are first-class — coordinate-by-design via Temporal `worktree_registry`
+- Multiple worktrees per project are first-class — coordinate-by-design via the disk `worktree_registry`
 
 ## Post-Change Cleanup (Merge Before Delete)
 
@@ -140,5 +140,5 @@ Before creating a worktree, explain why isolation helps. Ask the user only when 
 
 worktree, git worktree, branch isolation, parallel development, merge before delete,
 worktree create, worktree delete, feature branch, risky refactor,
-exploratory work, worktree cleanup, multi-session, peer-session, Temporal coordination,
+exploratory work, worktree cleanup, multi-session, peer-session, disk coordination,
 adv-worktree


### PR DESCRIPTION
Companion to #393/#394. Cleans the last Temporal residue from skill files. adv-backend-stack-eval intentionally keeps Temporal as a technology-choice reference.