### PR TITLE
fix: bound target worktree deletion routing

### DIFF
--- a/plugin/src/tools/adv-worktree.test.ts
+++ b/plugin/src/tools/adv-worktree.test.ts
@@ -2,7 +2,7 @@
  * Smoke tests for ADV worktree tool wrappers.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const worktreeMock = vi.hoisted(() => ({
   advWorktreeCreate: vi.fn(),
@@ -85,6 +85,10 @@ describe("advWorktreeTools", () => {
           store: targetStore,
         }),
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("adv_worktree_create delegates to advWorktreeCreate", async () => {
@@ -756,6 +760,8 @@ describe("advWorktreeTools", () => {
         target_path: "/target",
         target_confirmed: true,
         confirmationEvidence: "User approved target cleanup",
+        planToken: "target-plan-token",
+        approvalEvidence: "User approved exact target deletion plan",
       },
       store,
     );
@@ -766,20 +772,133 @@ describe("advWorktreeTools", () => {
         target_path: "/target",
         target_confirmed: true,
         confirmationEvidence: "User approved target cleanup",
-        stateRequirement: "authoritative",
+        stateRequirement: "snapshot-ok",
+        mutation: true,
       }),
       expect.any(Function),
     );
     expect(stateMock.initStateDb).toHaveBeenCalledWith("/target");
     expect(worktreeMock.advWorktreeDelete).toHaveBeenCalledWith(
       "change/x",
-      expect.any(Object),
+      expect.objectContaining({
+        planToken: "target-plan-token",
+        approvalEvidence: "User approved exact target deletion plan",
+      }),
       expect.objectContaining({
         projectRoot: "/target",
         database,
         store: targetStore,
       }),
     );
+  });
+
+  it("adv_worktree_delete routes dry-run target reads through snapshot access without mutation trust", async () => {
+    const database = {
+      projectDir: "/target",
+      projectId: "0a00e00000ec0000000000000000000000000000",
+    };
+    stateMock.initStateDb.mockResolvedValue(database);
+    worktreeMock.advWorktreeDelete.mockResolvedValue({
+      ok: true,
+      branch: "change/x",
+      dryRun: true,
+    });
+
+    await advWorktreeTools.adv_worktree_delete.execute(
+      { branch: "change/x", dryRun: true, target_path: "/target" },
+      store,
+    );
+
+    expect(targetProjectMock.withTargetPathStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stateRequirement: "snapshot-ok",
+        mutation: false,
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it("adv_worktree_delete passes only the remaining target-routing budget to planning", async () => {
+    const database = {
+      projectDir: "/target",
+      projectId: "0a00e00000ec0000000000000000000000000000",
+    };
+    stateMock.initStateDb.mockResolvedValue(database);
+    worktreeMock.advWorktreeDelete.mockResolvedValue({
+      ok: true,
+      branch: "change/x",
+    });
+    targetProjectMock.withTargetPathStore.mockImplementation(
+      async (_input, fn) => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return fn({
+          context: {
+            root: "/target",
+            projectId: "0a00e00000ec0000000000000000000000000000",
+            externalRoot: "/external/target-project",
+            trusted: true,
+            trustSource: "explicit",
+            stateMode: "disk-snapshot",
+          },
+          store: targetStore,
+        });
+      },
+    );
+
+    await advWorktreeTools.adv_worktree_delete.execute(
+      { branch: "change/x", target_path: "/target", dryRun: true },
+      store,
+    );
+
+    const [, , deps] = worktreeMock.advWorktreeDelete.mock.calls.at(-1)!;
+    expect(deps.operationTimeoutMs).toBeLessThan(
+      WORKTREE_TOOL_SAFE_TIMEOUT_MS - 500,
+    );
+    expect(deps.operationTimeoutMs).toBeGreaterThan(1);
+  });
+
+  it("adv_worktree_delete returns a typed target-resolution timeout and blocks a late callback", async () => {
+    vi.useFakeTimers();
+    let releaseTarget!: () => void;
+    let lateRoute!: Promise<unknown>;
+    const targetPending = new Promise<void>((resolve) => {
+      releaseTarget = resolve;
+    });
+    targetProjectMock.withTargetPathStore.mockImplementation(
+      async (_input, fn) => {
+        await targetPending;
+        lateRoute = fn({
+          context: {
+            root: "/target",
+            projectId: "0a00e00000ec0000000000000000000000000000",
+            externalRoot: "/external/target-project",
+            trusted: true,
+            trustSource: "explicit",
+            stateMode: "disk-snapshot",
+          },
+          store: targetStore,
+        });
+        return lateRoute;
+      },
+    );
+
+    const resultPromise = advWorktreeTools.adv_worktree_delete.execute(
+      { branch: "change/x", target_path: "/target", dryRun: true },
+      store,
+    );
+    await vi.advanceTimersByTimeAsync(WORKTREE_TOOL_SAFE_TIMEOUT_MS - 500 + 1);
+
+    const parsed = JSON.parse(await resultPromise);
+    expect(parsed).toMatchObject({
+      timedOut: true,
+      status: "deadline_exceeded",
+      stage: "target_resolution",
+    });
+
+    releaseTarget();
+    await vi.runAllTicks();
+    await lateRoute;
+    expect(worktreeMock.advWorktreeDelete).not.toHaveBeenCalled();
   });
 
   it("adv_worktree_delete rejects unconfirmed target mutation before deleting", async () => {

--- a/plugin/src/tools/adv-worktree.ts
+++ b/plugin/src/tools/adv-worktree.ts
@@ -42,6 +42,10 @@ import {
   withTargetPathStore,
   type TargetProjectContext,
 } from "./target-project";
+import {
+  createWorktreeOperationContext,
+  type WorktreeOperationContext,
+} from "../utils/worktree-operation";
 
 /**
  * Safe timeout budget for worktree tool wrappers (cleanup and delete).
@@ -244,10 +248,21 @@ async function executeWorktreeResume(
 async function executeWorktreeDelete(
   args: WorktreeDeleteArgs,
   store: Store,
-  options: { serverUrl?: URL; client?: OpencodeClient } = {},
+  options: {
+    serverUrl?: URL;
+    client?: OpencodeClient;
+    operation?: WorktreeOperationContext;
+  } = {},
   context?: TargetProjectContext,
 ): Promise<string> {
   const projectRoot = store.paths.root;
+  const ownsOperation = !options.operation;
+  const operation =
+    options.operation ??
+    createWorktreeOperationContext({
+      budgetMs: WORKTREE_TOOL_SAFE_TIMEOUT_MS,
+      responseReserveMs: WORKTREE_TOOL_RETURN_RESERVE_MS,
+    });
   const database = await initWorktreeDb(projectRoot);
   const log = createLogger();
   const warpDeps = buildWarpDeps({
@@ -256,57 +271,185 @@ async function executeWorktreeDelete(
     client: options.client,
   });
 
-  // rq-worktreeBoundedCleanup02 AC1: bound delete with safe budget so the
-  // tool never exceeds the SDK's 10s hard ceiling.
+  try {
+    // The operation starts at the public handler, so target routing time is
+    // deducted before planning/execution. Keep the response reserve outside
+    // the child budget; the planner and executor then share the same remaining
+    // end-to-end budget instead of resetting their clocks after routing.
+    const effectiveTimeoutMs = Math.max(1, operation.remainingMs());
+    const operationTimeoutMs = Math.max(
+      1,
+      Math.floor(effectiveTimeoutMs - operation.responseReserveMs),
+    );
+    if (
+      operation.signal.aborted ||
+      operation.remainingMs() <= operation.responseReserveMs
+    ) {
+      return formatMaybeTargetOutput(
+        formatToolOutput({
+          ok: false,
+          timedOut: true,
+          error: `DEADLINE_EXCEEDED: adv_worktree_delete timed out during target routing`,
+          status: "deadline_exceeded",
+          stage: "target_resolution",
+          effectiveTimeoutMs,
+          remediation:
+            "Retry with a fresh dry-run plan; the shared executor owns cancellation and revalidation.",
+        }),
+        context,
+      );
+    }
+
+    const deletePromise = advWorktreeDelete(
+      args.branch,
+      {
+        ...(args.force !== undefined ? { force: args.force } : {}),
+        ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+        ...(args.planToken !== undefined ? { planToken: args.planToken } : {}),
+        ...(args.approvalEvidence !== undefined
+          ? { approvalEvidence: args.approvalEvidence }
+          : {}),
+      },
+      {
+        projectRoot,
+        database,
+        log,
+        store,
+        warpDeps,
+        operationTimeoutMs,
+      },
+    );
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeoutRace = new Promise<{ _timedOut: true }>((resolve) => {
+      timeoutHandle = setTimeout(
+        () => resolve({ _timedOut: true }),
+        Math.max(1, effectiveTimeoutMs),
+      );
+    });
+    const result = await Promise.race([deletePromise, timeoutRace]);
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    if ("_timedOut" in result && result._timedOut) {
+      await operation.abort("deadline");
+      return formatMaybeTargetOutput(
+        formatToolOutput({
+          ok: false,
+          timedOut: true,
+          error: `DEADLINE_EXCEEDED: adv_worktree_delete timed out after ${effectiveTimeoutMs}ms`,
+          status: "deadline_exceeded",
+          stage: "handler",
+          effectiveTimeoutMs,
+          remediation:
+            "Retry with a fresh dry-run plan; the shared executor owns cancellation and revalidation.",
+        }),
+        context,
+      );
+    }
+    return formatMaybeTargetOutput(
+      formatToolOutput(result as Awaited<ReturnType<typeof advWorktreeDelete>>),
+      context,
+    );
+  } finally {
+    if (ownsOperation) {
+      await operation.abort("operation_complete");
+      operation.dispose();
+    }
+  }
+}
+
+function targetDeleteRoutingExpired(
+  operation: WorktreeOperationContext,
+): boolean {
+  return (
+    operation.signal.aborted ||
+    operation.remainingMs() <= operation.responseReserveMs
+  );
+}
+
+function targetDeleteRoutingTimeout(effectiveTimeoutMs: number): string {
+  return formatToolOutput({
+    ok: false,
+    timedOut: true,
+    error: `DEADLINE_EXCEEDED: adv_worktree_delete target resolution timed out after ${effectiveTimeoutMs}ms`,
+    status: "deadline_exceeded",
+    stage: "target_resolution",
+    effectiveTimeoutMs,
+    remediation:
+      "Retry with a fresh dry-run plan; target routing did not finish before the internal deadline.",
+  });
+}
+
+async function executeTargetWorktreeDelete(
+  args: WorktreeDeleteArgs,
+  store: Store,
+  options: { serverUrl?: URL; client?: OpencodeClient },
+): Promise<string> {
   const { effectiveTimeoutMs } = clampToSafeBudget(undefined);
-  const deletePromise = advWorktreeDelete(
-    args.branch,
+  const operation = createWorktreeOperationContext({
+    budgetMs: effectiveTimeoutMs,
+    responseReserveMs: WORKTREE_TOOL_RETURN_RESERVE_MS,
+  });
+  const routedPromise = withTargetPathStore(
     {
-      ...(args.force !== undefined ? { force: args.force } : {}),
-      ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
-      ...(args.planToken !== undefined ? { planToken: args.planToken } : {}),
-      ...(args.approvalEvidence !== undefined
-        ? { approvalEvidence: args.approvalEvidence }
-        : {}),
+      currentProjectPath: store.paths.root,
+      target_path: args.target_path!,
+      target_confirmed: args.target_confirmed,
+      confirmationEvidence: args.confirmationEvidence,
+      // The store is only a lightweight terminal-proof input. Git census and
+      // the executor own all deletion effects, including apply.
+      stateRequirement: "snapshot-ok",
+      // Keep the mutation trust gate for apply even though the store itself is
+      // deliberately not initialized or migrated.
+      mutation: !args.dryRun,
     },
-    {
-      projectRoot,
-      database,
-      log,
-      store,
-      warpDeps,
-      operationTimeoutMs: cleanupItemTimeoutForToolBudget(effectiveTimeoutMs),
+    async ({ context, store: targetStore }) => {
+      // withTargetPathStore is intentionally non-cancelling. A late target
+      // resolution may finish, but it must never enter planning or execution
+      // after the public handler has returned its timeout response.
+      if (targetDeleteRoutingExpired(operation)) {
+        return targetDeleteRoutingTimeout(effectiveTimeoutMs);
+      }
+      return executeWorktreeDelete(
+        args,
+        targetStore,
+        { ...options, operation },
+        context,
+      );
     },
   );
 
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
   const timeoutRace = new Promise<{ _timedOut: true }>((resolve) => {
     timeoutHandle = setTimeout(
       () => resolve({ _timedOut: true }),
-      effectiveTimeoutMs,
+      Math.max(1, operation.remainingMs() - operation.responseReserveMs),
     );
   });
-  const result = await Promise.race([deletePromise, timeoutRace]);
-  if (timeoutHandle) clearTimeout(timeoutHandle);
-  if ("_timedOut" in result && result._timedOut) {
-    return formatMaybeTargetOutput(
-      formatToolOutput({
-        ok: false,
-        timedOut: true,
-        error: `DEADLINE_EXCEEDED: adv_worktree_delete timed out after ${effectiveTimeoutMs}ms`,
-        status: "deadline_exceeded",
-        stage: "handler",
-        effectiveTimeoutMs,
-        remediation:
-          "Retry with a fresh dry-run plan; the shared executor owns cancellation and revalidation.",
-      }),
-      context,
-    );
+  try {
+    const result = await Promise.race([routedPromise, timeoutRace]);
+    if (typeof result !== "string") {
+      if (result._timedOut) {
+        timedOut = true;
+        await operation.abort("target_resolution_deadline");
+        return targetDeleteRoutingTimeout(effectiveTimeoutMs);
+      }
+      throw new Error("unexpected target delete routing result");
+    }
+    return result;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    if (timedOut) {
+      // Keep the aborted guard alive until the non-cancelling resolution
+      // settles, then release its deadline timer and child leases.
+      void routedPromise.then(
+        () => operation.dispose(),
+        () => operation.dispose(),
+      );
+    } else {
+      operation.dispose();
+    }
   }
-  return formatMaybeTargetOutput(
-    formatToolOutput(result as Awaited<ReturnType<typeof advWorktreeDelete>>),
-    context,
-  );
 }
 
 async function executeWorktreeCleanup(
@@ -890,18 +1033,7 @@ export const advWorktreeTools = {
       // rq-worktreeTargetCleanup01: target_path delete uses the target store
       // while preserving advWorktreeDelete as the sole deletion authority.
       if (args.target_path) {
-        return withTargetPathStore(
-          {
-            currentProjectPath: store.paths.root,
-            target_path: args.target_path,
-            target_confirmed: args.target_confirmed,
-            confirmationEvidence: args.confirmationEvidence,
-            stateRequirement: "authoritative",
-            mutation: !args.dryRun,
-          },
-          async ({ context, store: targetStore }) =>
-            executeWorktreeDelete(args, targetStore, options, context),
-        );
+        return executeTargetWorktreeDelete(args, store, options);
       }
       return executeWorktreeDelete(args, store, options);
     },

--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -42,7 +42,6 @@ import {
 import { formatToolOutput } from "../../utils/tool-output";
 import {
   withTargetPathStore,
-  targetPathSchema,
   appendTargetProjectContextOutput,
 } from "../target-project";
 import {


### PR DESCRIPTION
## Summary
- start deletion budget before target-project routing
- use snapshot-only target store access instead of authoritative initialization
- preserve mutation trust for token-bound apply
- prevent late target callbacks from invoking deletion after timeout
- propagate only remaining end-to-end budget into planner/executor
- remove stale archive import currently breaking trunk lint

## Verification
- focused target/public/planner suites: 65 passed
- plugin check: passed
- independent review: READY

## Acceptance reproduction
Fixes live v1.20.5 target-path dry-run calls that still exceeded the host 10-second ceiling before planner entry.