### PR TITLE
fix: migrate historical artifact metadata to disk

### DIFF
--- a/plugin/src/storage/artifact-metadata-migration.test.ts
+++ b/plugin/src/storage/artifact-metadata-migration.test.ts
@@ -1,0 +1,364 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { createTempDir, cleanupTempDir } from "../__tests__/setup";
+import { normalizeArtifactMetadataForReadback } from "../tools/change/artifacts";
+import { createDiskStore } from "./store-disk";
+import { migrateArtifactMetadataProjections } from "./artifact-metadata-migration";
+
+function changeFixture(
+  id: string,
+  status: "draft" | "archived",
+): Record<string, unknown> {
+  return {
+    id,
+    title: id,
+    status,
+    created_at: "2026-08-07T00:00:00.000Z",
+    tasks: [],
+    deltas: {},
+    documents: { proposal: "artifact content must remain unchanged" },
+    artifacts: {
+      proposal: {
+        path: `/legacy/${id}/proposal.md`,
+        updatedAt: "2026-08-07T00:00:00.000Z",
+        source: "temporal",
+        readable: true,
+      },
+    },
+  };
+}
+
+function markerPath(root: string): string {
+  return join(root, ".adv", "artifact-metadata-migration-complete.json");
+}
+
+async function writeProjection(
+  directory: string,
+  id: string,
+  change: Record<string, unknown>,
+): Promise<string> {
+  const changeDir = join(directory, id);
+  await mkdir(changeDir, { recursive: true });
+  const path = join(changeDir, "change.json");
+  await writeFile(path, JSON.stringify(change, null, 2));
+  return path;
+}
+
+describe("artifact metadata migration", () => {
+  test("migrates active projection metadata without changing artifact content", async () => {
+    const root = await createTempDir();
+    try {
+      const activePath = await writeProjection(
+        join(root, ".adv", "changes"),
+        "active-legacy",
+        changeFixture("active-legacy", "draft"),
+      );
+
+      await createDiskStore(root);
+
+      const migrated = JSON.parse(await readFile(activePath, "utf8"));
+      expect(migrated.artifacts.proposal.source).toBe("disk");
+      expect(migrated.documents.proposal).toBe(
+        "artifact content must remain unchanged",
+      );
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("migrates archived projection metadata", async () => {
+    const root = await createTempDir();
+    try {
+      const archivePath = await writeProjection(
+        join(root, ".adv", "archive"),
+        "2026-08-07-archived-legacy",
+        changeFixture("archived-legacy", "archived"),
+      );
+
+      await createDiskStore(root);
+
+      const migrated = JSON.parse(await readFile(archivePath, "utf8"));
+      expect(migrated.artifacts.proposal.source).toBe("disk");
+      expect(migrated.documents.proposal).toBe(
+        "artifact content must remain unchanged",
+      );
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("preserves archive and recovery provenance", async () => {
+    const root = await createTempDir();
+    try {
+      const change = changeFixture("preserve-provenance", "draft");
+      change.artifacts = {
+        proposal: {
+          path: "/legacy/proposal.md",
+          updatedAt: "2026-08-07T00:00:00.000Z",
+          source: "temporal",
+          readable: true,
+        },
+        design: {
+          path: "/archive/design.md",
+          updatedAt: "2026-08-07T00:00:00.000Z",
+          source: "archive",
+          readable: true,
+        },
+        acceptance: {
+          path: "/recovery/acceptance.md",
+          updatedAt: "2026-08-07T00:00:00.000Z",
+          source: "recovery",
+          readable: true,
+        },
+      };
+      const path = await writeProjection(
+        join(root, ".adv", "changes"),
+        "preserve-provenance",
+        change,
+      );
+
+      await createDiskStore(root);
+
+      const migrated = JSON.parse(await readFile(path, "utf8"));
+      expect(migrated.artifacts).toMatchObject({
+        proposal: { source: "disk" },
+        design: { source: "archive" },
+        acceptance: { source: "recovery" },
+      });
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("is idempotent", async () => {
+    const root = await createTempDir();
+    try {
+      await writeProjection(
+        join(root, ".adv", "changes"),
+        "idempotent-legacy",
+        changeFixture("idempotent-legacy", "draft"),
+      );
+
+      const store = await createDiskStore(root);
+      const before = await readFile(
+        join(store.paths.changes, "idempotent-legacy", "change.json"),
+        "utf8",
+      );
+      const report = await migrateArtifactMetadataProjections(
+        store.paths.changes,
+        store.paths.archive,
+      );
+      const after = await readFile(
+        join(store.paths.changes, "idempotent-legacy", "change.json"),
+        "utf8",
+      );
+
+      expect(report.migrated).toBe(0);
+      expect(after).toBe(before);
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("reports malformed projections without overwriting them", async () => {
+    const root = await createTempDir();
+    try {
+      const path = await writeProjection(
+        join(root, ".adv", "changes"),
+        "malformed",
+        changeFixture("malformed", "draft"),
+      );
+      await writeFile(path, "{ malformed json\n");
+
+      const report = await migrateArtifactMetadataProjections(
+        join(root, ".adv", "changes"),
+        join(root, ".adv", "archive"),
+      );
+
+      expect(report.failed).toHaveLength(1);
+      expect(await readFile(path, "utf8")).toBe("{ malformed json\n");
+      await expect(readFile(markerPath(root), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("writes a completion marker only after success and skips later scans", async () => {
+    const root = await createTempDir();
+    try {
+      const path = await writeProjection(
+        join(root, ".adv", "changes"),
+        "marker-skip",
+        changeFixture("marker-skip", "draft"),
+      );
+
+      await createDiskStore(root);
+      await expect(readFile(markerPath(root), "utf8")).resolves.toContain(
+        '"version":1',
+      );
+      const migrated = JSON.parse(await readFile(path, "utf8"));
+      migrated.artifacts.proposal.source = "temporal";
+      await writeFile(path, JSON.stringify(migrated, null, 2));
+
+      await createDiskStore(root);
+
+      const skipped = JSON.parse(await readFile(path, "utf8"));
+      expect(skipped.artifacts.proposal.source).toBe("temporal");
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("retries after malformed projections are repaired", async () => {
+    const root = await createTempDir();
+    try {
+      const path = await writeProjection(
+        join(root, ".adv", "changes"),
+        "marker-retry",
+        changeFixture("marker-retry", "draft"),
+      );
+      await writeFile(path, "{ malformed json\n");
+
+      await createDiskStore(root);
+      await expect(readFile(markerPath(root), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+
+      await writeFile(
+        path,
+        JSON.stringify(changeFixture("marker-retry", "draft"), null, 2),
+      );
+      await createDiskStore(root);
+
+      const migrated = JSON.parse(await readFile(path, "utf8"));
+      expect(migrated.artifacts.proposal.source).toBe("disk");
+      await expect(readFile(markerPath(root), "utf8")).resolves.toContain(
+        '"version":1',
+      );
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+});
+
+describe("normalizeArtifactMetadataForReadback", () => {
+  test("normalizes an existing historical path to disk", async () => {
+    const root = await createTempDir();
+    try {
+      const path = join(root, "proposal.md");
+      await writeFile(path, "proposal");
+
+      const result = await normalizeArtifactMetadataForReadback({
+        proposal: {
+          path,
+          updatedAt: "2026-08-07T00:00:00.000Z",
+          source: "temporal",
+          readable: true,
+        },
+      });
+
+      expect(result.proposal).toMatchObject({
+        path,
+        source: "disk",
+        readable: true,
+      });
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("preserves missing-path behavior", async () => {
+    const result = await normalizeArtifactMetadataForReadback({
+      proposal: {
+        path: "/does/not/exist.md",
+        updatedAt: "2026-08-07T00:00:00.000Z",
+        source: "temporal",
+        readable: true,
+      },
+    });
+
+    expect(result.proposal).toMatchObject({
+      source: "temporal",
+      readable: false,
+    });
+    expect(result.proposal).not.toHaveProperty("path");
+  });
+
+  test("preserves rejected and unreadable artifacts", async () => {
+    const root = await createTempDir();
+    try {
+      const path = join(root, "proposal.md");
+      await writeFile(path, "proposal");
+      const rejection = {
+        reason: "ARTIFACT_OVERSIZED" as const,
+        attempted_size: 10,
+        cap: 5,
+        rejected_at: "2026-08-07T00:00:00.000Z",
+      };
+
+      const result = await normalizeArtifactMetadataForReadback({
+        proposal: {
+          path,
+          updatedAt: "2026-08-07T00:00:00.000Z",
+          source: "temporal",
+          readable: true,
+          rejection,
+        },
+        design: {
+          path,
+          updatedAt: "2026-08-07T00:00:00.000Z",
+          source: "temporal",
+          readable: false,
+        },
+      });
+
+      expect(result.proposal).toMatchObject({
+        source: "temporal",
+        readable: false,
+        rejection,
+      });
+      expect(result.design).toMatchObject({
+        source: "temporal",
+        readable: false,
+      });
+      expect(result.proposal).not.toHaveProperty("path");
+      expect(result.design).not.toHaveProperty("path");
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("preserves readable archive and recovery provenance", async () => {
+    const root = await createTempDir();
+    try {
+      const path = join(root, "proposal.md");
+      await writeFile(path, "proposal");
+
+      const result = await normalizeArtifactMetadataForReadback({
+        proposal: {
+          path,
+          updatedAt: "2026-08-07T00:00:00.000Z",
+          source: "archive",
+          readable: true,
+        },
+        design: {
+          path,
+          updatedAt: "2026-08-07T00:00:00.000Z",
+          source: "recovery",
+          readable: true,
+        },
+      });
+
+      expect(result).toMatchObject({
+        proposal: { path, source: "archive", readable: true },
+        design: { path, source: "recovery", readable: true },
+      });
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+});

--- a/plugin/src/storage/artifact-metadata-migration.ts
+++ b/plugin/src/storage/artifact-metadata-migration.ts
@@ -1,0 +1,216 @@
+/**
+ * Storage-owned migration for artifact metadata written before disk became
+ * the durable artifact source.
+ *
+ * The migration only changes metadata.source. Projection documents and
+ * materialized artifact files are never rewritten. Every projection read is
+ * byte-bounded, schema-validated, and written through the shared atomic file
+ * writer; malformed projections are reported and left untouched.
+ */
+
+import { join } from "node:path";
+import { readdir } from "node:fs/promises";
+
+import { ChangeSchema } from "../types";
+import { atomicWriteFile } from "../utils/fs";
+import { createLogger } from "../utils/debug-log";
+import {
+  normalizeProjectionDocument,
+  readBoundedProjectionDocument,
+} from "./change-projection-reader";
+
+const logger = createLogger("artifact-metadata-migration");
+
+/** Keep startup work bounded while covering both active and archive trees. */
+export const ARTIFACT_METADATA_MIGRATION_MAX_PROJECTIONS = 1000;
+const ARTIFACT_METADATA_MIGRATION_MARKER_VERSION = 1;
+
+export interface ArtifactMetadataMigrationFailure {
+  path: string;
+  reason: string;
+}
+
+export interface ArtifactMetadataMigrationReport {
+  scanned: number;
+  migrated: number;
+  failed: ArtifactMetadataMigrationFailure[];
+  truncated: boolean;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function projectionPath(parent: string, id: string): string {
+  return join(parent, id, "change.json");
+}
+
+async function hasCompletionMarker(markerPath: string): Promise<boolean> {
+  const result = await readBoundedProjectionDocument(markerPath);
+  if (result.kind !== "ok") return false;
+  try {
+    const marker = asRecord(JSON.parse(result.content));
+    return marker?.version === ARTIFACT_METADATA_MIGRATION_MARKER_VERSION;
+  } catch {
+    return false;
+  }
+}
+
+async function writeCompletionMarker(
+  markerPath: string,
+  report: ArtifactMetadataMigrationReport,
+): Promise<void> {
+  try {
+    await atomicWriteFile(
+      markerPath,
+      JSON.stringify({ version: ARTIFACT_METADATA_MIGRATION_MARKER_VERSION }),
+    );
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    report.failed.push({ path: markerPath, reason });
+    logger.warn(
+      `Artifact metadata migration could not write completion marker ${markerPath}: ${reason}`,
+    );
+  }
+}
+
+async function migrateProjection(
+  path: string,
+): Promise<"unchanged" | "migrated" | { reason: string }> {
+  const readResult = await readBoundedProjectionDocument(path);
+  if (readResult.kind === "not_found") return "unchanged";
+  if (readResult.kind !== "ok") {
+    return {
+      reason:
+        readResult.kind === "oversized"
+          ? `projection exceeds ${readResult.limit} bytes`
+          : `${readResult.kind}: ${readResult.error}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readResult.content);
+  } catch (error) {
+    return {
+      reason: `corrupt JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const raw = asRecord(parsed);
+  if (!raw) return { reason: "projection root must be an object" };
+
+  const [normalized] = normalizeProjectionDocument(parsed);
+  const validation = ChangeSchema.safeParse(normalized);
+  if (!validation.success) {
+    return { reason: "projection failed ChangeSchema validation" };
+  }
+
+  if (raw.artifacts === undefined) return "unchanged";
+  const rawArtifacts = asRecord(raw.artifacts);
+  if (!rawArtifacts) return { reason: "artifacts must be an object" };
+
+  let changed = false;
+  const artifacts: Record<string, unknown> = { ...rawArtifacts };
+  for (const [kind, rawMetadata] of Object.entries(rawArtifacts)) {
+    if (rawMetadata === undefined) continue;
+    const metadata = asRecord(rawMetadata);
+    if (!metadata) {
+      return { reason: `artifacts.${kind} metadata must be an object` };
+    }
+    if (metadata.source === undefined || metadata.source === "disk") continue;
+    if (typeof metadata.source !== "string") {
+      return { reason: `artifacts.${kind}.source must be a string` };
+    }
+    // Only the historical Temporal metadata is stale. Archive and recovery
+    // provenance remains meaningful and must not be rewritten.
+    if (metadata.source !== "temporal") continue;
+    artifacts[kind] = { ...metadata, source: "disk" };
+    changed = true;
+  }
+
+  if (!changed) return "unchanged";
+
+  // Only the source metadata is replaced; all projection documents and other
+  // fields are carried over byte-for-byte at the parsed JSON value level.
+  await atomicWriteFile(path, JSON.stringify({ ...raw, artifacts }, null, 2));
+  return "migrated";
+}
+
+async function migrateDirectory(
+  directory: string,
+  report: ArtifactMetadataMigrationReport,
+): Promise<void> {
+  let ids: string[];
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    ids = entries
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+      .map((entry) => entry.name)
+      .sort();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    const reason = error instanceof Error ? error.message : String(error);
+    report.failed.push({ path: directory, reason });
+    logger.warn(
+      `Artifact metadata migration could not list ${directory}: ${reason}`,
+    );
+    return;
+  }
+  const boundedIds = ids.slice(0, ARTIFACT_METADATA_MIGRATION_MAX_PROJECTIONS);
+  if (boundedIds.length < ids.length) report.truncated = true;
+
+  for (const id of boundedIds) {
+    const path = projectionPath(directory, id);
+    report.scanned += 1;
+    try {
+      const result = await migrateProjection(path);
+      if (result === "migrated") {
+        report.migrated += 1;
+      } else if (typeof result === "object") {
+        report.failed.push({ path, reason: result.reason });
+        logger.warn(
+          `Artifact metadata migration skipped ${path}: ${result.reason}`,
+        );
+      }
+    } catch (error) {
+      // Fail closed: a write or unexpected read failure never causes a partial
+      // object to replace the original projection.
+      const reason = error instanceof Error ? error.message : String(error);
+      report.failed.push({ path, reason });
+      logger.warn(`Artifact metadata migration failed for ${path}: ${reason}`);
+    }
+  }
+}
+
+export async function migrateArtifactMetadataProjections(
+  activeDirectory: string,
+  archiveDirectory: string,
+  completionMarkerPath?: string,
+): Promise<ArtifactMetadataMigrationReport> {
+  const report: ArtifactMetadataMigrationReport = {
+    scanned: 0,
+    migrated: 0,
+    failed: [],
+    truncated: false,
+  };
+  if (
+    completionMarkerPath &&
+    (await hasCompletionMarker(completionMarkerPath))
+  ) {
+    return report;
+  }
+  await migrateDirectory(activeDirectory, report);
+  await migrateDirectory(archiveDirectory, report);
+  if (report.truncated) {
+    logger.warn(
+      `Artifact metadata migration scan capped at ${ARTIFACT_METADATA_MIGRATION_MAX_PROJECTIONS} projections per directory`,
+    );
+  }
+  if (completionMarkerPath && report.failed.length === 0 && !report.truncated) {
+    await writeCompletionMarker(completionMarkerPath, report);
+  }
+  return report;
+}

--- a/plugin/src/storage/json.test.ts
+++ b/plugin/src/storage/json.test.ts
@@ -60,6 +60,9 @@ describe("getProjectPaths", () => {
     expect("agenda" in paths).toBe(false);
     expect(paths.reflections).toBe("/project/.adv/reflections.jsonl");
     expect(paths.projectMetadata).toBe("/project/.adv/project-metadata.json");
+    expect(paths.artifactMetadataMigrationMarker).toBe(
+      "/project/.adv/artifact-metadata-migration-complete.json",
+    );
     expect(paths.snapshotRepairAudit).toBe(
       "/project/.adv/snapshot-repair-audit.jsonl",
     );
@@ -96,6 +99,9 @@ describe("getProjectPaths", () => {
     expect(paths.reflections).toBe("/ext/data/abc123/reflections.jsonl");
     expect(paths.projectMetadata).toBe(
       "/ext/data/abc123/project-metadata.json",
+    );
+    expect(paths.artifactMetadataMigrationMarker).toBe(
+      "/ext/data/abc123/artifact-metadata-migration-complete.json",
     );
     expect(paths.snapshotRepairAudit).toBe(
       "/ext/data/abc123/snapshot-repair-audit.jsonl",

--- a/plugin/src/storage/json.ts
+++ b/plugin/src/storage/json.ts
@@ -75,6 +75,8 @@ export interface ProjectPaths {
   wisdom: string;
   reflections: string;
   projectMetadata: string;
+  /** Storage-owned completion marker for the bounded artifact metadata migration. */
+  artifactMetadataMigrationMarker: string;
   /**
    * Append-only audit log for adv_snapshot_health repairs. Purpose-specific
    * (not Agenda) per retireAgendaWorkflow AC4: every successful snapshot
@@ -119,6 +121,10 @@ export function getProjectPaths(
       wisdom: join(ext, "wisdom.jsonl"),
       reflections: join(ext, "reflections.jsonl"),
       projectMetadata: join(ext, "project-metadata.json"),
+      artifactMetadataMigrationMarker: join(
+        ext,
+        "artifact-metadata-migration-complete.json",
+      ),
       snapshotRepairAudit: join(ext, "snapshot-repair-audit.jsonl"),
       external: ext,
     };
@@ -138,6 +144,10 @@ export function getProjectPaths(
     wisdom: join(root, ".adv/wisdom.jsonl"),
     reflections: join(root, ".adv/reflections.jsonl"),
     projectMetadata: join(root, ".adv/project-metadata.json"),
+    artifactMetadataMigrationMarker: join(
+      root,
+      ".adv/artifact-metadata-migration-complete.json",
+    ),
     snapshotRepairAudit: join(root, ".adv/snapshot-repair-audit.jsonl"),
     external: null,
   };

--- a/plugin/src/storage/store-disk.ts
+++ b/plugin/src/storage/store-disk.ts
@@ -93,6 +93,7 @@ import { searchWisdom, filterChanges } from "./content-search";
 import { listProjectWisdom } from "./project-wisdom";
 import { createLogger } from "../utils/debug-log";
 import { createEpicDiskOps } from "./epics-disk";
+import { migrateArtifactMetadataProjections } from "./artifact-metadata-migration";
 
 const logger = createLogger("store-disk");
 
@@ -134,6 +135,15 @@ export async function createDiskStore(
   if (paths.external) {
     await mkdir(paths.external, { recursive: true });
   }
+
+  // Repair pre-disk artifact metadata before exposing the store. The migration
+  // is storage-owned and fail-closed: malformed projections are reported and
+  // left untouched by migrateArtifactMetadataProjections.
+  await migrateArtifactMetadataProjections(
+    paths.changes,
+    paths.archive,
+    paths.artifactMetadataMigrationMarker,
+  );
 
   const loadArchivedChanges = async (): Promise<Change[]> => {
     const archiveDirs = await listChangeDirs(paths.archive);

--- a/plugin/src/tools/change/artifacts.ts
+++ b/plugin/src/tools/change/artifacts.ts
@@ -87,14 +87,17 @@ export async function normalizeArtifactMetadataForReadback(
       // Readback re-validates paths because persisted state can retain legacy
       // path metadata after active artifacts moved to content-only storage.
       const readable =
-        metadata.source !== "temporal" &&
         metadata.readable !== false &&
+        !metadata.rejection &&
         (await fileExists(metadata.path));
-      if (readable) {
+      if (readable && metadata.source === "temporal") {
+        metadata.source = "disk";
         metadata.readable = true;
       } else {
-        delete metadata.path;
-        metadata.readable = false;
+        if (!readable) {
+          delete metadata.path;
+          metadata.readable = false;
+        }
       }
     }
     normalized[kind as keyof NonNullable<Change["artifacts"]>] = metadata;


### PR DESCRIPTION
## Summary

- Existing artifact files are no longer marked unreadable because their historical writer metadata says Temporal.
- Storage initialization performs an atomic, idempotent, marker-backed migration of historical artifact metadata to `source: disk` across active and archived projections.
- Only the historical Temporal label is migrated; `archive` and `recovery` provenance remain intact.
- Malformed or oversized projections remain untouched and prevent completion marking, so migration retries safely.

## Verification

- 11 focused migration/readback tests pass.
- 23 related storage/artifact tests pass.
- `pnpm run check` passes.

## Note

ADV checkpointing committed the code but failed to reread its own task afterward. This reproduces the separate task/report contract-drift issue and did not affect the git commit.
