### PR TITLE
fix: bound cross-project projection reads

### DIFF
--- a/plugin/src/storage/artifact-metadata-migration.test.ts
+++ b/plugin/src/storage/artifact-metadata-migration.test.ts
@@ -56,7 +56,8 @@ describe("artifact metadata migration", () => {
         changeFixture("active-legacy", "draft"),
       );
 
-      await createDiskStore(root);
+      const store = await createDiskStore(root);
+      await store.init();
 
       const migrated = JSON.parse(await readFile(activePath, "utf8"));
       expect(migrated.artifacts.proposal.source).toBe("disk");
@@ -77,7 +78,8 @@ describe("artifact metadata migration", () => {
         changeFixture("archived-legacy", "archived"),
       );
 
-      await createDiskStore(root);
+      const store = await createDiskStore(root);
+      await store.init();
 
       const migrated = JSON.parse(await readFile(archivePath, "utf8"));
       expect(migrated.artifacts.proposal.source).toBe("disk");
@@ -119,7 +121,8 @@ describe("artifact metadata migration", () => {
         change,
       );
 
-      await createDiskStore(root);
+      const store = await createDiskStore(root);
+      await store.init();
 
       const migrated = JSON.parse(await readFile(path, "utf8"));
       expect(migrated.artifacts).toMatchObject({
@@ -142,6 +145,7 @@ describe("artifact metadata migration", () => {
       );
 
       const store = await createDiskStore(root);
+      await store.init();
       const before = await readFile(
         join(store.paths.changes, "idempotent-legacy", "change.json"),
         "utf8",
@@ -196,7 +200,8 @@ describe("artifact metadata migration", () => {
         changeFixture("marker-skip", "draft"),
       );
 
-      await createDiskStore(root);
+      const store = await createDiskStore(root);
+      await store.init();
       await expect(readFile(markerPath(root), "utf8")).resolves.toContain(
         '"version":1',
       );
@@ -204,7 +209,8 @@ describe("artifact metadata migration", () => {
       migrated.artifacts.proposal.source = "temporal";
       await writeFile(path, JSON.stringify(migrated, null, 2));
 
-      await createDiskStore(root);
+      const secondStore = await createDiskStore(root);
+      await secondStore.init();
 
       const skipped = JSON.parse(await readFile(path, "utf8"));
       expect(skipped.artifacts.proposal.source).toBe("temporal");
@@ -223,7 +229,8 @@ describe("artifact metadata migration", () => {
       );
       await writeFile(path, "{ malformed json\n");
 
-      await createDiskStore(root);
+      const store = await createDiskStore(root);
+      await store.init();
       await expect(readFile(markerPath(root), "utf8")).rejects.toMatchObject({
         code: "ENOENT",
       });
@@ -232,7 +239,8 @@ describe("artifact metadata migration", () => {
         path,
         JSON.stringify(changeFixture("marker-retry", "draft"), null, 2),
       );
-      await createDiskStore(root);
+      const secondStore = await createDiskStore(root);
+      await secondStore.init();
 
       const migrated = JSON.parse(await readFile(path, "utf8"));
       expect(migrated.artifacts.proposal.source).toBe("disk");

--- a/plugin/src/storage/projection-health.ts
+++ b/plugin/src/storage/projection-health.ts
@@ -15,12 +15,41 @@ interface ProjectionCounters {
   task_count: number;
 }
 
+export type CanonicalProjectionFailureType =
+  | "not_found"
+  | "schema_error"
+  | "read_error"
+  | "oversized"
+  | "corrupt"
+  | "unreadable"
+  | "counter_extraction";
+
+export interface CanonicalProjectionError {
+  type: CanonicalProjectionFailureType;
+  reason: string;
+}
+
 export interface ProjectionDivergence {
   change_id: string;
-  canonical: ProjectionCounters;
+  /** Omitted only when the canonical projection could not be read/extracted. */
+  canonical?: ProjectionCounters;
+  canonical_error?: CanonicalProjectionError;
   legacy?: ProjectionCounters;
   summary?: ProjectionCounters;
   reasons: string[];
+}
+
+export interface ProjectionDivergenceScan {
+  divergences: ProjectionDivergence[];
+  scanned: number;
+  omitted: number;
+  truncated: boolean;
+  budgetExceeded: boolean;
+}
+
+export interface ProjectionDivergenceScanOptions {
+  maxChanges?: number;
+  budgetMs?: number;
 }
 
 function counters(value: unknown): ProjectionCounters | null {
@@ -43,6 +72,17 @@ function sameCounters(left: ProjectionCounters, right: ProjectionCounters) {
     left.state_revision === right.state_revision &&
     left.task_count === right.task_count
   );
+}
+
+function canonicalFailure(
+  changeId: string,
+  error: CanonicalProjectionError,
+): ProjectionDivergence {
+  return {
+    change_id: changeId,
+    canonical_error: error,
+    reasons: [`canonical projection ${error.type}: ${error.reason}`],
+  };
 }
 
 async function readLegacyCounters(
@@ -84,13 +124,53 @@ async function readLegacyCounters(
  */
 export async function findProjectionDivergences(
   paths: SummaryIndexPaths,
-): Promise<ProjectionDivergence[]> {
+  options: ProjectionDivergenceScanOptions = {},
+): Promise<ProjectionDivergenceScan> {
   const divergences: ProjectionDivergence[] = [];
-  for (const changeId of await listChangeDirs(paths.changesDir)) {
+  const changeIds = await listChangeDirs(paths.changesDir);
+  const maxChanges = Math.max(1, options.maxChanges ?? changeIds.length);
+  const deadline =
+    options.budgetMs === undefined
+      ? Number.POSITIVE_INFINITY
+      : Date.now() + Math.max(1, options.budgetMs);
+  const candidates = changeIds.slice(0, maxChanges);
+  let budgetExceeded = false;
+  let scanned = 0;
+  for (const changeId of candidates) {
+    if (Date.now() >= deadline) {
+      budgetExceeded = true;
+      break;
+    }
+    scanned += 1;
     const loaded = await loadChange(paths.changesDir, changeId);
-    if (!loaded.success || !loaded.data) continue;
+    if (!loaded.success) {
+      divergences.push(
+        canonicalFailure(changeId, {
+          type: loaded.type,
+          reason: loaded.error,
+        }),
+      );
+      continue;
+    }
+    if (!loaded.data) {
+      divergences.push(
+        canonicalFailure(changeId, {
+          type: "not_found",
+          reason: "canonical change projection is missing",
+        }),
+      );
+      continue;
+    }
     const canonical = counters(loaded.data);
-    if (!canonical) continue;
+    if (!canonical) {
+      divergences.push(
+        canonicalFailure(changeId, {
+          type: "counter_extraction",
+          reason: "canonical projection counters are unavailable",
+        }),
+      );
+      continue;
+    }
 
     const reasons: string[] = [];
     const legacy = await readLegacyCounters(paths.changesDir, changeId);
@@ -137,5 +217,11 @@ export async function findProjectionDivergences(
       });
     }
   }
-  return divergences;
+  return {
+    divergences,
+    scanned,
+    omitted: Math.max(0, changeIds.length - scanned),
+    truncated: scanned < changeIds.length,
+    budgetExceeded,
+  };
 }

--- a/plugin/src/storage/store-disk-concurrency.test.ts
+++ b/plugin/src/storage/store-disk-concurrency.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  CHANGE_LIST_DEFAULT_VALIDATION_CONCURRENCY,
+  loadChangesInBatches,
+} from "./store-disk";
+
+describe("disk change-list hydration bounds", () => {
+  test("default batch bound never exceeds four concurrent projection loads", async () => {
+    let active = 0;
+    let peak = 0;
+    const ids = Array.from({ length: 20 }, (_, index) => String(index));
+
+    const loaded = await loadChangesInBatches(
+      ids,
+      CHANGE_LIST_DEFAULT_VALIDATION_CONCURRENCY,
+      async (id) => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        active -= 1;
+        return id;
+      },
+    );
+
+    expect(loaded).toEqual(ids);
+    expect(peak).toBe(CHANGE_LIST_DEFAULT_VALIDATION_CONCURRENCY);
+  });
+});

--- a/plugin/src/storage/store-disk.ts
+++ b/plugin/src/storage/store-disk.ts
@@ -94,7 +94,26 @@ import { searchWisdom, filterChanges } from "./content-search";
 import { listProjectWisdom } from "./project-wisdom";
 import { createLogger } from "../utils/debug-log";
 import { createEpicDiskOps } from "./epics-disk";
-import { migrateArtifactMetadataProjections } from "./artifact-metadata-migration";
+
+/** Keep broad list hydration from exhausting the tool timeout on large stores. */
+export const CHANGE_LIST_DEFAULT_VALIDATION_CONCURRENCY = 4;
+
+export async function loadChangesInBatches<T>(
+  ids: string[],
+  concurrency: number,
+  loader: (id: string) => Promise<T>,
+): Promise<T[]> {
+  const boundedConcurrency = Math.max(1, Math.floor(concurrency));
+  const loaded: T[] = [];
+  for (let i = 0; i < ids.length; i += boundedConcurrency) {
+    loaded.push(
+      ...(await Promise.all(
+        ids.slice(i, i + boundedConcurrency).map((id) => loader(id)),
+      )),
+    );
+  }
+  return loaded;
+}
 
 const logger = createLogger("store-disk");
 
@@ -149,15 +168,6 @@ export async function createDiskStore(
   if (paths.external) {
     await mkdir(paths.external, { recursive: true });
   }
-
-  // Repair pre-disk artifact metadata before exposing the store. The migration
-  // is storage-owned and fail-closed: malformed projections are reported and
-  // left untouched by migrateArtifactMetadataProjections.
-  await migrateArtifactMetadataProjections(
-    paths.changes,
-    paths.archive,
-    paths.artifactMetadataMigrationMarker,
-  );
 
   const loadArchivedChanges = async (): Promise<Change[]> => {
     const archiveDirs = await listChangeDirs(paths.archive);
@@ -279,6 +289,16 @@ export async function createDiskStore(
           } satisfies NonNullable<ProjectConfig["features"]>,
         });
       }
+      // Repair pre-disk artifact metadata only on the authoritative
+      // initialization path. Snapshot reads must not scan or rewrite the
+      // target project's projections while constructing a read store.
+      const { migrateArtifactMetadataProjections } =
+        await import("./artifact-metadata-migration");
+      await migrateArtifactMetadataProjections(
+        paths.changes,
+        paths.archive,
+        paths.artifactMetadataMigrationMarker,
+      );
     },
     sync: async () => {
       // No-op — disk is the source of truth in this backend.
@@ -372,7 +392,11 @@ export async function createDiskStore(
     // -------------------------------------------------------------------
     changes: {
       list: async (filter) => {
-        const ids = await listChangeDirs(paths.changes);
+        const discoveredIds = await listChangeDirs(paths.changes);
+        const ids =
+          filter?.maxCandidates === undefined
+            ? discoveredIds
+            : discoveredIds.slice(0, Math.max(0, filter.maxCandidates));
         // When status is explicitly "archived"/"closed", auto-enable the
         // corresponding include flag so the status filter isn't immediately
         // undone by the exclusion below.
@@ -382,18 +406,14 @@ export async function createDiskStore(
           filter?.includeClosed || filter?.status === "closed";
         const concurrency = Math.max(
           1,
-          Math.floor(filter?.validationConcurrency ?? Math.max(ids.length, 1)),
+          Math.floor(
+            filter?.validationConcurrency ??
+              Math.min(ids.length, CHANGE_LIST_DEFAULT_VALIDATION_CONCURRENCY),
+          ),
         );
-        const loaded: Awaited<ReturnType<typeof loadChange>>[] = [];
-        for (let i = 0; i < ids.length; i += concurrency) {
-          loaded.push(
-            ...(await Promise.all(
-              ids
-                .slice(i, i + concurrency)
-                .map((id) => loadChange(paths.changes, id)),
-            )),
-          );
-        }
+        const loaded = await loadChangesInBatches(ids, concurrency, (id) =>
+          loadChange(paths.changes, id),
+        );
         let changes = loaded
           .filter((r): r is { success: true; data: Change } =>
             Boolean(r.success && r.data),

--- a/plugin/src/storage/store-types.ts
+++ b/plugin/src/storage/store-types.ts
@@ -314,6 +314,8 @@ export interface ReadStore extends StoreBase {
       offset?: number;
       /** Internal caller-specific cap for per-change hydration. */
       validationConcurrency?: number;
+      /** Internal caller-specific cap for diagnostic hydration. */
+      maxCandidates?: number;
     }) => Promise<ChangeListResponse>;
     get: (changeId: string) => Promise<LoadResult<Change | null>>;
   };
@@ -686,6 +688,8 @@ export interface Store extends ReadStore, CommandStore {
        * this to keep its request-wide Store work within its four-read budget.
        */
       validationConcurrency?: number;
+      /** Internal caller-specific cap for diagnostic hydration. */
+      maxCandidates?: number;
     }) => Promise<ChangeListResponse>;
     get: (changeId: string) => Promise<LoadResult<Change | null>>;
     /**

--- a/plugin/src/tools/doctor.test.ts
+++ b/plugin/src/tools/doctor.test.ts
@@ -11,6 +11,42 @@ import { SAMPLE_CHANGE } from "../__tests__/setup";
 
 const mockGetWorktreeCensus = vi.hoisted(() => vi.fn());
 const mockScanSnapshotHealth = vi.hoisted(() => vi.fn());
+const targetStoreRef = vi.hoisted(() => ({ current: null as Store | null }));
+const mockWithTargetPathStore = vi.hoisted(() =>
+  vi.fn(
+    async (
+      input: {
+        store: Store;
+        target_path: string;
+        mutation?: boolean;
+        target_confirmed?: true;
+        confirmationEvidence?: string;
+      },
+      fn: (scope: { store: Store; context: unknown }) => Promise<string>,
+    ) => {
+      if (
+        input.mutation &&
+        (!input.target_confirmed || !input.confirmationEvidence?.trim())
+      ) {
+        throw new Error(
+          "Untrusted target_path mutation requires target_confirmed: true and confirmationEvidence",
+        );
+      }
+      const targetStore = targetStoreRef.current ?? input.store;
+      return fn({
+        store: targetStore,
+        context: {
+          root: targetStore.paths.root,
+          projectId: "target-project",
+          externalRoot: targetStore.paths.external,
+          trusted: Boolean(input.target_confirmed),
+          trustSource: "explicit",
+          stateMode: "disk-snapshot",
+        },
+      });
+    },
+  ),
+);
 
 vi.mock("../utils/worktree-census", () => ({
   getWorktreeCensus: mockGetWorktreeCensus,
@@ -18,6 +54,11 @@ vi.mock("../utils/worktree-census", () => ({
 
 vi.mock("./snapshot-scan", () => ({
   scanSnapshotHealth: mockScanSnapshotHealth,
+}));
+
+vi.mock("./target-project", () => ({
+  formatTargetProjectContext: (context: Record<string, unknown>) => context,
+  withTargetPathStore: mockWithTargetPathStore,
 }));
 
 function makeStore(root: string, overrides: Partial<Store> = {}): Store {
@@ -58,11 +99,14 @@ describe("adv_doctor disk diagnostics", () => {
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "adv-doctor-test-"));
     setHealthyProbes();
+    targetStoreRef.current = null;
+    mockWithTargetPathStore.mockClear();
     setDoctorPointerRepairProvider(null);
   });
 
   afterEach(async () => {
     setDoctorPointerRepairProvider(null);
+    targetStoreRef.current = null;
     await rm(root, { recursive: true, force: true });
   });
 
@@ -73,9 +117,8 @@ describe("adv_doctor disk diagnostics", () => {
   });
 
   test("healthy disk state returns verified predicates without fixes", async () => {
-    const parsed = JSON.parse(
-      await doctorTools.adv_doctor.execute({}, makeStore(root)),
-    );
+    const store = makeStore(root);
+    const parsed = JSON.parse(await doctorTools.adv_doctor.execute({}, store));
 
     expect(parsed.success).toBe(true);
     expect(parsed.findings).toEqual(
@@ -83,6 +126,9 @@ describe("adv_doctor disk diagnostics", () => {
     );
     expect(parsed.fixes_applied).toEqual([]);
     expect(parsed.fixes_refused).toEqual([]);
+    expect(parsed.verification.projection_scan.status).toBe("complete");
+    expect(store.status).toHaveBeenCalledTimes(1);
+    expect(store.changes.list).toHaveBeenCalledTimes(1);
     expect(parsed.verification).toMatchObject({
       healthy: true,
       projection_readable: true,
@@ -90,6 +136,28 @@ describe("adv_doctor disk diagnostics", () => {
       session_pointer_sane: true,
       worktree_census_reachable: true,
     });
+  });
+
+  test("returns partial projection evidence instead of claiming a full scan", async () => {
+    for (let index = 0; index < 65; index++) {
+      const directory = join(root, "changes", `change-${index}`);
+      await mkdir(directory, { recursive: true });
+      await writeFile(
+        join(directory, "change.json"),
+        JSON.stringify({ ...SAMPLE_CHANGE, id: `change-${index}` }),
+      );
+    }
+
+    const parsed = JSON.parse(
+      await doctorTools.adv_doctor.execute({}, makeStore(root)),
+    );
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.verification.canonical_projection_consistent).toBe(false);
+    const scan = parsed.verification.projection_scan;
+    expect(["partial", "budget_exceeded"]).toContain(scan.status);
+    expect(scan.scanned).toBeLessThanOrEqual(64);
+    expect(scan.scanned + scan.omitted).toBe(65);
   });
 
   test("projection failures are reported as unhealthy rather than hidden", async () => {
@@ -106,6 +174,65 @@ describe("adv_doctor disk diagnostics", () => {
         expect.objectContaining({
           class: "unhealthy",
           finding: "projectionReadable",
+        }),
+      ]),
+    );
+  });
+
+  test("malformed canonical change is reported as an unhealthy divergence", async () => {
+    const changeId = "malformed-canonical-change";
+    await mkdir(join(root, "changes", changeId), { recursive: true });
+    await writeFile(
+      join(root, "changes", changeId, "change.json"),
+      "{ malformed json",
+    );
+
+    const parsed = JSON.parse(
+      await doctorTools.adv_doctor.execute({}, makeStore(root)),
+    );
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.verification.healthy).toBe(false);
+    expect(parsed.verification.canonical_projection_consistent).toBe(false);
+    expect(parsed.verification.projection_scan).toMatchObject({
+      status: "complete",
+      scanned: 1,
+      omitted: 0,
+      divergence_count: 1,
+    });
+    expect(parsed.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          class: "unhealthy",
+          finding: "canonical_projection_divergence",
+          detail: expect.stringContaining("corrupt"),
+        }),
+      ]),
+    );
+  });
+
+  test("schema-invalid canonical change is reported as an unhealthy divergence", async () => {
+    const changeId = "schema-invalid-canonical-change";
+    await mkdir(join(root, "changes", changeId), { recursive: true });
+    await writeFile(
+      join(root, "changes", changeId, "change.json"),
+      JSON.stringify({ id: changeId }),
+    );
+
+    const parsed = JSON.parse(
+      await doctorTools.adv_doctor.execute({}, makeStore(root)),
+    );
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.verification.healthy).toBe(false);
+    expect(parsed.verification.canonical_projection_consistent).toBe(false);
+    expect(parsed.verification.projection_scan.divergence_count).toBe(1);
+    expect(parsed.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          class: "unhealthy",
+          finding: "canonical_projection_divergence",
+          detail: expect.stringContaining("schema_error"),
         }),
       ]),
     );
@@ -256,5 +383,92 @@ describe("adv_doctor disk diagnostics", () => {
     expect(doctorTools.adv_doctor.args).not.toHaveProperty(
       "approvedLockReclaim",
     );
+  });
+
+  test("rejects an untrusted target_path without confirmation", async () => {
+    await expect(
+      doctorTools.adv_doctor.execute(
+        { target_path: "/target/project" },
+        makeStore(root),
+      ),
+    ).rejects.toThrow(/target_confirmed.*confirmationEvidence/i);
+    expect(mockWithTargetPathStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target_path: "/target/project",
+        mutation: true,
+        stateRequirement: "snapshot-ok",
+      }),
+      expect.any(Function),
+    );
+  });
+
+  test("confirmed target_path routes diagnostics to the target store", async () => {
+    const currentStore = makeStore(root);
+    const targetStore = makeStore(join(root, "target"));
+    targetStoreRef.current = targetStore;
+
+    const parsed = JSON.parse(
+      await doctorTools.adv_doctor.execute(
+        {
+          target_path: "/target/project",
+          target_confirmed: true,
+          confirmationEvidence: "user approved target doctor",
+        },
+        currentStore,
+      ),
+    );
+
+    expect(mockWithTargetPathStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target_path: "/target/project",
+        mutation: true,
+        stateRequirement: "snapshot-ok",
+        target_confirmed: true,
+        confirmationEvidence: "user approved target doctor",
+      }),
+      expect.any(Function),
+    );
+    expect(targetStore.status).toHaveBeenCalled();
+    expect(currentStore.status).not.toHaveBeenCalled();
+    expect(parsed._projectContext).toEqual(
+      expect.objectContaining({ root: targetStore.paths.root }),
+    );
+  });
+
+  test("foreign target diagnostics do not probe or clear the current-session pointer", async () => {
+    const provider = {
+      getActivePointer: vi.fn(() => "phantom-change"),
+      clearActivePointer: vi.fn(),
+    };
+    setDoctorPointerRepairProvider(provider);
+    targetStoreRef.current = makeStore(join(root, "foreign-target"));
+
+    const parsed = JSON.parse(
+      await doctorTools.adv_doctor.execute(
+        {
+          target_path: "/foreign/project",
+          target_confirmed: true,
+          confirmationEvidence: "user approved foreign target doctor",
+        },
+        makeStore(root),
+      ),
+    );
+
+    expect(provider.getActivePointer).not.toHaveBeenCalled();
+    expect(provider.clearActivePointer).not.toHaveBeenCalled();
+    expect(parsed.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          class: "informational",
+          finding: "session_pointer_out_of_scope",
+        }),
+      ]),
+    );
+    expect(parsed.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ class: "phantom_pointer" }),
+      ]),
+    );
+    expect(parsed.verification.session_pointer_sane).toBe(true);
   });
 });

--- a/plugin/src/tools/doctor.ts
+++ b/plugin/src/tools/doctor.ts
@@ -15,6 +15,15 @@ import { getWorktreeCensus } from "../utils/worktree-census";
 import { scanSnapshotHealth } from "./snapshot-scan";
 import { findProjectionDivergences } from "../storage/projection-health";
 import { reclaimDeadWorkerLock } from "../storage/worker-lock";
+import {
+  formatTargetProjectContext,
+  withTargetPathStore,
+} from "./target-project";
+
+const DOCTOR_CHANGE_READ_CONCURRENCY = 4;
+const DOCTOR_CHANGE_READ_LIMIT = 32;
+const DOCTOR_PROJECTION_SCAN_LIMIT = 64;
+const DOCTOR_PROJECTION_SCAN_BUDGET_MS = 1500;
 
 export type DoctorFindingClass =
   | "healthy"
@@ -54,6 +63,12 @@ interface DoctorVerification {
   worktree_census_reachable: boolean;
   canonical_projection_consistent: boolean;
   worker_lock_sane: boolean;
+  projection_scan: {
+    status: "complete" | "partial" | "budget_exceeded";
+    scanned: number;
+    omitted: number;
+    divergence_count: number;
+  };
   rechecked_at: string;
 }
 
@@ -113,9 +128,12 @@ async function probeDiskState(
   let projectionReadable = false;
   try {
     await Promise.all([
-      store.status(),
+      store.status({ recentLimit: 10, sourceRanked: true }),
       store.specs.list(),
-      store.changes.list({}),
+      store.changes.list({
+        maxCandidates: DOCTOR_CHANGE_READ_LIMIT,
+        validationConcurrency: DOCTOR_CHANGE_READ_CONCURRENCY,
+      }),
     ]);
     projectionReadable = true;
   } catch (err) {
@@ -155,20 +173,31 @@ async function probeDiskState(
     );
   }
 
-  const projectionDivergences = await findProjectionDivergences({
-    changesDir: store.paths.changes,
-    summariesDir:
-      store.paths.summariesDir ??
-      join(dirname(store.paths.changes), "summaries"),
-  });
-  if (projectionDivergences.length > 0) {
+  const projectionDivergences = await findProjectionDivergences(
+    {
+      changesDir: store.paths.changes,
+      summariesDir:
+        store.paths.summariesDir ??
+        join(dirname(store.paths.changes), "summaries"),
+    },
+    {
+      maxChanges: DOCTOR_PROJECTION_SCAN_LIMIT,
+      budgetMs: DOCTOR_PROJECTION_SCAN_BUDGET_MS,
+    },
+  );
+  if (projectionDivergences.divergences.length > 0) {
     errors.push(
-      projectionDivergences
+      projectionDivergences.divergences
         .map(
           (divergence) =>
             `${divergence.change_id}: ${divergence.reasons.join(", ")}`,
         )
         .join("; "),
+    );
+  }
+  if (projectionDivergences.truncated || projectionDivergences.budgetExceeded) {
+    errors.push(
+      `projection divergence scan was ${projectionDivergences.budgetExceeded ? "budget-exhausted" : "bounded"}; ${projectionDivergences.omitted} projection(s) were not inspected`,
     );
   }
 
@@ -189,7 +218,10 @@ async function probeDiskState(
     projectionReadable,
     snapshotIntegrity,
     worktreeCensusReachable,
-    canonicalProjectionConsistent: projectionDivergences.length === 0,
+    canonicalProjectionConsistent:
+      projectionDivergences.divergences.length === 0 &&
+      !projectionDivergences.truncated &&
+      !projectionDivergences.budgetExceeded,
     projectionDivergences,
     workerLockSane,
     workerLockReclaimed:
@@ -201,6 +233,7 @@ async function probeDiskState(
 async function probeSessionPointer(
   store: Store,
   projectId: string | undefined,
+  enabled = true,
 ): Promise<{
   sane: boolean;
   probe: {
@@ -208,6 +241,8 @@ async function probeSessionPointer(
     evidence: string;
   } | null;
 }> {
+  if (!enabled) return { sane: true, probe: null };
+
   const activePointer = pointerRepairProvider?.getActivePointer() ?? null;
   if (!pointerRepairProvider || !activePointer || !projectId) {
     return { sane: true, probe: null };
@@ -277,159 +312,215 @@ export const doctorTools = {
           "Required with target_confirmed for untrusted target_path mutation. Cite user approval evidence.",
         ),
     },
-    execute: async (_args: DoctorInput, store: Store): Promise<string> => {
-      const projectId = projectFromStore(store);
-      const findings: DoctorFinding[] = [];
-      const fixesApplied: DoctorFixApplied[] = [];
-      const fixesRefused: DoctorFixRefused[] = [];
-      const startedAt = new Date().toISOString();
-
-      const initialDisk = await probeDiskState(store, projectId);
-      const initialPointer = await probeSessionPointer(store, projectId);
-      const initialChecks = {
-        projectionReadable: initialDisk.projectionReadable,
-        snapshotIntegrity: initialDisk.snapshotIntegrity,
-        sessionPointerSane: initialPointer.sane,
-        worktreeCensusReachable: initialDisk.worktreeCensusReachable,
-        canonicalProjectionConsistent:
-          initialDisk.canonicalProjectionConsistent,
-        workerLockSane: initialDisk.workerLockSane,
-      };
-
-      if (initialDisk.workerLockReclaimed) {
-        fixesApplied.push({
-          class: "informational",
-          action: "remove_dead_worker_lock",
-          outcome: "applied",
-          evidence: `Removed retired worker.lock for dead PID ${initialDisk.workerLockReclaimed.pid}.`,
-        });
+    execute: async (args: DoctorInput, store: Store): Promise<string> => {
+      if (!args.target_path) {
+        return executeDoctor(store, projectFromStore(store));
       }
 
-      for (const [name, passed] of Object.entries(initialChecks)) {
-        if (!passed) {
-          if (name === "canonicalProjectionConsistent") {
-            for (const divergence of initialDisk.projectionDivergences) {
-              addNonHealthyFinding(findings, {
-                class: "unhealthy",
-                finding: "canonical_projection_divergence",
-                detail: `${divergence.change_id}: ${divergence.reasons.join("; ")}`,
-                severity: "error",
-              });
-            }
-            continue;
-          }
-          addNonHealthyFinding(findings, {
-            class: "unhealthy",
-            finding: name,
-            detail:
-              initialDisk.errors.join("; ") ||
-              "disk probe reported an unhealthy state",
-          });
-        }
-      }
-
-      if (initialPointer.probe && !initialPointer.sane) {
-        addNonHealthyFinding(findings, {
-          class: "phantom_pointer",
-          detail: `Session active-change pointer is not sane (${initialPointer.probe.evidence})`,
-        });
-      }
-
-      if (findings.length === 0) {
-        findings.push({ class: "healthy", detail: "All disk checks passed" });
-      }
-
-      const activePointer = pointerRepairProvider?.getActivePointer() ?? null;
-      const phantomProbe = initialPointer.probe;
-      for (const finding of findings) {
-        if (finding.class !== "phantom_pointer") continue;
-        if (
-          phantomProbe?.status === "confirmed_absent" &&
-          pointerRepairProvider
-        ) {
-          const before = activePointer;
-          try {
-            pointerRepairProvider.clearActivePointer();
-            fixesApplied.push({
-              class: "phantom_pointer",
-              action: "clear_session_pointer",
-              outcome: "applied",
-              before,
-              after: null,
-              evidence: `Cleared phantom session pointer '${before}': ${phantomProbe.evidence}`,
-            });
-          } catch (err) {
-            fixesApplied.push({
-              class: "phantom_pointer",
-              action: "clear_session_pointer",
-              outcome: "failed",
-              before,
-              evidence: `clearActivePointer threw: ${err instanceof Error ? err.message : String(err)}`,
-            });
-          }
-        } else {
-          fixesRefused.push({
-            class: "phantom_pointer",
-            outcome: "approval_required",
-            operator_action:
-              "Confirm the session pointer target or clear it explicitly, then rerun adv_doctor.",
-            proposal: `Session pointer '${activePointer ?? "unknown"}' could not be proven sane. Doctor refuses to clear an indeterminate pointer.`,
-            evidence: phantomProbe?.evidence ?? "no probe result",
-          });
-        }
-      }
-
-      const recheckDisk = await probeDiskState(store, projectId);
-      const recheckPointer = await probeSessionPointer(store, projectId);
-      const verification: DoctorVerification = {
-        healthy:
-          recheckDisk.projectionReadable &&
-          recheckDisk.snapshotIntegrity &&
-          recheckPointer.sane &&
-          recheckDisk.worktreeCensusReachable &&
-          recheckDisk.canonicalProjectionConsistent &&
-          recheckDisk.workerLockSane,
-        projection_readable: recheckDisk.projectionReadable,
-        snapshot_integrity: recheckDisk.snapshotIntegrity,
-        session_pointer_sane: recheckPointer.sane,
-        worktree_census_reachable: recheckDisk.worktreeCensusReachable,
-        canonical_projection_consistent:
-          recheckDisk.canonicalProjectionConsistent,
-        worker_lock_sane: recheckDisk.workerLockSane,
-        rechecked_at: new Date().toISOString(),
-      };
-
-      const appliedCount = fixesApplied.filter(
-        (fix) => fix.outcome === "applied",
-      ).length;
-      const failedCount = fixesApplied.filter(
-        (fix) => fix.outcome === "failed",
-      ).length;
-      const refusedCount = fixesRefused.length;
-      const success =
-        verification.healthy && failedCount === 0 && refusedCount === 0;
-
-      return formatToolOutput({
-        success,
-        started_at: startedAt,
-        findings,
-        fixes_applied: fixesApplied,
-        fixes_refused: fixesRefused,
-        verification,
-        ...(appliedCount > 0
-          ? {
-              note: "Disk repair applied; verification reflects the repaired state.",
-            }
-          : {}),
-        recommendedNextAction:
-          refusedCount > 0
-            ? `${refusedCount} approval-required proposal(s) returned; resolve them and rerun adv_doctor.`
-            : failedCount > 0
-              ? `${failedCount} disk repair(s) failed; rerun adv_doctor after resolving the reported error.`
-              : verification.healthy
-                ? "System healthy; no action needed."
-                : "Disk state is unhealthy; inspect the reported predicates and rerun adv_doctor.",
-      });
+      return withTargetPathStore(
+        {
+          currentProjectPath: store.paths.root,
+          target_path: args.target_path,
+          mutation: true,
+          stateRequirement: "snapshot-ok",
+          target_confirmed: args.target_confirmed,
+          confirmationEvidence: args.confirmationEvidence,
+        },
+        async ({ context, store: targetStore }) =>
+          executeDoctor(
+            targetStore,
+            projectFromStore(targetStore),
+            formatTargetProjectContext(context),
+            context.trustSource === "current_project",
+          ),
+      );
     },
   },
 };
+
+async function executeDoctor(
+  store: Store,
+  projectId: string | undefined,
+  projectContext?: unknown,
+  sessionPointerEnabled = true,
+): Promise<string> {
+  const findings: DoctorFinding[] = [];
+  const fixesApplied: DoctorFixApplied[] = [];
+  const fixesRefused: DoctorFixRefused[] = [];
+  const startedAt = new Date().toISOString();
+
+  const initialDisk = await probeDiskState(store, projectId);
+  const initialPointer = await probeSessionPointer(
+    store,
+    projectId,
+    sessionPointerEnabled,
+  );
+  const initialChecks = {
+    projectionReadable: initialDisk.projectionReadable,
+    snapshotIntegrity: initialDisk.snapshotIntegrity,
+    sessionPointerSane: initialPointer.sane,
+    worktreeCensusReachable: initialDisk.worktreeCensusReachable,
+    canonicalProjectionConsistent: initialDisk.canonicalProjectionConsistent,
+    workerLockSane: initialDisk.workerLockSane,
+  };
+
+  if (initialDisk.workerLockReclaimed) {
+    fixesApplied.push({
+      class: "informational",
+      action: "remove_dead_worker_lock",
+      outcome: "applied",
+      evidence: `Removed retired worker.lock for dead PID ${initialDisk.workerLockReclaimed.pid}.`,
+    });
+  }
+
+  for (const [name, passed] of Object.entries(initialChecks)) {
+    if (!passed) {
+      if (name === "canonicalProjectionConsistent") {
+        for (const divergence of initialDisk.projectionDivergences
+          .divergences) {
+          addNonHealthyFinding(findings, {
+            class: "unhealthy",
+            finding: "canonical_projection_divergence",
+            detail: `${divergence.change_id}: ${divergence.reasons.join("; ")}`,
+            severity: "error",
+          });
+        }
+        continue;
+      }
+      addNonHealthyFinding(findings, {
+        class: "unhealthy",
+        finding: name,
+        detail:
+          initialDisk.errors.join("; ") ||
+          "disk probe reported an unhealthy state",
+      });
+    }
+  }
+
+  if (!sessionPointerEnabled) {
+    addNonHealthyFinding(findings, {
+      class: "informational",
+      finding: "session_pointer_out_of_scope",
+      detail:
+        "Current-session pointer was not probed or repaired for a foreign target project.",
+    });
+  } else if (initialPointer.probe && !initialPointer.sane) {
+    addNonHealthyFinding(findings, {
+      class: "phantom_pointer",
+      detail: `Session active-change pointer is not sane (${initialPointer.probe.evidence})`,
+    });
+  }
+
+  if (findings.length === 0) {
+    findings.push({ class: "healthy", detail: "All disk checks passed" });
+  }
+
+  const activePointer = sessionPointerEnabled
+    ? (pointerRepairProvider?.getActivePointer() ?? null)
+    : null;
+  const phantomProbe = initialPointer.probe;
+  for (const finding of findings) {
+    if (finding.class !== "phantom_pointer") continue;
+    if (phantomProbe?.status === "confirmed_absent" && pointerRepairProvider) {
+      const before = activePointer;
+      try {
+        pointerRepairProvider.clearActivePointer();
+        fixesApplied.push({
+          class: "phantom_pointer",
+          action: "clear_session_pointer",
+          outcome: "applied",
+          before,
+          after: null,
+          evidence: `Cleared phantom session pointer '${before}': ${phantomProbe.evidence}`,
+        });
+      } catch (err) {
+        fixesApplied.push({
+          class: "phantom_pointer",
+          action: "clear_session_pointer",
+          outcome: "failed",
+          before,
+          evidence: `clearActivePointer threw: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    } else {
+      fixesRefused.push({
+        class: "phantom_pointer",
+        outcome: "approval_required",
+        operator_action:
+          "Confirm the session pointer target or clear it explicitly, then rerun adv_doctor.",
+        proposal: `Session pointer '${activePointer ?? "unknown"}' could not be proven sane. Doctor refuses to clear an indeterminate pointer.`,
+        evidence: phantomProbe?.evidence ?? "no probe result",
+      });
+    }
+  }
+
+  const appliedCount = fixesApplied.filter(
+    (fix) => fix.outcome === "applied",
+  ).length;
+  const shouldRecheck =
+    appliedCount > 0 &&
+    !initialDisk.projectionDivergences.budgetExceeded &&
+    !initialDisk.projectionDivergences.truncated;
+  const recheckDisk = shouldRecheck
+    ? await probeDiskState(store, projectId)
+    : initialDisk;
+  const recheckPointer = shouldRecheck
+    ? await probeSessionPointer(store, projectId, sessionPointerEnabled)
+    : initialPointer;
+  const verification: DoctorVerification = {
+    healthy:
+      recheckDisk.projectionReadable &&
+      recheckDisk.snapshotIntegrity &&
+      recheckPointer.sane &&
+      recheckDisk.worktreeCensusReachable &&
+      recheckDisk.canonicalProjectionConsistent &&
+      recheckDisk.workerLockSane,
+    projection_readable: recheckDisk.projectionReadable,
+    snapshot_integrity: recheckDisk.snapshotIntegrity,
+    session_pointer_sane: recheckPointer.sane,
+    worktree_census_reachable: recheckDisk.worktreeCensusReachable,
+    canonical_projection_consistent: recheckDisk.canonicalProjectionConsistent,
+    worker_lock_sane: recheckDisk.workerLockSane,
+    projection_scan: {
+      status: recheckDisk.projectionDivergences.budgetExceeded
+        ? "budget_exceeded"
+        : recheckDisk.projectionDivergences.truncated
+          ? "partial"
+          : "complete",
+      scanned: recheckDisk.projectionDivergences.scanned,
+      omitted: recheckDisk.projectionDivergences.omitted,
+      divergence_count: recheckDisk.projectionDivergences.divergences.length,
+    },
+    rechecked_at: new Date().toISOString(),
+  };
+
+  const failedCount = fixesApplied.filter(
+    (fix) => fix.outcome === "failed",
+  ).length;
+  const refusedCount = fixesRefused.length;
+  const success =
+    verification.healthy && failedCount === 0 && refusedCount === 0;
+
+  return formatToolOutput({
+    success,
+    started_at: startedAt,
+    findings,
+    fixes_applied: fixesApplied,
+    fixes_refused: fixesRefused,
+    verification,
+    ...(projectContext ? { _projectContext: projectContext } : {}),
+    ...(appliedCount > 0
+      ? {
+          note: "Disk repair applied; verification reflects the repaired state.",
+        }
+      : {}),
+    recommendedNextAction:
+      refusedCount > 0
+        ? `${refusedCount} approval-required proposal(s) returned; resolve them and rerun adv_doctor.`
+        : failedCount > 0
+          ? `${failedCount} disk repair(s) failed; rerun adv_doctor after resolving the reported error.`
+          : verification.healthy
+            ? "System healthy; no action needed."
+            : "Disk state is unhealthy; inspect the reported predicates and rerun adv_doctor.",
+  });
+}

--- a/plugin/src/tools/target-read-bounds.test.ts
+++ b/plugin/src/tools/target-read-bounds.test.ts
@@ -1,0 +1,140 @@
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  createTempDir,
+  cleanupTempDir,
+  SAMPLE_CHANGE,
+} from "../__tests__/setup";
+import type { Store } from "../storage/store";
+
+const mockMigrateArtifactMetadataProjections = vi.hoisted(() => vi.fn());
+const targetStoreRef = vi.hoisted(() => ({ current: null as Store | null }));
+
+vi.mock("../storage/artifact-metadata-migration", () => ({
+  migrateArtifactMetadataProjections: mockMigrateArtifactMetadataProjections,
+}));
+
+vi.mock("./target-project", async () => {
+  const actual =
+    await vi.importActual<typeof import("./target-project")>(
+      "./target-project",
+    );
+  return {
+    ...actual,
+    withOptionalTargetPathStore: vi.fn(
+      async (
+        _input: unknown,
+        fn: (store: Store, projectContext?: unknown) => Promise<string>,
+      ) => {
+        const targetStore = targetStoreRef.current;
+        if (!targetStore) throw new Error("target store was not initialized");
+        return fn(targetStore, {
+          root: targetStore.paths.root,
+          projectId: "target-project",
+          trusted: false,
+          trustSource: "explicit",
+          stateMode: "disk-snapshot",
+          authority: "disk_snapshot_non_authoritative",
+        });
+      },
+    ),
+  };
+});
+
+import { createDiskStore } from "../storage/store-disk";
+import { advChangeShowHandler } from "./change/handlers-query";
+import { taskTools } from "./task";
+
+function fixtureChange(id: string, taskCount: number): Record<string, unknown> {
+  return {
+    ...JSON.parse(JSON.stringify(SAMPLE_CHANGE)),
+    id,
+    title: id,
+    tasks: Array.from({ length: taskCount }, (_, index) => ({
+      id: `tk-${id}-${index}`,
+      title: `Task ${index}`,
+      type: "code",
+      status: "pending",
+      priority: index,
+      created_at: "2026-08-07T00:00:00.000Z",
+    })),
+  };
+}
+
+async function writeCanonicalChange(
+  root: string,
+  id: string,
+  taskCount = 0,
+): Promise<void> {
+  const directory = join(root, ".adv", "changes", id);
+  await mkdir(directory, { recursive: true });
+  await writeFile(
+    join(directory, "change.json"),
+    JSON.stringify(fixtureChange(id, taskCount)),
+  );
+}
+
+describe("target-path read bounds", () => {
+  let currentRoot: string;
+  let targetRoot: string;
+  let currentStore: Store;
+
+  afterEach(async () => {
+    targetStoreRef.current?.close();
+    currentStore?.close();
+    targetStoreRef.current = null;
+    await cleanupTempDir(currentRoot);
+    await cleanupTempDir(targetRoot);
+  });
+
+  test("reads a 500+ projection target without startup artifact migration", async () => {
+    currentRoot = await createTempDir("target-read-current-");
+    targetRoot = await createTempDir("target-read-large-");
+    for (let index = 0; index < 501; index++) {
+      await writeCanonicalChange(
+        targetRoot,
+        `change-${String(index).padStart(4, "0")}`,
+        index === 0 ? 12 : 0,
+      );
+    }
+
+    currentStore = await createDiskStore(currentRoot);
+    targetStoreRef.current = await createDiskStore(targetRoot);
+
+    expect(mockMigrateArtifactMetadataProjections).not.toHaveBeenCalled();
+    await expect(
+      access(
+        join(targetRoot, ".adv", "artifact-metadata-migration-complete.json"),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+
+    const taskOutput = JSON.parse(
+      await taskTools.adv_task_list.execute(
+        {
+          changeId: "change-0000",
+          target_path: targetRoot,
+        },
+        currentStore,
+      ),
+    );
+    expect(taskOutput.tasks).toHaveLength(12);
+
+    const showOutput = JSON.parse(
+      await advChangeShowHandler(
+        {
+          changeId: "change-0000",
+          target_path: targetRoot,
+          include: { artifactOnly: true },
+        },
+        currentStore,
+      ),
+    );
+    expect(showOutput.id).toBe("change-0000");
+    expect(mockMigrateArtifactMetadataProjections).not.toHaveBeenCalled();
+
+    await targetStoreRef.current.init();
+    expect(mockMigrateArtifactMetadataProjections).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- keep artifact migration on authoritative store initialization, not snapshot-only target reads
- return canonical task/change reads without scanning every target projection first
- route doctor to confirmed target stores with foreign-pointer isolation
- bound doctor divergence scans and change hydration concurrency
- fail closed on malformed or unreadable canonical projections

## Verification
- focused affected suite: 40 passed
- doctor suite: 15 passed twice consecutively
- pnpm --dir plugin run check: passed
- independent review: READY
- no full-suite or stress reruns per release instruction