### PR TITLE
fix: archive tool target_path schema mismatch

### DIFF
--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -881,7 +881,7 @@ export const archiveChangeTools = {
       noCloseIssue: z.boolean().optional(),
       phase9: z.enum(["run", "skip"]).optional(),
       prTitleType: z.string().optional(),
-      target_path: targetPathSchema.shape.target_path,
+      target_path: z.string().optional(),
       target_confirmed: z.literal(true).optional(),
       confirmationEvidence: z.string().optional(),
     },


### PR DESCRIPTION
JSON schema for adv_change_archive target_path generated as object instead of string, causing every archive invocation to crash. Fix: replace targetPathSchema.shape.target_path with z.string().optional().