### PR TITLE
fix: accept patch-equivalent worktree branches

### DIFF
--- a/plugin/src/tools/worktree/deletion-contracts.test.ts
+++ b/plugin/src/tools/worktree/deletion-contracts.test.ts
@@ -102,4 +102,41 @@ describe("worktree deletion contracts", () => {
       }),
     ).toMatchObject({ status: "drifted" });
   });
+
+  it("binds the integration proof kind and evidence into the plan token", () => {
+    const integration = {
+      kind: "patch_equivalent" as const,
+      branch: "release/v1",
+      defaultBranch: "trunk",
+      head: facts.head,
+      evidence: "git cherry -v trunk release/v1 (all patches equivalent)",
+    };
+    const expiresAt = 1_800_000_000_000;
+    const token = encodeWorktreeDeletionToken({
+      facts,
+      expiresAt,
+      integration,
+    });
+    const plan = {
+      version: "wdp1" as const,
+      repository: facts.repository,
+      facts,
+      expiresAt,
+      token,
+      integration,
+    };
+
+    expect(WorktreeDeletionPlanSchema.parse(plan)).toEqual(plan);
+    expect(() =>
+      WorktreeDeletionPlanSchema.parse({
+        ...plan,
+        integration: { ...integration, kind: "merged_to_default" },
+      }),
+    ).toThrow(/token must bind/);
+    expect(
+      validateWorktreeDeletionToken(token, {
+        integration: { ...integration, evidence: "changed" },
+      }),
+    ).toEqual({ ok: false, reason: "facts_changed" });
+  });
 });

