### PR TITLE
fix(artifacts): read projection from canonical {changeId}/change.json (#403)

### DIFF
--- a/plugin/src/tools/change.read-artifact.test.ts
+++ b/plugin/src/tools/change.read-artifact.test.ts
@@ -361,3 +361,61 @@ describe("readArtifact — active projection fallback", () => {
     }
   });
 });
+
+describe("readArtifact — canonical projection layout (#403 regression)", () => {
+  it("reads agreement from {changeId}/change.json when no agreement.md exists", async () => {
+    const dir = await createTempDir();
+    try {
+      const changesDir = join(dir, "changes");
+      const changeDir = join(changesDir, "test-change");
+      await mkdir(changeDir, { recursive: true });
+      // Canonical projection: {changeId}/change.json with documents. No
+      // agreement.md on disk — the #403 scenario where an update-written
+      // artifact exists only in the projection. Previously readProjectionDocuments
+      // read only the flat {changeId}.json (which never exists), so this missed
+      // and readArtifact fell through to disk and returned null.
+      await writeFile(
+        join(changeDir, "change.json"),
+        JSON.stringify({
+          documents: { agreement: "from canonical projection" },
+        }),
+      );
+
+      const store = buildMockStore({ changesDir, rootDir: dir });
+      const result = await readArtifact(store, "test-change", "agreement");
+      expect(result).toEqual({
+        content: "from canonical projection",
+        source: "active_projection",
+      });
+    } finally {
+      await cleanupTempDir(dir);
+    }
+  });
+
+  it("prefers canonical {changeId}/change.json over a stale flat envelope", async () => {
+    const dir = await createTempDir();
+    try {
+      const changesDir = join(dir, "changes");
+      const changeDir = join(changesDir, "test-change");
+      await mkdir(changeDir, { recursive: true });
+      await writeFile(
+        join(changeDir, "change.json"),
+        JSON.stringify({ documents: { agreement: "canonical" } }),
+      );
+      // Stale flat envelope that must NOT win over canonical.
+      await writeFile(
+        join(changesDir, "test-change.json"),
+        JSON.stringify({ documents: { agreement: "stale flat" } }),
+      );
+
+      const store = buildMockStore({ changesDir, rootDir: dir });
+      const result = await readArtifact(store, "test-change", "agreement");
+      expect(result).toEqual({
+        content: "canonical",
+        source: "active_projection",
+      });
+    } finally {
+      await cleanupTempDir(dir);
+    }
+  });
+});

--- a/plugin/src/tools/change/artifacts.ts
+++ b/plugin/src/tools/change/artifacts.ts
@@ -76,11 +76,7 @@ async function readProjectionDocuments(
       ? state
       : parsed;
   const documents = (projection as { documents?: unknown }).documents;
-  if (
-    !documents ||
-    typeof documents !== "object" ||
-    Array.isArray(documents)
-  ) {
+  if (!documents || typeof documents !== "object" || Array.isArray(documents)) {
     return {};
   }
   return documents as Partial<Record<ArtifactKind, string>>;

--- a/plugin/src/tools/change/artifacts.ts
+++ b/plugin/src/tools/change/artifacts.ts
@@ -46,32 +46,44 @@ async function readProjectionDocuments(
   changesDir: string,
   changeId: string,
 ): Promise<Partial<Record<ArtifactKind, string>>> {
-  const projectionPath = join(changesDir, `${changeId}.json`);
-  const result = await readBoundedProjectionDocument(projectionPath);
-  if (result.kind !== "ok") return {};
-
-  try {
-    const parsed: unknown = JSON.parse(result.content);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {};
+  // Canonical projection lives at {changesDir}/{changeId}/change.json (matches
+  // read-change-projection.ts:17). The flat {changeId}.json envelope is a
+  // legacy read-only fallback. Previously this read ONLY the flat path, which
+  // never exists for canonical-layout changes — so the projection-first read
+  // always missed and fell through to disk. That silent miss is the root cause
+  // of #403 (update-written artifacts unreadable from the projection).
+  const candidates = [
+    join(changesDir, changeId, "change.json"),
+    join(changesDir, `${changeId}.json`),
+  ];
+  let parsed: unknown = null;
+  for (const projectionPath of candidates) {
+    const result = await readBoundedProjectionDocument(projectionPath);
+    if (result.kind !== "ok") continue;
+    try {
+      parsed = JSON.parse(result.content);
+    } catch {
+      continue;
     }
-    const state = (parsed as { state?: unknown }).state;
-    const projection =
-      state && typeof state === "object" && !Array.isArray(state)
-        ? state
-        : parsed;
-    const documents = (projection as { documents?: unknown }).documents;
-    if (
-      !documents ||
-      typeof documents !== "object" ||
-      Array.isArray(documents)
-    ) {
-      return {};
-    }
-    return documents as Partial<Record<ArtifactKind, string>>;
-  } catch {
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) break;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     return {};
   }
+  const state = (parsed as { state?: unknown }).state;
+  const projection =
+    state && typeof state === "object" && !Array.isArray(state)
+      ? state
+      : parsed;
+  const documents = (projection as { documents?: unknown }).documents;
+  if (
+    !documents ||
+    typeof documents !== "object" ||
+    Array.isArray(documents)
+  ) {
+    return {};
+  }
+  return documents as Partial<Record<ArtifactKind, string>>;
 }
 
 export async function normalizeArtifactMetadataForReadback(


### PR DESCRIPTION
## What

`readProjectionDocuments` (`plugin/src/tools/change/artifacts.ts`) read only the flat `{changesDir}/{changeId}.json` path, which **never exists** for canonical-layout changes. The real projection is at `{changeId}/change.json` (see `read-change-projection.ts:17`, `json.ts:342`). So `readArtifact`'s projection-first step always missed and fell through to disk.

## Why (#403)

Update-written artifacts (via `adv_change_update`) exist only in `change.documents` — no `.md` is materialized. With the projection read broken, `readArtifact` fell to disk, found no `agreement.md`, and `adv_contract_mint` threw `"Agreement artifact is empty"`. This blocked **all** contract mints for projection-only agreements — a workflow meta-blocker.

The existing `change.read-artifact.test.ts` wrote the projection as a flat `{changeId}.json` file (matching the buggy path), so it passed while production (directory layout) was broken — false confidence.

## Fix

Read the canonical `{changeId}/change.json` **first**, flat `{changeId}.json` as a legacy read-only fallback (mirrors `read-change-projection.ts`). Preserves the bounded-read invariant.

## Tests

- 2 new regression tests: canonical layout (#403 scenario), canonical-preferred-over-stale-flat.
- All 13 existing flat-layout tests stay green (legacy fallback).
- 15/15 pass in the change worktree.

This is AC0 of `fixArtifactMaterialization` (the primary/root-cause fix). The response-contract + AC8 retire-disk-materialization work follows as the rest of that change.