### PR TITLE
fix: align archive target path schema

### DIFF
--- a/plugin/src/tools/change/handlers-archive.schema.test.ts
+++ b/plugin/src/tools/change/handlers-archive.schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { archiveChangeTools } from "./handlers-archive";
+
+describe("adv_change_archive arguments", () => {
+  const schema = z.object(archiveChangeTools.adv_change_archive.args);
+
+  it("accepts a string target_path used by the archive handler", () => {
+    expect(
+      schema.safeParse({
+        changeId: "archive-me",
+        target_path: "/tmp/target-project",
+        target_confirmed: true,
+        confirmationEvidence: "user approved archive",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects the obsolete nested target_path shape", () => {
+    expect(
+      schema.safeParse({
+        changeId: "archive-me",
+        target_path: { target_path: "/tmp/target-project" },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -868,7 +868,7 @@ export const archiveChangeTools = {
       noCloseIssue: z.boolean().optional(),
       phase9: z.enum(["run", "skip"]).optional(),
       prTitleType: z.string().optional(),
-      target_path: targetPathSchema,
+      target_path: targetPathSchema.shape.target_path,
       target_confirmed: z.literal(true).optional(),
       confirmationEvidence: z.string().optional(),
     },


### PR DESCRIPTION
## Summary
- expose adv_change_archive target_path as the string consumed by its handler
- reject the obsolete nested object shape
- unblock approved cross-project/worktree archive finalization

## Verification
- focused schema regression: 2 passed
- pnpm --dir plugin run schemas:generate
- pnpm --dir plugin run check
- no full-suite or stress reruns per release instruction