--- a/plugin/src/tools/worktree/deletion-contracts.ts
+++ b/plugin/src/tools/worktree/deletion-contracts.ts
@@ -35,7 +35,7 @@ export type WorktreeDeletionFacts = z.infer<typeof WorktreeDeletionFactsSchema>;
 
 export const WorktreeDeletionIntegrationProofSchema = z
   .object({
-    kind: z.enum(["merged_to_default", "pr_merged"]),
+    kind: z.enum(["merged_to_default", "patch_equivalent", "pr_merged"]),
     branch: NonEmptyTextSchema,
     defaultBranch: NonEmptyTextSchema,
     head: z.string().regex(HEX_SHA_RE),

--- a/plugin/src/tools/worktree/deletion-executor.test.ts
+++ b/plugin/src/tools/worktree/deletion-executor.test.ts
@@ -167,6 +167,33 @@ describe("WorktreeDeletionExecutor", () => {
     }
   });
 
+  it("refuses when the planned patch-equivalence proof changes at apply time", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx, {
+        integration: { kind: "patch_equivalent" },
+      });
+      const deps = depsFor(fx, plan, {
+        integrationProof: vi.fn(async () => ({
+          kind: "merged_to_default" as const,
+          branch: "release/v1",
+          defaultBranch: "trunk",
+          head: sha,
+          evidence: "ancestry proof after plan",
+        })),
+      });
+      const result = await executeWorktreeDeletion({ plan }, deps);
+      expect(result).toMatchObject({
+        ok: false,
+        status: "drifted",
+        reason: "integration_proof_changed",
+      });
+      expect(deps.runProcess).not.toHaveBeenCalled();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
   it.each([
     ["head", { head: "fedcba9876543210fedcba9876543210fedcba98" }],
     ["dirty", { dirty: true }],

--- a/plugin/src/tools/worktree/deletion-executor.ts
+++ b/plugin/src/tools/worktree/deletion-executor.ts
@@ -31,6 +31,10 @@ import {
 } from "../../utils/worktree-operation";
 import { stableStringify } from "../../utils/digest";
 import { isWorktreeInUse } from "./in-use";
+import {
+  LocalBranchIntegrationDeadline,
+  proveLocalBranchIntegration,
+} from "../../utils/branch-integration";
 
 /** Dependency seams keep the destructive boundary testable without bypassing Git. */
 export interface WorktreeDeletionExecutorDeps {
@@ -369,13 +373,27 @@ export class WorktreeDeletionExecutor {
       if (
         !branchFact ||
         !integration ||
-        branchFact.headSha !== integration.head ||
-        (!branchFact.merged && !this.deps.integrationProof)
+        branchFact.headSha !== integration.head
       )
         return failure("drifted", "integration_fact_changed", stage);
       if (this.deps.integrationProof) {
         const currentProof = await runBounded(stage, () =>
           this.deps.integrationProof!(
+            plan.facts.branch ?? "",
+            actual.head,
+            integration.defaultBranch,
+            plan.repository,
+            operation,
+          ),
+        );
+        if (!sameProof(integration, currentProof))
+          return failure("drifted", "integration_proof_changed", stage);
+      } else if (branchFact.merged) {
+        if (integration.kind !== "merged_to_default")
+          return failure("drifted", "integration_proof_changed", stage);
+      } else {
+        const currentProof = await runBounded(stage, () =>
+          proveLocalBranchIntegration(
             plan.facts.branch ?? "",
             actual.head,
             integration.defaultBranch,
@@ -624,6 +642,12 @@ export class WorktreeDeletionExecutor {
         );
       if (error instanceof WorktreeDeletionStageDeadline)
         return failure("deadline_exceeded", error.message, error.stage);
+      if (error instanceof LocalBranchIntegrationDeadline)
+        return failure(
+          "deadline_exceeded",
+          error.message,
+          operation.currentStage,
+        );
       if (
         error instanceof Error &&
         /unsupported.*platform/i.test(error.message)

--- a/plugin/src/tools/worktree/deletion-planner.test.ts
+++ b/plugin/src/tools/worktree/deletion-planner.test.ts
@@ -1,9 +1,9 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   WorktreeDeletionPlanner,
@@ -67,6 +67,53 @@ describe("WorktreeDeletionPlanner", () => {
       }
     } finally {
       fixture.cleanup();
+    }
+  });
+
+  it("plans a squash-equivalent release branch from two all-minus cherry lines", async () => {
+    const root = mkdtempSync(join(tmpdir(), "adv-deletion-planner-squash-"));
+    const worktree = `${root}-linked`;
+    try {
+      git(root, "init", "-b", "trunk");
+      git(root, "config", "user.email", "test@example.invalid");
+      git(root, "config", "user.name", "ADV test");
+      execFileSync("touch", [join(root, "README.md")]);
+      git(root, "add", ".");
+      git(root, "commit", "-m", "initial");
+      git(
+        root,
+        "worktree",
+        "add",
+        "-b",
+        "release/fixPostRemovalRelease",
+        worktree,
+      );
+      writeFileSync(join(worktree, "one.txt"), "one\n");
+      git(worktree, "add", ".");
+      git(worktree, "commit", "-m", "first release change");
+      writeFileSync(join(worktree, "two.txt"), "two\n");
+      git(worktree, "add", ".");
+      git(worktree, "commit", "-m", "second release change");
+      const first = git(worktree, "rev-parse", "HEAD~1");
+      const second = git(worktree, "rev-parse", "HEAD");
+      git(root, "cherry-pick", "--no-commit", first);
+      git(root, "commit", "-m", "squash first release change");
+      git(root, "cherry-pick", "--no-commit", second);
+      git(root, "commit", "-m", "squash second release change");
+
+      const result = await new WorktreeDeletionPlanner().plan({
+        repository: root,
+        branch: "release/fixPostRemovalRelease",
+        defaultBranch: "trunk",
+        cwd: root,
+        registry: [],
+      });
+
+      expect(result.kind).toBe("planned");
+      if (result.kind === "planned")
+        expect(result.plan.integration?.kind).toBe("patch_equivalent");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 
@@ -169,6 +216,27 @@ describe("WorktreeDeletionPlanner", () => {
       kind: "refused",
       reason: "terminal_proof_required",
     });
+  });
+
+  it("rejects invalid branch and default refs before the Git census", async () => {
+    const census = vi.fn(async () => ({ branches: [], worktrees: [] }));
+    const planner = new WorktreeDeletionPlanner({ census });
+
+    await expect(
+      planner.plan({
+        repository: "/repo",
+        branch: "release/v1..trunk",
+        defaultBranch: "trunk",
+      }),
+    ).resolves.toMatchObject({ kind: "refused", reason: "invalid_ref" });
+    await expect(
+      planner.plan({
+        repository: "/repo",
+        branch: "release/v1",
+        defaultBranch: "--upload-pack=evil",
+      }),
+    ).resolves.toMatchObject({ kind: "refused", reason: "invalid_ref" });
+    expect(census).not.toHaveBeenCalled();
   });
 
   it("returns a deadline result when target resolution consumes the budget", async () => {

--- a/plugin/src/tools/worktree/deletion-planner.ts
+++ b/plugin/src/tools/worktree/deletion-planner.ts
@@ -21,6 +21,11 @@ import {
   type WorktreeStageTiming,
 } from "../../utils/worktree-operation";
 import { getDefaultBranch } from "../../utils/git";
+import { isValidGitBranchRef } from "../../utils/git-ref";
+import {
+  proveLocalBranchIntegration,
+  type LocalBranchIntegrationProof,
+} from "../../utils/branch-integration";
 import { getExternalRootForProject } from "../../utils/project-id";
 
 /** A plan is intentionally short-lived and self-contained. */
@@ -42,6 +47,7 @@ export type WorktreeDeletionRefusalReason =
   | "git_corrupt"
   | "bare_worktree"
   | "branch_not_merged"
+  | "invalid_ref"
   | "terminal_proof_required";
 
 export type WorktreeDeletionRepairReason =
@@ -340,8 +346,24 @@ export class WorktreeDeletionPlanner {
           { target },
         );
       }
+      if (!isValidGitBranchRef(branch)) {
+        return refusal(
+          "invalid_ref",
+          "The requested branch is not a valid local Git branch name.",
+          operation,
+          { target },
+        );
+      }
       const defaultBranch =
         input.defaultBranch ?? (await getDefaultBranch(target.repository));
+      if (!isValidGitBranchRef(defaultBranch)) {
+        return refusal(
+          "invalid_ref",
+          "The default branch is not a valid local Git branch name.",
+          operation,
+          { target },
+        );
+      }
 
       operation.startStage("git_census");
       let census: GitWorkspaceFacts;
@@ -495,14 +517,6 @@ export class WorktreeDeletionPlanner {
           operation,
           { facts, target },
         );
-      if (!branchFact.merged && !this.deps.integrationProof)
-        return refusal(
-          "branch_not_merged",
-          `Branch ${branch} is not integrated into ${defaultBranch}.`,
-          operation,
-          { facts, target },
-        );
-
       operation.startStage("integration_proof");
       let integration: WorktreeDeletionIntegrationProof | undefined;
       try {
@@ -516,13 +530,21 @@ export class WorktreeDeletionPlanner {
                 operation,
               ),
             )
-          : {
-              kind: "merged_to_default",
-              branch,
-              defaultBranch,
-              head: candidate.headSha,
-              evidence: `git branch --merged ${defaultBranch}`,
-            });
+          : branchFact.merged
+            ? {
+                kind: "merged_to_default" as const,
+                branch,
+                defaultBranch,
+                head: candidate.headSha,
+                evidence: `git branch --merged ${defaultBranch}`,
+              }
+            : ((await proveLocalBranchIntegration(
+                branch,
+                candidate.headSha,
+                defaultBranch,
+                target.repository,
+                operation,
+              )) as LocalBranchIntegrationProof | undefined));
       } catch (error) {
         if (isTimeoutError(error) || operation.remainingMs() <= 0)
           return this.deadline(operation, "integration_proof", error, target);

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -30,6 +30,7 @@ import {
 } from "node:fs/promises";
 import * as path from "node:path";
 import { execFileGitCb } from "../../utils/git-binary";
+import { isValidGitBranchRef } from "../../utils/git-ref";
 import { boundedRetry } from "../../utils/fs";
 import { type Plugin, tool } from "@opencode-ai/plugin";
 import type {
@@ -113,6 +114,8 @@ import {
 import type { Store } from "../../storage/store";
 import { withTimeout, TimeoutError } from "../../utils/with-timeout";
 import { execGh } from "../../integrations/gh-cli";
+import { proveLocalBranchIntegration } from "../../utils/branch-integration";
+import type { WorktreeOperationContext } from "../../utils/worktree-operation";
 
 export { advWorktreeDetachBatch } from "./detach";
 export {
@@ -196,17 +199,6 @@ const Result = {
  * Git branch name validation - blocks invalid refs and shell metacharacters
  * Characters blocked: control chars (0x00-0x1f, 0x7f), ~^:?*[]\\, and shell metacharacters
  */
-function isValidBranchName(name: string): boolean {
-  // Check for control characters
-  for (let i = 0; i < name.length; i++) {
-    const code = name.charCodeAt(i);
-    if (code <= 0x1f || code === 0x7f) return false;
-  }
-  // Check for invalid git ref characters and shell metacharacters
-  if (/[~^:?*[\]\\;&|`$()]/.test(name)) return false;
-  return true;
-}
-
 const branchNameSchema = z
   .string()
   .min(1, "Branch name cannot be empty")
@@ -231,7 +223,7 @@ const branchNameSchema = z
   })
   .max(255, "Branch name too long")
   .refine(
-    (name) => isValidBranchName(name),
+    (name) => isValidGitBranchRef(name),
     "Contains invalid git ref characters",
   )
   .refine(
@@ -1785,13 +1777,35 @@ async function advWorktreeDeleteShared(
     };
   };
   const integrationProof =
-    deps.prMergeEvidence || deps.mergedBranches
+    deps.integrationCheck || deps.prMergeEvidence || deps.mergedBranches
       ? async (
           branchName: string,
           head: string,
           defaultBranch: string,
           repository: string,
+          operation: WorktreeOperationContext,
         ) => {
+          if (deps.integrationCheck) {
+            const checked = await deps.integrationCheck(
+              branchName,
+              repository,
+              {},
+              {
+                registry: deps.registry,
+                mergedBranches: deps.mergedBranches,
+              },
+            );
+            if (checked.ok) {
+              return {
+                kind: "merged_to_default" as const,
+                branch: branchName,
+                defaultBranch,
+                head,
+                evidence: "legacy integration check",
+              };
+            }
+            if (checked.reason !== "branch_not_merged") return undefined;
+          }
           if (deps.mergedBranches) {
             const merged = await deps.mergedBranches(defaultBranch, repository);
             if (
@@ -1807,20 +1821,29 @@ async function advWorktreeDeleteShared(
                 evidence: `git branch --merged ${defaultBranch}`,
               };
           }
-          if (!deps.prMergeEvidence) return undefined;
-          const proof = await deps.prMergeEvidence(branchName, repository);
-          if (!proof.ok) return undefined;
-          appendDebugLog(
-            "worktree-delete",
-            `verified squash PR merge for ${branchName} via PR #${proof.prNumber} (${proof.proof})`,
-          );
-          return {
-            kind: "pr_merged" as const,
-            branch: branchName,
-            defaultBranch,
+          if (deps.prMergeEvidence) {
+            const proof = await deps.prMergeEvidence(branchName, repository);
+            if (proof.ok) {
+              appendDebugLog(
+                "worktree-delete",
+                `verified squash PR merge for ${branchName} via PR #${proof.prNumber} (${proof.proof})`,
+              );
+              return {
+                kind: "pr_merged" as const,
+                branch: branchName,
+                defaultBranch,
+                head,
+                evidence: `merged PR #${proof.prNumber}${proof.prUrl ? ` (${proof.prUrl})` : ""}`,
+              };
+            }
+          }
+          return proveLocalBranchIntegration(
+            branchName,
             head,
-            evidence: `merged PR #${proof.prNumber}${proof.prUrl ? ` (${proof.prUrl})` : ""}`,
-          };
+            defaultBranch,
+            repository,
+            operation,
+          );
         }
       : undefined;
   const planner =

--- a/plugin/src/utils/branch-integration.test.ts
+++ b/plugin/src/utils/branch-integration.test.ts
@@ -4,11 +4,14 @@
  * Pure unit tests — all external dependencies (Temporal, git) are injected.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  LocalBranchIntegrationDeadline,
+  proveLocalBranchIntegration,
   verifyBranchIntegration,
   type BranchIntegrationDeps,
 } from "./branch-integration";
+import { createWorktreeOperationContext } from "./worktree-operation";
 
 function makeDeps(
   overrides: Partial<BranchIntegrationDeps> = {},
@@ -288,5 +291,103 @@ describe("verifyBranchIntegration (T29)", () => {
       ok: false,
       reason: "git_failed",
     });
+  });
+});
+
+describe("proveLocalBranchIntegration", () => {
+  const head = "0123456789abcdef0123456789abcdef01234567";
+  const minus = `- ${head} equivalent patch`;
+
+  async function prove(
+    cherryOutput: string,
+    cherryError?: unknown,
+  ): Promise<Awaited<ReturnType<typeof proveLocalBranchIntegration>>> {
+    const operation = createWorktreeOperationContext({ budgetMs: 1_000 });
+    try {
+      return await proveLocalBranchIntegration(
+        "release/fixPostRemovalRelease",
+        head,
+        "trunk",
+        "/repo",
+        operation,
+        {
+          runGit: async (args) => {
+            if (args[0] === "merge-base")
+              throw Object.assign(new Error("not an ancestor"), { code: 1 });
+            if (cherryError) throw cherryError;
+            return { stdout: cherryOutput, stderr: "" };
+          },
+        },
+      );
+    } finally {
+      operation.dispose();
+    }
+  }
+
+  it("accepts the live squash-equivalent shape with two minus lines", async () => {
+    await expect(prove(`${minus}\n${minus}\n`)).resolves.toMatchObject({
+      kind: "patch_equivalent",
+      branch: "release/fixPostRemovalRelease",
+      defaultBranch: "trunk",
+      head,
+    });
+  });
+
+  it.each([
+    ["one plus line", `${minus}\n+ ${head} unique patch\n`],
+    ["mixed plus and minus", `+ ${head} unique patch\n${minus}\n`],
+    ["malformed line", `${minus}\nnot git cherry output\n`],
+  ])("rejects %s", async (_label, output) => {
+    await expect(prove(output)).resolves.toBeUndefined();
+  });
+
+  it("rejects a nonzero cherry command", async () => {
+    await expect(
+      prove("", Object.assign(new Error("git failed"), { code: 2 })),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns a typed deadline for a timed-out child", async () => {
+    const operation = createWorktreeOperationContext({ budgetMs: 1_000 });
+    try {
+      await expect(
+        proveLocalBranchIntegration(
+          "release/v1",
+          head,
+          "trunk",
+          "/repo",
+          operation,
+          {
+            runGit: async () => {
+              throw Object.assign(new Error("timed out"), {
+                name: "AbortError",
+              });
+            },
+          },
+        ),
+      ).rejects.toBeInstanceOf(LocalBranchIntegrationDeadline);
+    } finally {
+      operation.dispose();
+    }
+  });
+
+  it("rejects invalid refs before constructing a Git command", async () => {
+    const runGit = vi.fn(async () => ({ stdout: "", stderr: "" }));
+    const operation = createWorktreeOperationContext({ budgetMs: 1_000 });
+    try {
+      await expect(
+        proveLocalBranchIntegration(
+          "release/v1..trunk",
+          head,
+          "trunk",
+          "/repo",
+          operation,
+          { runGit },
+        ),
+      ).resolves.toBeUndefined();
+      expect(runGit).not.toHaveBeenCalled();
+    } finally {
+      operation.dispose();
+    }
   });
 });

--- a/plugin/src/utils/branch-integration.ts
+++ b/plugin/src/utils/branch-integration.ts
@@ -14,8 +14,10 @@
  * requirements stay intact: closed ≠ unmerged-OK.
  */
 
-import { execFileGitCb } from "./git-binary";
+import { execFileGitAsync, execFileGitCb } from "./git-binary";
+import { isValidGitBranchRef } from "./git-ref";
 import { getDefaultBranch } from "./git";
+import type { WorktreeOperationContext } from "./worktree-operation";
 import {
   getWorktreeRegistrySnapshot,
   getWorktreePath,
@@ -54,6 +56,177 @@ export interface BranchIntegrationDeps {
   ) => Promise<string[]>;
   worktreeStatus?: (worktreePath: string) => Promise<string>;
   registry?: { branch: string; changeId?: string; path: string }[];
+}
+
+export type LocalBranchIntegrationProof =
+  | {
+      kind: "merged_to_default";
+      branch: string;
+      defaultBranch: string;
+      head: string;
+      evidence: string;
+    }
+  | {
+      kind: "patch_equivalent";
+      branch: string;
+      defaultBranch: string;
+      head: string;
+      evidence: string;
+    };
+
+export class LocalBranchIntegrationDeadline extends Error {
+  constructor(stage: "merge-base" | "cherry") {
+    super(`Local branch integration ${stage} exceeded the operation budget.`);
+    this.name = "LocalBranchIntegrationDeadline";
+  }
+}
+
+export interface LocalBranchIntegrationGitOptions {
+  cwd: string;
+  timeout: number;
+  remainingMs: number;
+  signal: AbortSignal;
+}
+
+export interface LocalBranchIntegrationOptions {
+  /** Test seam; production always uses the bounded git helper below. */
+  runGit?: (
+    args: readonly string[],
+    options: LocalBranchIntegrationGitOptions,
+  ) => Promise<{ stdout: string; stderr: string }>;
+}
+
+function errorExitCode(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "number" ? code : undefined;
+}
+
+function isProcessDeadline(
+  error: unknown,
+  operation: WorktreeOperationContext,
+) {
+  if (operation.signal.aborted) return true;
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as {
+    name?: unknown;
+    killed?: unknown;
+    signal?: unknown;
+    message?: unknown;
+  };
+  return (
+    candidate.name === "AbortError" ||
+    candidate.killed === true ||
+    typeof candidate.signal === "string" ||
+    (typeof candidate.message === "string" &&
+      /timeout|timed out|deadline|abort/i.test(candidate.message))
+  );
+}
+
+function validPatchEquivalentCherryLine(line: string): boolean {
+  return /^-[ \t]+[0-9a-f]{4,64}(?:[ \t]+.*)?$/i.test(line);
+}
+
+/**
+ * Prove a local branch is integrated without relying on remote PR state.
+ *
+ * The ancestry check is authoritative when it succeeds. A non-ancestor may
+ * still be safely deletable after a squash merge, but only when `git cherry`
+ * exits successfully and every emitted patch is a well-formed `-` line.
+ * Every child receives the remaining operation budget and cancellation signal.
+ */
+export async function proveLocalBranchIntegration(
+  branch: string,
+  head: string,
+  defaultBranch: string,
+  repoRoot: string,
+  operation: WorktreeOperationContext,
+  options: LocalBranchIntegrationOptions = {},
+): Promise<LocalBranchIntegrationProof | undefined> {
+  if (
+    !isValidGitBranchRef(branch) ||
+    !isValidGitBranchRef(defaultBranch) ||
+    branch === defaultBranch ||
+    branch.startsWith("-") ||
+    defaultBranch.startsWith("-")
+  )
+    return undefined;
+
+  const runGit =
+    options.runGit ??
+    ((args: readonly string[], gitOptions: LocalBranchIntegrationGitOptions) =>
+      execFileGitAsync(args, gitOptions));
+  const runBoundedGit = async (
+    stage: "merge-base" | "cherry",
+    args: readonly string[],
+  ): Promise<{ stdout: string; stderr: string } | undefined> => {
+    const remainingMs = operation.remainingMs();
+    if (remainingMs <= 0 || operation.signal.aborted)
+      throw new LocalBranchIntegrationDeadline(stage);
+    try {
+      return await runGit(args, {
+        cwd: repoRoot,
+        timeout: Math.max(1, remainingMs),
+        remainingMs: Math.max(1, remainingMs),
+        signal: operation.signal,
+      });
+    } catch (error) {
+      if (isProcessDeadline(error, operation))
+        throw new LocalBranchIntegrationDeadline(stage);
+      throw error;
+    }
+  };
+
+  let ancestry: { stdout: string; stderr: string } | undefined;
+  try {
+    ancestry = await runBoundedGit("merge-base", [
+      "merge-base",
+      "--is-ancestor",
+      branch,
+      defaultBranch,
+    ]);
+  } catch (error) {
+    // Exit 1 is Git's explicit "not an ancestor" result. Any other exit
+    // code means the refs/repository were not safely interpretable.
+    if (error instanceof LocalBranchIntegrationDeadline) throw error;
+    if (errorExitCode(error) !== 1) return undefined;
+  }
+  if (ancestry) {
+    return {
+      kind: "merged_to_default",
+      branch,
+      defaultBranch,
+      head,
+      evidence: `git merge-base --is-ancestor ${branch} ${defaultBranch}`,
+    };
+  }
+
+  let cherry: { stdout: string; stderr: string } | undefined;
+  try {
+    cherry = await runBoundedGit("cherry", [
+      "cherry",
+      "-v",
+      defaultBranch,
+      branch,
+    ]);
+  } catch (error) {
+    if (error instanceof LocalBranchIntegrationDeadline) throw error;
+    return undefined;
+  }
+  if (!cherry) return undefined;
+  const lines = cherry.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (!lines.every(validPatchEquivalentCherryLine)) return undefined;
+
+  return {
+    kind: "patch_equivalent",
+    branch,
+    defaultBranch,
+    head,
+    evidence: `git cherry -v ${defaultBranch} ${branch} (all patches equivalent)`,
+  };
 }
 
 // =============================================================================

--- a/plugin/src/utils/git-ref.ts
+++ b/plugin/src/utils/git-ref.ts
@@ -1,0 +1,23 @@
+/**
+ * Validate a local Git branch/ref name before passing it to a Git subprocess.
+ *
+ * This intentionally accepts ordinary local branch names only, not revision
+ * expressions. Deletion paths must never reinterpret caller input as a range,
+ * reflog selector, or command option.
+ */
+export function isValidGitBranchRef(name: string): boolean {
+  if (name.length === 0 || name.length > 255) return false;
+  if (name.startsWith("-") || name.startsWith("/") || name.endsWith("/"))
+    return false;
+  if (
+    name.includes("//") ||
+    name.includes("@{") ||
+    name.includes("..") ||
+    name.startsWith(".") ||
+    name.endsWith(".") ||
+    name.endsWith(".lock")
+  )
+    return false;
+  // eslint-disable-next-line no-control-regex -- control character detection is intentional for security
+  return !/[\x00-\x1f\x7f ~^:?*[\]\\;&|`$()]/.test(name);
+}


### PR DESCRIPTION
## Summary
- add bounded cancellable `git cherry -v` integration proof after ancestry check
- accept only empty/all-minus patch-equivalent output
- fail closed on plus, mixed, malformed, timeout, nonzero, or invalid refs
- bind patch-equivalence proof into deletion plan tokens and executor drift checks
- preserve terminal proof for change branches

## Verification
- full focused contracts/planner/executor/public/delete suites: 114 passed
- post-rebase planner/executor/integration suites: 47 passed
- plugin check: passed
- independent review: READY

## Live acceptance
`git cherry trunk release/fixPostRemovalRelease` returns two minus entries for commits integrated through PRs #400/#402; v1.20.6 currently refuses this safe retained worktree as branch_not_merged.