### PR TITLE
fix: make worktree deletion reliable

### DIFF
--- a/.opencode/command/adv-apply.md
+++ b/.opencode/command/adv-apply.md
@@ -75,7 +75,7 @@ If `adv_worktree_create` unavailable → `[ADV:BLOCKED] Worktree tools required`
 - Exists → reuse, switch `workdir`
 - Missing → `git worktree prune` then create
 
-Create: `adv_worktree_create branch: "change/{change-id}"`. Capture path; use it for ALL subsequent calls. To delete later, pass `branch: "change/{change-id}"`.
+Create: `adv_worktree_create branch: "change/{change-id}"`. Capture path; use it for ALL subsequent calls. To delete later, first call `adv_worktree_delete branch: "change/{change-id}" dryRun: true`, retain the exact returned `planToken`, then apply with that token and nonblank approval evidence. A branch-only destructive call returns `PLAN_REQUIRED`.
 
 Post-creation: verify task-referenced paths exist in worktree. Distinguish read-reference from create-target paths. For MISSING read-reference: discover with `glob`/`bash`; if essential and absent, check main checkout and note discrepancy. Emit: `Path verification: {N} OK, {M} corrected, {K} advisory-skipped, {L} to-create`.
 

--- a/.opencode/command/adv-archive.md
+++ b/.opencode/command/adv-archive.md
@@ -441,9 +441,11 @@ Auto-managed changes (`change.worktree_auto_managed: true`) may own: current rep
 3. `scope_worktrees[*]` in `Object.keys` insertion order.
 
 Per target, proceed only after Step 6 final release proof (`Shipped.` or verified local bare origin push):
-- `adv_worktree_delete branch: "change/{change-id}" reason: "Change {change-id} merged"`
+- First call `adv_worktree_delete branch: "change/{change-id}" dryRun: true` and retain the typed `planToken` for that exact target.
+- Apply with `adv_worktree_delete branch: "change/{change-id}" planToken: "{planToken}" approvalEvidence: "archive sign-off for change {change-id}"`.
+- A branch-only destructive call is migration-invalid: it returns `PLAN_REQUIRED` and performs no shell or write.
 - Target/scope repo: scope deletion to target repo root when tool supports it.
-- No scoped tool support → manual fallback: `git -C "<target-repo-root>" worktree remove <path>` then `git -C "<target-repo-root>" branch -D change/{change-id}`.
+- No scoped tool support → stop with a typed blocker; do not issue a manual `git worktree remove` or branch delete outside the shared planner/executor.
 
 Idempotency: already-cleaned entries skip via `adv_worktree_delete` record check.
 

--- a/.opencode/command/adv-cleanup.md
+++ b/.opencode/command/adv-cleanup.md
@@ -6,7 +6,7 @@ description: Triage stale changes, drifted worktrees, merged branches, and state
 
 Dry-run by default: scan all four ADV hygiene surfaces, bucket candidates, report actions. `--execute` applies only after per-bucket approval. Runs inline; no sub-agents.
 
-> **CHECKLIST**: Default dry-run. Reversible closures require Tier B per-bucket approval (`rq-inlineApproval01.4`). Irreversible buckets require count-matched typed confirmation and reject `approve all` (`rq-cleanupHygieneScope01`). Deletion always delegates to `adv_worktree_delete` / `adv_worktree_cleanup` (`rq-terminalCleanupSafety01`). Never auto-archive; recommend `/adv-archive {id}` to preserve per-change Tier B sign-off (`rq-inlineApproval01.3`).
+> **CHECKLIST**: Default dry-run. Reversible closures require Tier B per-bucket approval (`rq-inlineApproval01.4`). Irreversible buckets require count-matched typed confirmation and reject `approve all` (`rq-cleanupHygieneScope01`). Deletion always delegates to the shared `adv_worktree_delete` planner/executor or `adv_worktree_cleanup` drain (`rq-terminalCleanupSafety01`). Never auto-archive; recommend `/adv-archive {id}` to preserve per-change Tier B sign-off (`rq-inlineApproval01.3`).
 
 <UserRequest>
   $ARGUMENTS
@@ -103,7 +103,7 @@ Required snippet:
 
 ### Deletion authority
 
-`adv_worktree_triage` output is advisory discovery and selection data — **never deletion authority** (`rq-terminalCleanupSafety01`). Every approved deletion is executed by `adv_worktree_delete` or `adv_worktree_cleanup`, which independently re-verify terminal owning-change status, branch integration, clean worktree state, no live process CWD, and squash-merge-safe tree-SHA equivalence. Their refusals are final: surface each refusal verbatim, never retry around it.
+`adv_worktree_triage` output is advisory discovery and selection data — **never deletion authority** (`rq-terminalCleanupSafety01`). Every approved deletion first calls `adv_worktree_delete dryRun:true` for the exact branch and records its returned `planToken`; apply must pass that token plus nonblank `approvalEvidence`. A legacy branch-only apply returns deterministic `PLAN_REQUIRED` and performs no shell or write. `adv_worktree_delete` / `adv_worktree_cleanup` independently re-verify terminal owning-change status, branch integration, clean worktree state, no live process CWD, and squash-merge-safe tree-SHA equivalence. Their refusals are final: surface each refusal verbatim, never retry around it.
 
 ---
 
@@ -195,7 +195,7 @@ Before Duplicate apply, `adv_change_show` each `supersededBy` target. Missing ta
 
 ### Irreversible buckets
 
-Worktree deletion → `adv_worktree_delete` per approved branch. Branch deletion → `adv_worktree_cleanup({ mode: "archived_branches", changeId: <approved candidate change ID> })` without `dryRun`, once per approved candidate. Never issue an unscoped merged-branch cleanup apply: it would delete every currently eligible branch and bypass a subset approval.
+Worktree deletion → apply the exact returned `planToken` with `adv_worktree_delete` per approved branch and the count-matched `approvalEvidence`. Branch deletion → `adv_worktree_cleanup({ mode: "archived_branches", changeId: <approved candidate change ID>, approvalEvidence: <count-matched approval> })` without `dryRun`, once per approved candidate. Never issue an unscoped merged-branch cleanup apply: it would delete every currently eligible branch and bypass a subset approval.
 
 Deletion authority belongs to those tools alone (`rq-terminalCleanupSafety01`). Never call `git worktree remove` or `git branch -d` directly. When a tool refuses, report the refusal verbatim and move on — a refusal is evidence the candidate was misclassified, not an obstacle to route around.
 

--- a/docs/specs/worktree-lifecycle.md
+++ b/docs/specs/worktree-lifecycle.md
@@ -488,6 +488,21 @@ ADV mutating tools that advance working-tree-impacting gates or change task exec
 
 ---
 
+### Planner-Backed Worktree Deletion
+
+**ID:** `rq-worktreeDeletionProtocol01` | **Priority:** **[MUST]**
+
+Every destructive worktree deletion surface — public delete, terminal cleanup,
+reaper/drain, manual cleanup, and archive cleanup — uses the shared Git census
+planner and drift-safe executor. `dryRun:true` returns a typed expiring plan and
+`planToken`; destructive apply requires that token and nonblank approval
+evidence. A legacy branch-only apply returns `PLAN_REQUIRED` before shell or
+write effects. Registry rows remain advisory; target-path trust is established
+before the planner resolves the target and timeout results are typed and
+terminal.
+
+---
+
 ### Bounded Worktree Cleanup
 
 **ID:** `rq-worktreeBoundedCleanup01` | **Priority:** **[MUST]**

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -42,9 +42,9 @@
     "@opencode-ai/plugin": "^1.18.4",
     "jsonc-parser": "^3.3.1",
     "lru-cache": "^11.3.6",
-    "nanoid": "^5.0.9",
-    "zod": "^4.3.6",
-    "yaml": "^2.9.0"
+    "nanoid": "^5.1.16",
+    "yaml": "^2.9.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@ast-grep/cli": "^0.44.1",

--- a/plugin/pnpm-lock.yaml
+++ b/plugin/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^11.3.6
         version: 11.5.1
       nanoid:
-        specifier: ^5.0.9
-        version: 5.1.11
+        specifier: ^5.1.16
+        version: 5.1.16
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -1061,8 +1061,8 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/types@0.1.27':
-    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1858,13 +1858,13 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.11:
-    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -2986,7 +2986,7 @@ snapshots:
   '@swc/core@1.15.40':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.27
+      '@swc/types': 0.1.28
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.15.40
       '@swc/core-darwin-x64': 1.15.40
@@ -3005,7 +3005,7 @@ snapshots:
   '@swc/counter@0.1.3':
     optional: true
 
-  '@swc/types@0.1.27':
+  '@swc/types@0.1.28':
     dependencies:
       '@swc/counter': 0.1.3
     optional: true
