### PR TITLE
test: isolate checkpoint repo state

### DIFF
--- a/plugin/src/tools/checkpoint.test.ts
+++ b/plugin/src/tools/checkpoint.test.ts
@@ -1,6 +1,7 @@
 /** Checkpoint behavior that remains after the Temporal transport removal. */
 
 import { describe, expect, test } from "vitest";
+import { createTempGitWorktree } from "../__tests__/setup";
 import { buildCommitMessage, detectRepoState } from "./checkpoint";
 
 describe("checkpoint helpers", () => {
@@ -20,7 +21,12 @@ describe("checkpoint helpers", () => {
   });
 
   test("detects a clean repository state", async () => {
-    const result = await detectRepoState(process.cwd());
-    expect(result).toBe("ok");
+    const fixture = await createTempGitWorktree("checkpoint-state-");
+    try {
+      const result = await detectRepoState(fixture.worktreePath);
+      expect(result).toBe("ok");
+    } finally {
+      await fixture.cleanup();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- stop checkpoint helper test from depending on CI checkout branch state
- use a real temporary linked worktree fixture
- preserve production detached-HEAD detection

## Verification
- focused checkpoint test: 2 passed
- pnpm --dir plugin run check
- no full-suite or stress reruns per release instruction