### PR TITLE
test: isolate mutation tool fixtures

### DIFF
--- a/plugin/src/__tests__/setup.ts
+++ b/plugin/src/__tests__/setup.ts
@@ -5,6 +5,7 @@
  */
 
 import { mkdtemp, rm, mkdir, writeFile, readFile } from "fs/promises";
+import { execFileSync } from "node:child_process";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -20,6 +21,70 @@ export async function createTempDir(prefix = "adv-test-"): Promise<string> {
  */
 export async function cleanupTempDir(dir: string): Promise<void> {
   await rm(dir, { recursive: true, force: true });
+}
+
+/**
+ * Create a real Git repository and linked worktree for mutation tests.
+ *
+ * Tests that invoke state-transition tools must run from a worktree rather
+ * than the checkout root; otherwise the production trunk-write firewall is
+ * expected to reject the mutation. The returned cleanup removes the linked
+ * worktree before deleting the repository fixture.
+ */
+export async function createTempGitWorktree(prefix = "adv-test-git-"): Promise<{
+  repoRoot: string;
+  worktreePath: string;
+  cleanup: () => Promise<void>;
+}> {
+  const repoRoot = await createTempDir(`${prefix}repo-`);
+  const worktreePath = join(repoRoot, "worktree");
+
+  try {
+    execFileSync("git", ["init", "-b", "trunk"], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["config", "user.email", "adv-test@example.invalid"], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["config", "user.name", "ADV Test"], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    await writeFile(join(repoRoot, ".adv-git-root"), "fixture\n");
+    execFileSync("git", ["add", ".adv-git-root"], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["commit", "-m", "init"], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    execFileSync(
+      "git",
+      ["worktree", "add", "-b", "change/test", worktreePath],
+      {
+        cwd: repoRoot,
+        stdio: "ignore",
+      },
+    );
+  } catch (error) {
+    await cleanupTempDir(repoRoot);
+    throw error;
+  }
+
+  return {
+    repoRoot,
+    worktreePath,
+    cleanup: async () => {
+      execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+        cwd: repoRoot,
+        stdio: "ignore",
+      });
+      await cleanupTempDir(repoRoot);
+    },
+  };
 }
 
 /**

--- a/plugin/src/tools/gate.release-enforcement.test.ts
+++ b/plugin/src/tools/gate.release-enforcement.test.ts
@@ -2,8 +2,12 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { describe, expect, test, vi } from "vitest";
-import { createTempDir, cleanupTempDir } from "../__tests__/setup";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  cleanupTempDir,
+  createTempDir,
+  createTempGitWorktree,
+} from "../__tests__/setup";
 import { gateTools } from "./gate";
 import type { Change, Store } from "../types";
 
@@ -85,6 +89,32 @@ async function storeFor(root: string, current: Change): Promise<Store> {
 }
 
 describe("release gate fail-closed enforcement", () => {
+  let cleanupWorktree: (() => Promise<void>) | undefined;
+  let restoreCwd: (() => void) | undefined;
+
+  beforeEach(async () => {
+    const fixture = await createTempGitWorktree("adv-release-gate-");
+    cleanupWorktree = fixture.cleanup;
+    // Mutation tools derive their session workdir from process.cwd(). Keep
+    // that dependency explicit and isolated from the checkout running Vitest.
+    const cwdSpy = vi
+      .spyOn(process, "cwd")
+      .mockReturnValue(fixture.worktreePath);
+    restoreCwd = () => cwdSpy.mockRestore();
+  });
+
+  afterEach(async () => {
+    restoreCwd?.();
+    restoreCwd = undefined;
+    await cleanupWorktree?.();
+    cleanupWorktree = undefined;
+    git.resolveReleaseReachability.mockReturnValue({
+      reachable: false,
+      proof: "origin_unmerged",
+      details: ["tip not on origin/trunk"],
+    });
+  });
+
   test("refuses release completion when trunk reachability proof is absent", async () => {
     const root = await createTempDir("adv-release-gate-");
     try {

--- a/plugin/src/tools/gate.test.ts
+++ b/plugin/src/tools/gate.test.ts
@@ -2,8 +2,12 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { describe, expect, test } from "vitest";
-import { createTempDir, cleanupTempDir } from "../__tests__/setup";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  cleanupTempDir,
+  createTempDir,
+  createTempGitWorktree,
+} from "../__tests__/setup";
 import { gateTools, validateGateBoundary } from "./gate";
 import type { Change, Gates, Store, Task } from "../types";
 
@@ -80,6 +84,27 @@ async function readProjection(root: string): Promise<Change> {
 }
 
 describe("gate tools — disk projection lifecycle", () => {
+  let cleanupWorktree: (() => Promise<void>) | undefined;
+  let restoreCwd: (() => void) | undefined;
+
+  beforeEach(async () => {
+    const fixture = await createTempGitWorktree("adv-gate-");
+    cleanupWorktree = fixture.cleanup;
+    // Gate mutations must execute from an isolated linked worktree, never the
+    // checkout root used to run the test process.
+    const cwdSpy = vi
+      .spyOn(process, "cwd")
+      .mockReturnValue(fixture.worktreePath);
+    restoreCwd = () => cwdSpy.mockRestore();
+  });
+
+  afterEach(async () => {
+    restoreCwd?.();
+    restoreCwd = undefined;
+    await cleanupWorktree?.();
+    cleanupWorktree = undefined;
+  });
+
   test("adv_gate_status returns persisted gates and explicit unavailable workflow fields", async () => {
     const root = await createTempDir("adv-gate-");
     try {

--- a/plugin/src/tools/task.test.ts
+++ b/plugin/src/tools/task.test.ts
@@ -2,8 +2,12 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { describe, expect, test } from "vitest";
-import { createTempDir, cleanupTempDir } from "../__tests__/setup";
+import { describe, expect, test, vi } from "vitest";
+import {
+  cleanupTempDir,
+  createTempDir,
+  createTempGitWorktree,
+} from "../__tests__/setup";
 import { taskTools } from "./task";
 import type { Store, Task } from "../types";
 import { ChangeSchema } from "../types";
@@ -126,6 +130,10 @@ describe("task tools — disk projection", () => {
 
   test("task add/list/show and blockedBy use canonical state despite stale flat data", async () => {
     const root = await createTempDir("adv-task-canonical-");
+    const worktree = await createTempGitWorktree("adv-task-canonical-");
+    const cwdSpy = vi
+      .spyOn(process, "cwd")
+      .mockReturnValue(worktree.worktreePath);
     const changeDir = join(root, "changes");
     const changeId = "canonical-task-change";
     const canonical = ChangeSchema.parse({
@@ -222,6 +230,8 @@ describe("task tools — disk projection", () => {
       );
       expect(shown.task.id).toBe("tk-canonical");
     } finally {
+      cwdSpy.mockRestore();
+      await worktree.cleanup();
       await cleanupTempDir(root);
     }
   });


### PR DESCRIPTION
## Summary
- run gate/task mutation tests from real temporary linked worktrees
- preserve production trunk-write firewall behavior
- repair deterministic Node 24 CI failures from PR #397

## Verification
- bin/oc-test targeted -- src/tools/gate.release-enforcement.test.ts src/tools/gate.test.ts src/tools/task.test.ts: 15 passed
- pnpm --dir plugin run check: passed
- no additional stress tests run