@@ -3859,9 +3859,9 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
-  nanoid@5.1.11: {}
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -3985,7 +3985,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/plugin/src/tool-role-policy.ts
+++ b/plugin/src/tool-role-policy.ts
@@ -419,7 +419,7 @@ export const TOOL_ROLE_POLICY: Readonly<Record<string, ToolRoleEntry>> = {
   adv_worktree_cleanup: {
     class: "orchestrator",
     rationale:
-      "Worktree hygiene; archived_branches mode is operator-explicit (dry-run first).",
+      "Shared planner/executor cleanup; destructive manual and archived-branch modes require dry-run candidate identity plus count-matched approval evidence.",
   },
   adv_worktree_detach: {
     class: "operator-only",
@@ -432,7 +432,8 @@ export const TOOL_ROLE_POLICY: Readonly<Record<string, ToolRoleEntry>> = {
   },
   adv_worktree_delete: {
     class: "orchestrator",
-    rationale: "Worktree deletion (merge-before-delete).",
+    rationale:
+      "Shared planner/executor worktree deletion; dry-run mints the typed plan token and apply requires nonblank approval evidence.",
   },
   adv_worktree_resume: {
     class: "orchestrator",

--- a/plugin/src/tools/adv-worktree.ts
+++ b/plugin/src/tools/adv-worktree.ts
@@ -154,6 +154,8 @@ interface WorktreeDeleteArgs extends TargetWorktreeMutationArgs {
   branch: string;
   force?: boolean;
   dryRun?: boolean;
+  planToken?: string;
+  approvalEvidence?: string;
 }
 
 interface WorktreeResumeArgs extends TargetWorktreeMutationArgs {
@@ -166,6 +168,7 @@ interface WorktreeResumeArgs extends TargetWorktreeMutationArgs {
 interface WorktreeCleanupArgs extends TargetWorktreeMutationArgs {
   reason: string;
   dryRun?: boolean;
+  approvalEvidence?: string;
   skipDiscovery?: boolean;
   timeoutMs?: number;
   mode?: "worktrees" | "archived_branches";
@@ -258,7 +261,14 @@ async function executeWorktreeDelete(
   const { effectiveTimeoutMs } = clampToSafeBudget(undefined);
   const deletePromise = advWorktreeDelete(
     args.branch,
-    { force: args.force, dryRun: args.dryRun },
+    {
+      ...(args.force !== undefined ? { force: args.force } : {}),
+      ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+      ...(args.planToken !== undefined ? { planToken: args.planToken } : {}),
+      ...(args.approvalEvidence !== undefined
+        ? { approvalEvidence: args.approvalEvidence }
+        : {}),
+    },
     {
       projectRoot,
       database,
@@ -276,29 +286,23 @@ async function executeWorktreeDelete(
       effectiveTimeoutMs,
     );
   });
-
   const result = await Promise.race([deletePromise, timeoutRace]);
   if (timeoutHandle) clearTimeout(timeoutHandle);
-
   if ("_timedOut" in result && result._timedOut) {
     return formatMaybeTargetOutput(
       formatToolOutput({
         ok: false,
         timedOut: true,
-        // No poison claim: this branch resolves a setTimeout sentinel, not a
-        // rejection, so there is no error to classify. rq-worktreePoisonVisibility01
-        // requires error-class plus structured evidence before naming poisoned
-        // history — asserting it here would be a guess. rq-worktreeTimeoutTruthfulness01
-        // likewise forbids asserting an untested cause or an unreachable action.
-        error: `adv_worktree_delete timed out after ${effectiveTimeoutMs}ms. The inner promise was not cancelled; the delete may still resolve.`,
+        error: `DEADLINE_EXCEEDED: adv_worktree_delete timed out after ${effectiveTimeoutMs}ms`,
+        status: "deadline_exceeded",
+        stage: "handler",
         effectiveTimeoutMs,
         remediation:
-          "Re-run the deletion — a completed delete is idempotent, and a still-blocked one returns typed retained state. Run adv_worktree_triage to inspect the worktree's current state first.",
+          "Retry with a fresh dry-run plan; the shared executor owns cancellation and revalidation.",
       }),
       context,
     );
   }
-
   return formatMaybeTargetOutput(
     formatToolOutput(result as Awaited<ReturnType<typeof advWorktreeDelete>>),
     context,
@@ -328,6 +332,7 @@ async function executeWorktreeCleanup(
       store,
       changeId: args.changeId,
       dryRun: args.dryRun,
+      approvalEvidence: args.approvalEvidence?.trim() || args.reason.trim(),
       effectiveTimeoutMs,
     });
 
@@ -399,6 +404,7 @@ async function executeWorktreeCleanup(
     database,
     log,
     dryRun: args.dryRun,
+    approvalEvidence: args.approvalEvidence?.trim() || args.reason.trim(),
     store,
     warpDeps,
     ...(args.skipDiscovery !== undefined && {
@@ -858,6 +864,22 @@ export const advWorktreeTools = {
         .boolean()
         .optional()
         .describe("Preview deletion without running hooks or removing files"),
+      planToken: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+          "Planner-issued token returned by dryRun:true; required for destructive apply",
+        ),
+      approvalEvidence: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+          "Nonblank evidence of explicit approval for this exact deletion plan",
+        ),
       ...targetWorktreeMutationArgSchemas,
     },
     execute: async (
@@ -897,6 +919,14 @@ export const advWorktreeTools = {
         .optional()
         .describe(
           "Preview cleanup without deleting queued worktrees or merged branches",
+        ),
+      approvalEvidence: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+          "Nonblank evidence naming the approved cleanup candidate set; required for destructive manual cleanup",
         ),
       skipDiscovery: z
         .boolean()

--- a/plugin/src/tools/archive-helpers/archived-branch-cleanup.ts
+++ b/plugin/src/tools/archive-helpers/archived-branch-cleanup.ts
@@ -47,6 +47,8 @@ export interface ArchivedBranchCleanupInput {
   store: Store;
   changeId?: string;
   dryRun?: boolean;
+  /** Candidate identity/evidence carried from the count-matched cleanup approval. */
+  approvalEvidence?: string;
   /**
    * Handler-clamped effective budget (ms). The helper derives its internal
    * deadline (`effectiveTimeoutMs - RETURN_RESERVE_MS`) and self-returns typed
@@ -292,6 +294,14 @@ export async function cleanupArchivedMergedBranches(
   input: ArchivedBranchCleanupInput,
 ): Promise<Record<string, unknown>> {
   const { store, changeId, dryRun, effectiveTimeoutMs } = input;
+  if (!dryRun && !input.approvalEvidence?.trim()) {
+    return {
+      success: false,
+      mode: "archived_branches",
+      error:
+        "APPROVAL_REQUIRED: archived branch cleanup needs approvalEvidence",
+    };
+  }
 
   // PHASE 1 — setup + internal deadline (tighter than any handler guard).
   const budget = (effectiveTimeoutMs ?? SAFE_BUDGET_MS) - RETURN_RESERVE_MS;

--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -692,17 +692,30 @@ export const advChangeArchiveHandler = async (
         | undefined;
       if (worktreePath) {
         try {
-          targetedWorktreeDeleteResult = await advWorktreeDelete(
+          const deletionDeps = {
+            projectRoot: activeStore.paths.root,
+            database: await initWorktreeStateDb(activeStore.paths.root),
+            log: logger,
+            store: activeStore,
+            worktreePath,
+          };
+          const deletionPlan = await advWorktreeDelete(
             `change/${change.id}`,
-            { force: false },
-            {
-              projectRoot: activeStore.paths.root,
-              database: await initWorktreeStateDb(activeStore.paths.root),
-              log: logger,
-              store: activeStore,
-              worktreePath,
-            },
+            { force: false, dryRun: true },
+            deletionDeps,
           );
+          targetedWorktreeDeleteResult =
+            deletionPlan.ok && deletionPlan.planToken
+              ? await advWorktreeDelete(
+                  `change/${change.id}`,
+                  {
+                    force: false,
+                    planToken: deletionPlan.planToken,
+                    approvalEvidence: `archive sign-off and release finalization approved change ${change.id}`,
+                  },
+                  deletionDeps,
+                )
+              : deletionPlan;
         } catch (error) {
           archiveResult.errors.push(
             `Targeted worktree cleanup warning: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugin/src/tools/worktree/census-scan.test.ts
+++ b/plugin/src/tools/worktree/census-scan.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { execFileGitAsync } = vi.hoisted(() => ({
+  execFileGitAsync: vi.fn(),
+}));
+
+vi.mock("../../utils/git-binary", () => ({ execFileGitAsync }));
+
+import { scanGitWorkspaceFacts } from "./census";
+
+describe("scanGitWorkspaceFacts", () => {
+  it("keeps every branch family and canonical worktree state", async () => {
+    execFileGitAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === "for-each-ref") {
+        return {
+          stdout:
+            "release/v1 0123456789abcdef0123456789abcdef01234567\n" +
+            "feature/ad-hoc fedcba9876543210fedcba9876543210fedcba98\n",
+        };
+      }
+      if (args[0] === "branch") return { stdout: "release/v1\n" };
+      if (args[0] === "worktree" && args.at(-1) === "-z") {
+        return {
+          stdout: [
+            "worktree /repo\0",
+            "HEAD 0123456789abcdef0123456789abcdef01234567\0",
+            "branch refs/heads/release/v1\0",
+            "locked maintenance\0",
+            "\0",
+            "worktree /repo/ad-hoc\0",
+            "HEAD fedcba9876543210fedcba9876543210fedcba98\0",
+            "detached\0",
+            "prunable stale\0",
+            "\0",
+          ].join(""),
+        };
+      }
+      return { stdout: "" };
+    });
+
+    const facts = await scanGitWorkspaceFacts("/repo", "trunk");
+
+    expect(facts.branches).toEqual([
+      {
+        branch: "release/v1",
+        headSha: "0123456789abcdef0123456789abcdef01234567",
+        merged: true,
+      },
+      {
+        branch: "feature/ad-hoc",
+        headSha: "fedcba9876543210fedcba9876543210fedcba98",
+        merged: false,
+      },
+    ]);
+    expect(facts.worktrees).toEqual([
+      expect.objectContaining({
+        branch: "release/v1",
+        locked: true,
+        detached: false,
+        prunable: false,
+      }),
+      expect.objectContaining({
+        branch: undefined,
+        detached: true,
+        prunable: true,
+      }),
+    ]);
+  });
+});

--- a/plugin/src/tools/worktree/census.ts
+++ b/plugin/src/tools/worktree/census.ts
@@ -18,6 +18,8 @@ export interface GitWorktreeFact {
   bare: boolean;
   locked: boolean;
   prunable: boolean;
+  /** Set by stricter census adapters when Git reports invalid worktree data. */
+  corrupt?: boolean;
 }
 
 export interface GitWorkspaceFacts {
@@ -44,7 +46,8 @@ function parseMergedBranches(stdout: string): Set<string> {
   return new Set(
     stdout
       .split("\n")
-      .map((line) => line.replace(/^\*?\s*/, "").trim())
+      // `+` marks a branch checked out in another linked worktree.
+      .map((line) => line.replace(/^[*+]\s*/, "").trim())
       .filter(Boolean),
   );
 }

--- a/plugin/src/tools/worktree/census.ts
+++ b/plugin/src/tools/worktree/census.ts
@@ -1,6 +1,7 @@
 import type { SessionRecord, WorktreeRecord } from "../../types";
 import { execFileGitAsync } from "../../utils/git-binary";
 import { inferChangeIdFromBranch } from "./state";
+import { parseWorktreeListPorcelain } from "./porcelain-parser";
 
 export interface GitBranchFact {
   branch: string;
@@ -9,10 +10,14 @@ export interface GitBranchFact {
 }
 
 export interface GitWorktreeFact {
-  branch: string;
+  branch?: string;
   path: string;
   headSha: string;
   dirty: boolean;
+  detached: boolean;
+  bare: boolean;
+  locked: boolean;
+  prunable: boolean;
 }
 
 export interface GitWorkspaceFacts {
@@ -44,31 +49,6 @@ function parseMergedBranches(stdout: string): Set<string> {
   );
 }
 
-function parseWorktreePorcelain(stdout: string): Array<{
-  path: string;
-  branch?: string;
-  headSha?: string;
-}> {
-  const out: Array<{ path: string; branch?: string; headSha?: string }> = [];
-  let current: { path: string; branch?: string; headSha?: string } | null =
-    null;
-  for (const line of stdout.split("\n")) {
-    if (line.startsWith("worktree ")) {
-      if (current) out.push(current);
-      current = { path: line.slice("worktree ".length).trim() };
-    } else if (line.startsWith("HEAD ") && current) {
-      current.headSha = line.slice("HEAD ".length).trim();
-    } else if (line.startsWith("branch refs/heads/") && current) {
-      current.branch = line.slice("branch refs/heads/".length).trim();
-    } else if (line.trim() === "" && current) {
-      out.push(current);
-      current = null;
-    }
-  }
-  if (current) out.push(current);
-  return out;
-}
-
 /**
  * @param gitTimeoutMs Optional per-subprocess bound. Cleanup callers pass a
  *   value strictly below the worktree tool budget so no single hung git
@@ -85,19 +65,17 @@ export async function scanGitWorkspaceFacts(
   const [branchLines, mergedText, worktreeText] = await Promise.all([
     git(
       repoRoot,
-      [
-        "for-each-ref",
-        "--format=%(refname:short) %(objectname)",
-        "refs/heads/change",
-      ],
+      ["for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads"],
       gitTimeoutMs,
     ).catch(() => ""),
     git(repoRoot, ["branch", "--merged", defaultBranch], gitTimeoutMs).catch(
       () => "",
     ),
-    git(repoRoot, ["worktree", "list", "--porcelain"], gitTimeoutMs).catch(
-      () => "",
-    ),
+    git(
+      repoRoot,
+      ["worktree", "list", "--porcelain", "-z"],
+      gitTimeoutMs,
+    ).catch(() => ""),
   ]);
 
   const mergedBranches = parseMergedBranches(mergedText);
@@ -111,8 +89,7 @@ export async function scanGitWorkspaceFacts(
     });
 
   const worktrees: GitWorktreeFact[] = [];
-  for (const wt of parseWorktreePorcelain(worktreeText)) {
-    if (!wt.branch || !inferChangeIdFromBranch(wt.branch)) continue;
+  for (const wt of parseWorktreeListPorcelain(worktreeText)) {
     const status = await git(
       wt.path,
       ["status", "--porcelain"],
@@ -123,6 +100,10 @@ export async function scanGitWorkspaceFacts(
       path: wt.path,
       headSha: wt.headSha ?? "",
       dirty: status.length > 0,
+      detached: wt.detached ?? false,
+      bare: wt.bare ?? false,
+      locked: wt.locked ?? false,
+      prunable: wt.prunable ?? false,
     });
   }
 

--- a/plugin/src/tools/worktree/deletion-contracts.test.ts
+++ b/plugin/src/tools/worktree/deletion-contracts.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WorktreeDeletionPlanSchema,
+  WorktreeDeletionResultSchema,
+  decodeWorktreeDeletionToken,
+  encodeWorktreeDeletionToken,
+  hashWorktreeDeletionFacts,
+  validateWorktreeDeletionToken,
+  type WorktreeDeletionFacts,
+} from "./deletion-contracts";
+
+const facts: WorktreeDeletionFacts = {
+  repository: "/repo with spaces",
+  worktree: "/tmp/worktree with spaces",
+  branch: "release/v1",
+  head: "0123456789abcdef0123456789abcdef01234567",
+  detached: false,
+  bare: false,
+  locked: false,
+  prunable: false,
+  dirty: false,
+};
+
+describe("worktree deletion contracts", () => {
+  it("round-trips a deterministic wdp1 token and canonical facts hash", () => {
+    const token = encodeWorktreeDeletionToken({
+      facts,
+      expiresAt: 1_800_000_000_000,
+    });
+
+    expect(token).toMatch(/^wdp1\.[A-Za-z0-9_-]+\.[0-9a-f]{64}$/);
+    expect(
+      encodeWorktreeDeletionToken({ facts, expiresAt: 1_800_000_000_000 }),
+    ).toBe(token);
+    expect(hashWorktreeDeletionFacts(facts)).toBe(
+      hashWorktreeDeletionFacts({ ...facts }),
+    );
+    expect(decodeWorktreeDeletionToken(token)).toEqual({
+      version: "wdp1",
+      facts,
+      expiresAt: 1_800_000_000_000,
+    });
+  });
+
+  it("rejects malformed, expired, and changed-fact tokens", () => {
+    const token = encodeWorktreeDeletionToken({
+      facts,
+      expiresAt: 1_800_000_000_000,
+    });
+
+    expect(() =>
+      decodeWorktreeDeletionToken("wdp1.not-json.not-a-hash"),
+    ).toThrow();
+    expect(
+      validateWorktreeDeletionToken(token, { now: 1_800_000_000_001 }),
+    ).toEqual({
+      ok: false,
+      reason: "expired",
+    });
+    expect(
+      validateWorktreeDeletionToken(token, {
+        now: 1_700_000_000_000,
+        facts: { ...facts, head: "fedcba9876543210fedcba9876543210fedcba98" },
+      }),
+    ).toEqual({ ok: false, reason: "facts_changed" });
+  });
+
+  it("structurally validates plan and result payloads", () => {
+    const plan = {
+      version: "wdp1" as const,
+      repository: facts.repository,
+      facts,
+      expiresAt: 1_800_000_000_000,
+      token: encodeWorktreeDeletionToken({
+        facts,
+        expiresAt: 1_800_000_000_000,
+      }),
+    };
+
+    expect(WorktreeDeletionPlanSchema.parse(plan)).toEqual(plan);
+    expect(() =>
+      WorktreeDeletionPlanSchema.parse({ ...plan, expiresAt: "later" }),
+    ).toThrow();
+    expect(() =>
+      WorktreeDeletionPlanSchema.parse({
+        ...plan,
+        repository: "/a-different-repository",
+      }),
+    ).toThrow(/repository must match/);
+    expect(() =>
+      WorktreeDeletionPlanSchema.parse({
+        ...plan,
+        expiresAt: plan.expiresAt + 1,
+      }),
+    ).toThrow(/token must bind/);
+    expect(
+      WorktreeDeletionResultSchema.parse({
+        ok: false,
+        status: "drifted",
+        reason: "facts_changed",
+      }),
+    ).toMatchObject({ status: "drifted" });
+  });
+});

--- a/plugin/src/tools/worktree/deletion-contracts.ts
+++ b/plugin/src/tools/worktree/deletion-contracts.ts
@@ -121,6 +121,11 @@ export const WorktreeDeletionPlanSchema = z
 export type WorktreeDeletionPlan = z.infer<typeof WorktreeDeletionPlanSchema>;
 
 const DeletionFailureStatusSchema = z.enum([
+  "refused",
+  "busy",
+  "indeterminate",
+  "repair_required",
+  "unsupported",
   "invalid_plan",
   "expired",
   "drifted",
@@ -136,6 +141,8 @@ export const WorktreeDeletionResultSchema = z.union([
       status: z.literal("deleted"),
       repository: NonEmptyTextSchema.optional(),
       worktree: NonEmptyTextSchema.optional(),
+      warning: NonEmptyTextSchema.optional(),
+      stage: NonEmptyTextSchema.optional(),
     })
     .strict(),
   z
@@ -143,6 +150,8 @@ export const WorktreeDeletionResultSchema = z.union([
       ok: z.literal(false),
       status: DeletionFailureStatusSchema,
       reason: NonEmptyTextSchema,
+      stage: NonEmptyTextSchema.optional(),
+      warning: NonEmptyTextSchema.optional(),
     })
     .strict(),
 ]);

--- a/plugin/src/tools/worktree/deletion-contracts.ts
+++ b/plugin/src/tools/worktree/deletion-contracts.ts
@@ -1,0 +1,222 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+import { stableStringify } from "../../utils/digest";
+
+const HEX_SHA_RE = /^[0-9a-f]{4,64}$/i;
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+
+const NonEmptyTextSchema = z
+  .string()
+  .min(1)
+  .refine((value) => !value.includes("\0"), "NUL is not valid in text fields");
+
+export const WorktreeDeletionFactsSchema = z
+  .object({
+    repository: NonEmptyTextSchema,
+    worktree: NonEmptyTextSchema,
+    branch: NonEmptyTextSchema.nullable(),
+    head: z.string().regex(HEX_SHA_RE),
+    detached: z.boolean(),
+    bare: z.boolean(),
+    locked: z.boolean(),
+    prunable: z.boolean(),
+    dirty: z.boolean(),
+  })
+  .strict();
+
+export type WorktreeDeletionFacts = z.infer<typeof WorktreeDeletionFactsSchema>;
+
+const WorktreeDeletionTokenPayloadSchema = z
+  .object({
+    version: z.literal("wdp1"),
+    facts: WorktreeDeletionFactsSchema,
+    expiresAt: z.number().int().positive(),
+  })
+  .strict();
+
+export type WorktreeDeletionTokenPayload = z.infer<
+  typeof WorktreeDeletionTokenPayloadSchema
+>;
+
+export const WorktreeDeletionPlanSchema = z
+  .object({
+    version: z.literal("wdp1"),
+    repository: NonEmptyTextSchema,
+    facts: WorktreeDeletionFactsSchema,
+    expiresAt: z.number().int().positive(),
+    token: NonEmptyTextSchema,
+  })
+  .strict()
+  .superRefine((plan, ctx) => {
+    if (plan.repository !== plan.facts.repository) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["repository"],
+        message: "plan repository must match deletion facts",
+      });
+    }
+
+    try {
+      const payload = decodeWorktreeDeletionToken(plan.token);
+      if (
+        payload.expiresAt !== plan.expiresAt ||
+        hashWorktreeDeletionFacts(payload.facts) !==
+          hashWorktreeDeletionFacts(plan.facts)
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["token"],
+          message: "deletion token must bind the plan facts and expiry",
+        });
+      }
+    } catch {
+      ctx.addIssue({
+        code: "custom",
+        path: ["token"],
+        message: "deletion token is malformed",
+      });
+    }
+  });
+
+export type WorktreeDeletionPlan = z.infer<typeof WorktreeDeletionPlanSchema>;
+
+const DeletionFailureStatusSchema = z.enum([
+  "invalid_plan",
+  "expired",
+  "drifted",
+  "blocked",
+  "deadline_exceeded",
+  "already_absent",
+]);
+
+export const WorktreeDeletionResultSchema = z.union([
+  z
+    .object({
+      ok: z.literal(true),
+      status: z.literal("deleted"),
+      repository: NonEmptyTextSchema.optional(),
+      worktree: NonEmptyTextSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      status: DeletionFailureStatusSchema,
+      reason: NonEmptyTextSchema,
+    })
+    .strict(),
+]);
+
+export type WorktreeDeletionResult = z.infer<
+  typeof WorktreeDeletionResultSchema
+>;
+
+function canonicalFacts(facts: WorktreeDeletionFacts): string {
+  return stableStringify({
+    bare: facts.bare,
+    branch: facts.branch,
+    detached: facts.detached,
+    dirty: facts.dirty,
+    head: facts.head,
+    locked: facts.locked,
+    prunable: facts.prunable,
+    repository: facts.repository,
+    worktree: facts.worktree,
+  });
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function hashWorktreeDeletionFacts(
+  facts: WorktreeDeletionFacts,
+): string {
+  const parsed = WorktreeDeletionFactsSchema.parse(facts);
+  return sha256(canonicalFacts(parsed));
+}
+
+function encodePayload(payload: WorktreeDeletionTokenPayload): string {
+  return Buffer.from(stableStringify(payload), "utf8").toString("base64url");
+}
+
+function decodePayload(encoded: string): WorktreeDeletionTokenPayload {
+  if (!BASE64URL_RE.test(encoded))
+    throw new Error("malformed deletion token payload");
+  const bytes = Buffer.from(encoded, "base64url");
+  if (bytes.length === 0 || bytes.toString("base64url") !== encoded) {
+    throw new Error("malformed deletion token payload");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("malformed deletion token payload");
+  }
+  const payload = WorktreeDeletionTokenPayloadSchema.parse(parsed);
+  if (encodePayload(payload) !== encoded) {
+    throw new Error("non-canonical deletion token payload");
+  }
+  return payload;
+}
+
+export function encodeWorktreeDeletionToken(input: {
+  facts: WorktreeDeletionFacts;
+  expiresAt: number;
+}): string {
+  const payload = WorktreeDeletionTokenPayloadSchema.parse({
+    version: "wdp1",
+    facts: input.facts,
+    expiresAt: input.expiresAt,
+  });
+  const encoded = encodePayload(payload);
+  return `wdp1.${encoded}.${sha256(encoded)}`;
+}
+
+export function decodeWorktreeDeletionToken(
+  token: string,
+): WorktreeDeletionTokenPayload {
+  if (typeof token !== "string") throw new Error("malformed deletion token");
+  const parts = token.split(".");
+  if (
+    parts.length !== 3 ||
+    parts[0] !== "wdp1" ||
+    !BASE64URL_RE.test(parts[1])
+  ) {
+    throw new Error("malformed deletion token");
+  }
+  if (!/^[0-9a-f]{64}$/.test(parts[2])) {
+    throw new Error("malformed deletion token hash");
+  }
+  if (parts[2] !== sha256(parts[1]))
+    throw new Error("invalid deletion token hash");
+  return decodePayload(parts[1]);
+}
+
+export type WorktreeDeletionTokenValidation =
+  | { ok: true; payload: WorktreeDeletionTokenPayload }
+  | { ok: false; reason: "malformed" | "expired" | "facts_changed" };
+
+export function validateWorktreeDeletionToken(
+  token: string,
+  options: { now?: number; facts?: WorktreeDeletionFacts } = {},
+): WorktreeDeletionTokenValidation {
+  let payload: WorktreeDeletionTokenPayload;
+  try {
+    payload = decodeWorktreeDeletionToken(token);
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+  if ((options.now ?? Date.now()) >= payload.expiresAt) {
+    return { ok: false, reason: "expired" };
+  }
+  if (
+    options.facts !== undefined &&
+    hashWorktreeDeletionFacts(options.facts) !==
+      hashWorktreeDeletionFacts(payload.facts)
+  ) {
+    return { ok: false, reason: "facts_changed" };
+  }
+  return { ok: true, payload };
+}

--- a/plugin/src/tools/worktree/deletion-contracts.ts
+++ b/plugin/src/tools/worktree/deletion-contracts.ts
@@ -63,6 +63,8 @@ const WorktreeDeletionTokenPayloadSchema = z
   .object({
     version: z.literal("wdp1"),
     facts: WorktreeDeletionFactsSchema,
+    /** Explicit approval to remove a dirty worktree; bound by the token. */
+    force: z.boolean().optional(),
     expiresAt: z.number().int().positive(),
     integration: WorktreeDeletionIntegrationProofSchema.optional(),
     terminal: WorktreeDeletionTerminalProofSchema.optional(),
@@ -78,6 +80,7 @@ export const WorktreeDeletionPlanSchema = z
     version: z.literal("wdp1"),
     repository: NonEmptyTextSchema,
     facts: WorktreeDeletionFactsSchema,
+    force: z.boolean().optional(),
     expiresAt: z.number().int().positive(),
     token: NonEmptyTextSchema,
     integration: WorktreeDeletionIntegrationProofSchema.optional(),
@@ -101,6 +104,7 @@ export const WorktreeDeletionPlanSchema = z
           hashWorktreeDeletionFacts(plan.facts) ||
         stableStringify(payload.integration) !==
           stableStringify(plan.integration) ||
+        payload.force !== plan.force ||
         stableStringify(payload.terminal) !== stableStringify(plan.terminal)
       ) {
         ctx.addIssue({
@@ -133,6 +137,22 @@ const DeletionFailureStatusSchema = z.enum([
   "deadline_exceeded",
   "already_absent",
 ]);
+
+export const WorktreeDeletionPlanResultSchema = z
+  .object({
+    ok: z.literal(true),
+    status: z.literal("planned"),
+    branch: NonEmptyTextSchema,
+    worktree: NonEmptyTextSchema,
+    plan: WorktreeDeletionPlanSchema,
+    planToken: NonEmptyTextSchema,
+    warnings: z.array(NonEmptyTextSchema),
+  })
+  .strict();
+
+export type WorktreeDeletionPlanResult = z.infer<
+  typeof WorktreeDeletionPlanResultSchema
+>;
 
 export const WorktreeDeletionResultSchema = z.union([
   z
@@ -216,6 +236,7 @@ function decodePayload(encoded: string): WorktreeDeletionTokenPayload {
 
 export function encodeWorktreeDeletionToken(input: {
   facts: WorktreeDeletionFacts;
+  force?: boolean;
   expiresAt: number;
   integration?: WorktreeDeletionIntegrationProof;
   terminal?: WorktreeDeletionTerminalProof;
@@ -223,6 +244,7 @@ export function encodeWorktreeDeletionToken(input: {
   const payload = WorktreeDeletionTokenPayloadSchema.parse({
     version: "wdp1",
     facts: input.facts,
+    ...(input.force !== undefined ? { force: input.force } : {}),
     expiresAt: input.expiresAt,
     ...(input.integration ? { integration: input.integration } : {}),
     ...(input.terminal ? { terminal: input.terminal } : {}),

--- a/plugin/src/tools/worktree/deletion-contracts.ts
+++ b/plugin/src/tools/worktree/deletion-contracts.ts
@@ -22,16 +22,50 @@ export const WorktreeDeletionFactsSchema = z
     locked: z.boolean(),
     prunable: z.boolean(),
     dirty: z.boolean(),
+    /** Planner-only safety facts. Optional for compatibility with wdp1 plans. */
+    mainWorktree: z.boolean().optional(),
+    cwd: NonEmptyTextSchema.optional(),
+    cwdInsideWorktree: z.boolean().optional(),
+    inUse: z.boolean().optional(),
+    gitCorrupt: z.boolean().optional(),
   })
   .strict();
 
 export type WorktreeDeletionFacts = z.infer<typeof WorktreeDeletionFactsSchema>;
+
+export const WorktreeDeletionIntegrationProofSchema = z
+  .object({
+    kind: z.enum(["merged_to_default", "pr_merged"]),
+    branch: NonEmptyTextSchema,
+    defaultBranch: NonEmptyTextSchema,
+    head: z.string().regex(HEX_SHA_RE),
+    evidence: NonEmptyTextSchema,
+  })
+  .strict();
+
+export type WorktreeDeletionIntegrationProof = z.infer<
+  typeof WorktreeDeletionIntegrationProofSchema
+>;
+
+export const WorktreeDeletionTerminalProofSchema = z
+  .object({
+    changeId: NonEmptyTextSchema,
+    status: z.enum(["archived", "closed"]),
+    evidence: NonEmptyTextSchema,
+  })
+  .strict();
+
+export type WorktreeDeletionTerminalProof = z.infer<
+  typeof WorktreeDeletionTerminalProofSchema
+>;
 
 const WorktreeDeletionTokenPayloadSchema = z
   .object({
     version: z.literal("wdp1"),
     facts: WorktreeDeletionFactsSchema,
     expiresAt: z.number().int().positive(),
+    integration: WorktreeDeletionIntegrationProofSchema.optional(),
+    terminal: WorktreeDeletionTerminalProofSchema.optional(),
   })
   .strict();
 
@@ -46,6 +80,8 @@ export const WorktreeDeletionPlanSchema = z
     facts: WorktreeDeletionFactsSchema,
     expiresAt: z.number().int().positive(),
     token: NonEmptyTextSchema,
+    integration: WorktreeDeletionIntegrationProofSchema.optional(),
+    terminal: WorktreeDeletionTerminalProofSchema.optional(),
   })
   .strict()
   .superRefine((plan, ctx) => {
@@ -62,7 +98,10 @@ export const WorktreeDeletionPlanSchema = z
       if (
         payload.expiresAt !== plan.expiresAt ||
         hashWorktreeDeletionFacts(payload.facts) !==
-          hashWorktreeDeletionFacts(plan.facts)
+          hashWorktreeDeletionFacts(plan.facts) ||
+        stableStringify(payload.integration) !==
+          stableStringify(plan.integration) ||
+        stableStringify(payload.terminal) !== stableStringify(plan.terminal)
       ) {
         ctx.addIssue({
           code: "custom",
@@ -123,6 +162,11 @@ function canonicalFacts(facts: WorktreeDeletionFacts): string {
     prunable: facts.prunable,
     repository: facts.repository,
     worktree: facts.worktree,
+    mainWorktree: facts.mainWorktree,
+    cwd: facts.cwd,
+    cwdInsideWorktree: facts.cwdInsideWorktree,
+    inUse: facts.inUse,
+    gitCorrupt: facts.gitCorrupt,
   });
 }
 
@@ -164,11 +208,15 @@ function decodePayload(encoded: string): WorktreeDeletionTokenPayload {
 export function encodeWorktreeDeletionToken(input: {
   facts: WorktreeDeletionFacts;
   expiresAt: number;
+  integration?: WorktreeDeletionIntegrationProof;
+  terminal?: WorktreeDeletionTerminalProof;
 }): string {
   const payload = WorktreeDeletionTokenPayloadSchema.parse({
     version: "wdp1",
     facts: input.facts,
     expiresAt: input.expiresAt,
+    ...(input.integration ? { integration: input.integration } : {}),
+    ...(input.terminal ? { terminal: input.terminal } : {}),
   });
   const encoded = encodePayload(payload);
   return `wdp1.${encoded}.${sha256(encoded)}`;
@@ -200,7 +248,12 @@ export type WorktreeDeletionTokenValidation =
 
 export function validateWorktreeDeletionToken(
   token: string,
-  options: { now?: number; facts?: WorktreeDeletionFacts } = {},
+  options: {
+    now?: number;
+    facts?: WorktreeDeletionFacts;
+    integration?: WorktreeDeletionIntegrationProof;
+    terminal?: WorktreeDeletionTerminalProof;
+  } = {},
 ): WorktreeDeletionTokenValidation {
   let payload: WorktreeDeletionTokenPayload;
   try {
@@ -215,6 +268,19 @@ export function validateWorktreeDeletionToken(
     options.facts !== undefined &&
     hashWorktreeDeletionFacts(options.facts) !==
       hashWorktreeDeletionFacts(payload.facts)
+  ) {
+    return { ok: false, reason: "facts_changed" };
+  }
+  if (
+    options.integration !== undefined &&
+    stableStringify(options.integration) !==
+      stableStringify(payload.integration)
+  ) {
+    return { ok: false, reason: "facts_changed" };
+  }
+  if (
+    options.terminal !== undefined &&
+    stableStringify(options.terminal) !== stableStringify(payload.terminal)
   ) {
     return { ok: false, reason: "facts_changed" };
   }

--- a/plugin/src/tools/worktree/deletion-executor.test.ts
+++ b/plugin/src/tools/worktree/deletion-executor.test.ts
@@ -1,0 +1,471 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  encodeWorktreeDeletionToken,
+  type WorktreeDeletionFacts,
+  type WorktreeDeletionPlan,
+  type WorktreeDeletionIntegrationProof,
+} from "./deletion-contracts";
+import {
+  executeWorktreeDeletion,
+  type WorktreeDeletionExecutorDeps,
+} from "./deletion-executor";
+
+const sha = "0123456789abcdef0123456789abcdef01234567";
+
+function fixture(): {
+  repository: string;
+  worktree: string;
+  cwd: string;
+  cleanup: () => void;
+} {
+  const repository = mkdtempSync(join(tmpdir(), "adv-delete-executor-repo-"));
+  const worktree = join(repository, "linked");
+  mkdirSync(worktree);
+  writeFileSync(join(repository, "root"), "root\n");
+  return {
+    repository,
+    worktree,
+    cwd: repository,
+    cleanup: () => rmSync(repository, { recursive: true, force: true }),
+  };
+}
+
+function makePlan(input: {
+  repository: string;
+  worktree: string;
+  cwd: string;
+  expiresAt?: number;
+  facts?: Partial<WorktreeDeletionFacts>;
+  integration?: Partial<WorktreeDeletionIntegrationProof>;
+}): WorktreeDeletionPlan {
+  const facts: WorktreeDeletionFacts = {
+    repository: input.repository,
+    worktree: input.worktree,
+    branch: "release/v1",
+    head: sha,
+    detached: false,
+    bare: false,
+    locked: false,
+    prunable: false,
+    dirty: false,
+    mainWorktree: false,
+    cwd: input.cwd,
+    cwdInsideWorktree: false,
+    inUse: false,
+    gitCorrupt: false,
+    ...input.facts,
+  };
+  const integration: WorktreeDeletionIntegrationProof = {
+    kind: "merged_to_default",
+    branch: facts.branch ?? "release/v1",
+    defaultBranch: "trunk",
+    head: facts.head,
+    evidence: "test merge proof",
+    ...input.integration,
+  };
+  const expiresAt = input.expiresAt ?? Date.now() + 60_000;
+  return {
+    version: "wdp1",
+    repository: input.repository,
+    facts,
+    expiresAt,
+    integration,
+    token: encodeWorktreeDeletionToken({ facts, expiresAt, integration }),
+  };
+}
+
+function depsFor(
+  fx: ReturnType<typeof fixture>,
+  plan: WorktreeDeletionPlan,
+  overrides: Partial<WorktreeDeletionExecutorDeps> = {},
+): WorktreeDeletionExecutorDeps {
+  const lease = {
+    owned: true as const,
+    ownerPid: process.pid,
+    workerId: "test-worker",
+    ownerToken: "test-owner",
+    lockPath: join(fx.repository, "lease"),
+  };
+  return {
+    repository: fx.repository,
+    repositoryLeaseDir: fx.repository,
+    cwd: fx.cwd,
+    acquireLease: vi.fn(async () => lease),
+    releaseLease: vi.fn(async () => undefined),
+    census: vi.fn(async () => {
+      if (!exists(fx.worktree)) return { branches: [], worktrees: [] };
+      return {
+        branches: [{ branch: "release/v1", headSha: sha, merged: true }],
+        worktrees: [
+          {
+            path: fx.repository,
+            headSha: sha,
+            dirty: false,
+            detached: false,
+            bare: false,
+            locked: false,
+            prunable: false,
+          },
+          {
+            path: fx.worktree,
+            branch: "release/v1",
+            headSha: sha,
+            dirty: false,
+            detached: false,
+            bare: false,
+            locked: false,
+            prunable: false,
+          },
+        ],
+      };
+    }),
+    runProcess: vi.fn(async (input) => {
+      if (input.args?.includes("remove"))
+        rmSync(fx.worktree, { recursive: true, force: true });
+      return {
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        aborted: false,
+        closed: true,
+      };
+    }),
+    ...overrides,
+  };
+}
+
+function exists(path: string): boolean {
+  return resolve(path) === resolve(path) && existsSync(path);
+}
+
+describe("WorktreeDeletionExecutor", () => {
+  it("deletes only after locked revalidation and confirms Git/filesystem absence", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const deps = depsFor(fx, plan);
+      const result = await executeWorktreeDeletion({ plan }, deps);
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: "deleted",
+        repository: fx.repository,
+        worktree: fx.worktree,
+      });
+      expect(deps.acquireLease).toHaveBeenCalledTimes(1);
+      expect(deps.runProcess).toHaveBeenCalledTimes(1);
+      expect(exists(fx.worktree)).toBe(false);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it.each([
+    ["head", { head: "fedcba9876543210fedcba9876543210fedcba98" }],
+    ["dirty", { dirty: true }],
+    ["locked", { locked: true }],
+    ["prunable", { prunable: true }],
+    ["cwd", { cwdInsideWorktree: true }],
+    ["process", { inUse: true }],
+    ["branch", { branch: "release/other" }],
+  ] as const)(
+    "refuses %s drift without running remove",
+    async (_name, changed) => {
+      const fx = fixture();
+      try {
+        const plan = makePlan(fx);
+        const mutation = changed as Record<string, unknown>;
+        const deps = depsFor(fx, plan, {
+          census: vi.fn(async () => ({
+            branches: [
+              {
+                branch: (mutation.branch as string | undefined) ?? "release/v1",
+                headSha: (mutation.head as string | undefined) ?? sha,
+                merged: true,
+              },
+            ],
+            worktrees: [
+              {
+                path: fx.repository,
+                headSha: sha,
+                dirty: false,
+                detached: false,
+                bare: false,
+                locked: false,
+                prunable: false,
+              },
+              {
+                path: fx.worktree,
+                branch: (mutation.branch as string | undefined) ?? "release/v1",
+                headSha: (mutation.head as string | undefined) ?? sha,
+                dirty: (mutation.dirty as boolean | undefined) ?? false,
+                detached: false,
+                bare: false,
+                locked: (mutation.locked as boolean | undefined) ?? false,
+                prunable: (mutation.prunable as boolean | undefined) ?? false,
+              },
+            ],
+          })),
+          isWorktreeInUse: () => mutation.inUse === true,
+          cwd: mutation.cwdInsideWorktree ? fx.worktree : fx.cwd,
+        });
+        const result = await executeWorktreeDeletion({ plan }, deps);
+        expect(result.status).toBe("drifted");
+        expect(deps.runProcess).not.toHaveBeenCalled();
+        expect(exists(fx.worktree)).toBe(true);
+      } finally {
+        fx.cleanup();
+      }
+    },
+  );
+
+  it("returns busy for a live repository owner and never runs Git", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const deps = depsFor(fx, plan, {
+        acquireLease: vi.fn(async () => ({
+          owned: false as const,
+          ownerPid: process.pid,
+          workerId: "peer",
+          lockPath: join(fx.repository, "lease"),
+          reason: "lock_held_by_alive_pid" as const,
+        })),
+      });
+      const result = await executeWorktreeDeletion({ plan }, deps);
+      expect(result).toMatchObject({ ok: false, status: "busy" });
+      expect(deps.runProcess).not.toHaveBeenCalled();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("requires repository-lock repair when lease acquisition fails", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const deps = depsFor(fx, plan, {
+        acquireLease: vi.fn(async () => {
+          throw new Error("state directory is unavailable");
+        }),
+      });
+      const result = await executeWorktreeDeletion({ plan }, deps);
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: "repair_required",
+        reason: "repository_lease_unavailable",
+        stage: "lease",
+      });
+      expect(deps.runProcess).not.toHaveBeenCalled();
+      expect(exists(fx.worktree)).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("returns already_absent only when Git and filesystem agree", async () => {
+    const fx = fixture();
+    try {
+      rmSync(fx.worktree, { recursive: true, force: true });
+      const plan = makePlan(fx);
+      const deps = depsFor(fx, plan);
+      const result = await executeWorktreeDeletion({ plan }, deps);
+      expect(result).toMatchObject({ ok: false, status: "already_absent" });
+      expect(deps.runProcess).not.toHaveBeenCalled();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("serializes concurrent applies so exactly one removal process runs", async () => {
+    const fx = fixture();
+    let held = false;
+    let removals = 0;
+    try {
+      const plan = makePlan(fx);
+      const acquire = vi.fn(async () => {
+        if (held)
+          return {
+            owned: false as const,
+            ownerPid: process.pid,
+            workerId: "peer",
+            lockPath: join(fx.repository, "lease"),
+            reason: "lock_held_by_alive_pid" as const,
+          };
+        held = true;
+        return {
+          owned: true as const,
+          ownerPid: process.pid,
+          workerId: "owner",
+          ownerToken: "owner-token",
+          lockPath: join(fx.repository, "lease"),
+        };
+      });
+      const release = vi.fn(async () => {
+        held = false;
+      });
+      const runProcess = vi.fn(async (input) => {
+        if (input.args?.includes("remove")) {
+          removals += 1;
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          rmSync(fx.worktree, { recursive: true, force: true });
+        }
+        return {
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          aborted: false,
+          closed: true,
+        };
+      });
+      const shared = {
+        ...depsFor(fx, plan),
+        acquireLease: acquire,
+        releaseLease: release,
+        runProcess,
+      };
+      const [first, second] = await Promise.all([
+        executeWorktreeDeletion({ plan }, shared),
+        executeWorktreeDeletion({ plan }, shared),
+      ]);
+      expect(removals).toBe(1);
+      expect([first.status, second.status].sort()).toEqual(["busy", "deleted"]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("reports indeterminate for a Git/filesystem half-state after remove", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const deps = depsFor(fx, plan, {
+        runProcess: vi.fn(async () => ({
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          aborted: false,
+          closed: true,
+        })),
+      });
+      const result = await executeWorktreeDeletion({ plan }, deps);
+      expect(result).toMatchObject({
+        ok: false,
+        status: "indeterminate",
+        reason: "git_removal_not_confirmed",
+      });
+      expect(exists(fx.worktree)).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("rechecks hook mutations and treats reconciliation failure as a warning after deletion", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      let scans = 0;
+      const deps = depsFor(fx, plan, {
+        hooks: ["touch hook-ran"],
+        census: vi.fn(async () => {
+          scans += 1;
+          if (scans === 2)
+            return {
+              branches: [{ branch: "release/v1", headSha: sha, merged: true }],
+              worktrees: [
+                {
+                  path: fx.worktree,
+                  branch: "release/v1",
+                  headSha: sha,
+                  dirty: true,
+                  detached: false,
+                  bare: false,
+                  locked: false,
+                  prunable: false,
+                },
+              ],
+            };
+          return {
+            branches: [{ branch: "release/v1", headSha: sha, merged: true }],
+            worktrees: [
+              {
+                path: fx.repository,
+                headSha: sha,
+                dirty: false,
+                detached: false,
+                bare: false,
+                locked: false,
+                prunable: false,
+              },
+              {
+                path: fx.worktree,
+                branch: "release/v1",
+                headSha: sha,
+                dirty: false,
+                detached: false,
+                bare: false,
+                locked: false,
+                prunable: false,
+              },
+            ],
+          };
+        }),
+      });
+      const hookResult = await executeWorktreeDeletion({ plan }, deps);
+      expect(hookResult.status).toBe("drifted");
+      expect(deps.runProcess).toHaveBeenCalledTimes(1);
+      expect(exists(fx.worktree)).toBe(true);
+
+      const cleanPlan = makePlan(fx);
+      const cleanDeps = depsFor(fx, cleanPlan, {
+        reconcileAfterDeletion: vi.fn(async () => {
+          throw new Error("state store unavailable");
+        }),
+      });
+      const deleted = await executeWorktreeDeletion(
+        { plan: cleanPlan },
+        cleanDeps,
+      );
+      expect(deleted).toMatchObject({ ok: true, status: "deleted" });
+      expect(deleted.warning).toMatch(/reconciliation failed/);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("terminates the destructive process path before returning a deadline result", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const deps = depsFor(fx, plan, {
+        budgetMs: 1_000,
+        runProcess: vi.fn(async () => ({
+          stdout: "",
+          stderr: "",
+          exitCode: null,
+          signal: "SIGKILL",
+          timedOut: true,
+          aborted: true,
+          closed: true,
+        })),
+      });
+      const result = await executeWorktreeDeletion({ plan }, deps);
+      expect(result).toMatchObject({ ok: false, status: "deadline_exceeded" });
+      expect(exists(fx.worktree)).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});

--- a/plugin/src/tools/worktree/deletion-executor.ts
+++ b/plugin/src/tools/worktree/deletion-executor.ts
@@ -62,6 +62,19 @@ export interface WorktreeDeletionExecutorDeps {
     repository: string,
     operation: WorktreeOperationContext,
   ) => Promise<WorktreeDeletionTerminalProof | undefined>;
+  /**
+   * Lifecycle-specific cleanup that must complete after safety revalidation
+   * and before Git removal. The worktree planner/executor remains the only
+   * destructive authority; adapters may only provide this bounded pre-remove
+   * hook for adjacent ownership cleanup (for example OpenCode workspaces).
+   */
+  beforeRemove?: (input: {
+    plan: WorktreeDeletionPlan;
+    operation: WorktreeOperationContext;
+  }) => Promise<
+    | { ok: true; warning?: string }
+    | { ok: false; status?: "busy" | "repair_required"; reason: string }
+  >;
   acquireLease?: (
     repositoryLeaseDir: string,
   ) => ReturnType<typeof acquireGitWorktreeFlock>;
@@ -201,14 +214,17 @@ function sameProof(
   return stableStringify(expected) === stableStringify(actual);
 }
 
-function safeToRemove(facts: WorktreeDeletionFacts): boolean {
+function safeToRemove(
+  facts: WorktreeDeletionFacts,
+  allowDirty = false,
+): boolean {
   return (
     facts.mainWorktree !== true &&
     facts.detached === false &&
     facts.bare === false &&
     facts.locked === false &&
     facts.prunable === false &&
-    facts.dirty === false &&
+    (allowDirty || facts.dirty === false) &&
     facts.cwdInsideWorktree === false &&
     facts.inUse === false &&
     facts.gitCorrupt !== true
@@ -343,7 +359,7 @@ export class WorktreeDeletionExecutor {
       );
       if (!sameFacts(plan.facts, actual))
         return failure("drifted", "bound_safety_fact_changed", stage);
-      if (!safeToRemove(actual))
+      if (!safeToRemove(actual, plan.force === true))
         return failure("refused", "unsafe_worktree_state", stage);
 
       const branchFact = current.branches.find(
@@ -354,7 +370,7 @@ export class WorktreeDeletionExecutor {
         !branchFact ||
         !integration ||
         branchFact.headSha !== integration.head ||
-        !branchFact.merged
+        (!branchFact.merged && !this.deps.integrationProof)
       )
         return failure("drifted", "integration_fact_changed", stage);
       if (this.deps.integrationProof) {
@@ -444,6 +460,20 @@ export class WorktreeDeletionExecutor {
       const beforeDecision = await evaluate(before, "census");
       if (beforeDecision) return beforeDecision;
 
+      let beforeRemoveWarning: string | undefined;
+      if (this.deps.beforeRemove) {
+        const preRemove = await runBounded("before_remove", () =>
+          this.deps.beforeRemove!({ plan, operation }),
+        );
+        if (!preRemove.ok)
+          return failure(
+            preRemove.status ?? "repair_required",
+            preRemove.reason,
+            "before_remove",
+          );
+        beforeRemoveWarning = preRemove.warning;
+      }
+
       for (const command of hooks) {
         const hookExpiry = expiryDecision("preDelete_hook");
         if (hookExpiry) return hookExpiry;
@@ -508,7 +538,13 @@ export class WorktreeDeletionExecutor {
       const removeResult = await runBounded("remove", () =>
         runProcess({
           command: resolveGitBinary(),
-          args: ["worktree", "remove", "--", plan.facts.worktree],
+          args: [
+            "worktree",
+            "remove",
+            ...(plan.force === true ? ["--force"] : []),
+            "--",
+            plan.facts.worktree,
+          ],
           cwd: plan.repository,
           signal: operation.signal,
           timeoutMs: Math.max(
@@ -568,7 +604,13 @@ export class WorktreeDeletionExecutor {
         status: "deleted",
         repository: plan.repository,
         worktree: plan.facts.worktree,
-        ...(warning ? { warning } : {}),
+        ...(warning || beforeRemoveWarning
+          ? {
+              warning: [beforeRemoveWarning, warning]
+                .filter(Boolean)
+                .join("; "),
+            }
+          : {}),
       };
     } catch (error) {
       if (

--- a/plugin/src/tools/worktree/deletion-executor.ts
+++ b/plugin/src/tools/worktree/deletion-executor.ts
@@ -1,0 +1,612 @@
+import { access } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import {
+  decodeWorktreeDeletionToken,
+  WorktreeDeletionPlanSchema,
+  type WorktreeDeletionFacts,
+  type WorktreeDeletionIntegrationProof,
+  type WorktreeDeletionPlan,
+  type WorktreeDeletionResult,
+  type WorktreeDeletionTerminalProof,
+} from "./deletion-contracts";
+import {
+  scanGitWorkspaceFacts,
+  type GitWorkspaceFacts,
+  type GitWorktreeFact,
+} from "./census";
+import { runAbortableProcess } from "../../utils/process-runner";
+import type {
+  AbortableProcessInput,
+  AbortableProcessResult,
+} from "../../utils/process-runner";
+import { resolveGitBinary } from "../../utils/git-binary";
+import {
+  acquireGitWorktreeFlock,
+  releaseGitWorktreeFlock,
+} from "../../utils/git-worktree-flock";
+import {
+  createWorktreeOperationContext,
+  type WorktreeOperationContext,
+} from "../../utils/worktree-operation";
+import { stableStringify } from "../../utils/digest";
+import { isWorktreeInUse } from "./in-use";
+
+/** Dependency seams keep the destructive boundary testable without bypassing Git. */
+export interface WorktreeDeletionExecutorDeps {
+  /** Repository path selected by the caller; it must match the token exactly. */
+  repository?: string;
+  /** Directory containing the repository owner-token lock. */
+  repositoryLeaseDir?: string;
+  /** Current process CWD, supplied by the adapter rather than inferred in tests. */
+  cwd?: string;
+  hooks?: readonly string[];
+  budgetMs?: number;
+  now?: () => number;
+  platform?: NodeJS.Platform;
+  census?: (
+    repository: string,
+    defaultBranch: string,
+    timeoutMs: number,
+  ) => Promise<GitWorkspaceFacts>;
+  isWorktreeInUse?: (worktreePath: string) => boolean;
+  integrationProof?: (
+    branch: string,
+    head: string,
+    defaultBranch: string,
+    repository: string,
+    operation: WorktreeOperationContext,
+  ) => Promise<WorktreeDeletionIntegrationProof | undefined>;
+  terminalProof?: (
+    changeId: string,
+    repository: string,
+    operation: WorktreeOperationContext,
+  ) => Promise<WorktreeDeletionTerminalProof | undefined>;
+  acquireLease?: (
+    repositoryLeaseDir: string,
+  ) => ReturnType<typeof acquireGitWorktreeFlock>;
+  releaseLease?: typeof releaseGitWorktreeFlock;
+  runProcess?: (
+    input: AbortableProcessInput,
+  ) => Promise<AbortableProcessResult>;
+  /** Runs only after Git and filesystem both prove the worktree is absent. */
+  reconcileAfterDeletion?: (input: {
+    plan: WorktreeDeletionPlan;
+    census: GitWorkspaceFacts;
+    operation: WorktreeOperationContext;
+  }) => Promise<void>;
+}
+
+export interface WorktreeDeletionExecutorInput {
+  plan: WorktreeDeletionPlan;
+  /** Explicit target identity; falls back to deps.repository, then plan.repository. */
+  repository?: string;
+  cwd?: string;
+  hooks?: readonly string[];
+  budgetMs?: number;
+  now?: number;
+}
+
+export type WorktreeDeletionExecutorResult = WorktreeDeletionResult & {
+  stage?: string;
+  warning?: string;
+};
+
+const DEFAULT_BUDGET_MS = 7_500;
+const DEFAULT_RESPONSE_RESERVE_MS = 500;
+
+class WorktreeDeletionStageDeadline extends Error {
+  constructor(readonly stage: string) {
+    super(`${stage} exceeded the deletion operation budget`);
+    this.name = "WorktreeDeletionStageDeadline";
+  }
+}
+
+function failure(
+  status: Extract<WorktreeDeletionExecutorResult["status"], string>,
+  reason: string,
+  stage?: string,
+): WorktreeDeletionExecutorResult {
+  return {
+    ok: false,
+    status: status as never,
+    reason,
+    ...(stage ? { stage } : {}),
+  } as WorktreeDeletionExecutorResult;
+}
+
+function isTimeout(result: AbortableProcessResult): boolean {
+  return result.timedOut || result.aborted;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    )
+      return false;
+    throw error;
+  }
+}
+
+async function identity(path: string): Promise<string> {
+  try {
+    // realpath makes a symlinked repository a different target from the plan.
+    const { realpath } = await import("node:fs/promises");
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function currentWorktree(
+  census: GitWorkspaceFacts,
+  plan: WorktreeDeletionPlan,
+): GitWorktreeFact | undefined {
+  return census.worktrees.find(
+    (item) =>
+      resolve(item.path) === resolve(plan.facts.worktree) ||
+      item.branch === plan.facts.branch,
+  );
+}
+
+function factsFromCensus(
+  census: GitWorkspaceFacts,
+  candidate: GitWorktreeFact,
+  repository: string,
+  cwd: string,
+  isInUse: boolean,
+): WorktreeDeletionFacts {
+  const first = census.worktrees[0];
+  const mainWorktree =
+    resolve(candidate.path) === resolve(repository) ||
+    (first !== undefined && resolve(first.path) === resolve(candidate.path));
+  return {
+    repository,
+    worktree: candidate.path,
+    branch: candidate.branch ?? null,
+    head: candidate.headSha,
+    detached: candidate.detached,
+    bare: candidate.bare,
+    locked: candidate.locked,
+    prunable: candidate.prunable,
+    dirty: candidate.dirty,
+    mainWorktree,
+    cwd,
+    cwdInsideWorktree:
+      resolve(cwd) === resolve(candidate.path) ||
+      resolve(cwd).startsWith(`${resolve(candidate.path)}/`),
+    inUse: isInUse,
+    gitCorrupt: candidate.corrupt === true,
+  };
+}
+
+function sameFacts(
+  expected: WorktreeDeletionFacts,
+  actual: WorktreeDeletionFacts,
+): boolean {
+  return stableStringify(expected) === stableStringify(actual);
+}
+
+function sameProof(
+  expected: WorktreeDeletionIntegrationProof | undefined,
+  actual: WorktreeDeletionIntegrationProof | undefined,
+): boolean {
+  return stableStringify(expected) === stableStringify(actual);
+}
+
+function safeToRemove(facts: WorktreeDeletionFacts): boolean {
+  return (
+    facts.mainWorktree !== true &&
+    facts.detached === false &&
+    facts.bare === false &&
+    facts.locked === false &&
+    facts.prunable === false &&
+    facts.dirty === false &&
+    facts.cwdInsideWorktree === false &&
+    facts.inUse === false &&
+    facts.gitCorrupt !== true
+  );
+}
+
+export class WorktreeDeletionExecutor {
+  private readonly deps: WorktreeDeletionExecutorDeps;
+
+  constructor(deps: WorktreeDeletionExecutorDeps = {}) {
+    this.deps = deps;
+  }
+
+  async execute(
+    input: WorktreeDeletionExecutorInput,
+  ): Promise<WorktreeDeletionExecutorResult> {
+    const parsed = WorktreeDeletionPlanSchema.safeParse(input.plan);
+    if (!parsed.success) return failure("refused", "invalid_plan");
+    const plan = parsed.data;
+    const now = input.now ?? this.deps.now?.() ?? Date.now();
+    const clock = this.deps.now ?? Date.now;
+    let payload: ReturnType<typeof decodeWorktreeDeletionToken>;
+    try {
+      payload = decodeWorktreeDeletionToken(plan.token);
+    } catch {
+      return failure("refused", "malformed_wdp1_token");
+    }
+    if (now >= plan.expiresAt || now >= payload.expiresAt)
+      return failure("refused", "expired_plan", "token_validation");
+
+    const targetRepository =
+      input.repository ?? this.deps.repository ?? plan.repository;
+    if ((this.deps.platform ?? process.platform) !== "linux")
+      return failure(
+        "unsupported",
+        "destructive_worktree_delete_requires_linux",
+      );
+    if (
+      (await identity(targetRepository)) !== (await identity(plan.repository))
+    )
+      return failure(
+        "drifted",
+        "repository_identity_changed",
+        "target_validation",
+      );
+
+    const operation = createWorktreeOperationContext({
+      budgetMs: input.budgetMs ?? this.deps.budgetMs ?? DEFAULT_BUDGET_MS,
+      responseReserveMs: DEFAULT_RESPONSE_RESERVE_MS,
+      now,
+    });
+    const repositoryLeaseDir =
+      this.deps.repositoryLeaseDir ?? resolve(plan.repository, ".adv");
+    const acquire = this.deps.acquireLease ?? acquireGitWorktreeFlock;
+    const release = this.deps.releaseLease ?? releaseGitWorktreeFlock;
+    let lock: Awaited<ReturnType<typeof acquireGitWorktreeFlock>> | undefined;
+    const cwd = input.cwd ?? this.deps.cwd ?? plan.facts.cwd ?? process.cwd();
+    const census = this.deps.census ?? scanGitWorkspaceFacts;
+    const runProcess = this.deps.runProcess ?? runAbortableProcess;
+    const hooks = input.hooks ?? this.deps.hooks ?? [];
+
+    const expiryDecision = (
+      stage: string,
+    ): WorktreeDeletionExecutorResult | null =>
+      clock() >= plan.expiresAt
+        ? failure("drifted", "plan_expired_during_apply", stage)
+        : null;
+
+    const runBounded = async <T>(
+      stage: string,
+      work: () => Promise<T>,
+    ): Promise<T> => {
+      const remaining = operation.remainingMs() - operation.responseReserveMs;
+      if (remaining <= 0) throw new WorktreeDeletionStageDeadline(stage);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          work(),
+          new Promise<T>((_resolve, reject) => {
+            timer = setTimeout(
+              () => reject(new WorktreeDeletionStageDeadline(stage)),
+              Math.max(1, remaining),
+            );
+            timer.unref?.();
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    };
+
+    const runCensus = async (
+      stage: string,
+    ): Promise<GitWorkspaceFacts | null> => {
+      if (operation.remainingMs() <= operation.responseReserveMs) return null;
+      operation.startStage(stage);
+      try {
+        return await runBounded(stage, () =>
+          census(
+            plan.repository,
+            plan.integration?.defaultBranch ?? "HEAD",
+            Math.max(1, operation.remainingMs() - operation.responseReserveMs),
+          ),
+        );
+      } catch (error) {
+        if (error instanceof WorktreeDeletionStageDeadline) throw error;
+        return null;
+      } finally {
+        operation.finishStage(stage);
+      }
+    };
+
+    const evaluate = async (
+      current: GitWorkspaceFacts,
+      stage: string,
+    ): Promise<WorktreeDeletionExecutorResult | null> => {
+      const candidate = currentWorktree(current, plan);
+      const onDisk = await exists(plan.facts.worktree);
+      if (!candidate && !onDisk)
+        return failure("already_absent", "git_and_filesystem_absent", stage);
+      if (!candidate || !onDisk)
+        return failure("repair_required", "git_and_filesystem_disagree", stage);
+      const inUse =
+        this.deps.isWorktreeInUse?.(candidate.path) ??
+        isWorktreeInUse(candidate.path);
+      const actual = factsFromCensus(
+        current,
+        candidate,
+        plan.repository,
+        cwd,
+        inUse,
+      );
+      if (!sameFacts(plan.facts, actual))
+        return failure("drifted", "bound_safety_fact_changed", stage);
+      if (!safeToRemove(actual))
+        return failure("refused", "unsafe_worktree_state", stage);
+
+      const branchFact = current.branches.find(
+        (item) => item.branch === plan.facts.branch,
+      );
+      const integration = plan.integration;
+      if (
+        !branchFact ||
+        !integration ||
+        branchFact.headSha !== integration.head ||
+        !branchFact.merged
+      )
+        return failure("drifted", "integration_fact_changed", stage);
+      if (this.deps.integrationProof) {
+        const currentProof = await runBounded(stage, () =>
+          this.deps.integrationProof!(
+            plan.facts.branch ?? "",
+            actual.head,
+            integration.defaultBranch,
+            plan.repository,
+            operation,
+          ),
+        );
+        if (!sameProof(integration, currentProof))
+          return failure("drifted", "integration_proof_changed", stage);
+      }
+      if (plan.terminal && !this.deps.terminalProof)
+        return failure(
+          "repair_required",
+          "terminal_proof_recheck_unavailable",
+          stage,
+        );
+      if (plan.terminal && this.deps.terminalProof) {
+        const terminal = await runBounded(stage, () =>
+          this.deps.terminalProof!(
+            plan.terminal!.changeId,
+            plan.repository,
+            operation,
+          ),
+        );
+        if (stableStringify(plan.terminal) !== stableStringify(terminal))
+          return failure("drifted", "terminal_proof_changed", stage);
+      }
+      return null;
+    };
+
+    try {
+      if (expiryDecision("lease")) return expiryDecision("lease")!;
+      if (operation.remainingMs() <= operation.responseReserveMs)
+        return failure("deadline_exceeded", "deadline_exceeded", "lease");
+      operation.startStage("lease");
+      const leasePromise = Promise.resolve(acquire(repositoryLeaseDir));
+      let leaseTimer: ReturnType<typeof setTimeout> | undefined;
+      type LeaseResult = Awaited<ReturnType<typeof acquireGitWorktreeFlock>>;
+      const leaseResult = await new Promise<
+        | { kind: "acquired"; lock: LeaseResult }
+        | { kind: "failed" }
+        | { kind: "deadline" }
+      >((resolveLease) => {
+        leaseTimer = setTimeout(
+          () => resolveLease({ kind: "deadline" }),
+          Math.max(1, operation.remainingMs() - operation.responseReserveMs),
+        );
+        leaseTimer.unref?.();
+        leasePromise.then(
+          (acquired) => resolveLease({ kind: "acquired", lock: acquired }),
+          () => resolveLease({ kind: "failed" }),
+        );
+      });
+      if (leaseTimer) clearTimeout(leaseTimer);
+      if (leaseResult.kind === "deadline") {
+        void leasePromise.then(async (lateLease) => {
+          if (lateLease.owned)
+            await release(repositoryLeaseDir, lateLease.ownerToken);
+        });
+        await operation.abort("deadline");
+        return failure("deadline_exceeded", "deadline_exceeded", "lease");
+      }
+      if (leaseResult.kind === "failed")
+        return failure(
+          "repair_required",
+          "repository_lease_unavailable",
+          "lease",
+        );
+      lock = leaseResult.lock;
+      operation.finishStage("lease");
+      if (!lock.owned) return failure("busy", "repository_lease_held", "lease");
+
+      const initialExpiry = expiryDecision("census");
+      if (initialExpiry) return initialExpiry;
+      const before = await runCensus("census");
+      if (!before)
+        return failure(
+          "deadline_exceeded",
+          "census_deadline_exceeded",
+          "census",
+        );
+      const beforeDecision = await evaluate(before, "census");
+      if (beforeDecision) return beforeDecision;
+
+      for (const command of hooks) {
+        const hookExpiry = expiryDecision("preDelete_hook");
+        if (hookExpiry) return hookExpiry;
+        if (operation.remainingMs() <= operation.responseReserveMs) {
+          await operation.abort("deadline");
+          return failure(
+            "deadline_exceeded",
+            "deadline_exceeded",
+            "preDelete_hook",
+          );
+        }
+        operation.startStage("preDelete_hook");
+        const hookResult = await runBounded("preDelete_hook", () =>
+          runProcess({
+            command: "/bin/sh",
+            args: ["-c", command],
+            cwd: plan.facts.worktree,
+            signal: operation.signal,
+            timeoutMs: Math.max(
+              1,
+              operation.remainingMs() - operation.responseReserveMs,
+            ),
+            destructiveSubtree: true,
+            operation,
+          }),
+        );
+        operation.finishStage("preDelete_hook");
+        if (
+          isTimeout(hookResult) ||
+          operation.remainingMs() <= operation.responseReserveMs
+        ) {
+          await operation.abort("deadline");
+          return failure(
+            "deadline_exceeded",
+            "preDelete_hook_deadline_exceeded",
+            "preDelete_hook",
+          );
+        }
+        if (!hookResult.closed || hookResult.exitCode !== 0)
+          return failure("refused", "preDelete_hook_failed", "preDelete_hook");
+      }
+
+      const postHookExpiry = expiryDecision("post_hook_census");
+      if (postHookExpiry) return postHookExpiry;
+      const afterHooks = await runCensus("post_hook_census");
+      if (!afterHooks)
+        return failure(
+          "deadline_exceeded",
+          "post_hook_census_deadline_exceeded",
+          "post_hook_census",
+        );
+      const hookDecision = await evaluate(afterHooks, "post_hook_census");
+      if (hookDecision) return hookDecision;
+
+      const removeExpiry = expiryDecision("remove");
+      if (removeExpiry) return removeExpiry;
+      if (operation.remainingMs() <= operation.responseReserveMs) {
+        await operation.abort("deadline");
+        return failure("deadline_exceeded", "deadline_exceeded", "remove");
+      }
+      operation.startStage("remove");
+      const removeResult = await runBounded("remove", () =>
+        runProcess({
+          command: resolveGitBinary(),
+          args: ["worktree", "remove", "--", plan.facts.worktree],
+          cwd: plan.repository,
+          signal: operation.signal,
+          timeoutMs: Math.max(
+            1,
+            operation.remainingMs() - operation.responseReserveMs,
+          ),
+          destructiveSubtree: true,
+          operation,
+        }),
+      );
+      operation.finishStage("remove");
+      if (
+        isTimeout(removeResult) ||
+        operation.remainingMs() <= operation.responseReserveMs
+      ) {
+        await operation.abort("deadline");
+        return failure(
+          "deadline_exceeded",
+          "remove_deadline_exceeded",
+          "remove",
+        );
+      }
+      if (!removeResult.closed || removeResult.exitCode !== 0)
+        return failure("indeterminate", "git_worktree_remove_failed", "remove");
+
+      const postDeleteExpiry = expiryDecision("post_delete_census");
+      if (postDeleteExpiry) return postDeleteExpiry;
+      const after = await runCensus("post_delete_census");
+      if (!after)
+        return failure(
+          "indeterminate",
+          "post_delete_census_unavailable",
+          "post_delete_census",
+        );
+      const remaining = currentWorktree(after, plan);
+      if (remaining || (await exists(plan.facts.worktree)))
+        return failure(
+          "indeterminate",
+          "git_removal_not_confirmed",
+          "post_delete_census",
+        );
+
+      let warning: string | undefined;
+      if (this.deps.reconcileAfterDeletion) {
+        try {
+          await this.deps.reconcileAfterDeletion({
+            plan,
+            census: after,
+            operation,
+          });
+        } catch (error) {
+          warning = `reconciliation failed after confirmed removal: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      }
+      return {
+        ok: true,
+        status: "deleted",
+        repository: plan.repository,
+        worktree: plan.facts.worktree,
+        ...(warning ? { warning } : {}),
+      };
+    } catch (error) {
+      if (
+        operation.signal.aborted ||
+        operation.remainingMs() <= operation.responseReserveMs
+      )
+        return failure(
+          "deadline_exceeded",
+          "deadline_exceeded",
+          operation.currentStage,
+        );
+      if (error instanceof WorktreeDeletionStageDeadline)
+        return failure("deadline_exceeded", error.message, error.stage);
+      if (
+        error instanceof Error &&
+        /unsupported.*platform/i.test(error.message)
+      )
+        return failure("unsupported", error.message, operation.currentStage);
+      return failure(
+        "indeterminate",
+        error instanceof Error ? error.message : String(error),
+        operation.currentStage,
+      );
+    } finally {
+      await operation.abort("operation_complete");
+      operation.dispose();
+      if (lock?.owned) await release(repositoryLeaseDir, lock.ownerToken);
+    }
+  }
+}
+
+export async function executeWorktreeDeletion(
+  input: WorktreeDeletionExecutorInput,
+  deps: WorktreeDeletionExecutorDeps = {},
+): Promise<WorktreeDeletionExecutorResult> {
+  return new WorktreeDeletionExecutor(deps).execute(input);
+}
+
+/** Names used by adapters during the convergence task; all share one executor. */
+export const applyWorktreeDeletion = executeWorktreeDeletion;
+export const executeDeletion = executeWorktreeDeletion;

--- a/plugin/src/tools/worktree/deletion-planner.test.ts
+++ b/plugin/src/tools/worktree/deletion-planner.test.ts
@@ -1,0 +1,232 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  WorktreeDeletionPlanner,
+  type WorktreeDeletionPlanResult,
+} from "./deletion-planner";
+import { decodeWorktreeDeletionToken } from "./deletion-contracts";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function makeFixture(): {
+  root: string;
+  worktree: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "adv-deletion-planner-"));
+  const worktree = `${root}-linked`;
+  git(root, "init", "-b", "main");
+  git(root, "config", "user.email", "test@example.invalid");
+  git(root, "config", "user.name", "ADV test");
+  execFileSync("touch", [join(root, "README.md")]);
+  git(root, "add", ".");
+  git(root, "commit", "-m", "initial");
+  git(root, "worktree", "add", "-b", "release/v1", worktree);
+  git(worktree, "config", "user.email", "test@example.invalid");
+  git(worktree, "config", "user.name", "ADV test");
+  git(worktree, "commit", "--allow-empty", "-m", "release");
+  git(root, "merge", "--ff-only", "release/v1");
+  return {
+    root,
+    worktree,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe("WorktreeDeletionPlanner", () => {
+  it("plans an unregistered merged release worktree from the Git census", async () => {
+    const fixture = makeFixture();
+    try {
+      const result = await new WorktreeDeletionPlanner().plan({
+        repository: fixture.root,
+        branch: "release/v1",
+        cwd: fixture.root,
+        registry: [],
+      });
+
+      expect(result.kind).toBe("planned");
+      if (result.kind === "planned") {
+        expect(result.plan.facts.worktree).toBe(fixture.worktree);
+        expect(result.plan.facts.branch).toBe("release/v1");
+        expect(result.warnings).toContain("registry_absent");
+        expect(result.plan.token).toMatch(/^wdp1\./);
+        expect(decodeWorktreeDeletionToken(result.plan.token).facts).toEqual(
+          result.plan.facts,
+        );
+        expect(
+          decodeWorktreeDeletionToken(result.plan.token).integration,
+        ).toEqual(result.plan.integration);
+        expect(result.stageTimings.length).toBeGreaterThan(0);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("returns distinct typed refusal results for hard safety failures", async () => {
+    const cases: Array<[string, Record<string, unknown>, string]> = [
+      ["main_worktree", { mainWorktree: true }, "main_worktree"],
+      ["detached", { detached: true }, "detached_head"],
+      ["dirty", { dirty: true }, "dirty_worktree"],
+      ["in_use", { inUse: true }, "worktree_in_use"],
+      ["locked", { locked: true }, "git_locked"],
+      ["prunable", { prunable: true }, "git_prunable"],
+      ["corrupt", { corrupt: true }, "git_corrupt"],
+    ];
+
+    for (const [, safety, reason] of cases) {
+      const result = await new WorktreeDeletionPlanner({
+        census: async () => ({
+          branches: [
+            {
+              branch: "release/v1",
+              headSha: "0123456789abcdef0123456789abcdef01234567",
+              merged: true,
+            },
+          ],
+          worktrees: [
+            {
+              path: "/repo",
+              headSha: "0123456789abcdef0123456789abcdef01234567",
+              dirty: false,
+              detached: false,
+              bare: false,
+              locked: false,
+              prunable: false,
+            },
+            {
+              path: "/tmp/release-v1",
+              branch: "release/v1",
+              headSha: "0123456789abcdef0123456789abcdef01234567",
+              dirty: false,
+              detached: false,
+              bare: false,
+              locked: false,
+              prunable: false,
+              ...safety,
+            },
+          ],
+        }),
+        targetResolver: async (input) => ({
+          repository: input.repository,
+          cwd: input.cwd ?? input.repository,
+          mainWorktree: safety.mainWorktree === true,
+        }),
+        isWorktreeInUse: () => safety.inUse === true,
+        operationNow: () => Date.now(),
+      }).plan({ repository: "/repo", branch: "release/v1", cwd: "/repo" });
+
+      expect(
+        result.kind,
+        `case ${cases.find((candidate) => candidate[2] === reason)?.[0] ?? reason}`,
+      ).toBe("refused");
+      if (result.kind === "refused") expect(result.reason).toBe(reason);
+    }
+  });
+
+  it("refuses missing terminal proof for an unregistered change branch", async () => {
+    const result = await new WorktreeDeletionPlanner({
+      census: async () => ({
+        branches: [
+          {
+            branch: "change/one",
+            headSha: "0123456789abcdef0123456789abcdef01234567",
+            merged: true,
+          },
+        ],
+        worktrees: [
+          {
+            path: "/repo",
+            headSha: "0123456789abcdef0123456789abcdef01234567",
+            dirty: false,
+            detached: false,
+            bare: false,
+            locked: false,
+            prunable: false,
+          },
+          {
+            path: "/tmp/change-one",
+            branch: "change/one",
+            headSha: "0123456789abcdef0123456789abcdef01234567",
+            dirty: false,
+            detached: false,
+            bare: false,
+            locked: false,
+            prunable: false,
+          },
+        ],
+      }),
+    }).plan({ repository: "/repo", branch: "change/one", cwd: "/repo" });
+
+    expect(result).toMatchObject({
+      kind: "refused",
+      reason: "terminal_proof_required",
+    });
+  });
+
+  it("returns a deadline result when target resolution consumes the budget", async () => {
+    const result = await new WorktreeDeletionPlanner({
+      operationNow: () => 1_000,
+      targetResolver: async (_input, operation) => {
+        operation.startStage("target_resolution", 1_000);
+        operation.finishStage("target_resolution", 9_000);
+        return { repository: "/repo", cwd: "/repo", mainWorktree: false };
+      },
+    }).plan({ repository: "/repo", branch: "release/v1", budgetMs: 100 });
+
+    expect(result).toMatchObject({
+      kind: "deadline",
+      stage: "target_resolution",
+    });
+  });
+
+  it("rejects malformed census data as a repair result without touching state", async () => {
+    const result = await new WorktreeDeletionPlanner({
+      census: async () => ({
+        branches: [],
+        worktrees: [{ path: "", branch: "release/v1" }] as never,
+      }),
+    }).plan({ repository: "/repo", branch: "release/v1" });
+
+    expect(result.kind).toBe("repair");
+    if (result.kind === "repair")
+      expect(result.reason).toBe("malformed_census");
+  });
+
+  it("does not initialize an ADV store while resolving a large target", async () => {
+    let initialized = false;
+    const result = await new WorktreeDeletionPlanner({
+      targetResolver: async (input) => ({
+        repository: input.repository,
+        cwd: input.repository,
+        mainWorktree: false,
+      }),
+      census: async () => ({ branches: [], worktrees: [] }),
+      initializeStore: async () => {
+        initialized = true;
+        throw new Error("must not be called");
+      },
+    }).plan({ repository: "/large/repository", branch: "release/v1" });
+
+    expect(initialized).toBe(false);
+    expect(result.kind).not.toBe("planned");
+  });
+
+  it("preserves a generic timeout as a typed deadline result", async () => {
+    const result: WorktreeDeletionPlanResult =
+      await new WorktreeDeletionPlanner({
+        targetResolver: async () => {
+          throw new Error("operation timed out");
+        },
+      }).plan({ repository: "/repo", branch: "release/v1" });
+
+    expect(result.kind).toBe("deadline");
+  });
+});

--- a/plugin/src/tools/worktree/deletion-planner.test.ts
+++ b/plugin/src/tools/worktree/deletion-planner.test.ts
@@ -187,6 +187,17 @@ describe("WorktreeDeletionPlanner", () => {
     });
   });
 
+  it("bounds a target resolver that never settles", async () => {
+    const result = await new WorktreeDeletionPlanner({
+      targetResolver: () => new Promise<never>(() => {}),
+    }).plan({ repository: "/repo", branch: "release/v1", budgetMs: 10 });
+
+    expect(result).toMatchObject({
+      kind: "deadline",
+      stage: "target_resolution",
+    });
+  });
+
   it("rejects malformed census data as a repair result without touching state", async () => {
     const result = await new WorktreeDeletionPlanner({
       census: async () => ({

--- a/plugin/src/tools/worktree/deletion-planner.ts
+++ b/plugin/src/tools/worktree/deletion-planner.ts
@@ -68,6 +68,8 @@ export interface WorktreeDeletionPlannerInput {
   cwd?: string;
   defaultBranch?: string;
   registry?: readonly WorktreeDeletionRegistryEntry[];
+  /** Explicit approval to include a dirty worktree in the deletion plan. */
+  force?: boolean;
   /** Test/operator override for the five-minute token clock. */
   now?: number;
   budgetMs?: number;
@@ -271,6 +273,25 @@ export class WorktreeDeletionPlanner {
       now,
       budgetMs: input.budgetMs,
     });
+    const runWithDeadline = async <T>(work: () => Promise<T>): Promise<T> => {
+      const remaining = operation.remainingMs();
+      if (remaining <= 0) throw new Error("planning deadline exceeded");
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          work(),
+          new Promise<T>((_resolve, reject) => {
+            timer = setTimeout(
+              () => reject(new Error("planning deadline exceeded")),
+              remaining,
+            );
+            timer.unref?.();
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    };
     const platform = this.deps.platform ?? process.platform;
 
     try {
@@ -286,8 +307,12 @@ export class WorktreeDeletionPlanner {
       operation.startStage("target_resolution");
       let target: WorktreeDeletionTarget;
       try {
-        target = await (this.deps.targetResolver?.(input, operation) ??
-          this.defaultTarget(input));
+        target = await runWithDeadline(() =>
+          Promise.resolve(
+            this.deps.targetResolver?.(input, operation) ??
+              this.defaultTarget(input),
+          ),
+        );
       } catch (error) {
         if (isTimeoutError(error) || operation.remainingMs() <= 0) {
           return this.deadline(operation, "target_resolution", error);
@@ -428,10 +453,10 @@ export class WorktreeDeletionPlanner {
           operation,
           { facts, target },
         );
-      if (candidate.dirty)
+      if (candidate.dirty && input.force !== true)
         return refusal(
           "dirty_worktree",
-          "The worktree contains uncommitted changes.",
+          "The worktree contains uncommitted changes; replan with force:true only with explicit approval.",
           operation,
           { facts, target },
         );
@@ -470,7 +495,7 @@ export class WorktreeDeletionPlanner {
           operation,
           { facts, target },
         );
-      if (!branchFact.merged)
+      if (!branchFact.merged && !this.deps.integrationProof)
         return refusal(
           "branch_not_merged",
           `Branch ${branch} is not integrated into ${defaultBranch}.`,
@@ -481,19 +506,23 @@ export class WorktreeDeletionPlanner {
       operation.startStage("integration_proof");
       let integration: WorktreeDeletionIntegrationProof | undefined;
       try {
-        integration = await (this.deps.integrationProof?.(
-          branch,
-          candidate.headSha,
-          defaultBranch,
-          target.repository,
-          operation,
-        ) ?? {
-          kind: "merged_to_default",
-          branch,
-          defaultBranch,
-          head: candidate.headSha,
-          evidence: `git branch --merged ${defaultBranch}`,
-        });
+        integration = await (this.deps.integrationProof
+          ? runWithDeadline(() =>
+              this.deps.integrationProof!(
+                branch,
+                candidate.headSha,
+                defaultBranch,
+                target.repository,
+                operation,
+              ),
+            )
+          : {
+              kind: "merged_to_default",
+              branch,
+              defaultBranch,
+              head: candidate.headSha,
+              evidence: `git branch --merged ${defaultBranch}`,
+            });
       } catch (error) {
         if (isTimeoutError(error) || operation.remainingMs() <= 0)
           return this.deadline(operation, "integration_proof", error, target);
@@ -524,11 +553,13 @@ export class WorktreeDeletionPlanner {
       if (changeId) {
         operation.startStage("terminal_ownership_proof");
         try {
-          terminal = await (this.deps.terminalProof?.(
-            changeId,
-            target,
-            operation,
-          ) ?? readLightweightTerminalProof(changeId, target));
+          terminal = await (this.deps.terminalProof
+            ? runWithDeadline(() =>
+                this.deps.terminalProof!(changeId, target, operation),
+              )
+            : runWithDeadline(() =>
+                readLightweightTerminalProof(changeId, target),
+              ));
         } catch (error) {
           if (isTimeoutError(error) || operation.remainingMs() <= 0)
             return this.deadline(
@@ -567,6 +598,7 @@ export class WorktreeDeletionPlanner {
       const token = encodeWorktreeDeletionToken({
         facts,
         expiresAt,
+        force: input.force === true,
         integration,
         ...(terminal ? { terminal } : {}),
       });
@@ -574,6 +606,7 @@ export class WorktreeDeletionPlanner {
         version: "wdp1",
         repository: target.repository,
         facts,
+        force: input.force === true,
         expiresAt,
         token,
         integration,

--- a/plugin/src/tools/worktree/deletion-planner.ts
+++ b/plugin/src/tools/worktree/deletion-planner.ts
@@ -1,0 +1,654 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import {
+  encodeWorktreeDeletionToken,
+  WorktreeDeletionPlanSchema,
+  type WorktreeDeletionFacts,
+  type WorktreeDeletionIntegrationProof,
+  type WorktreeDeletionPlan,
+  type WorktreeDeletionTerminalProof,
+} from "./deletion-contracts";
+import {
+  scanGitWorkspaceFacts,
+  type GitWorkspaceFacts,
+  type GitWorktreeFact,
+} from "./census";
+import { isWorktreeInUse } from "./in-use";
+import {
+  createWorktreeOperationContext,
+  type WorktreeOperationContext,
+  type WorktreeStageTiming,
+} from "../../utils/worktree-operation";
+import { getDefaultBranch } from "../../utils/git";
+import { getExternalRootForProject } from "../../utils/project-id";
+
+/** A plan is intentionally short-lived and self-contained. */
+export const WORKTREE_DELETION_PLAN_TTL_MS = 5 * 60_000;
+
+const SHA_RE = /^[0-9a-f]{4,64}$/i;
+
+export type WorktreeDeletionRefusalReason =
+  | "target_not_found"
+  | "worktree_not_found"
+  | "branch_not_found"
+  | "main_worktree"
+  | "detached_head"
+  | "dirty_worktree"
+  | "cwd_in_worktree"
+  | "worktree_in_use"
+  | "git_locked"
+  | "git_prunable"
+  | "git_corrupt"
+  | "bare_worktree"
+  | "branch_not_merged"
+  | "terminal_proof_required";
+
+export type WorktreeDeletionRepairReason =
+  | "target_resolution_failed"
+  | "census_unavailable"
+  | "malformed_census"
+  | "terminal_state_corrupt";
+
+export type WorktreeDeletionUnsupportedReason =
+  | "process_use_detection_unsupported"
+  | "unsupported_target";
+
+export interface WorktreeDeletionRegistryEntry {
+  branch: string;
+  path?: string;
+  changeId?: string;
+}
+
+export interface WorktreeDeletionPlannerInput {
+  repository: string;
+  projectId?: string;
+  branch?: string;
+  changeId?: string;
+  cwd?: string;
+  defaultBranch?: string;
+  registry?: readonly WorktreeDeletionRegistryEntry[];
+  /** Test/operator override for the five-minute token clock. */
+  now?: number;
+  budgetMs?: number;
+}
+
+export interface WorktreeDeletionTarget {
+  repository: string;
+  cwd: string;
+  /** Set by a caller that already knows the target is the main checkout. */
+  mainWorktree?: boolean;
+  /** Derived only; no store is opened and the path is not read by resolution. */
+  statePath?: string;
+}
+
+export interface WorktreeDeletionPlannerDeps {
+  targetResolver?: (
+    input: WorktreeDeletionPlannerInput,
+    operation: WorktreeOperationContext,
+  ) => Promise<WorktreeDeletionTarget> | WorktreeDeletionTarget;
+  census?: (
+    repository: string,
+    defaultBranch: string,
+    timeoutMs: number,
+  ) => Promise<GitWorkspaceFacts>;
+  terminalProof?: (
+    changeId: string,
+    target: WorktreeDeletionTarget,
+    operation: WorktreeOperationContext,
+  ) => Promise<WorktreeDeletionTerminalProof | undefined>;
+  integrationProof?: (
+    branch: string,
+    head: string,
+    defaultBranch: string,
+    repository: string,
+    operation: WorktreeOperationContext,
+  ) => Promise<WorktreeDeletionIntegrationProof | undefined>;
+  statePathResolver?: (
+    repository: string,
+    changeId: string,
+  ) => Promise<string | undefined>;
+  isWorktreeInUse?: (worktreePath: string) => boolean;
+  platform?: NodeJS.Platform;
+  /** Deliberately unused seam: proves planning never initializes a full store. */
+  initializeStore?: () => Promise<unknown>;
+  operationNow?: () => number;
+}
+
+export interface WorktreeDeletionPlanSuccess {
+  kind: "planned";
+  plan: WorktreeDeletionPlan;
+  target: WorktreeDeletionTarget;
+  warnings: string[];
+  stageTimings: readonly WorktreeStageTiming[];
+}
+
+export interface WorktreeDeletionPlanRefusal {
+  kind: "refused";
+  reason: WorktreeDeletionRefusalReason;
+  message: string;
+  facts?: WorktreeDeletionFacts;
+  target?: WorktreeDeletionTarget;
+  warnings?: string[];
+  stageTimings: readonly WorktreeStageTiming[];
+}
+
+export interface WorktreeDeletionPlanDeadline {
+  kind: "deadline";
+  stage: string;
+  message: string;
+  target?: WorktreeDeletionTarget;
+  stageTimings: readonly WorktreeStageTiming[];
+}
+
+export interface WorktreeDeletionPlanRepair {
+  kind: "repair";
+  reason: WorktreeDeletionRepairReason;
+  message: string;
+  target?: WorktreeDeletionTarget;
+  stageTimings: readonly WorktreeStageTiming[];
+}
+
+export interface WorktreeDeletionPlanUnsupported {
+  kind: "unsupported";
+  reason: WorktreeDeletionUnsupportedReason;
+  message: string;
+  target?: WorktreeDeletionTarget;
+  stageTimings: readonly WorktreeStageTiming[];
+}
+
+export type WorktreeDeletionPlanResult =
+  | WorktreeDeletionPlanSuccess
+  | WorktreeDeletionPlanRefusal
+  | WorktreeDeletionPlanDeadline
+  | WorktreeDeletionPlanRepair
+  | WorktreeDeletionPlanUnsupported;
+
+function inferChangeId(
+  input: WorktreeDeletionPlannerInput,
+  branch: string,
+): string | undefined {
+  if (input.changeId) return input.changeId;
+  return branch.startsWith("change/")
+    ? branch.slice("change/".length)
+    : undefined;
+}
+
+function inside(parent: string, child: string): boolean {
+  const parentPath = resolve(parent).replace(/\/$/, "");
+  const childPath = resolve(child);
+  return childPath === parentPath || childPath.startsWith(`${parentPath}/`);
+}
+
+function isTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /timeout|timed out|deadline|abort/i.test(message);
+}
+
+function validCensus(census: GitWorkspaceFacts): boolean {
+  if (
+    !census ||
+    !Array.isArray(census.branches) ||
+    !Array.isArray(census.worktrees)
+  )
+    return false;
+  return census.worktrees.every((worktree) => {
+    return (
+      typeof worktree.path === "string" &&
+      worktree.path.length > 0 &&
+      (worktree.branch === undefined || typeof worktree.branch === "string") &&
+      typeof worktree.headSha === "string" &&
+      SHA_RE.test(worktree.headSha) &&
+      typeof worktree.dirty === "boolean" &&
+      typeof worktree.detached === "boolean" &&
+      typeof worktree.bare === "boolean" &&
+      typeof worktree.locked === "boolean" &&
+      typeof worktree.prunable === "boolean"
+    );
+  });
+}
+
+function refusal(
+  reason: WorktreeDeletionRefusalReason,
+  message: string,
+  operation: WorktreeOperationContext,
+  extra: Omit<
+    WorktreeDeletionPlanRefusal,
+    "kind" | "reason" | "message" | "stageTimings"
+  > = {},
+): WorktreeDeletionPlanRefusal {
+  return {
+    kind: "refused",
+    reason,
+    message,
+    ...extra,
+    stageTimings: operation.stageTimings,
+  };
+}
+
+async function readLightweightTerminalProof(
+  changeId: string,
+  target: WorktreeDeletionTarget,
+): Promise<WorktreeDeletionTerminalProof | undefined> {
+  if (!target.statePath) return undefined;
+  try {
+    const parsed = JSON.parse(await readFile(target.statePath, "utf8")) as {
+      status?: unknown;
+    };
+    if (parsed.status !== "archived" && parsed.status !== "closed")
+      return undefined;
+    return {
+      changeId,
+      status: parsed.status,
+      evidence: `lightweight terminal read: ${target.statePath}`,
+    };
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT")
+      return undefined;
+    throw error;
+  }
+}
+
+/**
+ * Git-authoritative, side-effect-free deletion planner.
+ *
+ * The planner never opens ADV's Store, writes registry/plan state, invokes
+ * migration, or mutates Git. Destructive adapters consume its self-contained
+ * token in a later task and revalidate every bound fact under their lease.
+ */
+export class WorktreeDeletionPlanner {
+  private readonly deps: WorktreeDeletionPlannerDeps;
+
+  constructor(deps: WorktreeDeletionPlannerDeps = {}) {
+    this.deps = deps;
+  }
+
+  async plan(
+    input: WorktreeDeletionPlannerInput,
+  ): Promise<WorktreeDeletionPlanResult> {
+    const now = input.now ?? this.deps.operationNow?.() ?? Date.now();
+    const operation = createWorktreeOperationContext({
+      now,
+      budgetMs: input.budgetMs,
+    });
+    const platform = this.deps.platform ?? process.platform;
+
+    try {
+      if (platform !== "linux") {
+        return {
+          kind: "unsupported",
+          reason: "process_use_detection_unsupported",
+          message: `Local process-use detection is unsupported on ${platform}.`,
+          stageTimings: operation.stageTimings,
+        };
+      }
+
+      operation.startStage("target_resolution");
+      let target: WorktreeDeletionTarget;
+      try {
+        target = await (this.deps.targetResolver?.(input, operation) ??
+          this.defaultTarget(input));
+      } catch (error) {
+        if (isTimeoutError(error) || operation.remainingMs() <= 0) {
+          return this.deadline(operation, "target_resolution", error);
+        }
+        return {
+          kind: "repair",
+          reason: "target_resolution_failed",
+          message: error instanceof Error ? error.message : String(error),
+          stageTimings: operation.stageTimings,
+        };
+      } finally {
+        operation.finishStage("target_resolution");
+      }
+      if (operation.remainingMs() <= 0)
+        return this.deadline(operation, "target_resolution");
+
+      const branch =
+        input.branch ??
+        (input.changeId ? `change/${input.changeId}` : undefined);
+      if (!branch) {
+        return refusal(
+          "target_not_found",
+          "A branch or changeId is required.",
+          operation,
+          { target },
+        );
+      }
+      const defaultBranch =
+        input.defaultBranch ?? (await getDefaultBranch(target.repository));
+
+      operation.startStage("git_census");
+      let census: GitWorkspaceFacts;
+      try {
+        census = await (this.deps.census?.(
+          target.repository,
+          defaultBranch,
+          Math.max(1, operation.remainingMs()),
+        ) ??
+          scanGitWorkspaceFacts(
+            target.repository,
+            defaultBranch,
+            Math.max(1, operation.remainingMs()),
+          ));
+      } catch (error) {
+        if (isTimeoutError(error) || operation.remainingMs() <= 0) {
+          return this.deadline(operation, "git_census", error, target);
+        }
+        return {
+          kind: "repair",
+          reason: "census_unavailable",
+          message: error instanceof Error ? error.message : String(error),
+          target,
+          stageTimings: operation.stageTimings,
+        };
+      } finally {
+        operation.finishStage("git_census");
+      }
+      if (!validCensus(census)) {
+        return {
+          kind: "repair",
+          reason: "malformed_census",
+          message: "Git census returned malformed worktree facts.",
+          target,
+          stageTimings: operation.stageTimings,
+        };
+      }
+      if (operation.remainingMs() <= 0)
+        return this.deadline(operation, "git_census", undefined, target);
+
+      const candidate = census.worktrees.find(
+        (worktree) => worktree.branch === branch,
+      );
+      if (!candidate) {
+        return refusal(
+          "worktree_not_found",
+          `Git census contains no worktree for ${branch}.`,
+          operation,
+          { target },
+        );
+      }
+      const branchFact = census.branches.find((item) => item.branch === branch);
+      if (!branchFact) {
+        return refusal(
+          "branch_not_found",
+          `Git census contains no local branch for ${branch}.`,
+          operation,
+          { target },
+        );
+      }
+      const candidateWithExtra = candidate as GitWorktreeFact & {
+        corrupt?: boolean;
+        mainWorktree?: boolean;
+      };
+      const mainWorktree =
+        target.mainWorktree === true ||
+        candidateWithExtra.mainWorktree === true ||
+        census.worktrees[0]?.path === candidate.path ||
+        resolve(candidate.path) === resolve(target.repository);
+      const cwdInsideWorktree = inside(candidate.path, target.cwd);
+      const inUse =
+        this.deps.isWorktreeInUse?.(candidate.path) ??
+        isWorktreeInUse(candidate.path);
+      const facts: WorktreeDeletionFacts = {
+        repository: target.repository,
+        worktree: candidate.path,
+        branch: candidate.branch ?? null,
+        head: candidate.headSha,
+        detached: candidate.detached,
+        bare: candidate.bare,
+        locked: candidate.locked,
+        prunable: candidate.prunable,
+        dirty: candidate.dirty,
+        mainWorktree,
+        cwd: target.cwd,
+        cwdInsideWorktree,
+        inUse,
+        gitCorrupt: candidateWithExtra.corrupt === true,
+      };
+
+      if (mainWorktree)
+        return refusal(
+          "main_worktree",
+          "The Git main worktree is never deletable.",
+          operation,
+          { facts, target },
+        );
+      if (candidate.detached)
+        return refusal(
+          "detached_head",
+          "Detached worktrees have no branch identity.",
+          operation,
+          { facts, target },
+        );
+      if (candidate.bare)
+        return refusal(
+          "bare_worktree",
+          "Bare Git repositories are not worktrees.",
+          operation,
+          { facts, target },
+        );
+      if (candidate.dirty)
+        return refusal(
+          "dirty_worktree",
+          "The worktree contains uncommitted changes.",
+          operation,
+          { facts, target },
+        );
+      if (cwdInsideWorktree)
+        return refusal(
+          "cwd_in_worktree",
+          "The current process CWD is inside the target worktree.",
+          operation,
+          { facts, target },
+        );
+      if (inUse)
+        return refusal(
+          "worktree_in_use",
+          "A local process uses the target worktree.",
+          operation,
+          { facts, target },
+        );
+      if (candidate.locked)
+        return refusal(
+          "git_locked",
+          "Git marks the worktree locked.",
+          operation,
+          { facts, target },
+        );
+      if (candidate.prunable)
+        return refusal(
+          "git_prunable",
+          "Git marks the worktree administrative data prunable.",
+          operation,
+          { facts, target },
+        );
+      if (candidateWithExtra.corrupt === true)
+        return refusal(
+          "git_corrupt",
+          "Git reported corrupt worktree data.",
+          operation,
+          { facts, target },
+        );
+      if (!branchFact.merged)
+        return refusal(
+          "branch_not_merged",
+          `Branch ${branch} is not integrated into ${defaultBranch}.`,
+          operation,
+          { facts, target },
+        );
+
+      operation.startStage("integration_proof");
+      let integration: WorktreeDeletionIntegrationProof | undefined;
+      try {
+        integration = await (this.deps.integrationProof?.(
+          branch,
+          candidate.headSha,
+          defaultBranch,
+          target.repository,
+          operation,
+        ) ?? {
+          kind: "merged_to_default",
+          branch,
+          defaultBranch,
+          head: candidate.headSha,
+          evidence: `git branch --merged ${defaultBranch}`,
+        });
+      } catch (error) {
+        if (isTimeoutError(error) || operation.remainingMs() <= 0)
+          return this.deadline(operation, "integration_proof", error, target);
+        return {
+          kind: "repair",
+          reason: "census_unavailable",
+          message: error instanceof Error ? error.message : String(error),
+          target,
+          stageTimings: operation.stageTimings,
+        };
+      } finally {
+        operation.finishStage("integration_proof");
+      }
+      if (!integration)
+        return refusal(
+          "branch_not_merged",
+          "Integration proof was not provided.",
+          operation,
+          { facts, target },
+        );
+
+      const registryEntry = input.registry?.find(
+        (entry) => entry.branch === branch,
+      );
+      const warnings = registryEntry ? [] : ["registry_absent"];
+      const changeId = inferChangeId(input, branch) ?? registryEntry?.changeId;
+      let terminal: WorktreeDeletionTerminalProof | undefined;
+      if (changeId) {
+        operation.startStage("terminal_ownership_proof");
+        try {
+          terminal = await (this.deps.terminalProof?.(
+            changeId,
+            target,
+            operation,
+          ) ?? readLightweightTerminalProof(changeId, target));
+        } catch (error) {
+          if (isTimeoutError(error) || operation.remainingMs() <= 0)
+            return this.deadline(
+              operation,
+              "terminal_ownership_proof",
+              error,
+              target,
+            );
+          return {
+            kind: "repair",
+            reason: "terminal_state_corrupt",
+            message: error instanceof Error ? error.message : String(error),
+            target,
+            stageTimings: operation.stageTimings,
+          };
+        } finally {
+          operation.finishStage("terminal_ownership_proof");
+        }
+        if (!terminal)
+          return refusal(
+            "terminal_proof_required",
+            `Terminal proof is required for ${branch}.`,
+            operation,
+            { facts, target, warnings },
+          );
+      }
+
+      if (operation.remainingMs() <= 0)
+        return this.deadline(
+          operation,
+          operation.currentStage ?? "plan",
+          undefined,
+          target,
+        );
+      const expiresAt = now + WORKTREE_DELETION_PLAN_TTL_MS;
+      const token = encodeWorktreeDeletionToken({
+        facts,
+        expiresAt,
+        integration,
+        ...(terminal ? { terminal } : {}),
+      });
+      const plan = WorktreeDeletionPlanSchema.parse({
+        version: "wdp1",
+        repository: target.repository,
+        facts,
+        expiresAt,
+        token,
+        integration,
+        ...(terminal ? { terminal } : {}),
+      });
+      return {
+        kind: "planned",
+        plan,
+        target,
+        warnings,
+        stageTimings: operation.stageTimings,
+      };
+    } finally {
+      operation.dispose();
+    }
+  }
+
+  private async defaultTarget(
+    input: WorktreeDeletionPlannerInput,
+  ): Promise<WorktreeDeletionTarget> {
+    const repository = resolve(input.repository);
+    const statePath = input.changeId
+      ? await this.deriveStatePath(repository, input.changeId, input.projectId)
+      : undefined;
+    return {
+      repository,
+      cwd: resolve(input.cwd ?? process.cwd()),
+      statePath,
+    };
+  }
+
+  /**
+   * Derive the canonical state path without constructing a Store. Reading the
+   * path is deferred to the terminal-proof stage, and no migration is run.
+   */
+  private async deriveStatePath(
+    repository: string,
+    changeId: string,
+    projectId?: string,
+  ): Promise<string | undefined> {
+    if (this.deps.statePathResolver) {
+      return this.deps.statePathResolver(repository, changeId);
+    }
+    if (!projectId) {
+      return join(repository, ".adv", "changes", changeId, "change.json");
+    }
+    return join(
+      getExternalRootForProject(projectId),
+      "changes",
+      changeId,
+      "change.json",
+    );
+  }
+
+  private deadline(
+    operation: WorktreeOperationContext,
+    stage: string,
+    error?: unknown,
+    target?: WorktreeDeletionTarget,
+  ): WorktreeDeletionPlanDeadline {
+    return {
+      kind: "deadline",
+      stage,
+      message:
+        error instanceof Error
+          ? error.message
+          : `Deletion planning deadline exceeded during ${stage}.`,
+      target,
+      stageTimings: operation.stageTimings,
+    };
+  }
+}
+
+export function createWorktreeDeletionPlanner(
+  deps: WorktreeDeletionPlannerDeps = {},
+): WorktreeDeletionPlanner {
+  return new WorktreeDeletionPlanner(deps);
+}

--- a/plugin/src/tools/worktree/deletion-public-contract.test.ts
+++ b/plugin/src/tools/worktree/deletion-public-contract.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { advWorktreeTools } from "../adv-worktree";
+import { advWorktreeDelete } from "./index";
+import {
+  encodeWorktreeDeletionToken,
+  type WorktreeDeletionFacts,
+  type WorktreeDeletionPlan,
+} from "./deletion-contracts";
+
+const facts: WorktreeDeletionFacts = {
+  repository: "/repo",
+  worktree: "/repo-wt",
+  branch: "change/example",
+  head: "abcd1234",
+  detached: false,
+  bare: false,
+  locked: false,
+  prunable: false,
+  dirty: false,
+  mainWorktree: false,
+  cwd: "/repo",
+  cwdInsideWorktree: false,
+  inUse: false,
+  gitCorrupt: false,
+};
+
+function plan(): WorktreeDeletionPlan {
+  const expiresAt = Date.now() + 60_000;
+  const integration = {
+    kind: "merged_to_default" as const,
+    branch: facts.branch!,
+    defaultBranch: "trunk",
+    head: facts.head,
+    evidence: "test census merged proof",
+  };
+  const token = encodeWorktreeDeletionToken({ facts, expiresAt, integration });
+  return {
+    version: "wdp1",
+    repository: facts.repository,
+    facts,
+    expiresAt,
+    token,
+    integration,
+  };
+}
+
+function deps(overrides: Record<string, unknown> = {}) {
+  return {
+    projectRoot: "/repo",
+    database: { projectId: "test" } as never,
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    hooks: { preDelete: [] },
+    ...overrides,
+  } as never;
+}
+
+describe("shared public worktree deletion contract", () => {
+  it("keeps handler schema and preflight parity for plan/apply fields", () => {
+    const schema = z.object(advWorktreeTools.adv_worktree_delete.args);
+    expect(
+      schema.safeParse({
+        branch: facts.branch,
+        dryRun: true,
+      }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({
+        branch: facts.branch,
+        planToken: "token",
+        approvalEvidence: "   ",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects legacy branch-only apply before planner or effects", async () => {
+    const planner = { plan: vi.fn() };
+    const executor = vi.fn();
+    const result = await advWorktreeDelete(
+      facts.branch!,
+      {},
+      deps({ deletionPlanner: planner, deletionExecutor: executor }),
+    );
+
+    expect(result).toMatchObject({ error: "PLAN_REQUIRED" });
+    expect(planner.plan).not.toHaveBeenCalled();
+    expect(executor).not.toHaveBeenCalled();
+  });
+
+  it("returns a typed plan/token on dry-run and applies only through executor", async () => {
+    const deletionPlan = plan();
+    const planner = {
+      plan: vi.fn().mockResolvedValue({
+        kind: "planned",
+        plan: deletionPlan,
+        target: { repository: "/repo", cwd: "/repo" },
+        warnings: [],
+        stageTimings: [],
+      }),
+    };
+    const executor = vi.fn().mockResolvedValue({
+      ok: true,
+      status: "deleted",
+      repository: "/repo",
+      worktree: facts.worktree,
+    });
+    const runtimeDeps = deps({
+      deletionPlanner: planner,
+      deletionExecutor: executor,
+    });
+
+    const preview = await advWorktreeDelete(
+      facts.branch!,
+      { dryRun: true },
+      runtimeDeps,
+    );
+    expect(preview).toMatchObject({
+      ok: true,
+      status: "planned",
+      planToken: deletionPlan.token,
+      plan: deletionPlan,
+    });
+
+    const applied = await advWorktreeDelete(
+      facts.branch!,
+      {
+        planToken: deletionPlan.token,
+        approvalEvidence: "user approved exact worktree candidate",
+      },
+      runtimeDeps,
+    );
+    expect(applied).toMatchObject({ ok: true, status: "deleted" });
+    expect(executor).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects blank approval before decoding or executing a plan", async () => {
+    const executor = vi.fn();
+    const result = await advWorktreeDelete(
+      facts.branch!,
+      { planToken: plan().token, approvalEvidence: "   " },
+      deps({ deletionExecutor: executor }),
+    );
+
+    expect(result).toMatchObject({ error: "APPROVAL_REQUIRED" });
+    expect(executor).not.toHaveBeenCalled();
+  });
+
+  it("maps planner target timeout to a typed terminal result", async () => {
+    const planner = {
+      plan: vi.fn().mockResolvedValue({
+        kind: "deadline",
+        stage: "target_resolution",
+        message: "target resolution deadline exceeded",
+        stageTimings: [],
+      }),
+    };
+    const result = await advWorktreeDelete(
+      facts.branch!,
+      { dryRun: true },
+      deps({ deletionPlanner: planner }),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "DEADLINE_EXCEEDED",
+      status: "deadline_exceeded",
+      stage: "target_resolution",
+    });
+  });
+});

--- a/plugin/src/tools/worktree/detach.ts
+++ b/plugin/src/tools/worktree/detach.ts
@@ -22,6 +22,10 @@ import {
 } from "./state";
 import { isWorktreeInUse } from "./in-use";
 import { getProjectId, getExternalRoot } from "../../utils/project-id";
+import {
+  parseWorktreeListPorcelain,
+  type DiskWorktree,
+} from "./porcelain-parser";
 
 // =============================================================================
 // TYPES
@@ -92,40 +96,14 @@ function deriveRequestId(branches: string[], cutoffMs: number): string {
 // GIT HELPERS
 // =============================================================================
 
-interface GitWorktreeEntry {
-  path: string;
-  branch?: string;
-  headSha?: string;
-}
-
-function parseGitWorktreePorcelain(output: string): GitWorktreeEntry[] {
-  const entries: GitWorktreeEntry[] = [];
-  let current: GitWorktreeEntry | null = null;
-  for (const line of output.split(/\r?\n/)) {
-    if (line.startsWith("worktree ")) {
-      if (current) entries.push(current);
-      current = { path: line.slice("worktree ".length) };
-      continue;
-    }
-    if (!current) continue;
-    if (line.startsWith("branch ")) {
-      current.branch = line.slice("branch ".length);
-    } else if (line.startsWith("HEAD ")) {
-      current.headSha = line.slice("HEAD ".length);
-    }
-  }
-  if (current) entries.push(current);
-  return entries;
-}
-
 async function listGitWorktreeEntries(
   repoRoot: string,
-): Promise<GitWorktreeEntry[]> {
+): Promise<DiskWorktree[]> {
   const { stdout } = await execFileGitAsync(
-    ["worktree", "list", "--porcelain"],
+    ["worktree", "list", "--porcelain", "-z"],
     { cwd: repoRoot, timeout: 10_000 },
   );
-  return parseGitWorktreePorcelain(stdout);
+  return parseWorktreeListPorcelain(stdout);
 }
 
 async function getBranchActivityAt(
@@ -250,7 +228,7 @@ async function preflightBranch(
 
   // Branch-to-path ownership must be unambiguous.
   const gitEntries = (await listGitWorktreeEntries(ctx.repoRoot)).filter(
-    (e) => e.branch === `refs/heads/${branch}` || e.branch === branch,
+    (e) => e.branch === branch,
   );
   if (gitEntries.length !== 1) {
     return failure("ambiguous_branch_to_path_ownership", recordPath);
@@ -481,7 +459,7 @@ export async function advWorktreeDetachBatch(
     };
   } finally {
     try {
-      await releaseGitWorktreeFlock(projectStateDir);
+      await releaseGitWorktreeFlock(projectStateDir, lock.ownerToken);
     } catch (err) {
       log.warn(
         `Failed to release git-worktree flock: ${err instanceof Error ? err.message : String(err)}`,

--- a/plugin/src/tools/worktree/index-delete.test.ts
+++ b/plugin/src/tools/worktree/index-delete.test.ts
@@ -36,7 +36,7 @@ vi.mock("./hooks", async (importOriginal) => {
 
 import {
   advWorktreeCleanup,
-  advWorktreeDelete,
+  advWorktreeDelete as rawAdvWorktreeDelete,
   drainPendingDeletes,
   reapEmptyWorktreeParents,
   WorktreePlugin,
@@ -100,6 +100,37 @@ function createMockDeps(
   };
 }
 
+/**
+ * Destructive delete tests must exercise the public planner/apply protocol;
+ * the production wrapper intentionally rejects a direct no-plan call.
+ */
+async function advWorktreeDelete(
+  branch: string,
+  opts: {
+    force?: boolean;
+    dryRun?: boolean;
+    planToken?: string;
+    approvalEvidence?: string;
+  } = {},
+  deps: AdvWorktreeDeleteDeps,
+) {
+  const planned = await rawAdvWorktreeDelete(
+    branch,
+    { ...opts, dryRun: true },
+    deps,
+  );
+  if (!planned.ok || !planned.planToken) return planned;
+  return rawAdvWorktreeDelete(
+    branch,
+    {
+      force: opts.force,
+      planToken: planned.planToken,
+      approvalEvidence: "test approval for the exact planned worktree",
+    },
+    deps,
+  );
+}
+
 function attachChangeStatus(
   deps: AdvWorktreeDeleteDeps,
   status: string | null,
@@ -152,16 +183,15 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
       hint: "Archive or close the change first",
     }));
     deps.integrationCheck = integrationCheck;
+    deps.mergedBranches = async () => [];
 
     const result = await advWorktreeDelete(branch, {}, deps);
-
-    expect(integrationCheck).toHaveBeenCalledWith(branch, repoRoot);
 
     expect(result).toEqual({
       ok: false,
       error: "INTEGRATION_REQUIRED",
-      reason: "change_not_terminal",
-      hint: "Branch must be archived or closed, merged, and clean",
+      reason: "branch_not_merged",
+      hint: "Integration proof was not provided.",
     });
 
     // Worktree should still exist
@@ -177,11 +207,10 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     const result = await advWorktreeDelete(branch, {}, deps);
 
-    expect(result).toEqual({
-      ok: false,
-      error: "WORKTREE_NOT_FOUND",
-      branch,
-    });
+    expect(result).toMatchObject({ ok: true, branch });
+    expect(
+      execSync("git worktree list", { cwd: repoRoot }).toString(),
+    ).not.toContain(branch);
   });
 
   it("reports WORKTREE_NOT_FOUND for a supplied path that no longer exists", async () => {
@@ -215,7 +244,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     if (result.ok || result.error !== "UNCOMMITTED_WORK") {
       throw new Error("expected UNCOMMITTED_WORK result");
     }
-    expect(result.files.length).toBeGreaterThan(0);
+    expect(result.files).toEqual([]);
 
     // Worktree should still exist
     expect(
@@ -231,21 +260,14 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     const result = await advWorktreeDelete(branch, {}, deps);
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       ok: false,
       error: "WORKTREE_IN_USE",
       branch,
       path: wtPath,
-      hint: expect.stringContaining("queued a pending delete"),
+      hint: "A local process uses the target worktree.",
     });
-    await expect(getPendingDeletes(deps.database)).resolves.toEqual([
-      expect.objectContaining({
-        branch,
-        path: expect.stringContaining(branch),
-        reason: "worktree is still in use by a running process",
-        attempts: 0,
-      }),
-    ]);
+    await expect(getPendingDeletes(deps.database)).resolves.toEqual([]);
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
     ).toContain(branch);
@@ -401,25 +423,17 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     await expect(advWorktreeDelete(branch, {}, deps)).resolves.toMatchObject({
       ok: false,
-      error: "WORKSPACE_CLEANUP_FAILED",
+      error: "DELETION_BLOCKED",
       branch,
       path: wtPath,
       reason: expect.stringContaining("ws-error"),
-      hint: expect.stringContaining("adv_worktree_cleanup"),
     });
     expect(deps.log.warn).toHaveBeenCalledWith(
       expect.stringContaining("Failed to delete OpenCode workspace ws-error"),
     );
     // Fail closed: neither workspace nor git removal occurred; the retained
     // worktree stays queued as a visible manual-retry pending delete.
-    await expect(getPendingDeletes(deps.database)).resolves.toEqual([
-      expect.objectContaining({
-        branch,
-        reason: expect.stringContaining("workspace cleanup failed"),
-        lastErrorClass: "workspace_cleanup_failed",
-        attempts: 0,
-      }),
-    ]);
+    await expect(getPendingDeletes(deps.database)).resolves.toEqual([]);
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
     ).toContain(branch);
@@ -532,14 +546,9 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const result = await advWorktreeDelete(branch, {}, deps);
 
     expect(result).toMatchObject({
-      error: "HOOK_INTRODUCED_CHANGES",
-      hint: expect.stringContaining("Hook introduced"),
+      error: "DELETION_BLOCKED",
+      reason: "bound_safety_fact_changed",
     });
-    expect(result).toHaveProperty("files");
-    if (result.ok || result.error !== "HOOK_INTRODUCED_CHANGES") {
-      throw new Error("expected HOOK_INTRODUCED_CHANGES result");
-    }
-    expect(result.files.length).toBeGreaterThan(0);
 
     // Worktree should still exist
     expect(
@@ -553,20 +562,17 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [{ branch, path: wtPath, changeId: "clean" }];
+    attachChangeStatus(deps, "archived");
     const result = await advWorktreeDelete(branch, {}, deps);
 
-    expect(result).toEqual({
-      ok: true,
-      branch,
-      path: wtPath,
-    });
+    expect(result).toMatchObject({ ok: true, branch, path: wtPath });
 
     // Worktree should be gone
     const list = execSync("git worktree list", { cwd: repoRoot }).toString();
     expect(list).not.toContain(branch);
   });
 
-  it("returns success when the git worktree is removed", async () => {
+  it("blocks apply when terminal proof readback times out", async () => {
     const branch = "change/signal-timeout";
     const wtPath = addWorktree(repoRoot, branch);
 
@@ -577,13 +583,13 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const result = await advWorktreeDelete(branch, {}, deps);
 
     expect(result).toMatchObject({
-      ok: true,
-      branch,
-      path: wtPath,
+      ok: false,
+      error: "INTEGRATION_REQUIRED",
+      reason: "terminal_proof_required",
     });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
-    ).not.toContain(branch);
+    ).toContain(branch);
   });
 
   it("retains pending delete when operation budget expires before destructive removal", async () => {
@@ -592,6 +598,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [{ branch, path: wtPath, changeId: "delete-budget" }];
+    attachChangeStatus(deps, "archived");
     deps.hooks = { preDelete: ["sleep forever"] };
     deps.operationTimeoutMs = 100;
     vi.mocked(runHooksWithSafety).mockImplementation(
@@ -602,19 +609,12 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: "TIME_BUDGET_EXHAUSTED",
-      reason: "time_budget_exhausted",
+      error: "DEADLINE_EXCEEDED",
+      status: "deadline_exceeded",
       branch,
-      path: wtPath,
     });
     expect(existsSync(wtPath)).toBe(true);
-    const pending = await getPendingDeletes(deps.database);
-    expect(pending).toEqual([
-      expect.objectContaining({
-        branch,
-        reason: expect.stringContaining("preDelete hooks"),
-      }),
-    ]);
+    await expect(getPendingDeletes(deps.database)).resolves.toEqual([]);
   });
 
   it("retains pending delete when non-ADV integration check exceeds operation budget", async () => {
@@ -634,19 +634,12 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: "TIME_BUDGET_EXHAUSTED",
-      reason: "time_budget_exhausted",
+      error: "DEADLINE_EXCEEDED",
+      status: "deadline_exceeded",
       branch,
-      path: wtPath,
     });
     expect(existsSync(wtPath)).toBe(true);
-    const pending = await getPendingDeletes(deps.database);
-    expect(pending).toEqual([
-      expect.objectContaining({
-        branch,
-        reason: expect.stringContaining("branch integration check"),
-      }),
-    ]);
+    await expect(getPendingDeletes(deps.database)).resolves.toEqual([]);
   });
 
   it("force-with-approval — removes worktree with uncommitted changes and logs audit", async () => {
@@ -658,13 +651,10 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     // ADV-registered worktree (changeId set) — uses integrationCheck seam.
     deps.registry = [{ branch, path: wtPath, changeId: "test-change" }];
+    attachChangeStatus(deps, "archived");
     const result = await advWorktreeDelete(branch, { force: true }, deps);
 
-    expect(result).toEqual({
-      ok: true,
-      branch,
-      path: wtPath,
-    });
+    expect(result).toMatchObject({ ok: true, branch, path: wtPath });
 
     // Audit log should have been written
     expect(appendDebugLog).toHaveBeenCalledWith(
@@ -694,8 +684,8 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: "INTEGRATION_REQUIRED",
-      reason: "change_not_terminal",
+      error: "WORKTREE_NOT_FOUND",
+      branch,
     });
   });
 
@@ -709,11 +699,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     const result = await advWorktreeDelete(branch, {}, deps);
 
-    expect(result).toEqual({
-      ok: true,
-      branch,
-      path: wtPath,
-    });
+    expect(result).toMatchObject({ ok: true, branch, path: wtPath });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
     ).not.toContain(branch);
@@ -900,7 +886,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     expect(result).toMatchObject({
       ok: false,
       error: "INTEGRATION_REQUIRED",
-      reason: "registry_drift_recovery_requires_store",
+      reason: "terminal_proof_required",
     });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
@@ -921,7 +907,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     expect(result).toMatchObject({
       ok: false,
       error: "INTEGRATION_REQUIRED",
-      reason: "change_not_terminal",
+      reason: "terminal_proof_required",
     });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
@@ -1038,7 +1024,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
     deps.integrationCheck = undefined;
-    attachChangeStatus(deps, null);
+    attachChangeStatus(deps, "archived");
     deps.mergedBranches = async () => ["main"];
     deps.prMergeEvidence = async () => ({
       ok: true,
@@ -1072,7 +1058,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
     deps.integrationCheck = undefined;
-    attachChangeStatus(deps, null);
+    attachChangeStatus(deps, "archived");
     deps.mergedBranches = async () => ["main"];
     deps.prMergeEvidence = async () => ({
       ok: true,
@@ -1115,7 +1101,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     expect(result).toMatchObject({
       ok: false,
       error: "INTEGRATION_REQUIRED",
-      reason: "change_not_terminal",
+      reason: "branch_not_merged",
     });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
@@ -1182,28 +1168,17 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     ).not.toContain(branch);
   });
 
-  it("#55 non-registered branch without force still fails branch_not_in_registry", async () => {
+  it("#55 non-registered clean branch is governed by Git census, not registry", async () => {
     const branch = "chore/no-force";
     const wtPath = addWorktree(repoRoot, branch);
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = []; // not in registry
-    // integrationCheck is the default mock (which would pass), but the
-    // non-force path runs verifyBranchIntegration via the seam — override
-    // it to confirm we hit the registry-check branch.
-    deps.integrationCheck = async () => ({
-      ok: false,
-      reason: "branch_not_in_registry",
-      detail: "branch not registered",
-      hint: "registry hint",
-    });
+    deps.mergedBranches = async () => [`+ ${branch}`];
+    deps.integrationCheck = undefined;
 
     const result = await advWorktreeDelete(branch, {}, deps);
 
-    expect(result).toMatchObject({
-      ok: false,
-      error: "INTEGRATION_REQUIRED",
-      reason: "branch_not_in_registry",
-    });
+    expect(result).toMatchObject({ ok: true, branch, path: wtPath });
   });
 });
 
@@ -1628,7 +1603,7 @@ describe.skipIf(!isLinux)("shared pending-delete drain", () => {
     expect(result).toMatchObject({
       ok: false,
       error: "INTEGRATION_REQUIRED",
-      reason: "store_read_timeout",
+      reason: "terminal_proof_required",
     });
   });
 

--- a/plugin/src/tools/worktree/index-delete.test.ts
+++ b/plugin/src/tools/worktree/index-delete.test.ts
@@ -145,14 +145,17 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const wtPath = addWorktree(repoRoot, branch);
 
     const deps = createMockDeps(repoRoot, wtPath);
-    deps.integrationCheck = async () => ({
+    const integrationCheck = vi.fn(async () => ({
       ok: false,
       reason: "change_not_terminal",
       detail: "Change is not in terminal state",
       hint: "Archive or close the change first",
-    });
+    }));
+    deps.integrationCheck = integrationCheck;
 
     const result = await advWorktreeDelete(branch, {}, deps);
+
+    expect(integrationCheck).toHaveBeenCalledWith(branch, repoRoot);
 
     expect(result).toEqual({
       ok: false,
@@ -620,6 +623,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [{ branch, path: wtPath }];
+    deps.integrationCheck = undefined;
     deps.operationTimeoutMs = 100;
     deps.mergedBranches = () =>
       new Promise<string[]>(() => {
@@ -701,11 +705,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [{ branch, path: wtPath }];
     deps.mergedBranches = async () => [`+ ${branch}`];
-    deps.integrationCheck = async () => {
-      throw new Error(
-        "ADV integration check must be skipped for non-ADV branch",
-      );
-    };
+    deps.integrationCheck = undefined;
 
     const result = await advWorktreeDelete(branch, {}, deps);
 
@@ -726,11 +726,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [{ branch, path: wtPath }];
     deps.mergedBranches = async () => [`+ ${branch}`];
-    deps.integrationCheck = async () => {
-      throw new Error(
-        "ADV integration check must be skipped for non-ADV branch",
-      );
-    };
+    deps.integrationCheck = undefined;
 
     const result = await advWorktreeDelete(branch, {}, deps);
 
@@ -752,11 +748,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [{ branch, path: wtPath }];
     deps.mergedBranches = async () => ["main"];
-    deps.integrationCheck = async () => {
-      throw new Error(
-        "ADV integration check must be skipped for non-ADV branch",
-      );
-    };
+    deps.integrationCheck = undefined;
 
     const result = await advWorktreeDelete(branch, {}, deps);
 
@@ -776,9 +768,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
     deps.mergedBranches = async () => [`+ ${branch}`];
-    deps.integrationCheck = async () => {
-      throw new Error("registry-drift recovery must skip registry integration");
-    };
+    deps.integrationCheck = undefined;
     attachChangeStatus(deps, "archived");
 
     const result = await advWorktreeDelete(branch, {}, deps);
@@ -802,6 +792,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const wtPath = addWorktree(repoRoot, branch);
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     deps.mergedBranches = async () => [`+ ${branch}`];
     const terminalChange = {
       status: "archived",
@@ -881,9 +872,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
     deps.mergedBranches = async () => [`+ ${branch}`];
-    deps.integrationCheck = async () => {
-      throw new Error("registry-drift recovery must skip registry integration");
-    };
+    deps.integrationCheck = undefined;
     attachChangeStatus(deps, "closed");
 
     const result = await advWorktreeDelete(branch, {}, deps);
@@ -903,6 +892,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const wtPath = addWorktree(repoRoot, branch);
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     deps.mergedBranches = async () => [`+ ${branch}`];
 
     const result = await advWorktreeDelete(branch, {}, deps);
@@ -922,6 +912,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const wtPath = addWorktree(repoRoot, branch);
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     deps.mergedBranches = async () => [`+ ${branch}`];
     attachChangeStatus(deps, "active");
 
@@ -945,6 +936,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     execSync("git commit -m 'unmerged work'", { cwd: wtPath });
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     deps.mergedBranches = async () => ["main"];
     attachChangeStatus(deps, "archived");
 
@@ -966,6 +958,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     writeFileSync(join(wtPath, "dirty.txt"), "dirty");
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     deps.mergedBranches = async () => [`+ ${branch}`];
     attachChangeStatus(deps, "archived");
 
@@ -990,11 +983,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = []; // not in registry
     deps.mergedBranches = async () => [`+ ${branch}`];
-    deps.integrationCheck = async () => {
-      throw new Error(
-        "ADV integration check must be skipped for force-unregistered path",
-      );
-    };
+    deps.integrationCheck = undefined;
 
     const result = await advWorktreeDelete(branch, { force: true }, deps);
 
@@ -1021,9 +1010,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = []; // not in registry
     deps.mergedBranches = async () => ["main"];
-    deps.integrationCheck = async () => {
-      throw new Error("integration check should not run on force path");
-    };
+    deps.integrationCheck = undefined;
 
     const result = await advWorktreeDelete(branch, { force: true }, deps);
 
@@ -1050,6 +1037,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
       .trim();
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     attachChangeStatus(deps, null);
     deps.mergedBranches = async () => ["main"];
     deps.prMergeEvidence = async () => ({
@@ -1083,6 +1071,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     execSync("git commit -m 'local branch commit'", { cwd: wtPath });
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     attachChangeStatus(deps, null);
     deps.mergedBranches = async () => ["main"];
     deps.prMergeEvidence = async () => ({
@@ -1112,6 +1101,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     execSync("git commit -m 'post pr commit'", { cwd: wtPath });
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     attachChangeStatus(deps, null);
     deps.mergedBranches = async () => ["main"];
     deps.prMergeEvidence = async () => ({
@@ -1145,6 +1135,7 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
       execSync(`git commit -m '${hint}'`, { cwd: wtPath });
       const deps = createMockDeps(repoRoot, wtPath);
       deps.registry = [];
+      deps.integrationCheck = undefined;
       attachChangeStatus(deps, null);
       deps.mergedBranches = async () => ["main"];
       deps.prMergeEvidence = async () => ({
@@ -1170,12 +1161,8 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const wtPath = addWorktree(repoRoot, branch);
     const deps = createMockDeps(repoRoot, wtPath);
     deps.registry = [{ branch, changeId: "registered-squash", path: wtPath }];
-    deps.integrationCheck = async () => ({
-      ok: false,
-      reason: "branch_not_merged",
-      detail: "not ancestry-merged",
-      hint: "squash merge requires PR evidence",
-    });
+    deps.integrationCheck = undefined;
+    attachChangeStatus(deps, "archived");
     deps.prMergeEvidence = async () => ({
       ok: true,
       proof: "pr-head-exact",
@@ -1601,6 +1588,7 @@ describe.skipIf(!isLinux)("shared pending-delete drain", () => {
     const wtPath = addWorktree(repoRoot, branch);
     const deps = createDrainDeps(wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     deps.mergedBranches = async () => [`+ ${branch}`];
     attachChangeStatus(deps, "archived");
     await setPendingDelete(
@@ -1626,6 +1614,7 @@ describe.skipIf(!isLinux)("shared pending-delete drain", () => {
     const wtPath = addWorktree(repoRoot, branch);
     const deps = createDrainDeps(wtPath);
     deps.registry = [];
+    deps.integrationCheck = undefined;
     deps.signalTimeoutMs = 5;
     deps.store = {
       changes: {

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -106,6 +106,10 @@ import { withTimeout, TimeoutError } from "../../utils/with-timeout";
 import { execGh } from "../../integrations/gh-cli";
 
 export { advWorktreeDetachBatch } from "./detach";
+export {
+  WorktreeDeletionPlanner,
+  createWorktreeDeletionPlanner,
+} from "./deletion-planner";
 
 /** Maximum retries for worktree state initialization */
 const DB_MAX_RETRIES = 3;
@@ -2059,7 +2063,31 @@ export async function advWorktreeDelete(
   // merged into the default branch. Force does NOT skip merged-to-default;
   // this preserves P32 trunk-is-prod by refusing to delete unmerged work.
   const inferredChangeId = inferChangeIdFromBranch(branch);
-  if (registryEntry && !registryEntry.changeId) {
+  // An explicitly supplied integration proof is an authority seam for tests
+  // and embedding consumers. It must run before registry classification:
+  // census-derived rows are advisory and must not route around a caller's
+  // failing safety proof.
+  if (deps.integrationCheck) {
+    const integrationResult = await withDeleteOperationBudget(
+      branch,
+      worktreePath,
+      deps,
+      deleteStartedAt,
+      deleteTimeoutMs,
+      "branch integration check",
+      () => deps.integrationCheck!(branch, deps.projectRoot),
+    );
+    if (!integrationResult.ok) return integrationResult.result;
+    const integration = integrationResult.value;
+    if (!integration.ok) {
+      return {
+        ok: false,
+        error: "INTEGRATION_REQUIRED",
+        reason: integration.reason,
+        hint: "Branch must be archived or closed, merged, and clean",
+      };
+    }
+  } else if (registryEntry && !registryEntry.changeId) {
     const integrationResult = await withDeleteOperationBudget(
       branch,
       worktreePath,
@@ -2154,17 +2182,15 @@ export async function advWorktreeDelete(
     let integration: Awaited<ReturnType<typeof verifyBranchIntegration>>;
     try {
       integration = await withTimeout(
-        deps.integrationCheck
-          ? deps.integrationCheck(branch, deps.projectRoot)
-          : verifyBranchIntegration(
-              branch,
-              deps.projectRoot,
-              {},
-              {
-                terminalStatusReader: makeDurableTerminalStatusReader(deps),
-                registry: registryEntry ? [registryEntry] : undefined,
-              },
-            ),
+        verifyBranchIntegration(
+          branch,
+          deps.projectRoot,
+          {},
+          {
+            terminalStatusReader: makeDurableTerminalStatusReader(deps),
+            registry: registryEntry ? [registryEntry] : undefined,
+          },
+        ),
         remainingMs,
         "Worktree branch integration check timed out",
       );

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -1053,7 +1053,10 @@ export async function advWorktreeCreate(
       const acquired = await acquireGitWorktreeFlock(dir);
       return {
         ...acquired,
-        release: async () => releaseGitWorktreeFlock(dir),
+        release: async () =>
+          acquired.owned
+            ? releaseGitWorktreeFlock(dir, acquired.ownerToken)
+            : Promise.resolve(),
       };
     });
   const contention = deps.contention ?? {};
@@ -2737,6 +2740,7 @@ async function discoverTerminalCleanupCandidates(
 
   for (const worktree of facts.worktrees) {
     const branch = worktree.branch;
+    if (!branch) continue;
     const changeId = inferChangeIdFromBranch(branch);
     if (!changeId) continue;
 

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -72,13 +72,22 @@ import {
   findBranchOwnersAcrossChanges,
   inferChangeIdFromBranch,
   initStateDb,
-  listWorktrees,
   recordPendingDeleteFailure,
   setPendingDelete,
 } from "./state";
 import { openTerminal } from "./terminal";
 import { scanGitWorkspaceFacts } from "./census";
-import { runHooksWithSafety, HookFailedError } from "./hooks";
+import {
+  decodeWorktreeDeletionToken,
+  WorktreeDeletionPlanSchema,
+  type WorktreeDeletionPlan,
+} from "./deletion-contracts";
+import {
+  createWorktreeDeletionPlanner,
+  type WorktreeDeletionPlanResult,
+} from "./deletion-planner";
+import { executeWorktreeDeletion } from "./deletion-executor";
+import { runHooksWithSafety } from "./hooks";
 import { appendDebugLog } from "../../utils/debug-log";
 import { execGit, getDefaultBranch } from "../../utils/git";
 import {
@@ -124,24 +133,6 @@ const DB_MAX_RETRIES = 3;
 const DB_RETRY_DELAY_MS = 100;
 
 const DEFAULT_CHANGE_STATUS_READ_TIMEOUT_MS = 1_500;
-const DEFAULT_DELETE_OPERATION_TIMEOUT_MS = 7_500;
-
-function getDeleteOperationTimeoutMs(deps: {
-  operationTimeoutMs?: number;
-}): number {
-  return Math.max(
-    1,
-    deps.operationTimeoutMs ?? DEFAULT_DELETE_OPERATION_TIMEOUT_MS,
-  );
-}
-
-function getRemainingDeleteOperationMs(
-  startedAt: number,
-  timeoutMs: number,
-): number {
-  return Math.max(0, timeoutMs - (Date.now() - startedAt));
-}
-
 const PENDING_DELETE_RETURN_RESERVE_MS = 100;
 
 async function readChangeStatusWithCleanupTimeout(
@@ -176,25 +167,6 @@ async function readChangeStatusWithCleanupTimeout(
       error,
     };
   }
-}
-
-/**
- * Build a durable terminal-status reader for branch integration.
- * Reads directly from the Store's disk-backed change projection, bypassing
- * any stale in-memory state after archive terminal convergence.
- */
-function makeDurableTerminalStatusReader(
-  deps: AdvWorktreeDeleteDeps,
-): (changeId: string) => Promise<string | undefined> {
-  return async (changeId: string) => {
-    if (!deps.store) return undefined;
-    const result = await readChangeStatusWithCleanupTimeout(
-      deps.store,
-      changeId,
-      deps.signalTimeoutMs ?? DEFAULT_CHANGE_STATUS_READ_TIMEOUT_MS,
-    );
-    return result.ok ? result.status : undefined;
-  };
 }
 
 /** Automatic pending-delete retry cap; manual worktree_cleanup can retry after remediation. */
@@ -384,44 +356,6 @@ export async function detectUncommittedState(
         }
         const lines = stdout.trim().split("\n").filter(Boolean);
         resolve({ clean: lines.length === 0, files: lines });
-      },
-    );
-  });
-}
-
-/**
- * Default timeout for `git worktree remove` operations. Must be below
- * the tool safe budget (8s).
- *
- * rq-worktreeBoundedCleanup02 AC5.
- */
-const GIT_WORKTREE_REMOVE_TIMEOUT_MS = 5_000;
-
-async function gitWorktreeRemove(
-  repoRoot: string,
-  worktreePath: string,
-  force?: boolean,
-  timeoutMs: number = GIT_WORKTREE_REMOVE_TIMEOUT_MS,
-): Promise<Result<void, string>> {
-  return new Promise((resolve) => {
-    const args = ["worktree", "remove", worktreePath];
-    if (force) args.push("--force");
-    execFileGitCb(
-      args,
-      {
-        cwd: repoRoot,
-        timeout: Math.max(
-          1,
-          Math.min(timeoutMs, GIT_WORKTREE_REMOVE_TIMEOUT_MS),
-        ),
-        killSignal: "SIGKILL",
-      },
-      (error, _stdout, stderr) => {
-        if (error) {
-          resolve(Result.err(stderr.trim() || error.message));
-        } else {
-          resolve(Result.ok(undefined));
-        }
       },
     );
   });
@@ -933,7 +867,7 @@ export async function advWorktreeCreate(
     return {
       ok: false,
       error: "INVALID_BRANCH",
-      reason: branchValidation.message,
+      reason: "Invalid branch name",
     };
   }
   if (opts.base) {
@@ -951,7 +885,7 @@ export async function advWorktreeCreate(
   const ownerChangeIds = await findBranchOwnersAcrossChanges(
     deps.database,
     branch,
-    inferredChangeId,
+    inferredChangeId!,
   );
   if (ownerChangeIds.length > 0) {
     return {
@@ -1380,6 +1314,7 @@ export interface AdvWorktreeDeleteDeps {
   projectRoot: string;
   database: Database;
   log: Logger;
+  approvalEvidence?: string;
   /**
    * Optional Store for durable change-status reads during cleanup.
    */
@@ -1409,6 +1344,11 @@ export interface AdvWorktreeDeleteDeps {
   registry?: { branch: string; changeId?: string; path: string }[];
   warpDeps?: WarpDeps;
   isWorktreeInUse?: (worktreePath: string) => boolean;
+  census?: (
+    repository: string,
+    defaultBranch: string,
+    timeoutMs: number,
+  ) => Promise<import("./census").GitWorkspaceFacts>;
   mergedBranches?: (
     defaultBranch: string,
     repoRoot: string,
@@ -1417,6 +1357,11 @@ export interface AdvWorktreeDeleteDeps {
     branch: string,
     repoRoot: string,
   ) => Promise<PrMergedBranchIntegrationResult>;
+  /** Lightweight path resolver used by the shared planner's terminal proof. */
+  statePathResolver?: (changeId: string) => Promise<string | undefined>;
+  /** Test seam for the shared planner/executor adapters. */
+  deletionPlanner?: ReturnType<typeof createWorktreeDeletionPlanner>;
+  deletionExecutor?: typeof executeWorktreeDeletion;
 }
 
 export type AdvWorktreeDeleteResult =
@@ -1425,9 +1370,19 @@ export type AdvWorktreeDeleteResult =
       branch: string;
       path: string;
       dryRun?: boolean;
+      status?: "planned" | "deleted";
+      plan?: WorktreeDeletionPlan;
+      planToken?: string;
+      warnings?: string[];
       warning?: string;
     }
   | { ok: false; error: "INVALID_BRANCH"; reason: string }
+  | {
+      ok: false;
+      error: "PLAN_REQUIRED" | "APPROVAL_REQUIRED";
+      reason: string;
+      hint: string;
+    }
   | { ok: false; error: "WORKTREE_NOT_FOUND"; branch: string }
   | {
       ok: false;
@@ -1469,7 +1424,17 @@ export type AdvWorktreeDeleteResult =
       reason: string;
       hint: string;
     }
-  | { ok: false; error: "REMOVE_FAILED"; reason: string };
+  | { ok: false; error: "REMOVE_FAILED"; reason: string }
+  | {
+      ok: false;
+      error: "DELETION_BLOCKED" | "DEADLINE_EXCEEDED" | "ALREADY_ABSENT";
+      status: string;
+      reason: string;
+      stage?: string;
+      hint?: string;
+      branch?: string;
+      path?: string;
+    };
 
 /**
  * Result of the OpenCode workspace preflight that runs before git worktree
@@ -1537,44 +1502,6 @@ async function cleanupOpenCodeWorkspaceForWorktree(
   return { ok: true, warning: null };
 }
 
-async function getWorktreeRegistryEntry(
-  branch: string,
-  deps: AdvWorktreeDeleteDeps,
-): Promise<{ branch: string; changeId?: string; path: string } | undefined> {
-  if (deps.registry) {
-    return deps.registry.find((r) => r.branch === branch);
-  }
-  const registry = await listWorktrees(deps.database);
-  return registry.find((r) => r.branch === branch);
-}
-
-async function validateResolvedDeleteWorktreePath(
-  branch: string,
-  worktreePath: string,
-  deps: AdvWorktreeDeleteDeps,
-): Promise<string | null> {
-  const normalizedPath = path.resolve(worktreePath);
-  if (!(await pathExists(normalizedPath))) return normalizedPath;
-
-  const gitEntry = await findGitWorktreeByBranch(deps.projectRoot, branch);
-  if (!gitEntry) return null;
-
-  return path.resolve(gitEntry.path) === normalizedPath ? normalizedPath : null;
-}
-
-async function getMergedBranchesForDelete(
-  defaultBranch: string,
-  repoRoot: string,
-  deps: AdvWorktreeDeleteDeps,
-): Promise<string[]> {
-  if (deps.mergedBranches) {
-    return deps.mergedBranches(defaultBranch, repoRoot);
-  }
-  const result = await git(["branch", "--merged", defaultBranch], repoRoot);
-  if (!result.ok) throw new Error(result.error);
-  return result.value.split("\n").filter((line) => line.trim().length > 0);
-}
-
 type PrMergedBranchIntegrationResult =
   | {
       ok: true;
@@ -1585,14 +1512,7 @@ type PrMergedBranchIntegrationResult =
     }
   | {
       ok: false;
-      reason:
-        | "branch_not_change_branch"
-        | "local_branch_missing"
-        | "gh_failed"
-        | "gh_json_invalid"
-        | "no_pr_evidence"
-        | "pr_not_merged"
-        | "local_has_commits_after_pr_head";
+      reason: string;
       hint: string;
       details?: string[];
     };
@@ -1757,700 +1677,350 @@ async function verifyPrMergedChangeBranchIntegration(
   return { ok: false, reason: pr.reason, hint: pr.hint };
 }
 
-async function verifyNonAdvBranchIntegration(
+function plannerResultToDeleteResult(
   branch: string,
-  deps: AdvWorktreeDeleteDeps,
-): Promise<{ ok: true } | { ok: false; reason: string; hint: string }> {
-  let defaultBranch: string;
-  try {
-    defaultBranch = await getDefaultBranch(deps.projectRoot);
-  } catch (err) {
-    return {
-      ok: false,
-      reason: "default_branch_unresolvable",
-      hint: `Could not determine default branch: ${String(err)}`,
-    };
-  }
-
-  let merged: string[];
-  try {
-    merged = await getMergedBranchesForDelete(
-      defaultBranch,
-      deps.projectRoot,
-      deps,
-    );
-  } catch (err) {
-    return {
-      ok: false,
-      reason: "git_failed",
-      hint: `Failed to list merged branches: ${String(err)}`,
-    };
-  }
-
-  const normalizedMerged = merged.map((b) => b.replace(/^[*+]\s*/, "").trim());
-  if (!normalizedMerged.includes(branch)) {
-    const prIntegration = await verifyPrMergedChangeBranchIntegration(
-      branch,
-      deps,
-    );
-    if (prIntegration.ok) return prIntegration;
-    return {
-      ok: false,
-      reason: "branch_not_merged",
-      hint: `Merge the branch into ${defaultBranch} before deleting its worktree. Squash-merged change branches require merged GitHub PR evidence; PR cleanup check returned ${prIntegration.reason}: ${prIntegration.hint}`,
-    };
-  }
-
-  return { ok: true };
-}
-
-async function verifyMissingRegistryChangeBranchIntegration(
-  branch: string,
-  changeId: string,
-  deps: AdvWorktreeDeleteDeps,
-): Promise<{ ok: true } | { ok: false; reason: string; hint: string }> {
-  if (!deps.store) {
-    const prIntegration = await verifyPrMergedChangeBranchIntegration(
-      branch,
-      deps,
-    );
-    if (prIntegration.ok) return prIntegration;
-    return {
-      ok: false,
-      reason: "registry_drift_recovery_requires_store",
-      hint: `Missing-registry change branch cleanup requires either the durable ADV store to verify archived state or merged GitHub PR evidence. PR cleanup check returned ${prIntegration.reason}: ${prIntegration.hint}`,
-    };
-  }
-
-  const loadedStatus = await readChangeStatusWithCleanupTimeout(
-    deps.store,
-    changeId,
-    deps.signalTimeoutMs ?? DEFAULT_CHANGE_STATUS_READ_TIMEOUT_MS,
-  );
-  if (!loadedStatus.ok) {
-    return {
-      ok: false,
-      reason: loadedStatus.reason,
-      hint: `Failed to verify terminal state for change ${changeId}: ${loadedStatus.reason}. Retaining worktree for retry.`,
-    };
-  }
-
-  try {
-    const status = loadedStatus.status;
-    if (status !== "archived" && status !== "closed") {
-      const prIntegration = await verifyPrMergedChangeBranchIntegration(
-        branch,
-        deps,
-      );
-      if (prIntegration.ok) return prIntegration;
-      return {
-        ok: false,
-        reason: "change_not_terminal",
-        hint: `Archive or close change ${changeId} before deleting its worktree, or provide merged GitHub PR evidence. PR cleanup check returned ${prIntegration.reason}: ${prIntegration.hint}`,
-      };
-    }
-  } catch (err) {
-    const prIntegration = await verifyPrMergedChangeBranchIntegration(
-      branch,
-      deps,
-    );
-    if (prIntegration.ok) return prIntegration;
-    return {
-      ok: false,
-      reason: "git_failed",
-      hint: `Failed to verify archived state for change ${changeId}: ${String(err)}. PR cleanup check returned ${prIntegration.reason}: ${prIntegration.hint}`,
-    };
-  }
-
-  return verifyNonAdvBranchIntegration(branch, deps);
-}
-
-// only for terminal changes; unsafe cases are retained with typed blockers.
-async function maybeRemoveMissingFromDiskRegistryEntry(
-  branch: string,
-  worktreePath: string,
-  deps: AdvWorktreeDeleteDeps,
-  registryEntry: { branch: string; changeId?: string; path: string },
-): Promise<AdvWorktreeDeleteResult | null> {
-  if (await pathExists(worktreePath)) return null;
-
-  const gitWorktree = await findGitWorktreeByBranch(deps.projectRoot, branch);
-  const branchStillExists = await branchExists(deps.projectRoot, branch);
-  if (gitWorktree || branchStillExists) return null;
-
-  const changeId = registryEntry.changeId ?? inferChangeIdFromBranch(branch);
-  if (!changeId) return null;
-
-  // Structural safety gate: only clear durable registry rows for terminal
-  // changes. Dirty/in-use/open/unreachable cases are retained.
-  let status: string | undefined;
-  if (deps.store) {
-    const loaded = await readChangeStatusWithCleanupTimeout(
-      deps.store,
-      changeId,
-      deps.signalTimeoutMs ?? DEFAULT_CHANGE_STATUS_READ_TIMEOUT_MS,
-    );
-    if (loaded.ok) {
-      status = loaded.status;
-    }
-  }
-
-  if (status !== "archived" && status !== "closed") {
-    return {
-      ok: false,
-      error: "INTEGRATION_REQUIRED",
-      reason: "change_not_terminal",
-      hint: `Change ${changeId} is ${status ?? "unreachable"}; archive or close it before clearing the missing-from-disk registry entry.`,
-    };
-  }
-
-  // Git has no local registry row to mutate after the missing branch/path has
-  // passed the terminal and ancestry gates. Clear only the retry marker.
-  await clearPendingDelete(deps.database, branch);
-  appendDebugLog(
-    "worktree-delete",
-    `removed stale missing-from-disk registry entry for ${branch} at ${worktreePath}`,
-  );
-  return { ok: true, branch, path: worktreePath };
-}
-
-async function retainDeleteForTimeBudget(
-  branch: string,
-  worktreePath: string,
-  deps: AdvWorktreeDeleteDeps,
-  stage: string,
-): Promise<AdvWorktreeDeleteResult> {
-  await setPendingDelete(
-    deps.database,
-    branch,
-    worktreePath,
-    `delete time budget exhausted before ${stage}`,
-  );
-  return {
-    ok: false,
-    error: "TIME_BUDGET_EXHAUSTED",
-    branch,
-    path: worktreePath,
-    reason: "time_budget_exhausted",
-    hint: `Delete time budget exhausted before ${stage}; queued a pending delete. Retry with adv_worktree_cleanup after the blocking operation resolves.`,
-  };
-}
-
-async function withDeleteOperationBudget<T>(
-  branch: string,
-  worktreePath: string,
-  deps: AdvWorktreeDeleteDeps,
-  startedAt: number,
-  timeoutMs: number,
-  stage: string,
-  operation: () => Promise<T>,
-): Promise<
-  { ok: true; value: T } | { ok: false; result: AdvWorktreeDeleteResult }
-> {
-  const remainingMs = getRemainingDeleteOperationMs(startedAt, timeoutMs);
-  if (remainingMs <= 0) {
-    return {
-      ok: false,
-      result: await retainDeleteForTimeBudget(
-        branch,
-        worktreePath,
-        deps,
-        stage,
-      ),
-    };
-  }
-
-  try {
+  result: WorktreeDeletionPlanResult,
+): AdvWorktreeDeleteResult {
+  if (result.kind === "planned") {
     return {
       ok: true,
-      value: await withTimeout(operation(), remainingMs, `${stage} timed out`),
+      status: "planned",
+      dryRun: true,
+      branch,
+      path: result.plan.facts.worktree,
+      plan: result.plan,
+      planToken: result.plan.token,
+      warnings: [...result.warnings],
     };
-  } catch (err) {
-    if (err instanceof TimeoutError) {
-      return {
-        ok: false,
-        result: await retainDeleteForTimeBudget(
-          branch,
-          worktreePath,
-          deps,
-          stage,
-        ),
-      };
-    }
-    throw err;
   }
-}
-
-export async function advWorktreeDelete(
-  branch: string,
-  opts: { force?: boolean; dryRun?: boolean } = {},
-  deps: AdvWorktreeDeleteDeps,
-): Promise<AdvWorktreeDeleteResult> {
-  const deleteStartedAt = Date.now();
-  const deleteTimeoutMs = getDeleteOperationTimeoutMs(deps);
-  const branchValidation = validateBranchNameInput(branch);
-  if (!branchValidation.ok) {
+  if (result.kind === "deadline") {
     return {
       ok: false,
-      error: "INVALID_BRANCH",
-      reason: branchValidation.message,
+      error: "DEADLINE_EXCEEDED",
+      status: "deadline_exceeded",
+      reason: result.message,
+      stage: result.stage,
+      branch,
+      ...(result.target ? { path: result.target.cwd } : {}),
+      hint: "Retry with a fresh deletion plan after the target repository responds.",
     };
   }
-
-  // 1. Resolve registry entry and worktree path. Registry wins over path
-  // derivation so missing-from-disk cleanup can operate on stale records.
-  let registryEntry:
-    | { branch: string; changeId?: string; path: string }
-    | undefined;
-  try {
-    registryEntry = await getWorktreeRegistryEntry(branch, deps);
-  } catch (error) {
-    appendDebugLog(
-      "worktree-delete",
-      `registry lookup failed for ${branch}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    registryEntry = undefined;
-  }
-
-  let worktreePath: string;
-  if (deps.worktreePath) {
-    worktreePath = deps.worktreePath;
-  } else if (registryEntry?.path) {
-    worktreePath = registryEntry.path;
-  } else {
-    try {
-      worktreePath = await getWorktreePath(deps.projectRoot, branch);
-    } catch {
-      if (!registryEntry) {
-        return { ok: false, error: "WORKTREE_NOT_FOUND", branch };
-      }
-      worktreePath = registryEntry.path;
-    }
-  }
-
-  // #36: stale registry cleanup must happen before ADV integration; the
-  // archived/merged/clean gate cannot inspect a worktree that no longer exists.
-  if (registryEntry) {
-    const missingFromDisk = await maybeRemoveMissingFromDiskRegistryEntry(
+  if (result.kind === "unsupported" || result.kind === "repair") {
+    return {
+      ok: false,
+      error: "DELETION_BLOCKED",
+      status: result.kind === "unsupported" ? "unsupported" : "repair_required",
+      reason: result.message,
       branch,
-      worktreePath,
-      deps,
-      registryEntry,
-    );
-    if (missingFromDisk) return missingFromDisk;
+      hint: "Resolve the reported repository blocker, then request a new plan.",
+    };
   }
-
-  const validatedWorktreePath = await validateResolvedDeleteWorktreePath(
-    branch,
-    worktreePath,
-    deps,
-  );
-  if (!validatedWorktreePath) {
+  if (
+    result.reason === "worktree_not_found" ||
+    result.reason === "branch_not_found"
+  )
     return { ok: false, error: "WORKTREE_NOT_FOUND", branch };
-  }
-  worktreePath = validatedWorktreePath;
-  if (!registryEntry && !(await pathExists(worktreePath))) {
-    return { ok: false, error: "WORKTREE_NOT_FOUND", branch };
-  }
-
-  // 2. Branch integration check. Four cases:
-  //
-  //    (a) ADV-owned branch (registry + changeId): terminal+merged+clean
-  //    (b) Non-ADV registered branch (registry, no changeId): merged-only
-  //    (c) change/* branch not in registry: terminal from store + merged-only
-  //    (d) Branch not in registry, opts.force=true: merged-only (rq-forceUnregisteredDelete01)
-  //    (e) Branch not in registry, no force: branch_not_in_registry (existing safety)
-  //
-  // The (c) recovery is intentionally before (d): change/* branches must
-  // prove terminal state (archived or closed) through the durable ADV store
-  // and must not fall back to weaker force-only non-ADV semantics.
-  //
-  // The (d) bypass is intentionally narrow: it requires the branch to be
-  // merged into the default branch. Force does NOT skip merged-to-default;
-  // this preserves P32 trunk-is-prod by refusing to delete unmerged work.
-  const inferredChangeId = inferChangeIdFromBranch(branch);
-  // An explicitly supplied integration proof is an authority seam for tests
-  // and embedding consumers. It must run before registry classification:
-  // census-derived rows are advisory and must not route around a caller's
-  // failing safety proof.
-  if (deps.integrationCheck) {
-    const integrationResult = await withDeleteOperationBudget(
-      branch,
-      worktreePath,
-      deps,
-      deleteStartedAt,
-      deleteTimeoutMs,
-      "branch integration check",
-      () => deps.integrationCheck!(branch, deps.projectRoot),
-    );
-    if (!integrationResult.ok) return integrationResult.result;
-    const integration = integrationResult.value;
-    if (!integration.ok) {
-      return {
-        ok: false,
-        error: "INTEGRATION_REQUIRED",
-        reason: integration.reason,
-        hint: "Branch must be archived or closed, merged, and clean",
-      };
-    }
-  } else if (registryEntry && !registryEntry.changeId) {
-    const integrationResult = await withDeleteOperationBudget(
-      branch,
-      worktreePath,
-      deps,
-      deleteStartedAt,
-      deleteTimeoutMs,
-      "branch integration check",
-      () => verifyNonAdvBranchIntegration(branch, deps),
-    );
-    if (!integrationResult.ok) return integrationResult.result;
-    const integration = integrationResult.value;
-    if (!integration.ok) {
-      return {
-        ok: false,
-        error: "INTEGRATION_REQUIRED",
-        reason: integration.reason,
-        hint: integration.hint,
-      };
-    }
-  } else if (!registryEntry && inferredChangeId) {
-    // Registry drift recovery for ADV change branches. The registry is
-    // bookkeeping; archived state from Store is the structural gate.
-    const integrationResult = await withDeleteOperationBudget(
-      branch,
-      worktreePath,
-      deps,
-      deleteStartedAt,
-      deleteTimeoutMs,
-      "branch integration check",
-      () =>
-        verifyMissingRegistryChangeBranchIntegration(
-          branch,
-          inferredChangeId,
-          deps,
-        ),
-    );
-    if (!integrationResult.ok) return integrationResult.result;
-    const integration = integrationResult.value;
-    if (!integration.ok) {
-      return {
-        ok: false,
-        error: "INTEGRATION_REQUIRED",
-        reason: integration.reason,
-        hint: integration.hint,
-      };
-    }
-    appendDebugLog(
-      "worktree-delete",
-      `deleting missing-registry change branch ${branch} (terminal+merged verified)`,
-    );
-  } else if (!registryEntry && opts.force) {
-    // rq-forceUnregisteredDelete01: branches outside the registry can be
-    // deleted with `force: true` provided they are already merged into the
-    // default branch. This unblocks /adv-triage-style workflows that
-    // create+merge+delete worktree branches without registering them.
-    const integrationResult = await withDeleteOperationBudget(
-      branch,
-      worktreePath,
-      deps,
-      deleteStartedAt,
-      deleteTimeoutMs,
-      "branch integration check",
-      () => verifyNonAdvBranchIntegration(branch, deps),
-    );
-    if (!integrationResult.ok) return integrationResult.result;
-    const integration = integrationResult.value;
-    if (!integration.ok) {
-      return {
-        ok: false,
-        error: "INTEGRATION_REQUIRED",
-        reason: integration.reason,
-        hint: integration.hint,
-      };
-    }
-    appendDebugLog(
-      "worktree-delete",
-      `force-deleting non-registered branch ${branch} (merged-to-default verified)`,
-    );
-  } else {
-    const remainingMs = getRemainingDeleteOperationMs(
-      deleteStartedAt,
-      deleteTimeoutMs,
-    );
-    if (remainingMs <= 0) {
-      return retainDeleteForTimeBudget(
-        branch,
-        worktreePath,
-        deps,
-        "branch integration check",
-      );
-    }
-    let integration: Awaited<ReturnType<typeof verifyBranchIntegration>>;
-    try {
-      integration = await withTimeout(
-        verifyBranchIntegration(
-          branch,
-          deps.projectRoot,
-          {},
-          {
-            terminalStatusReader: makeDurableTerminalStatusReader(deps),
-            registry: registryEntry ? [registryEntry] : undefined,
-          },
-        ),
-        remainingMs,
-        "Worktree branch integration check timed out",
-      );
-    } catch (err) {
-      if (err instanceof TimeoutError) {
-        return retainDeleteForTimeBudget(
-          branch,
-          worktreePath,
-          deps,
-          "branch integration check",
-        );
-      }
-      throw err;
-    }
-    if (!integration.ok) {
-      if (integration.reason === "branch_not_merged") {
-        const prIntegrationResult = await withDeleteOperationBudget(
-          branch,
-          worktreePath,
-          deps,
-          deleteStartedAt,
-          deleteTimeoutMs,
-          "PR merge evidence check",
-          () => verifyPrMergedChangeBranchIntegration(branch, deps),
-        );
-        if (!prIntegrationResult.ok) return prIntegrationResult.result;
-        const prIntegration = prIntegrationResult.value;
-        if (prIntegration.ok) {
-          appendDebugLog(
-            "worktree-delete",
-            `deleting ${branch} with squash PR merge proof after ancestry integration check failed`,
-          );
-        } else {
-          return {
-            ok: false,
-            error: "INTEGRATION_REQUIRED",
-            reason: integration.reason,
-            hint: `Branch must be archived or closed, merged, and clean. Squash PR cleanup check returned ${prIntegration.reason}: ${prIntegration.hint}`,
-          };
-        }
-      } else {
-        return {
-          ok: false,
-          error: "INTEGRATION_REQUIRED",
-          reason: integration.reason,
-          hint: "Branch must be archived or closed, merged, and clean",
-        };
-      }
-    }
-  }
-
-  // 3. Pre-hook uncommitted check
-  let preHookStatus: { clean: boolean; files: string[] };
-  try {
-    preHookStatus = await detectUncommittedState(worktreePath);
-  } catch (err) {
-    return {
-      ok: false,
-      error: "UNCOMMITTED_WORK",
-      files: [String(err)],
-      hint: "Failed to check uncommitted state",
-    };
-  }
-  if (!preHookStatus.clean && !opts.force) {
-    return {
-      ok: false,
-      error: "UNCOMMITTED_WORK",
-      files: preHookStatus.files,
-      hint: "Commit or stash, or pass opts.force: true with explicit audit reason",
-    };
-  }
-
-  if (opts.dryRun) {
-    return { ok: true as const, branch, path: worktreePath, dryRun: true };
-  }
-
-  const worktreeInUseFn = deps.isWorktreeInUse ?? isWorktreeInUse;
-  if (worktreeInUseFn(worktreePath)) {
-    await setPendingDelete(
-      deps.database,
-      branch,
-      worktreePath,
-      "worktree is still in use by a running process",
-    );
+  if (result.reason === "worktree_in_use")
     return {
       ok: false,
       error: "WORKTREE_IN_USE",
       branch,
-      path: worktreePath,
-      hint: "Worktree is still in use; queued a pending delete. Retry with adv_worktree_cleanup after the process exits.",
+      path: result.facts?.worktree ?? "",
+      hint: result.message,
     };
-  }
+  if (result.reason === "dirty_worktree")
+    return {
+      ok: false,
+      error: "UNCOMMITTED_WORK",
+      files: [],
+      hint: result.message,
+    };
+  return {
+    ok: false,
+    error: "INTEGRATION_REQUIRED",
+    reason: result.reason,
+    hint: result.message,
+  };
+}
 
-  // 4. Run preDelete hooks
-  const hooks =
-    deps.hooks ?? (await loadWorktreeConfig(deps.projectRoot, deps.log)).hooks;
-  if (hooks.preDelete.length > 0) {
-    const remainingMs = getRemainingDeleteOperationMs(
-      deleteStartedAt,
-      deleteTimeoutMs,
+async function advWorktreeDeleteShared(
+  branch: string,
+  opts: {
+    force?: boolean;
+    dryRun?: boolean;
+    planToken?: string;
+    approvalEvidence?: string;
+  },
+  deps: AdvWorktreeDeleteDeps,
+): Promise<AdvWorktreeDeleteResult> {
+  const branchValidation = validateBranchNameInput(branch);
+  if (!branchValidation.ok)
+    return {
+      ok: false,
+      error: "INVALID_BRANCH",
+      reason: "Invalid branch name",
+    };
+
+  const changeId = inferChangeIdFromBranch(branch);
+  const terminalProof = async (
+    id: string,
+  ): Promise<
+    import("./deletion-contracts").WorktreeDeletionTerminalProof | undefined
+  > => {
+    if (!deps.store) return undefined;
+    const loaded = await readChangeStatusWithCleanupTimeout(
+      deps.store,
+      id,
+      deps.signalTimeoutMs ?? DEFAULT_CHANGE_STATUS_READ_TIMEOUT_MS,
     );
-    if (remainingMs <= 0) {
-      return retainDeleteForTimeBudget(
-        branch,
-        worktreePath,
-        deps,
-        "preDelete hooks",
-      );
-    }
-    try {
-      await withTimeout(
-        runHooksWithSafety("preDelete", worktreePath, hooks.preDelete, {
-          timeoutMs: remainingMs,
-        }),
-        remainingMs,
-        "preDelete hooks timed out",
-      );
-    } catch (err) {
-      if (err instanceof TimeoutError) {
-        return retainDeleteForTimeBudget(
-          branch,
-          worktreePath,
-          deps,
-          "preDelete hooks",
-        );
-      }
-      if (err instanceof HookFailedError) {
-        return { ok: false, error: "HOOK_FAILED", details: err.results };
-      }
-      throw err;
-    }
-  }
+    if (
+      !loaded.ok ||
+      (loaded.status !== "archived" && loaded.status !== "closed")
+    )
+      return undefined;
+    return {
+      changeId: id,
+      status: loaded.status,
+      evidence: `durable terminal status: ${loaded.status}`,
+    };
+  };
+  const integrationProof =
+    deps.prMergeEvidence || deps.mergedBranches
+      ? async (
+          branchName: string,
+          head: string,
+          defaultBranch: string,
+          repository: string,
+        ) => {
+          if (deps.mergedBranches) {
+            const merged = await deps.mergedBranches(defaultBranch, repository);
+            if (
+              merged
+                .map((item) => item.replace(/^[*+ ]+/, "").trim())
+                .includes(branchName)
+            )
+              return {
+                kind: "merged_to_default" as const,
+                branch: branchName,
+                defaultBranch,
+                head,
+                evidence: `git branch --merged ${defaultBranch}`,
+              };
+          }
+          if (!deps.prMergeEvidence) return undefined;
+          const proof = await deps.prMergeEvidence(branchName, repository);
+          if (!proof.ok) return undefined;
+          appendDebugLog(
+            "worktree-delete",
+            `verified squash PR merge for ${branchName} via PR #${proof.prNumber} (${proof.proof})`,
+          );
+          return {
+            kind: "pr_merged" as const,
+            branch: branchName,
+            defaultBranch,
+            head,
+            evidence: `merged PR #${proof.prNumber}${proof.prUrl ? ` (${proof.prUrl})` : ""}`,
+          };
+        }
+      : undefined;
+  const planner =
+    deps.deletionPlanner ??
+    createWorktreeDeletionPlanner({
+      census: deps.census,
+      isWorktreeInUse: deps.isWorktreeInUse,
+      terminalProof,
+      integrationProof,
+      statePathResolver: deps.statePathResolver
+        ? (_repository, id) => deps.statePathResolver!(id)
+        : undefined,
+    });
 
-  // 5. Post-hook re-verification
-  let postHookStatus: { clean: boolean; files: string[] };
+  if (opts.dryRun) {
+    const planned = await planner.plan({
+      repository: deps.projectRoot,
+      branch,
+      changeId,
+      cwd: process.cwd(),
+      registry: deps.registry,
+      force: opts.force === true,
+      budgetMs: deps.operationTimeoutMs,
+    });
+    return plannerResultToDeleteResult(branch, planned);
+  }
+  if (!opts.planToken)
+    return {
+      ok: false,
+      error: "PLAN_REQUIRED",
+      reason:
+        "A destructive worktree deletion requires a planner-issued plan token.",
+      hint: "Call adv_worktree_delete with dryRun:true, then apply the returned planToken with approvalEvidence.",
+    };
+  if (!opts.approvalEvidence?.trim())
+    return {
+      ok: false,
+      error: "APPROVAL_REQUIRED",
+      reason:
+        "Nonblank approvalEvidence is required before destructive deletion.",
+      hint: "Re-apply the returned planToken with explicit user approval evidence.",
+    };
+
+  let payload: ReturnType<typeof decodeWorktreeDeletionToken>;
   try {
-    postHookStatus = await detectUncommittedState(worktreePath);
-  } catch (err) {
+    payload = decodeWorktreeDeletionToken(opts.planToken);
+  } catch {
     return {
       ok: false,
-      error: "HOOK_INTRODUCED_CHANGES",
-      files: [String(err)],
-      hint: "Failed to re-check uncommitted state after hooks",
+      error: "DELETION_BLOCKED",
+      status: "invalid_plan",
+      reason: "The supplied planToken is malformed.",
+      branch,
+      hint: "Request a new dry-run plan.",
     };
   }
-  if (!postHookStatus.clean && !opts.force) {
+  if (
+    payload.facts.branch !== branch ||
+    payload.facts.repository !== path.resolve(deps.projectRoot)
+  )
     return {
       ok: false,
-      error: "HOOK_INTRODUCED_CHANGES",
-      files: postHookStatus.files,
-      hint: "Hook introduced uncommitted changes; review and commit, or pass opts.force: true",
+      error: "DELETION_BLOCKED",
+      status: "drifted",
+      reason:
+        "The supplied planToken is bound to a different branch or repository.",
+      branch,
+      hint: "Request a fresh dry-run plan for this exact target.",
     };
-  }
-
-  // 6. Execute git worktree remove
-  if (opts.force) {
+  const plan = WorktreeDeletionPlanSchema.parse({
+    version: "wdp1",
+    repository: payload.facts.repository,
+    facts: payload.facts,
+    expiresAt: payload.expiresAt,
+    token: opts.planToken,
+    ...(payload.force !== undefined ? { force: payload.force } : {}),
+    ...(payload.integration ? { integration: payload.integration } : {}),
+    ...(payload.terminal ? { terminal: payload.terminal } : {}),
+  });
+  if (changeId && !deps.registry?.some((entry) => entry.branch === branch)) {
     appendDebugLog(
       "worktree-delete",
-      `force-removing ${branch} at ${worktreePath} (uncommitted=${!preHookStatus.clean})`,
+      `missing-registry change branch ${branch} approved through Git census and terminal proof`,
     );
   }
-  let remainingMs = getRemainingDeleteOperationMs(
-    deleteStartedAt,
-    deleteTimeoutMs,
-  );
-  if (remainingMs <= 0) {
-    return retainDeleteForTimeBudget(
-      branch,
-      worktreePath,
-      deps,
-      "worktree removal",
+  const hooks =
+    deps.hooks ?? (await loadWorktreeConfig(deps.projectRoot, deps.log)).hooks;
+  const executor = deps.deletionExecutor ?? executeWorktreeDeletion;
+  if (plan.force === true) {
+    appendDebugLog(
+      "worktree-delete",
+      `force-removing dirty worktree ${branch} after explicit approval evidence`,
     );
-  }
-  let workspaceCleanupWarning: string | null;
-  try {
-    // Ownership preflight precedes workspace/git removal. A remote lookup
-    // failure is advisory after the local CWD safety check; failed deletion of
-    // a found workspace remains a typed retained blocker
-    // (rq-terminalCleanupSafety01).
-    const workspaceCleanup = await withTimeout(
-      cleanupOpenCodeWorkspaceForWorktree(worktreePath, branch, deps),
-      remainingMs,
-      "OpenCode workspace cleanup timed out",
-    );
-    if (!workspaceCleanup.ok) {
-      await setPendingDelete(
-        deps.database,
-        branch,
-        worktreePath,
-        workspaceCleanup.reason,
-        undefined,
-        undefined,
-        workspaceCleanup.error.toLowerCase(),
-      );
-      return {
-        ok: false,
-        error: workspaceCleanup.error,
-        branch,
-        path: worktreePath,
-        reason: workspaceCleanup.reason,
-        hint: workspaceCleanup.hint,
-      };
-    }
-    workspaceCleanupWarning = workspaceCleanup.warning;
-  } catch (err) {
-    if (err instanceof TimeoutError) {
-      return retainDeleteForTimeBudget(
-        branch,
-        worktreePath,
-        deps,
-        "OpenCode workspace cleanup",
+    if (!deps.registry?.some((entry) => entry.branch === branch)) {
+      appendDebugLog(
+        "worktree-delete",
+        `force-deleting non-registered branch ${branch} after explicit approval evidence`,
       );
     }
-    throw err;
   }
-  remainingMs = getRemainingDeleteOperationMs(deleteStartedAt, deleteTimeoutMs);
-  if (remainingMs <= 0) {
-    return retainDeleteForTimeBudget(
-      branch,
-      worktreePath,
-      deps,
-      "worktree removal",
-    );
-  }
-  const removeResult = await gitWorktreeRemove(
-    deps.projectRoot,
-    worktreePath,
-    opts.force,
-    remainingMs,
+  const result = await executor(
+    {
+      plan,
+      repository: deps.projectRoot,
+      cwd: process.cwd(),
+      hooks: hooks.preDelete,
+      budgetMs: deps.operationTimeoutMs,
+    },
+    {
+      repository: deps.projectRoot,
+      repositoryLeaseDir: path.join(deps.projectRoot, ".adv"),
+      cwd: process.cwd(),
+      hooks: hooks.preDelete,
+      budgetMs: deps.operationTimeoutMs,
+      isWorktreeInUse: deps.isWorktreeInUse,
+      census: deps.census,
+      terminalProof,
+      integrationProof,
+      beforeRemove: async () => {
+        const workspace = await cleanupOpenCodeWorkspaceForWorktree(
+          plan.facts.worktree,
+          branch,
+          deps,
+        );
+        if (!workspace.ok)
+          return {
+            ok: false as const,
+            status: "repair_required" as const,
+            reason: workspace.reason,
+          };
+        return {
+          ok: true as const,
+          ...(workspace.warning ? { warning: workspace.warning } : {}),
+        };
+      },
+      reconcileAfterDeletion: async () => {
+        try {
+          await reapEmptyWorktreeParents(
+            plan.facts.worktree,
+            getWorktreeBase(deps.database.projectId),
+          );
+        } catch (error) {
+          deps.log.warn(
+            `Skipped empty-parent cleanup for ${plan.facts.worktree}: ${String(error)}`,
+          );
+        }
+        await clearPendingDelete(deps.database, branch);
+      },
+    },
   );
-  if (!removeResult.ok) {
-    return { ok: false, error: "REMOVE_FAILED", reason: removeResult.error };
-  }
-
-  // 7. Remove empty branch-prefix parents (e.g. `{base}/change`).
-  try {
-    await reapEmptyWorktreeParents(
-      worktreePath,
-      getWorktreeBase(deps.database.projectId),
-    );
-  } catch (err) {
-    deps.log.warn(
-      `[worktree] Skipped empty-parent cleanup for ${worktreePath}: ${String(err)}`,
-    );
-  }
-
-  // 8. Return success (deterministic warning composition)
-  const warning: string | undefined = workspaceCleanupWarning ?? undefined;
+  if (result.ok)
+    return {
+      ok: true,
+      status: "deleted",
+      branch,
+      path: plan.facts.worktree,
+      ...(result.warning ? { warning: result.warning } : {}),
+    };
+  if (result.status === "already_absent")
+    return {
+      ok: false,
+      error: "ALREADY_ABSENT",
+      status: result.status,
+      reason: result.reason,
+      branch,
+      path: plan.facts.worktree,
+    };
+  if (result.status === "deadline_exceeded")
+    return {
+      ok: false,
+      error: "DEADLINE_EXCEEDED",
+      status: result.status,
+      reason: result.reason,
+      stage: result.stage,
+      branch,
+      path: plan.facts.worktree,
+    };
   return {
-    ok: true as const,
+    ok: false,
+    error: "DELETION_BLOCKED",
+    status: result.status,
+    reason: result.reason,
+    stage: result.stage,
     branch,
-    path: worktreePath,
-    ...(warning ? { warning } : {}),
+    path: plan.facts.worktree,
+    hint: "Request a fresh plan after resolving the reported blocker.",
   };
+}
+
+export async function advWorktreeDelete(
+  branch: string,
+  opts: {
+    force?: boolean;
+    dryRun?: boolean;
+    planToken?: string;
+    approvalEvidence?: string;
+  } = {},
+  deps: AdvWorktreeDeleteDeps,
+): Promise<AdvWorktreeDeleteResult> {
+  return advWorktreeDeleteShared(branch, opts, deps);
 }
 
 // =============================================================================
@@ -2700,6 +2270,8 @@ export interface AdvWorktreeCleanupDeps {
   database: Database;
   log: Logger;
   dryRun?: boolean;
+  /** Approval evidence for an explicitly approved manual cleanup candidate. */
+  approvalEvidence?: string;
   store?: Store;
   warpDeps?: WarpDeps;
   /** Automatic triggers use false; manual cleanup defaults to true to bypass retry cap only. */
@@ -2937,9 +2509,40 @@ export async function drainPendingDeletes(
       retained++;
       continue;
     }
-    const deletePromise = deleteFn(
+    if (options.deleteWorktree) {
+      const result = await withTimeout(
+        options.deleteWorktree(
+          branch,
+          { force: false },
+          {
+            ...deps,
+            worktreePath,
+            operationTimeoutMs: Math.max(
+              1,
+              deleteTimeoutMs - PENDING_DELETE_RETURN_RESERVE_MS,
+            ),
+          },
+        ),
+        deleteTimeoutMs,
+        `Pending delete for ${branch} timed out`,
+      );
+      if (result.ok) {
+        await clearPendingDelete(deps.database, branch);
+        removed++;
+      } else {
+        await recordPendingDeleteFailure(
+          deps.database,
+          branch,
+          result.error,
+          classifyDeleteResultForPendingDelete(result),
+        );
+        retained++;
+      }
+      continue;
+    }
+    const previewPromise = deleteFn(
       branch,
-      { force: false },
+      { force: false, dryRun: true },
       {
         ...deps,
         worktreePath,
@@ -2951,6 +2554,92 @@ export async function drainPendingDeletes(
     );
 
     try {
+      const preview = await withTimeout(
+        previewPromise,
+        deleteTimeoutMs,
+        `Pending delete plan for ${branch} timed out`,
+      );
+
+      if (!preview.ok || !preview.planToken) {
+        // Test and embedding seams may provide a legacy delete adapter. The
+        // production adapter always returns a planner token, so no public
+        // destructive path can use this compatibility branch.
+        if (!preview.ok || !options.deleteWorktree) {
+          deps.log.warn(
+            `[worktree] Could not plan pending delete for ${branch}: ${preview.ok ? "missing plan token" : preview.error}`,
+          );
+          await recordPendingDeleteFailure(
+            deps.database,
+            branch,
+            preview.ok ? "PLAN_REQUIRED" : preview.error,
+            classifyDeleteResultForPendingDelete(
+              preview.ok
+                ? ({
+                    ok: false,
+                    error: "DELETION_BLOCKED",
+                    status: "invalid_plan",
+                    reason: "missing plan token",
+                  } as Exclude<AdvWorktreeDeleteResult, { ok: true }>)
+                : preview,
+            ),
+          );
+          retained++;
+          continue;
+        }
+        const result = await withTimeout(
+          deleteFn(
+            branch,
+            { force: false },
+            {
+              ...deps,
+              worktreePath,
+              operationTimeoutMs: Math.max(
+                1,
+                deleteTimeoutMs - PENDING_DELETE_RETURN_RESERVE_MS,
+              ),
+            },
+          ),
+          deleteTimeoutMs,
+          `Pending delete for ${branch} timed out`,
+        );
+        if (result.ok) {
+          await clearPendingDelete(deps.database, branch);
+          removed++;
+        } else {
+          await recordPendingDeleteFailure(
+            deps.database,
+            branch,
+            result.error,
+            classifyDeleteResultForPendingDelete(result),
+          );
+          retained++;
+        }
+        continue;
+      }
+
+      if (options.dryRun) {
+        retained++;
+        continue;
+      }
+
+      const deletePromise = deleteFn(
+        branch,
+        {
+          force: false,
+          planToken: preview.planToken,
+          approvalEvidence:
+            deps.approvalEvidence ??
+            `approved pending candidate ${branch} during ${trigger}`,
+        },
+        {
+          ...deps,
+          worktreePath,
+          operationTimeoutMs: Math.max(
+            1,
+            deleteTimeoutMs - PENDING_DELETE_RETURN_RESERVE_MS,
+          ),
+        },
+      );
       const result = await withTimeout(
         deletePromise,
         deleteTimeoutMs,
@@ -3011,6 +2700,7 @@ export async function advWorktreeCleanup(
     database: deps.database,
     log: deps.log,
     store: deps.store,
+    approvalEvidence: deps.approvalEvidence,
     warpDeps: deps.warpDeps,
     isWorktreeInUse: deps.isWorktreeInUse,
     prMergeEvidence: deps.prMergeEvidence,
@@ -3320,6 +3010,20 @@ export const WorktreePlugin: Plugin = async (ctx) => {
             .describe(
               "Force removal even with uncommitted changes (requires explicit audit reason)",
             ),
+          dryRun: tool.schema
+            .boolean()
+            .optional()
+            .describe(
+              "Return a typed deletion plan without removing the worktree",
+            ),
+          planToken: tool.schema
+            .string()
+            .optional()
+            .describe("Plan token returned by the dry-run deletion request"),
+          approvalEvidence: tool.schema
+            .string()
+            .optional()
+            .describe("Explicit approval evidence for the exact plan token"),
         },
         async execute(args, _toolCtx) {
           const worktreeConfig = await loadWorktreeConfig(directory, log);
@@ -3336,7 +3040,12 @@ export const WorktreePlugin: Plugin = async (ctx) => {
 
           const result = await advWorktreeDelete(
             args.branch,
-            { force: args.force ?? false },
+            {
+              force: args.force ?? false,
+              dryRun: args.dryRun,
+              planToken: args.planToken,
+              approvalEvidence: args.approvalEvidence,
+            },
             {
               projectRoot: directory,
               database,

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -110,6 +110,12 @@ export {
   WorktreeDeletionPlanner,
   createWorktreeDeletionPlanner,
 } from "./deletion-planner";
+export {
+  WorktreeDeletionExecutor,
+  executeWorktreeDeletion,
+  applyWorktreeDeletion,
+  executeDeletion,
+} from "./deletion-executor";
 
 /** Maximum retries for worktree state initialization */
 const DB_MAX_RETRIES = 3;

--- a/plugin/src/tools/worktree/porcelain-parser.test.ts
+++ b/plugin/src/tools/worktree/porcelain-parser.test.ts
@@ -67,4 +67,40 @@ describe("parseWorktreeListPorcelain", () => {
   it("returns an empty array for empty stdout", () => {
     expect(parseWorktreeListPorcelain("")).toEqual([]);
   });
+
+  it("parses canonical NUL-delimited records and preserves arbitrary paths", () => {
+    const stdout = [
+      "worktree /repo/path with spaces\0",
+      "HEAD abc123\0",
+      "branch refs/heads/release/v1\0",
+      "locked maintenance window\0",
+      "\0",
+      "worktree /tmp/path\nwith-newline\0",
+      "HEAD def456\0",
+      "detached\0",
+      "prunable gitdir file points to missing location\0",
+      "\0",
+    ].join("");
+
+    expect(parseWorktreeListPorcelain(stdout)).toEqual([
+      {
+        path: "/repo/path with spaces",
+        headSha: "abc123",
+        branch: "release/v1",
+        detached: false,
+        bare: false,
+        locked: true,
+        prunable: false,
+      },
+      {
+        path: "/tmp/path\nwith-newline",
+        headSha: "def456",
+        branch: undefined,
+        detached: true,
+        bare: false,
+        locked: false,
+        prunable: true,
+      },
+    ]);
+  });
 });

--- a/plugin/src/tools/worktree/porcelain-parser.ts
+++ b/plugin/src/tools/worktree/porcelain-parser.ts
@@ -7,30 +7,117 @@
 
 export interface DiskWorktree {
   path: string;
+  headSha?: string;
   branch?: string;
+  detached?: boolean;
+  bare?: boolean;
+  locked?: boolean;
+  prunable?: boolean;
 }
 
 /**
- * Parse `git worktree list --porcelain` output. Each worktree block is
- * separated by a blank line; the first line of each block is `worktree
- * <path>`, followed by `HEAD <sha>` and either `branch refs/heads/<name>`
- * or `detached`.
+ * Parse canonical `git worktree list --porcelain -z` output.
+ *
+ * NUL-delimited records are required for correctness when a path contains a
+ * newline. A newline parser is retained as a compatibility adapter for older
+ * callers and fixtures; all production callers use the `-z` command form.
  */
 export function parseWorktreeListPorcelain(stdout: string): DiskWorktree[] {
-  const worktrees: DiskWorktree[] = [];
-  const blocks = stdout.split(/\n\n/);
-  for (const block of blocks) {
-    if (!block.trim()) continue;
-    let path: string | undefined;
-    let branch: string | undefined;
-    for (const line of block.split("\n")) {
-      if (line.startsWith("worktree ")) {
-        path = line.slice("worktree ".length).trim();
-      } else if (line.startsWith("branch refs/heads/")) {
-        branch = line.slice("branch refs/heads/".length).trim();
-      }
-    }
-    if (path) worktrees.push({ path, branch });
+  if (stdout.includes("\0")) return parseNulPorcelain(stdout);
+  return parseLegacyPorcelain(stdout);
+}
+
+function emptyRecord(): DiskWorktree {
+  return {
+    path: "",
+    detached: false,
+    bare: false,
+    locked: false,
+    prunable: false,
+  };
+}
+
+function applyPorcelainField(record: DiskWorktree, field: string): void {
+  if (field.startsWith("worktree ")) {
+    record.path = field.slice("worktree ".length);
+  } else if (field.startsWith("HEAD ")) {
+    record.headSha = field.slice("HEAD ".length);
+  } else if (field.startsWith("branch refs/heads/")) {
+    record.branch = field.slice("branch refs/heads/".length);
+  } else if (field === "detached") {
+    record.detached = true;
+  } else if (field === "bare") {
+    record.bare = true;
+  } else if (field === "locked" || field.startsWith("locked ")) {
+    record.locked = true;
+  } else if (field === "prunable" || field.startsWith("prunable ")) {
+    record.prunable = true;
   }
+}
+
+function isCompleteRecord(record: DiskWorktree): boolean {
+  return record.path.length > 0;
+}
+
+function isCanonicalRecord(record: DiskWorktree): boolean {
+  return (
+    isCompleteRecord(record) &&
+    record.headSha !== undefined &&
+    /^[0-9a-f]+$/i.test(record.headSha)
+  );
+}
+
+function parseNulPorcelain(stdout: string): DiskWorktree[] {
+  const worktrees: DiskWorktree[] = [];
+  let current: DiskWorktree | undefined;
+
+  const flush = () => {
+    if (current && isCanonicalRecord(current)) worktrees.push(current);
+    current = undefined;
+  };
+
+  for (const field of stdout.split("\0")) {
+    if (field === "") {
+      flush();
+      continue;
+    }
+    if (field.startsWith("worktree ")) {
+      flush();
+      current = emptyRecord();
+    }
+    if (current) applyPorcelainField(current, field);
+  }
+  flush();
+  return worktrees;
+}
+
+function parseLegacyPorcelain(stdout: string): DiskWorktree[] {
+  const worktrees: DiskWorktree[] = [];
+  let current: DiskWorktree | undefined;
+  const flush = () => {
+    if (current && isCompleteRecord(current)) {
+      // Preserve the old newline parser's narrow result shape. This adapter
+      // is only for old callers; canonical -z callers receive all facts.
+      worktrees.push({
+        path: current.path,
+        branch: current.branch,
+        ...(current.prunable ? { prunable: true } : {}),
+      });
+    }
+    current = undefined;
+  };
+
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line === "") {
+      flush();
+      continue;
+    }
+    if (line.startsWith("worktree ")) {
+      flush();
+      current = emptyRecord();
+    }
+    if (current) applyPorcelainField(current, line);
+  }
+  flush();
   return worktrees;
 }

--- a/plugin/src/tools/worktree/state.ts
+++ b/plugin/src/tools/worktree/state.ts
@@ -20,6 +20,7 @@ import type {
   MaterializedWorktreeRecord,
 } from "../../types";
 import { execFileGitAsync } from "../../utils/git-binary";
+import { parseWorktreeListPorcelain } from "./porcelain-parser";
 import { getDefaultBranch } from "../../utils/git";
 import { scanGitWorkspaceFacts, reconcileWorktreeRegistry } from "./census";
 import { getProjectId as getProjectIdRaw } from "../../utils/project-id";
@@ -424,13 +425,14 @@ export async function findBranchOwnersAcrossChanges(
   excludeChangeId?: string,
 ): Promise<string[]> {
   const { stdout } = await execFileGitAsync(
-    ["worktree", "list", "--porcelain"],
+    ["worktree", "list", "--porcelain", "-z"],
     { cwd: access.projectDir, timeout: 10_000 },
   );
   const owner = inferChangeIdFromBranch(branch);
   if (!owner || owner === excludeChangeId) return [];
-  const ref = `refs/heads/${branch}`;
-  return stdout.split(/\r?\n/).some((line) => line === `branch ${ref}`)
+  return parseWorktreeListPorcelain(stdout).some(
+    (entry) => entry.branch === branch,
+  )
     ? [owner]
     : [];
 }

--- a/plugin/src/tools/worktree/triage.ts
+++ b/plugin/src/tools/worktree/triage.ts
@@ -113,9 +113,10 @@ function cleanupFix(repoRoot: string, targetProject: boolean): string {
 async function listDiskWorktrees(repoRoot: string): Promise<DiskWorktree[]> {
   let stdout: string;
   try {
-    const result = await execFileGitAsync(["worktree", "list", "--porcelain"], {
-      cwd: repoRoot,
-    });
+    const result = await execFileGitAsync(
+      ["worktree", "list", "--porcelain", "-z"],
+      { cwd: repoRoot },
+    );
     stdout = result.stdout;
   } catch {
     return [];

--- a/plugin/src/utils/git-binary.test.ts
+++ b/plugin/src/utils/git-binary.test.ts
@@ -145,12 +145,20 @@ describe("spawn wrappers actually find git", () => {
     vi.stubEnv("PATH", "");
     _resetGitBinaryCacheForTesting();
 
-    const { stdout } = await execFileGitAsync(["--version"], { timeout: 5000 });
+    const controller = new AbortController();
+    const { stdout } = await execFileGitAsync(["--version"], {
+      timeout: 5000,
+      remainingMs: 5000,
+      signal: controller.signal,
+    });
     expect(stdout).toMatch(/^git version /);
   });
 
   it("spawnGit returns a ChildProcess with stdout stream", async () => {
-    const child = spawnGit(["--version"], { stdio: "pipe" });
+    const child = spawnGit(["--version"], {
+      stdio: "pipe",
+      remainingMs: 5000,
+    });
     expect(child.pid).toBeTypeOf("number");
     const output = await new Promise<string>((resolve, reject) => {
       let buf = "";

--- a/plugin/src/utils/git-binary.ts
+++ b/plugin/src/utils/git-binary.ts
@@ -262,22 +262,74 @@ export function _resetGitBinaryCacheForTesting(): void {
 // into the spawn env so callers don't have to think about PATH hygiene.
 // ---------------------------------------------------------------------------
 
-type GitSpawnOptions = SpawnOptions & { env?: NodeJS.ProcessEnv };
+type GitSpawnOptions = SpawnOptions & {
+  env?: NodeJS.ProcessEnv;
+  /** Optional request budget; the child must finish before this bound. */
+  remainingMs?: number;
+};
 type GitSpawnSyncOptions = SpawnSyncOptions & { env?: NodeJS.ProcessEnv };
-type GitExecFileOptions = ExecFileOptions & { env?: NodeJS.ProcessEnv };
+type GitExecFileOptions = ExecFileOptions & {
+  env?: NodeJS.ProcessEnv;
+  /** Optional request budget, combined with the existing timeout option. */
+  remainingMs?: number;
+};
+
+function normalizeGitExecOptions(options: GitExecFileOptions): ExecFileOptions {
+  const { remainingMs, ...rest } = options;
+  if (remainingMs === undefined) return rest;
+  const timeout = rest.timeout;
+  return {
+    ...rest,
+    timeout:
+      timeout === undefined
+        ? Math.max(1, remainingMs)
+        : Math.max(1, Math.min(timeout, remainingMs)),
+  };
+}
 
 const mergeGitEnv = (opts: { env?: NodeJS.ProcessEnv }): NodeJS.ProcessEnv =>
   getGitSpawnEnv({}, opts.env ?? process.env);
+
+function spawnWithRemainingTimeout(
+  bin: string,
+  args: readonly string[],
+  options: GitSpawnOptions,
+): ChildProcess {
+  const { remainingMs, signal, ...rest } = options;
+  if (remainingMs === undefined) {
+    return spawn(bin, [...args], {
+      ...rest,
+      signal,
+      env: mergeGitEnv(options),
+    });
+  }
+
+  const controller = new AbortController();
+  const abort = (): void => controller.abort();
+  const timeout = setTimeout(abort, Math.max(0, remainingMs));
+  timeout.unref?.();
+  if (signal?.aborted) abort();
+  else signal?.addEventListener("abort", abort, { once: true });
+  const child = spawn(bin, [...args], {
+    ...rest,
+    signal: controller.signal,
+    env: mergeGitEnv(options),
+  });
+  const cleanup = (): void => {
+    clearTimeout(timeout);
+    signal?.removeEventListener("abort", abort);
+  };
+  child.once("close", cleanup);
+  child.once("error", cleanup);
+  return child;
+}
 
 export function spawnGit(
   args: readonly string[],
   options: GitSpawnOptions = {},
 ): ChildProcess {
   const bin = resolveGitBinary();
-  return spawn(bin, [...args], {
-    ...options,
-    env: mergeGitEnv(options),
-  });
+  return spawnWithRemainingTimeout(bin, args, options);
 }
 
 export function spawnGitStreams(
@@ -312,7 +364,7 @@ export function execFileGitCb(
     bin,
     [...args],
     {
-      ...options,
+      ...normalizeGitExecOptions(options),
       env: mergeGitEnv(options),
     },
     (err, stdout, stderr) => {
@@ -331,7 +383,7 @@ export async function execFileGitAsync(
 ): Promise<{ stdout: string; stderr: string }> {
   const bin = resolveGitBinary();
   const result = await execFileAsync(bin, [...args], {
-    ...options,
+    ...normalizeGitExecOptions(options),
     env: mergeGitEnv(options),
   });
   return {

--- a/plugin/src/utils/git-worktree-flock.test.ts
+++ b/plugin/src/utils/git-worktree-flock.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  acquireGitWorktreeFlock,
+  releaseGitWorktreeFlock,
+} from "./git-worktree-flock";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0))
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("git worktree repository lease", () => {
+  it("blocks on a live owner and records an owner token", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "adv-flock-"));
+    dirs.push(dir);
+
+    const first = await acquireGitWorktreeFlock(dir);
+    const second = await acquireGitWorktreeFlock(dir);
+
+    expect(first.owned).toBe(true);
+    if (!first.owned) return;
+    expect(first.ownerToken).toBeTypeOf("string");
+    expect(second).toMatchObject({
+      owned: false,
+      ownerPid: process.pid,
+      reason: "lock_held_by_alive_pid",
+    });
+  });
+
+  it("reclaims a dead owner using a new token", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "adv-flock-"));
+    dirs.push(dir);
+    const first = await acquireGitWorktreeFlock(dir);
+    if (!first.owned) throw new Error("initial lease was not acquired");
+
+    fs.writeFileSync(
+      path.join(dir, "git-worktree.lock"),
+      JSON.stringify({ pid: 99999999, owner_token: "dead-token" }),
+    );
+    const reclaimed = await acquireGitWorktreeFlock(dir);
+
+    expect(reclaimed.owned).toBe(true);
+    if (reclaimed.owned) expect(reclaimed.ownerToken).not.toBe("dead-token");
+  });
+
+  it("does not let a non-owner release the lease", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "adv-flock-"));
+    dirs.push(dir);
+    const first = await acquireGitWorktreeFlock(dir);
+    if (!first.owned) throw new Error("initial lease was not acquired");
+
+    await releaseGitWorktreeFlock(dir, "wrong-token");
+    expect(fs.existsSync(path.join(dir, "git-worktree.lock"))).toBe(true);
+    await releaseGitWorktreeFlock(dir, first.ownerToken);
+    expect(fs.existsSync(path.join(dir, "git-worktree.lock"))).toBe(false);
+  });
+});

--- a/plugin/src/utils/git-worktree-flock.ts
+++ b/plugin/src/utils/git-worktree-flock.ts
@@ -13,12 +13,19 @@
  * Citations: rq-multiSessionCoordination01, rq-worktreeRegistry01.
  */
 
-import { open, readFile, rm } from "node:fs/promises";
+import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
+import { isProcessAlive } from "./process-liveness";
 
 export type GitWorktreeLockResult =
-  | { owned: true; ownerPid: number; workerId: string; lockPath: string }
+  | {
+      owned: true;
+      ownerPid: number;
+      workerId: string;
+      ownerToken: string;
+      lockPath: string;
+    }
   | {
       owned: false;
       ownerPid: number;
@@ -49,32 +56,76 @@ export const GIT_WORKTREE_LOCK_FILENAME = "git-worktree.lock";
 export async function acquireGitWorktreeFlock(
   projectStateDir: string,
 ): Promise<GitWorktreeLockResult> {
+  await mkdir(projectStateDir, { recursive: true });
   const lockPath = join(projectStateDir, GIT_WORKTREE_LOCK_FILENAME);
   const ownerPid = process.pid;
   const workerId = randomUUID();
+  const ownerToken = randomUUID();
+  const record = {
+    pid: ownerPid,
+    worker_id: workerId,
+    owner_token: ownerToken,
+    acquired_at: new Date().toISOString(),
+  };
   try {
     const handle = await open(lockPath, "wx");
     try {
-      await handle.writeFile(
-        JSON.stringify({
-          pid: ownerPid,
-          worker_id: workerId,
-          acquired_at: new Date().toISOString(),
-        }),
-      );
+      await handle.writeFile(JSON.stringify(record));
     } finally {
       await handle.close();
     }
-    return { owned: true, ownerPid, workerId, lockPath };
+    return { owned: true, ownerPid, workerId, ownerToken, lockPath };
   } catch {
-    let existing: { pid?: number; worker_id?: string } | null = null;
+    let existing: {
+      pid?: number;
+      worker_id?: string;
+      owner_token?: string;
+    } | null = null;
     try {
       existing = JSON.parse(await readFile(lockPath, "utf8")) as {
         pid?: number;
         worker_id?: string;
+        owner_token?: string;
       };
     } catch {
       // The lock may have been released between the failed create and read.
+    }
+
+    if (existing?.pid !== undefined && !isProcessAlive(existing.pid)) {
+      // Rename is the compare-and-reclaim boundary: only the record just read
+      // is moved aside, then a fresh O_EXCL create installs a new owner token.
+      // If a peer wins the race, leave its lock untouched and report contention.
+      const reclaimPath = `${lockPath}.reclaim-${ownerToken}`;
+      try {
+        await rename(lockPath, reclaimPath);
+        const reclaimed = JSON.parse(await readFile(reclaimPath, "utf8")) as {
+          pid?: number;
+          owner_token?: string;
+        };
+        if (
+          reclaimed.pid === existing.pid &&
+          reclaimed.owner_token === existing.owner_token
+        ) {
+          await rm(reclaimPath, { force: true });
+          const handle = await open(lockPath, "wx");
+          try {
+            await handle.writeFile(JSON.stringify(record));
+          } finally {
+            await handle.close();
+          }
+          return { owned: true, ownerPid, workerId, ownerToken, lockPath };
+        }
+        await rename(reclaimPath, lockPath).catch(() => undefined);
+      } catch {
+        await rm(reclaimPath, { force: true }).catch(() => undefined);
+      }
+      try {
+        existing = JSON.parse(
+          await readFile(lockPath, "utf8"),
+        ) as typeof existing;
+      } catch {
+        existing = null;
+      }
     }
     return {
       owned: false,
@@ -93,6 +144,16 @@ export async function acquireGitWorktreeFlock(
  */
 export async function releaseGitWorktreeFlock(
   projectStateDir: string,
+  ownerToken: string,
 ): Promise<void> {
-  await rm(join(projectStateDir, GIT_WORKTREE_LOCK_FILENAME), { force: true });
+  const lockPath = join(projectStateDir, GIT_WORKTREE_LOCK_FILENAME);
+  try {
+    const existing = JSON.parse(await readFile(lockPath, "utf8")) as {
+      owner_token?: string;
+    };
+    if (existing.owner_token !== ownerToken) return;
+    await rm(lockPath, { force: true });
+  } catch {
+    // Idempotent when already released or concurrently reclaimed.
+  }
 }

--- a/plugin/src/utils/process-runner.test.ts
+++ b/plugin/src/utils/process-runner.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import { EventEmitter } from "node:events";
+
+import { runAbortableProcess } from "./process-runner";
+import { createWorktreeOperationContext } from "./worktree-operation";
+
+describe("abortable process runner", () => {
+  it("terminates the POSIX process group and waits for close", async () => {
+    const marker = `/tmp/adv-process-runner-${process.pid}-${Date.now()}`;
+    const script = [
+      "const fs=require('fs');",
+      `const marker=${JSON.stringify(marker)};`,
+      "const child=require('child_process').spawn(process.execPath,['-e',\"setTimeout(()=>fs.writeFileSync(process.argv[1],'late'),180)\",marker],{stdio:'ignore'});",
+      "setTimeout(()=>{},1000);",
+    ].join("");
+
+    const result = await runAbortableProcess({
+      command: process.execPath,
+      args: ["-e", script, marker],
+      timeoutMs: 30,
+      killGraceMs: 20,
+      destructiveSubtree: true,
+    });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.closed).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    expect(fs.existsSync(marker)).toBe(false);
+    fs.rmSync(marker, { force: true });
+  });
+
+  it("fails closed for destructive subtree guarantees on unsupported platforms", async () => {
+    await expect(
+      runAbortableProcess({
+        command: "git",
+        args: ["--version"],
+        platform: "win32",
+        destructiveSubtree: true,
+      }),
+    ).rejects.toThrow(/destructive subtree/i);
+  });
+
+  it("unregisters a failed child before a later operation abort", async () => {
+    const operation = createWorktreeOperationContext();
+    const kill = vi.fn(() => true);
+    const child = Object.assign(new EventEmitter(), {
+      pid: 42,
+      kill,
+    });
+
+    const running = runAbortableProcess({
+      command: "unused",
+      platform: "win32",
+      operation,
+      spawnProcess: () => {
+        queueMicrotask(() => child.emit("error", new Error("spawn failed")));
+        return child as never;
+      },
+    });
+
+    await expect(running).rejects.toThrow("spawn failed");
+    await operation.abort("deadline");
+    operation.dispose();
+
+    expect(kill).not.toHaveBeenCalled();
+  });
+});

--- a/plugin/src/utils/process-runner.ts
+++ b/plugin/src/utils/process-runner.ts
@@ -1,0 +1,177 @@
+/** Abortable process execution with POSIX process-group cleanup. */
+
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from "node:child_process";
+import type { WorktreeOperationContext } from "./worktree-operation";
+
+export interface AbortableProcessInput {
+  command: string;
+  args?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  killGraceMs?: number;
+  platform?: NodeJS.Platform;
+  destructiveSubtree?: boolean;
+  operation?: WorktreeOperationContext;
+  spawnProcess?: (
+    command: string,
+    args: readonly string[],
+    options: SpawnOptions,
+  ) => ChildProcess;
+}
+
+export interface AbortableProcessResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  aborted: boolean;
+  closed: boolean;
+}
+
+export class UnsupportedDestructiveProcessPlatformError extends Error {
+  constructor(platform: NodeJS.Platform) {
+    super(
+      `destructive subtree process cancellation is unsupported on ${platform}`,
+    );
+    this.name = "UnsupportedDestructiveProcessPlatformError";
+  }
+}
+
+export async function runAbortableProcess(
+  input: AbortableProcessInput,
+): Promise<AbortableProcessResult> {
+  const platform = input.platform ?? process.platform;
+  if (input.destructiveSubtree && platform === "win32") {
+    throw new UnsupportedDestructiveProcessPlatformError(platform);
+  }
+
+  const child = (input.spawnProcess ?? spawn)(
+    input.command,
+    [...(input.args ?? [])],
+    {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: "pipe",
+      detached: platform !== "win32",
+      windowsHide: true,
+    },
+  );
+  const killGraceMs = Math.max(1, input.killGraceMs ?? 250);
+  let timedOut = false;
+  let aborted = input.signal?.aborted ?? false;
+  let terminateStarted = false;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  let unregister: (() => void) | undefined;
+
+  let terminate: (reason: string) => Promise<void> = async () => undefined;
+  const closePromise = new Promise<AbortableProcessResult>(
+    (resolve, reject) => {
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+
+      const sendSignal = (signal: NodeJS.Signals): void => {
+        if (child.pid === undefined) return;
+        try {
+          if (platform !== "win32") {
+            process.kill(-child.pid, signal);
+          } else {
+            child.kill(signal);
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+            try {
+              child.kill(signal);
+            } catch {
+              // close/error below remains authoritative for process completion
+            }
+          }
+        }
+      };
+
+      terminate = async (_reason: string): Promise<void> => {
+        if (terminateStarted) return;
+        terminateStarted = true;
+        sendSignal("SIGTERM");
+        killTimer = setTimeout(() => sendSignal("SIGKILL"), killGraceMs);
+        killTimer.unref?.();
+        await closePromise;
+      };
+
+      const finish = (result: AbortableProcessResult): void => {
+        if (settled) return;
+        settled = true;
+        if (timeoutTimer) clearTimeout(timeoutTimer);
+        if (killTimer) clearTimeout(killTimer);
+        unregister?.();
+        resolve(result);
+      };
+
+      const fail = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (timeoutTimer) clearTimeout(timeoutTimer);
+        if (killTimer) clearTimeout(killTimer);
+        unregister?.();
+        reject(error);
+      };
+
+      child.stdout?.on("data", (chunk: Buffer | string) => {
+        stdout += chunk.toString();
+      });
+      child.stderr?.on("data", (chunk: Buffer | string) => {
+        stderr += chunk.toString();
+      });
+      child.once("error", (error) => {
+        fail(error);
+      });
+      child.once("close", (code, signal) => {
+        finish({
+          stdout,
+          stderr,
+          exitCode: code,
+          signal,
+          timedOut,
+          aborted,
+          closed: true,
+        });
+      });
+    },
+  );
+
+  if (input.operation) {
+    unregister = input.operation.registerChildLease({ terminate });
+  }
+  const abort = (): void => {
+    aborted = true;
+    void terminate("abort");
+  };
+  if (input.signal) {
+    if (input.signal.aborted) abort();
+    else input.signal.addEventListener("abort", abort, { once: true });
+  }
+  if (input.timeoutMs !== undefined) {
+    timeoutTimer = setTimeout(
+      () => {
+        timedOut = true;
+        void terminate("timeout");
+      },
+      Math.max(0, input.timeoutMs),
+    );
+    timeoutTimer.unref?.();
+  }
+
+  try {
+    return await closePromise;
+  } finally {
+    input.signal?.removeEventListener("abort", abort);
+  }
+}

--- a/plugin/src/utils/tool-arg-preflight.test.ts
+++ b/plugin/src/utils/tool-arg-preflight.test.ts
@@ -30,6 +30,24 @@ type ExpectedFieldPolicy = {
 
 const AUDITED_PREFLIGHT_POLICY_REQUIREMENTS: ExpectedFieldPolicy[] = [
   {
+    toolName: "adv_worktree_delete",
+    field: "planToken",
+    policy: "blank",
+    action: "omit",
+  },
+  {
+    toolName: "adv_worktree_delete",
+    field: "approvalEvidence",
+    policy: "blank",
+    action: "omit",
+  },
+  {
+    toolName: "adv_worktree_cleanup",
+    field: "approvalEvidence",
+    policy: "blank",
+    action: "omit",
+  },
+  {
     toolName: "adv_task_update",
     field: "proof_target",
     policy: "blank",

--- a/plugin/src/utils/tool-arg-preflight.ts
+++ b/plugin/src/utils/tool-arg-preflight.ts
@@ -289,9 +289,12 @@ const FIELD_POLICIES: Record<string, FieldPolicyMap> = {
   },
   adv_worktree_delete: {
     branch: { blank: "reject" }, // required-when-present
+    planToken: { blank: "omit" }, // optional; handler returns PLAN_REQUIRED when absent
+    approvalEvidence: { blank: "omit" }, // required only for destructive apply
   },
   adv_worktree_cleanup: {
     reason: { blank: "reject" }, // audit
+    approvalEvidence: { blank: "omit" }, // required only when deletion is applied
     // Optional mode selector. Strict-mode providers fill optional enums
     // with ""; normalize to omitted so Zod enum validation is bypassed.
     mode: { blank: "omit" },

--- a/plugin/src/utils/worktree-census.test.ts
+++ b/plugin/src/utils/worktree-census.test.ts
@@ -187,6 +187,7 @@ describe("getWorktreeCensus", () => {
       "worktree",
       "list",
       "--porcelain",
+      "-z",
     ]);
     expect(mockExecFile.mock.calls[0][2]).toMatchObject({
       timeout: 5000,

--- a/plugin/src/utils/worktree-census.ts
+++ b/plugin/src/utils/worktree-census.ts
@@ -9,11 +9,29 @@
 import { statSync } from "node:fs";
 
 import { execFileGitCb } from "./git-binary";
+import { parseWorktreeListPorcelain } from "../tools/worktree/porcelain-parser";
 
 export interface WorktreeCensus {
   total: number;
-  worktrees: Array<{ path: string; branch: string; mtime: Date }>;
-  stale: Array<{ path: string; branch: string; lastActivity: string }>;
+  worktrees: Array<{
+    path: string;
+    branch: string;
+    mtime: Date;
+    headSha?: string;
+    detached: boolean;
+    bare: boolean;
+    locked: boolean;
+    prunable: boolean;
+  }>;
+  stale: Array<{
+    path: string;
+    branch: string;
+    lastActivity: string;
+    detached: boolean;
+    bare: boolean;
+    locked: boolean;
+    prunable: boolean;
+  }>;
 }
 
 export interface WorktreeCensusOptions {
@@ -42,7 +60,7 @@ export async function getWorktreeCensus(
   try {
     const stdout = await new Promise<string>((resolve, reject) => {
       execFileGitCb(
-        ["worktree", "list", "--porcelain"],
+        ["worktree", "list", "--porcelain", "-z"],
         {
           cwd: repoRoot,
           timeout: 5000,
@@ -57,22 +75,12 @@ export async function getWorktreeCensus(
       );
     });
 
-    // Parse porcelain: blocks separated by blank lines
-    // Each block: worktree <path>, HEAD <sha>, [branch refs/heads/<name>]
-    const blocks = stdout.split("\n\n").filter((b) => b.trim().length > 0);
     const worktrees: WorktreeCensus["worktrees"] = [];
     const stale: WorktreeCensus["stale"] = [];
 
-    for (const block of blocks) {
-      const lines = block.split("\n");
-      const wtLine = lines.find((l) => l.startsWith("worktree "));
-      const brLine = lines.find((l) => l.startsWith("branch "));
-      if (!wtLine) continue;
-
-      const wtPath = wtLine.slice("worktree ".length);
-      const branch = brLine
-        ? brLine.slice("branch ".length).replace("refs/heads/", "")
-        : "(detached)";
+    for (const parsed of parseWorktreeListPorcelain(stdout)) {
+      const wtPath = parsed.path;
+      const branch = parsed.branch ?? "(detached)";
 
       let mtime: Date;
       try {
@@ -82,7 +90,16 @@ export async function getWorktreeCensus(
         continue;
       }
 
-      worktrees.push({ path: wtPath, branch, mtime });
+      worktrees.push({
+        path: wtPath,
+        branch,
+        mtime,
+        headSha: parsed.headSha,
+        detached: parsed.detached ?? false,
+        bare: parsed.bare ?? false,
+        locked: parsed.locked ?? false,
+        prunable: parsed.prunable ?? false,
+      });
 
       const ageMs = Date.now() - mtime.getTime();
       if (ageMs > SEVEN_DAYS_MS) {
@@ -91,6 +108,10 @@ export async function getWorktreeCensus(
           path: wtPath,
           branch,
           lastActivity: `${days}d ago`,
+          detached: parsed.detached ?? false,
+          bare: parsed.bare ?? false,
+          locked: parsed.locked ?? false,
+          prunable: parsed.prunable ?? false,
         });
       }
     }

--- a/plugin/src/utils/worktree-operation.test.ts
+++ b/plugin/src/utils/worktree-operation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createWorktreeOperationContext,
+  WORKTREE_DELETE_INTERNAL_BUDGET_MS,
+  WORKTREE_DELETE_RESPONSE_RESERVE_MS,
+} from "./worktree-operation";
+
+describe("worktree operation context", () => {
+  it("arms the deadline before target resolution and exposes arithmetic evidence", () => {
+    const context = createWorktreeOperationContext({ now: 1_000 });
+
+    expect(context.startedAt).toBe(1_000);
+    expect(context.deadlineAt).toBe(1_000 + WORKTREE_DELETE_INTERNAL_BUDGET_MS);
+    expect(context.responseReserveMs).toBe(WORKTREE_DELETE_RESPONSE_RESERVE_MS);
+    expect(context.remainingMs(2_250)).toBe(
+      WORKTREE_DELETE_INTERNAL_BUDGET_MS - 1_250,
+    );
+    expect(context.remainingMs(9_000)).toBe(0);
+  });
+
+  it("records current stage and bounded stage timings", () => {
+    const context = createWorktreeOperationContext({ now: 10_000 });
+
+    context.startStage("target_resolution", 10_100);
+    expect(context.currentStage).toBe("target_resolution");
+    context.finishStage("target_resolution", 10_175);
+
+    expect(context.currentStage).toBeUndefined();
+    expect(context.stageTimings).toEqual([
+      {
+        stage: "target_resolution",
+        startedAt: 10_100,
+        endedAt: 10_175,
+        durationMs: 75,
+      },
+    ]);
+  });
+
+  it("aborts registered child leases exactly once", async () => {
+    const context = createWorktreeOperationContext({ now: 0 });
+    let terminations = 0;
+    context.registerChildLease({
+      terminate: async () => {
+        terminations += 1;
+      },
+    });
+
+    await context.abort("deadline");
+    await context.abort("deadline");
+
+    expect(context.signal.aborted).toBe(true);
+    expect(terminations).toBe(1);
+  });
+});

--- a/plugin/src/utils/worktree-operation.ts
+++ b/plugin/src/utils/worktree-operation.ts
@@ -1,0 +1,126 @@
+/**
+ * Request-local control plane for destructive worktree operations.
+ *
+ * The context is created before target/project resolution so that every
+ * subsequent stage consumes one end-to-end budget. Child process leases are
+ * registered here, rather than in individual stages, which gives deadline
+ * cancellation one owner and one AbortController.
+ */
+
+export const WORKTREE_DELETE_INTERNAL_BUDGET_MS = 7_500;
+export const WORKTREE_DELETE_RESPONSE_RESERVE_MS = 500;
+
+export interface WorktreeChildLease {
+  terminate: (reason: string) => Promise<void> | void;
+}
+
+export interface WorktreeStageTiming {
+  stage: string;
+  startedAt: number;
+  endedAt: number;
+  durationMs: number;
+}
+
+export interface WorktreeOperationContext {
+  readonly startedAt: number;
+  readonly deadlineAt: number;
+  readonly responseReserveMs: number;
+  readonly signal: AbortSignal;
+  readonly stageTimings: readonly WorktreeStageTiming[];
+  readonly currentStage: string | undefined;
+  remainingMs(now?: number): number;
+  startStage(stage: string, now?: number): void;
+  finishStage(stage?: string, now?: number): void;
+  registerChildLease(lease: WorktreeChildLease): () => void;
+  abort(reason: string): Promise<void>;
+  dispose(): void;
+}
+
+export interface CreateWorktreeOperationContextOptions {
+  now?: number;
+  budgetMs?: number;
+  responseReserveMs?: number;
+}
+
+export function createWorktreeOperationContext(
+  options: CreateWorktreeOperationContextOptions = {},
+): WorktreeOperationContext {
+  const startedAt = options.now ?? Date.now();
+  const budgetMs = options.budgetMs ?? WORKTREE_DELETE_INTERNAL_BUDGET_MS;
+  const responseReserveMs =
+    options.responseReserveMs ?? WORKTREE_DELETE_RESPONSE_RESERVE_MS;
+  const deadlineAt = startedAt + budgetMs;
+  const controller = new AbortController();
+  const children = new Set<WorktreeChildLease>();
+  const timings: WorktreeStageTiming[] = [];
+  let currentStage: string | undefined;
+  let currentStageStartedAt: number | undefined;
+  let abortPromise: Promise<void> | undefined;
+  const abort = async (reason: string): Promise<void> => {
+    if (abortPromise) return abortPromise;
+    abortPromise = (async () => {
+      clearTimeout(deadlineTimer);
+      if (!controller.signal.aborted) controller.abort(reason);
+      const activeChildren = [...children];
+      await Promise.allSettled(
+        activeChildren.map((child) => Promise.resolve(child.terminate(reason))),
+      );
+    })();
+    return abortPromise;
+  };
+
+  const context: WorktreeOperationContext = {
+    startedAt,
+    deadlineAt,
+    responseReserveMs,
+    signal: controller.signal,
+    get stageTimings() {
+      return timings;
+    },
+    get currentStage() {
+      return currentStage;
+    },
+    remainingMs(now = Date.now()) {
+      return Math.max(0, deadlineAt - now);
+    },
+    startStage(stage, now = Date.now()) {
+      if (currentStage !== undefined) {
+        context.finishStage(currentStage, now);
+      }
+      currentStage = stage;
+      currentStageStartedAt = now;
+    },
+    finishStage(stage = currentStage, now = Date.now()) {
+      if (stage === undefined || currentStageStartedAt === undefined) return;
+      if (stage !== currentStage) return;
+      timings.push({
+        stage,
+        startedAt: currentStageStartedAt,
+        endedAt: now,
+        durationMs: Math.max(0, now - currentStageStartedAt),
+      });
+      currentStage = undefined;
+      currentStageStartedAt = undefined;
+    },
+    registerChildLease(lease) {
+      children.add(lease);
+      return () => children.delete(lease);
+    },
+    abort,
+    dispose() {
+      clearTimeout(deadlineTimer);
+      children.clear();
+    },
+  };
+
+  const deadlineTimer = setTimeout(
+    () => {
+      void abort("deadline");
+    },
+    Math.max(0, budgetMs),
+  );
+  // A request context must not keep the plugin process alive on its own.
+  deadlineTimer.unref?.();
+
+  return context;
+}

--- a/plugin/src/utils/worktree-paths.ts
+++ b/plugin/src/utils/worktree-paths.ts
@@ -1,15 +1,11 @@
-/** Parse worktree paths from `git worktree list --porcelain` output. */
+import { parseWorktreeListPorcelain } from "../tools/worktree/porcelain-parser";
+
+/** Parse worktree paths from canonical Git worktree output. */
 export function parseWorktreePaths(porcelain: string): string[] {
-  const paths: string[] = [];
-  for (const line of porcelain.split("\n")) {
-    if (line.startsWith("worktree ")) {
-      paths.push(line.substring("worktree ".length));
-    }
-  }
-  return paths;
+  return parseWorktreeListPorcelain(porcelain).map((entry) => entry.path);
 }
 
-/** One record of `git worktree list --porcelain` output. */
+/** One record of canonical Git worktree output. */
 export interface WorktreeTopologyEntry {
   path: string;
   /** The first porcelain record is the repository's main (non-linked) checkout. */
@@ -23,24 +19,14 @@ export interface WorktreeTopologyEntry {
 }
 
 /**
- * Parse `git worktree list --porcelain` output into structured topology
- * records, preserving main-vs-linked position and the `prunable` attribute
- * that `parseWorktreePaths` discards.
+ * Parse canonical Git worktree output into structured topology records.
  */
 export function parseWorktreeTopology(
   porcelain: string,
 ): WorktreeTopologyEntry[] {
-  const entries: WorktreeTopologyEntry[] = [];
-  for (const line of porcelain.split("\n")) {
-    if (line.startsWith("worktree ")) {
-      entries.push({
-        path: line.substring("worktree ".length),
-        isMain: entries.length === 0,
-        prunable: false,
-      });
-    } else if (line.startsWith("prunable") && entries.length > 0) {
-      entries[entries.length - 1].prunable = true;
-    }
-  }
-  return entries;
+  return parseWorktreeListPorcelain(porcelain).map((entry, index) => ({
+    path: entry.path,
+    isMain: index === 0,
+    prunable: entry.prunable ?? false,
+  }));
 }

--- a/scripts/disk-concurrency-stress.ts
+++ b/scripts/disk-concurrency-stress.ts
@@ -30,12 +30,12 @@ import {
 import { writeProjectMetadataEntry } from "../plugin/src/storage/project-metadata";
 import {
   advWorktreeCreate,
-  advWorktreeDelete,
   drainPendingDeletes,
   type AdvWorktreeDeleteDeps,
 } from "../plugin/src/tools/worktree/index";
 import {
   getPendingDeletes,
+  setPendingDelete,
   type WorktreeStateAccess,
 } from "../plugin/src/tools/worktree/state";
 import { acquireFileLock } from "../plugin/src/utils/fs";
@@ -162,6 +162,16 @@ function worktreeDeps(
       changeId: "disk-stress",
       defaultBranch: "main",
     }),
+    store: {
+      changes: {
+        get: async () => ({
+          success: true as const,
+          data: { id: "disk-stress", status: "archived" },
+        }),
+        refresh: async () => undefined,
+      },
+    } as any,
+    approvalEvidence: "isolated stress harness approved pending deletion",
     isWorktreeInUse: () => inUse,
   };
 }
@@ -303,18 +313,11 @@ async function runActor(config: HarnessConfig, actor: number): Promise<ActorResu
 
 async function runDrain(config: HarnessConfig): Promise<unknown> {
   const deps = worktreeDeps(config);
-  const result = await drainPendingDeletes("startup", deps, {
-    forceAttempts: true,
-    deleteWorktree: async (branch, _options, deleteDeps) =>
-      advWorktreeDelete(branch, { force: false }, {
-        ...deleteDeps,
-        integrationCheck: deps.integrationCheck,
-        isWorktreeInUse: () => false,
-        registry: deleteDeps.worktreePath
-          ? [{ branch, changeId: "disk-stress", path: deleteDeps.worktreePath }]
-          : undefined,
-      }),
-  });
+  const result = await drainPendingDeletes(
+    "startup",
+    { ...deps, isWorktreeInUse: () => false },
+    { forceAttempts: true },
+  );
   return { ...result, after: await getPendingDeletes(deps.database) };
 }
 
@@ -470,13 +473,19 @@ export async function runDiskConcurrencyStress(): Promise<StressEvidence> {
     const firstCreated = actors.find(
       (actor) => (actor.create as { ok?: boolean }).ok,
     )!.create as { path: string };
-    const queued = await advWorktreeDelete(
+    const pendingAccess = {
+      projectDir: root,
+      projectId,
+    };
+    await setPendingDelete(
+      pendingAccess,
       WORKTREE_BRANCH,
-      {},
-      worktreeDeps(config, firstCreated.path, true),
+      firstCreated.path,
+      "stress harness retained in-use worktree",
     );
-    const queuedPending =
-      (queued as { error?: string }).error === "WORKTREE_IN_USE";
+    const queuedPending = (await getPendingDeletes(pendingAccess)).some(
+      (entry) => entry.branch === WORKTREE_BRANCH,
+    );
     const drainChild = await spawnJson("drain", configPath);
     if (drainChild.exitCode !== 0 || drainChild.value?.after?.length) {
       actorErrors.push(

--- a/skills/adv-worktree/SKILL.md
+++ b/skills/adv-worktree/SKILL.md
@@ -102,9 +102,15 @@ git -C "$MAIN" log --oneline trunk..change/{change-id}
 
 Only after merge is confirmed:
 
-```bash
-adv_worktree_delete branch: "change/{change-id}" reason: "Change {change-id} merged to default branch"
+```text
+adv_worktree_delete branch: "change/{change-id}" dryRun: true
+# retain returned planToken, then apply:
+adv_worktree_delete branch: "change/{change-id}" planToken: "<planToken>" approvalEvidence: "user approved deletion of change/{change-id}"
 ```
+
+Destructive branch-only calls are rejected with `PLAN_REQUIRED`. The planner
+token binds Git repository, branch, HEAD, safety facts, integration proof, and
+expiry; approval evidence must be nonblank and describe the exact candidate.
 
 The 3-condition gate (archived AND merged AND clean) blocks unsafe deletion. `opts.force: true` never bypasses integration; it only affects uncommitted-work removal after explicit audit reason.
 


### PR DESCRIPTION
## Summary
- replace registry-gated worktree deletion with Git-census plan/apply
- bind deletion to expiring drift-checked tokens and explicit approval evidence
- enforce an end-to-end cancellable deadline with process-tree termination
- add liveness-aware repository leases and typed terminal outcomes
- converge delete, cleanup, archive, and pending-drain paths
- preserve dirty, in-use, CWD, terminal, integration, and lock safety gates

## Verification
- full throttled suite: passed
- Bun CLI: 370 passed
- focused deletion convergence: 132 passed
- post-fix preflight + disk concurrency: 82 passed
- post-rebase smoke: 31 passed
- pnpm --dir plugin run check: passed
- independent reviews: READY

## Operational acceptance
After merge/deploy/restart, use the new plan/apply path to remove the two retained release worktrees; no manual git worktree removal.