### PR TITLE
fix: enforce worktree deletion cancellation barrier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
         run: pnpm test
         working-directory: plugin
 
+      - name: Build plugin bundle for CLI parity
+        run: pnpm run build
+        working-directory: plugin
+
       - name: Test bin CLI (Bun)
         run: bun test bin/
         working-directory: .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ bin/oc-test smoke
 bin/oc-test full
 ```
 
-- CI uses Node 24 and pnpm 11. CI order: schemas:check → typecheck → lint → format:check → test → build. Tests run on Node/Vitest; the OpenCode runtime is Bun. CI separately runs `bun test bin/` from the repo root.
+- CI uses Node 24 and pnpm 11. CI order: schemas:check → typecheck → lint → format:check → test → build. Tests run on Node/Vitest; the OpenCode runtime is Bun. CI builds the emitted plugin bundle before separately running `bun test bin/` from the repo root because CLI parity tests execute `plugin/dist/reconcile-cli.js`.
 - `pnpm` owns dependencies. Never add `bun.lock` or `bun.lockb` beside `plugin/pnpm-lock.yaml`.
 - `bin/adv` is a Bun-powered standalone CLI (`adv status`, `adv roadmap`, `adv epic list --json`); requires Bun 1.3+ on PATH. `bun test bin/` covers it as a separate CI job — do not put bin/ tests under Vitest.
 

--- a/plugin/src/tools/adv-worktree.test.ts
+++ b/plugin/src/tools/adv-worktree.test.ts
@@ -1333,7 +1333,22 @@ describe("advWorktreeTools", () => {
     };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDelete.mockImplementation(
-      () => new Promise(() => {}),
+      (_branch, _opts, deps) =>
+        new Promise((resolve) => {
+          deps.operation?.signal.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                ok: false,
+                timedOut: true,
+                status: "deadline_exceeded",
+                error: "DEADLINE_EXCEEDED: timed out after shared cancellation",
+                effectiveTimeoutMs: 7_500,
+                remediation: "retry with a fresh plan",
+              }),
+            { once: true },
+          );
+        }),
     );
 
     // The delete tool currently hardcodes the safe budget (8s) internally
@@ -1539,7 +1554,22 @@ describe("advWorktreeTools", () => {
     };
     stateMock.initStateDb.mockResolvedValue(database);
     worktreeMock.advWorktreeDelete.mockImplementation(
-      () => new Promise(() => {}),
+      (_branch, _opts, deps) =>
+        new Promise((resolve) => {
+          deps.operation?.signal.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                ok: false,
+                timedOut: true,
+                status: "deadline_exceeded",
+                error: "DEADLINE_EXCEEDED: timed out after shared cancellation",
+                effectiveTimeoutMs: 7_500,
+                remediation: "retry with a fresh plan",
+              }),
+            { once: true },
+          );
+        }),
     );
 
     const out = await advWorktreeTools.adv_worktree_delete.execute(

--- a/plugin/src/tools/adv-worktree.ts
+++ b/plugin/src/tools/adv-worktree.ts
@@ -51,9 +51,8 @@ import {
  * Safe timeout budget for worktree tool wrappers (cleanup and delete).
  *
  * Must be strictly below the SDK's `DEFAULT_TOOL_TIMEOUT_MS` (10 000 ms)
- * so that the tool-level `Promise.race` resolves *before* the SDK's
- * `safeExecute` wrapper rejects — giving the agent a typed, actionable
- * timeout response instead of an opaque `ToolExecutionTimeout` error.
+ * so the shared operation deadline can cancel and settle every destructive
+ * stage before the SDK's `safeExecute` wrapper rejects.
  *
  * rq-worktreeBoundedCleanup02 AC1.
  */
@@ -255,7 +254,6 @@ async function executeWorktreeDelete(
   } = {},
   context?: TargetProjectContext,
 ): Promise<string> {
-  const projectRoot = store.paths.root;
   const ownsOperation = !options.operation;
   const operation =
     options.operation ??
@@ -263,6 +261,17 @@ async function executeWorktreeDelete(
       budgetMs: WORKTREE_TOOL_SAFE_TIMEOUT_MS,
       responseReserveMs: WORKTREE_TOOL_RETURN_RESERVE_MS,
     });
+  if (targetDeleteRoutingExpired(operation)) {
+    const timeout = targetDeleteRoutingTimeout(
+      Math.max(1, operation.remainingMs()),
+    );
+    if (ownsOperation) {
+      await operation.abort("deadline");
+      operation.dispose();
+    }
+    return formatMaybeTargetOutput(timeout, context);
+  }
+  const projectRoot = store.paths.root;
   const database = await initWorktreeDb(projectRoot);
   const log = createLogger();
   const warpDeps = buildWarpDeps({
@@ -277,10 +286,6 @@ async function executeWorktreeDelete(
     // the child budget; the planner and executor then share the same remaining
     // end-to-end budget instead of resetting their clocks after routing.
     const effectiveTimeoutMs = Math.max(1, operation.remainingMs());
-    const operationTimeoutMs = Math.max(
-      1,
-      Math.floor(effectiveTimeoutMs - operation.responseReserveMs),
-    );
     if (
       operation.signal.aborted ||
       operation.remainingMs() <= operation.responseReserveMs
@@ -300,7 +305,7 @@ async function executeWorktreeDelete(
       );
     }
 
-    const deletePromise = advWorktreeDelete(
+    const result = await advWorktreeDelete(
       args.branch,
       {
         ...(args.force !== undefined ? { force: args.force } : {}),
@@ -316,35 +321,15 @@ async function executeWorktreeDelete(
         log,
         store,
         warpDeps,
-        operationTimeoutMs,
+        // Compatibility telemetry only; the shared operation is authoritative
+        // and prevents this value from creating a second deadline.
+        operationTimeoutMs: Math.max(
+          1,
+          Math.floor(operation.remainingMs() - operation.responseReserveMs),
+        ),
+        operation,
       },
     );
-
-    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-    const timeoutRace = new Promise<{ _timedOut: true }>((resolve) => {
-      timeoutHandle = setTimeout(
-        () => resolve({ _timedOut: true }),
-        Math.max(1, effectiveTimeoutMs),
-      );
-    });
-    const result = await Promise.race([deletePromise, timeoutRace]);
-    if (timeoutHandle) clearTimeout(timeoutHandle);
-    if ("_timedOut" in result && result._timedOut) {
-      await operation.abort("deadline");
-      return formatMaybeTargetOutput(
-        formatToolOutput({
-          ok: false,
-          timedOut: true,
-          error: `DEADLINE_EXCEEDED: adv_worktree_delete timed out after ${effectiveTimeoutMs}ms`,
-          status: "deadline_exceeded",
-          stage: "handler",
-          effectiveTimeoutMs,
-          remediation:
-            "Retry with a fresh dry-run plan; the shared executor owns cancellation and revalidation.",
-        }),
-        context,
-      );
-    }
     return formatMaybeTargetOutput(
       formatToolOutput(result as Awaited<ReturnType<typeof advWorktreeDelete>>),
       context,
@@ -398,6 +383,7 @@ async function executeTargetWorktreeDelete(
       // The store is only a lightweight terminal-proof input. Git census and
       // the executor own all deletion effects, including apply.
       stateRequirement: "snapshot-ok",
+      operation,
       // Keep the mutation trust gate for apply even though the store itself is
       // deliberately not initialized or migrated.
       mutation: !args.dryRun,
@@ -447,6 +433,7 @@ async function executeTargetWorktreeDelete(
         () => operation.dispose(),
       );
     } else {
+      await operation.abort("operation_complete");
       operation.dispose();
     }
   }

--- a/plugin/src/tools/target-project.ts
+++ b/plugin/src/tools/target-project.ts
@@ -10,6 +10,7 @@ import {
   getExternalRootForProject,
   getProjectId,
 } from "../utils/project-id";
+import type { WorktreeOperationContext } from "../utils/worktree-operation";
 
 export type TargetStateRequirement =
   | "snapshot-ok"
@@ -44,6 +45,7 @@ export interface ResolveTargetProjectInput {
   mutation?: boolean;
   target_confirmed?: boolean;
   confirmationEvidence?: string;
+  operation?: WorktreeOperationContext;
 }
 
 export interface WithTargetPathStoreInput extends ResolveTargetProjectInput {
@@ -141,6 +143,7 @@ export async function validateCrossRepoTarget(
 export async function resolveTargetProject(
   input: ResolveTargetProjectInput,
 ): Promise<TargetProjectContext> {
+  input.operation?.throwIfAborted("target_resolution_aborted");
   const currentRoot = resolve(input.currentProjectPath);
   const targetRoot = input.target_path
     ? resolve(input.target_path)
@@ -148,6 +151,7 @@ export async function resolveTargetProject(
   const isCurrentProject = targetRoot === currentRoot;
 
   const validation = await validateCrossRepoTarget(targetRoot);
+  input.operation?.throwIfAborted("target_resolution_aborted");
   if (!validation.ok) {
     throw new TargetProjectError(validation.error);
   }
@@ -212,6 +216,7 @@ export async function withTargetPathStore<T>(
     externalRoot: context.externalRoot,
   });
   try {
+    input.operation?.throwIfAborted("target_store_aborted");
     if (input.stateRequirement !== "snapshot-ok") await store.init();
     const stateMode =
       input.stateRequirement === "snapshot-ok"

--- a/plugin/src/tools/worktree/deletion-executor.test.ts
+++ b/plugin/src/tools/worktree/deletion-executor.test.ts
@@ -11,9 +11,13 @@ import {
   type WorktreeDeletionIntegrationProof,
 } from "./deletion-contracts";
 import {
+  createWorktreeBeforeRemoveStage,
+  createWorktreeReconciliationStage,
   executeWorktreeDeletion,
   type WorktreeDeletionExecutorDeps,
+  type WorktreeBeforeRemoveStage,
 } from "./deletion-executor";
+import { createWorktreeOperationContext } from "../../utils/worktree-operation";
 
 const sha = "0123456789abcdef0123456789abcdef01234567";
 
@@ -162,6 +166,74 @@ describe("WorktreeDeletionExecutor", () => {
       expect(deps.acquireLease).toHaveBeenCalledTimes(1);
       expect(deps.runProcess).toHaveBeenCalledTimes(1);
       expect(exists(fx.worktree)).toBe(false);
+
+      const repeated = await executeWorktreeDeletion({ plan }, deps);
+      expect(repeated).toMatchObject({
+        ok: false,
+        status: "already_absent",
+      });
+      expect(deps.runProcess).toHaveBeenCalledTimes(1);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("uses a kernel process lease for the production executor path", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const result = await executeWorktreeDeletion(
+        { plan },
+        depsFor(fx, plan, {
+          acquireLease: undefined,
+          releaseLease: undefined,
+        }),
+      );
+
+      expect(result).toMatchObject({ ok: true, status: "deleted" });
+      expect(existsSync(join(fx.repository, "git-worktree.lock"))).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("makes concurrent production applies mutually exclusive through flock", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      let censusStarted!: () => void;
+      const censusReady = new Promise<void>((resolve) => {
+        censusStarted = resolve;
+      });
+      const firstDeps = depsFor(fx, plan, {
+        acquireLease: undefined,
+        releaseLease: undefined,
+      });
+      const originalCensus = firstDeps.census!;
+      firstDeps.census = async (...args) => {
+        censusStarted();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return originalCensus(...args);
+      };
+
+      const firstPromise = executeWorktreeDeletion({ plan }, firstDeps);
+      await censusReady;
+      const second = await executeWorktreeDeletion(
+        { plan },
+        depsFor(fx, plan, {
+          acquireLease: undefined,
+          releaseLease: undefined,
+        }),
+      );
+      expect(second).toMatchObject({
+        ok: false,
+        status: "busy",
+        reason: "repository_lease_held",
+      });
+      await expect(firstPromise).resolves.toMatchObject({
+        ok: true,
+        status: "deleted",
+      });
     } finally {
       fx.cleanup();
     }
@@ -457,7 +529,7 @@ describe("WorktreeDeletionExecutor", () => {
 
       const cleanPlan = makePlan(fx);
       const cleanDeps = depsFor(fx, cleanPlan, {
-        reconcileAfterDeletion: vi.fn(async () => {
+        reconcileAfterDeletion: createWorktreeReconciliationStage(async () => {
           throw new Error("state store unavailable");
         }),
       });
@@ -491,6 +563,345 @@ describe("WorktreeDeletionExecutor", () => {
       const result = await executeWorktreeDeletion({ plan }, deps);
       expect(result).toMatchObject({ ok: false, status: "deadline_exceeded" });
       expect(exists(fx.worktree)).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("awaits a late lease settlement and releases an owned lock before responding", async () => {
+    const fx = fixture();
+    let resolveLease!: (
+      value: Awaited<
+        ReturnType<NonNullable<WorktreeDeletionExecutorDeps["acquireLease"]>>
+      >,
+    ) => void;
+    const lease = {
+      owned: true as const,
+      ownerPid: process.pid,
+      workerId: "late-owner",
+      ownerToken: "late-owner-token",
+      lockPath: join(fx.repository, "lease"),
+    };
+    try {
+      const plan = makePlan(fx);
+      const operation = createWorktreeOperationContext({
+        budgetMs: 25,
+        responseReserveMs: 5,
+      });
+      const acquireLease = vi.fn(
+        () =>
+          new Promise<
+            Awaited<
+              ReturnType<
+                NonNullable<WorktreeDeletionExecutorDeps["acquireLease"]>
+              >
+            >
+          >((resolve) => {
+            resolveLease = resolve;
+          }),
+      );
+      const releaseLease = vi.fn(async () => undefined);
+      const resultPromise = executeWorktreeDeletion(
+        { plan, operation },
+        depsFor(fx, plan, { acquireLease, releaseLease }),
+      );
+
+      await expect(resultPromise).resolves.toMatchObject({
+        ok: false,
+        status: "deadline_exceeded",
+        stage: "lease",
+      });
+      resolveLease(lease);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(releaseLease).not.toHaveBeenCalled();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("awaits late beforeRemove settlement and never removes after cancellation", async () => {
+    const fx = fixture();
+    let resolveBeforeRemove!: (value: { ok: true }) => void;
+    let beforeRemoveSignal!: AbortSignal;
+    let lateMutation = false;
+    try {
+      const plan = makePlan(fx);
+      const operation = createWorktreeOperationContext({
+        budgetMs: 25,
+        responseReserveMs: 5,
+      });
+      const beforeRemove = createWorktreeBeforeRemoveStage(
+        ({ signal }) =>
+          new Promise<{ ok: true }>((resolve) => {
+            beforeRemoveSignal = signal;
+            resolveBeforeRemove = (value) => {
+              if (!signal.aborted) lateMutation = true;
+              resolve(value);
+            };
+          }),
+      );
+      const deps = depsFor(fx, plan, {
+        beforeRemove,
+      });
+      const resultPromise = executeWorktreeDeletion({ plan, operation }, deps);
+
+      await expect(resultPromise).resolves.toMatchObject({
+        ok: false,
+        status: "deadline_exceeded",
+        stage: "before_remove",
+      });
+      expect(beforeRemoveSignal.aborted).toBe(true);
+      resolveBeforeRemove({ ok: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(lateMutation).toBe(false);
+      expect(deps.runProcess).not.toHaveBeenCalled();
+      expect(exists(fx.worktree)).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("rejects an unbranded beforeRemove callback before invocation", async () => {
+    const fx = fixture();
+    const callback = vi.fn(async () => ({ ok: true as const }));
+    try {
+      const plan = makePlan(fx);
+      const result = await executeWorktreeDeletion(
+        { plan },
+        depsFor(fx, plan, {
+          beforeRemove: callback as unknown as WorktreeBeforeRemoveStage,
+        }),
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: "repair_required",
+        reason: "uncooperative_before_remove",
+      });
+      expect(callback).not.toHaveBeenCalled();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("returns a typed post-census deadline before a held census is released", async () => {
+    const fx = fixture();
+    let releaseCensus!: (
+      value: Awaited<
+        ReturnType<NonNullable<WorktreeDeletionExecutorDeps["census"]>>
+      >,
+    ) => void;
+    const reconcileRun = vi.fn(async () => undefined);
+    try {
+      const plan = makePlan(fx);
+      const operation = createWorktreeOperationContext({
+        budgetMs: 25,
+        responseReserveMs: 5,
+      });
+      const deps = depsFor(fx, plan, {
+        census: vi.fn(
+          () =>
+            new Promise<
+              Awaited<
+                ReturnType<NonNullable<WorktreeDeletionExecutorDeps["census"]>>
+              >
+            >((resolve) => {
+              releaseCensus = resolve;
+            }),
+        ),
+        reconcileAfterDeletion: createWorktreeReconciliationStage(reconcileRun),
+      });
+      const resultPromise = executeWorktreeDeletion({ plan, operation }, deps);
+
+      await expect(resultPromise).resolves.toMatchObject({
+        ok: false,
+        status: "deadline_exceeded",
+        stage: "census",
+      });
+      releaseCensus({ branches: [], worktrees: [] });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(reconcileRun).not.toHaveBeenCalled();
+      expect(exists(fx.worktree)).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("returns indeterminate after Git removal when post-delete census is held", async () => {
+    const fx = fixture();
+    let calls = 0;
+    let releasePostDeleteCensus!: (value: {
+      branches: { branch: string; headSha: string; merged: boolean }[];
+      worktrees: never[];
+    }) => void;
+    const reconcileRun = vi.fn(async () => undefined);
+    try {
+      const plan = makePlan(fx);
+      const operation = createWorktreeOperationContext({
+        budgetMs: 35,
+        responseReserveMs: 5,
+      });
+      const base = depsFor(fx, plan);
+      const normalCensus = base.census!;
+      const deps: WorktreeDeletionExecutorDeps = {
+        ...base,
+        census: vi.fn((...args) => {
+          calls += 1;
+          if (calls === 3)
+            return new Promise<{
+              branches: { branch: string; headSha: string; merged: boolean }[];
+              worktrees: never[];
+            }>((resolve) => {
+              releasePostDeleteCensus = resolve;
+            });
+          return normalCensus(...args);
+        }),
+        reconcileAfterDeletion: createWorktreeReconciliationStage(reconcileRun),
+      };
+
+      const resultPromise = executeWorktreeDeletion({ plan, operation }, deps);
+      await expect(resultPromise).resolves.toMatchObject({
+        ok: false,
+        status: "indeterminate",
+        reason: "post_delete_census_deadline_exceeded",
+        stage: "post_delete_census",
+      });
+      expect(exists(fx.worktree)).toBe(false);
+      expect(reconcileRun).not.toHaveBeenCalled();
+
+      releasePostDeleteCensus({ branches: [], worktrees: [] });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(reconcileRun).not.toHaveBeenCalled();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("returns deleted with an awaited reconciliation warning before a held stage is released", async () => {
+    const fx = fixture();
+    let releaseReconciliation!: () => void;
+    let reconciliationSignal!: AbortSignal;
+    let lateMutation = false;
+    try {
+      const plan = makePlan(fx);
+      const operation = createWorktreeOperationContext({
+        budgetMs: 50,
+        responseReserveMs: 5,
+      });
+      const reconciliation = createWorktreeReconciliationStage(
+        ({ signal }) =>
+          new Promise<void>((resolve) => {
+            reconciliationSignal = signal;
+            releaseReconciliation = () => {
+              if (!signal.aborted) lateMutation = true;
+              resolve();
+            };
+          }),
+      );
+      const deps = depsFor(fx, plan, {
+        reconcileAfterDeletion: reconciliation,
+      });
+      const resultPromise = executeWorktreeDeletion({ plan, operation }, deps);
+
+      const result = await resultPromise;
+      expect(result).toMatchObject({ ok: true, status: "deleted" });
+      expect(result.warning).toMatch(/reconciliation deadline exceeded/);
+      expect(reconciliationSignal.aborted).toBe(true);
+      releaseReconciliation();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(lateMutation).toBe(false);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("surfaces lease quiescence failure instead of claiming a deadline barrier", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const operation = createWorktreeOperationContext({
+        budgetMs: 25,
+        responseReserveMs: 5,
+      });
+      const terminate = vi.fn(async () => {
+        throw new Error("process group remained alive");
+      });
+      const acquireLease = vi.fn(
+        async (_dir: string, options?: { operation?: typeof operation }) => {
+          options?.operation?.registerChildLease({ terminate });
+          return {
+            owned: true as const,
+            ownerPid: process.pid,
+            ownerToken: "quiescence-failure",
+            lockPath: join(fx.repository, "lease"),
+            process: undefined as never,
+            settled: Promise.resolve(),
+            terminate,
+          };
+        },
+      );
+      const deps = depsFor(fx, plan, {
+        acquireLease,
+        census: vi.fn(
+          () =>
+            new Promise<
+              Awaited<
+                ReturnType<NonNullable<WorktreeDeletionExecutorDeps["census"]>>
+              >
+            >(() => undefined),
+        ),
+      });
+
+      await expect(
+        executeWorktreeDeletion({ plan, operation }, deps),
+      ).resolves.toMatchObject({
+        ok: false,
+        status: "indeterminate",
+        reason: "operation_quiescence_failed",
+      });
+      expect(terminate).toHaveBeenCalled();
+      expect(deps.runProcess).not.toHaveBeenCalled();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("surfaces a held lease termination failure before reporting a deadline", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const operation = createWorktreeOperationContext({
+        budgetMs: 25,
+        responseReserveMs: 5,
+      });
+      const terminate = vi.fn(async () => {
+        throw new Error("held lease process group remained alive");
+      });
+      const acquireLease = vi.fn(
+        (_dir: string, options?: { operation?: typeof operation }) => {
+          options?.operation?.registerChildLease({ terminate });
+          return new Promise<
+            Awaited<
+              ReturnType<
+                NonNullable<WorktreeDeletionExecutorDeps["acquireLease"]>
+              >
+            >
+          >(() => undefined);
+        },
+      );
+
+      await expect(
+        executeWorktreeDeletion(
+          { plan, operation },
+          depsFor(fx, plan, { acquireLease }),
+        ),
+      ).resolves.toMatchObject({
+        ok: false,
+        status: "indeterminate",
+        reason: "operation_quiescence_failed",
+        stage: "lease",
+      });
+      expect(terminate).toHaveBeenCalled();
     } finally {
       fx.cleanup();
     }

--- a/plugin/src/tools/worktree/deletion-executor.ts
+++ b/plugin/src/tools/worktree/deletion-executor.ts
@@ -22,8 +22,10 @@ import type {
 } from "../../utils/process-runner";
 import { resolveGitBinary } from "../../utils/git-binary";
 import {
-  acquireGitWorktreeFlock,
-  releaseGitWorktreeFlock,
+  acquireGitWorktreeProcessLease,
+  type GitWorktreeProcessLeaseResult,
+  GitWorktreeFlockUnsupportedError,
+  GitWorktreeFlockQuiescenceError,
 } from "../../utils/git-worktree-flock";
 import {
   createWorktreeOperationContext,
@@ -46,6 +48,7 @@ export interface WorktreeDeletionExecutorDeps {
   cwd?: string;
   hooks?: readonly string[];
   budgetMs?: number;
+  operation?: WorktreeOperationContext;
   now?: () => number;
   platform?: NodeJS.Platform;
   census?: (
@@ -72,26 +75,24 @@ export interface WorktreeDeletionExecutorDeps {
    * destructive authority; adapters may only provide this bounded pre-remove
    * hook for adjacent ownership cleanup (for example OpenCode workspaces).
    */
-  beforeRemove?: (input: {
-    plan: WorktreeDeletionPlan;
-    operation: WorktreeOperationContext;
-  }) => Promise<
-    | { ok: true; warning?: string }
-    | { ok: false; status?: "busy" | "repair_required"; reason: string }
-  >;
+  beforeRemove?: WorktreeBeforeRemoveStage;
   acquireLease?: (
     repositoryLeaseDir: string,
-  ) => ReturnType<typeof acquireGitWorktreeFlock>;
-  releaseLease?: typeof releaseGitWorktreeFlock;
+    options?: {
+      signal?: AbortSignal;
+      operation?: WorktreeOperationContext;
+    },
+  ) => Promise<GitWorktreeProcessLeaseResult | LegacyGitWorktreeLock>;
+  /** Compatibility seam for direct tests; production leases terminate groups. */
+  releaseLease?: (
+    repositoryLeaseDir: string,
+    ownerToken: string,
+  ) => Promise<void>;
   runProcess?: (
     input: AbortableProcessInput,
   ) => Promise<AbortableProcessResult>;
   /** Runs only after Git and filesystem both prove the worktree is absent. */
-  reconcileAfterDeletion?: (input: {
-    plan: WorktreeDeletionPlan;
-    census: GitWorkspaceFacts;
-    operation: WorktreeOperationContext;
-  }) => Promise<void>;
+  reconcileAfterDeletion?: WorktreeReconciliationStage;
 }
 
 export interface WorktreeDeletionExecutorInput {
@@ -102,6 +103,8 @@ export interface WorktreeDeletionExecutorInput {
   hooks?: readonly string[];
   budgetMs?: number;
   now?: number;
+  /** Shared operation supplied by a public delete owner. */
+  operation?: WorktreeOperationContext;
 }
 
 export type WorktreeDeletionExecutorResult = WorktreeDeletionResult & {
@@ -109,8 +112,138 @@ export type WorktreeDeletionExecutorResult = WorktreeDeletionResult & {
   warning?: string;
 };
 
+export type WorktreeBeforeRemoveResult =
+  | { ok: true; warning?: string }
+  | { ok: false; status?: "busy" | "repair_required"; reason: string };
+
+export const WORKTREE_BEFORE_REMOVE_STAGE = Symbol(
+  "worktree-before-remove-stage",
+);
+
+export interface WorktreeBeforeRemoveInput {
+  plan: WorktreeDeletionPlan;
+  operation: WorktreeOperationContext;
+  signal: AbortSignal;
+}
+
+export interface WorktreeBeforeRemoveStage {
+  readonly [WORKTREE_BEFORE_REMOVE_STAGE]: true;
+  readonly kind: "worktree-before-remove";
+  readonly settled: Promise<void>;
+  start(input: WorktreeBeforeRemoveInput): Promise<WorktreeBeforeRemoveResult>;
+  cancel(reason: string): Promise<void>;
+}
+
+export const WORKTREE_RECONCILIATION_STAGE = Symbol(
+  "worktree-reconciliation-stage",
+);
+
+export interface WorktreeReconciliationInput {
+  plan: WorktreeDeletionPlan;
+  census: GitWorkspaceFacts;
+  operation: WorktreeOperationContext;
+  signal: AbortSignal;
+}
+
+export interface WorktreeReconciliationStage {
+  readonly [WORKTREE_RECONCILIATION_STAGE]: true;
+  readonly kind: "worktree-reconciliation";
+  readonly settled: Promise<void>;
+  start(input: WorktreeReconciliationInput): Promise<void>;
+  cancel(reason: string): Promise<void>;
+}
+
+/** Build the only accepted mutable pre-remove contract. */
+export function createWorktreeBeforeRemoveStage(
+  run: (
+    input: WorktreeBeforeRemoveInput,
+  ) => Promise<WorktreeBeforeRemoveResult>,
+): WorktreeBeforeRemoveStage {
+  let started = false;
+  let cancelled = false;
+  let resolveSettled!: () => void;
+  const settled = new Promise<void>((resolve) => {
+    resolveSettled = resolve;
+  });
+
+  return {
+    [WORKTREE_BEFORE_REMOVE_STAGE]: true,
+    kind: "worktree-before-remove",
+    settled,
+    start(input) {
+      if (started) return Promise.reject(new Error("beforeRemove reused"));
+      started = true;
+      if (cancelled) {
+        return Promise.resolve({
+          ok: false,
+          status: "repair_required" as const,
+          reason: "beforeRemove cancelled before start",
+        });
+      }
+      const result = Promise.resolve().then(() => run(input));
+      result.then(
+        () => resolveSettled(),
+        () => resolveSettled(),
+      );
+      return result;
+    },
+    async cancel(_reason) {
+      cancelled = true;
+      resolveSettled();
+    },
+  };
+}
+
+export function createWorktreeReconciliationStage(
+  run: (input: WorktreeReconciliationInput) => Promise<void>,
+): WorktreeReconciliationStage {
+  let started = false;
+  let cancelled = false;
+  let resolveSettled!: () => void;
+  const settled = new Promise<void>((resolve) => {
+    resolveSettled = resolve;
+  });
+
+  return {
+    [WORKTREE_RECONCILIATION_STAGE]: true,
+    kind: "worktree-reconciliation",
+    settled,
+    start(input) {
+      if (started) return Promise.reject(new Error("reconciliation reused"));
+      started = true;
+      if (cancelled) return Promise.resolve();
+      const result = Promise.resolve().then(() => run(input));
+      result.then(resolveSettled, resolveSettled);
+      return result;
+    },
+    async cancel(_reason) {
+      cancelled = true;
+      resolveSettled();
+    },
+  };
+}
+
 const DEFAULT_BUDGET_MS = 7_500;
 const DEFAULT_RESPONSE_RESERVE_MS = 500;
+
+type LegacyGitWorktreeLock =
+  | {
+      owned: true;
+      ownerPid: number;
+      workerId: string;
+      ownerToken: string;
+      lockPath: string;
+    }
+  | {
+      owned: false;
+      ownerPid: number;
+      workerId?: string;
+      lockPath: string;
+      reason: "lock_held_by_alive_pid";
+    };
+type WorktreeLeaseResult =
+  | GitWorktreeProcessLeaseResult
+  | LegacyGitWorktreeLock;
 
 class WorktreeDeletionStageDeadline extends Error {
   constructor(readonly stage: string) {
@@ -235,6 +368,20 @@ function safeToRemove(
   );
 }
 
+async function settleLease(
+  lock: WorktreeLeaseResult,
+  repositoryLeaseDir: string,
+  release?: WorktreeDeletionExecutorDeps["releaseLease"],
+): Promise<void> {
+  if (!lock.owned) return;
+  if ("terminate" in lock) {
+    await lock.terminate("operation_complete");
+    lock.unregister?.();
+    return;
+  }
+  if (release) await release(repositoryLeaseDir, lock.ownerToken);
+}
+
 export class WorktreeDeletionExecutor {
   private readonly deps: WorktreeDeletionExecutorDeps;
 
@@ -275,16 +422,21 @@ export class WorktreeDeletionExecutor {
         "target_validation",
       );
 
-    const operation = createWorktreeOperationContext({
-      budgetMs: input.budgetMs ?? this.deps.budgetMs ?? DEFAULT_BUDGET_MS,
-      responseReserveMs: DEFAULT_RESPONSE_RESERVE_MS,
-      now,
-    });
+    const ownsOperation =
+      input.operation === undefined && this.deps.operation === undefined;
+    const operation =
+      input.operation ??
+      this.deps.operation ??
+      createWorktreeOperationContext({
+        budgetMs: input.budgetMs ?? this.deps.budgetMs ?? DEFAULT_BUDGET_MS,
+        responseReserveMs: DEFAULT_RESPONSE_RESERVE_MS,
+        now,
+      });
     const repositoryLeaseDir =
       this.deps.repositoryLeaseDir ?? resolve(plan.repository, ".adv");
-    const acquire = this.deps.acquireLease ?? acquireGitWorktreeFlock;
-    const release = this.deps.releaseLease ?? releaseGitWorktreeFlock;
-    let lock: Awaited<ReturnType<typeof acquireGitWorktreeFlock>> | undefined;
+    const acquire = this.deps.acquireLease ?? acquireGitWorktreeProcessLease;
+    const release = this.deps.releaseLease;
+    let lock: WorktreeLeaseResult | undefined;
     const cwd = input.cwd ?? this.deps.cwd ?? plan.facts.cwd ?? process.cwd();
     const census = this.deps.census ?? scanGitWorkspaceFacts;
     const runProcess = this.deps.runProcess ?? runAbortableProcess;
@@ -302,21 +454,33 @@ export class WorktreeDeletionExecutor {
       work: () => Promise<T>,
     ): Promise<T> => {
       const remaining = operation.remainingMs() - operation.responseReserveMs;
-      if (remaining <= 0) throw new WorktreeDeletionStageDeadline(stage);
+      if (remaining <= 0 || operation.signal.aborted) {
+        await operation.abort("deadline");
+        throw new WorktreeDeletionStageDeadline(stage);
+      }
       let timer: ReturnType<typeof setTimeout> | undefined;
+      let onAbort: (() => void) | undefined;
+      const workPromise = Promise.resolve().then(work);
+      const deadlinePromise = new Promise<T>((_resolve, reject) => {
+        onAbort = () => reject(new WorktreeDeletionStageDeadline(stage));
+        operation.signal.addEventListener("abort", onAbort, { once: true });
+        timer = setTimeout(
+          () => reject(new WorktreeDeletionStageDeadline(stage)),
+          Math.max(1, remaining),
+        );
+        timer.unref?.();
+      });
       try {
-        return await Promise.race([
-          work(),
-          new Promise<T>((_resolve, reject) => {
-            timer = setTimeout(
-              () => reject(new WorktreeDeletionStageDeadline(stage)),
-              Math.max(1, remaining),
-            );
-            timer.unref?.();
-          }),
-        ]);
+        return await Promise.race([workPromise, deadlinePromise]);
+      } catch (error) {
+        if (error instanceof WorktreeDeletionStageDeadline) {
+          await operation.abort("deadline");
+          if (operation.terminationError) throw operation.terminationError;
+        }
+        throw error;
       } finally {
         if (timer) clearTimeout(timer);
+        if (onAbort) operation.signal.removeEventListener("abort", onAbort);
       }
     };
 
@@ -335,6 +499,7 @@ export class WorktreeDeletionExecutor {
         );
       } catch (error) {
         if (error instanceof WorktreeDeletionStageDeadline) throw error;
+        if (operation.terminationError) throw operation.terminationError;
         return null;
       } finally {
         operation.finishStage(stage);
@@ -429,40 +594,49 @@ export class WorktreeDeletionExecutor {
       if (operation.remainingMs() <= operation.responseReserveMs)
         return failure("deadline_exceeded", "deadline_exceeded", "lease");
       operation.startStage("lease");
-      const leasePromise = Promise.resolve(acquire(repositoryLeaseDir));
-      let leaseTimer: ReturnType<typeof setTimeout> | undefined;
-      type LeaseResult = Awaited<ReturnType<typeof acquireGitWorktreeFlock>>;
-      const leaseResult = await new Promise<
-        | { kind: "acquired"; lock: LeaseResult }
-        | { kind: "failed" }
-        | { kind: "deadline" }
-      >((resolveLease) => {
-        leaseTimer = setTimeout(
-          () => resolveLease({ kind: "deadline" }),
-          Math.max(1, operation.remainingMs() - operation.responseReserveMs),
+      try {
+        lock = await runBounded("lease", () =>
+          acquire(repositoryLeaseDir, {
+            signal: operation.signal,
+            operation,
+          }),
         );
-        leaseTimer.unref?.();
-        leasePromise.then(
-          (acquired) => resolveLease({ kind: "acquired", lock: acquired }),
-          () => resolveLease({ kind: "failed" }),
-        );
-      });
-      if (leaseTimer) clearTimeout(leaseTimer);
-      if (leaseResult.kind === "deadline") {
-        void leasePromise.then(async (lateLease) => {
-          if (lateLease.owned)
-            await release(repositoryLeaseDir, lateLease.ownerToken);
-        });
-        await operation.abort("deadline");
-        return failure("deadline_exceeded", "deadline_exceeded", "lease");
-      }
-      if (leaseResult.kind === "failed")
+      } catch (error) {
+        operation.finishStage("lease");
+        if (error instanceof GitWorktreeFlockUnsupportedError)
+          return failure("unsupported", "kernel_flock_unavailable", "lease");
+        if (operation.terminationError)
+          return failure(
+            "indeterminate",
+            "operation_quiescence_failed",
+            "lease",
+          );
+        if (
+          operation.signal.aborted ||
+          operation.remainingMs() <= operation.responseReserveMs
+        )
+          return failure("deadline_exceeded", "deadline_exceeded", "lease");
         return failure(
           "repair_required",
           "repository_lease_unavailable",
           "lease",
         );
-      lock = leaseResult.lock;
+      }
+      if (
+        operation.signal.aborted ||
+        operation.remainingMs() <= operation.responseReserveMs
+      ) {
+        if (lock.owned) {
+          try {
+            await settleLease(lock, repositoryLeaseDir, release);
+          } catch {
+            // The operation's terminationError is surfaced by the barrier;
+            // cleanup must not replace that typed result with a rejection.
+          }
+        }
+        await operation.abort("deadline");
+        return failure("deadline_exceeded", "deadline_exceeded", "lease");
+      }
       operation.finishStage("lease");
       if (!lock.owned) return failure("busy", "repository_lease_held", "lease");
 
@@ -480,9 +654,33 @@ export class WorktreeDeletionExecutor {
 
       let beforeRemoveWarning: string | undefined;
       if (this.deps.beforeRemove) {
-        const preRemove = await runBounded("before_remove", () =>
-          this.deps.beforeRemove!({ plan, operation }),
-        );
+        if (
+          this.deps.beforeRemove[WORKTREE_BEFORE_REMOVE_STAGE] !== true ||
+          this.deps.beforeRemove.kind !== "worktree-before-remove"
+        ) {
+          return failure(
+            "repair_required",
+            "uncooperative_before_remove",
+            "before_remove",
+          );
+        }
+        const unregisterBeforeRemove = operation.registerChildLease({
+          terminate: this.deps.beforeRemove.cancel,
+        });
+        operation.startStage("before_remove");
+        let preRemove;
+        try {
+          preRemove = await runBounded("before_remove", () =>
+            this.deps.beforeRemove!.start({
+              plan,
+              operation,
+              signal: operation.signal,
+            }),
+          );
+        } finally {
+          unregisterBeforeRemove();
+          operation.finishStage("before_remove");
+        }
         if (!preRemove.ok)
           return failure(
             preRemove.status ?? "repair_required",
@@ -588,9 +786,31 @@ export class WorktreeDeletionExecutor {
       if (!removeResult.closed || removeResult.exitCode !== 0)
         return failure("indeterminate", "git_worktree_remove_failed", "remove");
 
-      const postDeleteExpiry = expiryDecision("post_delete_census");
-      if (postDeleteExpiry) return postDeleteExpiry;
-      const after = await runCensus("post_delete_census");
+      // Post-delete census is read-only, so its late completion may be
+      // abandoned after the shared abort barrier. It must never reach
+      // reconciliation after a deadline response.
+      let after: GitWorkspaceFacts | null;
+      operation.startStage("post_delete_census");
+      try {
+        after = await runBounded("post_delete_census", () =>
+          census(
+            plan.repository,
+            plan.integration?.defaultBranch ?? "HEAD",
+            Math.max(1, operation.remainingMs()),
+          ),
+        );
+      } catch (error) {
+        if (error instanceof WorktreeDeletionStageDeadline) {
+          return failure(
+            "indeterminate",
+            "post_delete_census_deadline_exceeded",
+            "post_delete_census",
+          );
+        }
+        throw error;
+      } finally {
+        operation.finishStage("post_delete_census");
+      }
       if (!after)
         return failure(
           "indeterminate",
@@ -598,7 +818,22 @@ export class WorktreeDeletionExecutor {
           "post_delete_census",
         );
       const remaining = currentWorktree(after, plan);
-      if (remaining || (await exists(plan.facts.worktree)))
+      let stillOnDisk = false;
+      try {
+        stillOnDisk = await runBounded("post_delete_census", () =>
+          exists(plan.facts.worktree),
+        );
+      } catch (error) {
+        if (error instanceof WorktreeDeletionStageDeadline) {
+          return failure(
+            "indeterminate",
+            "post_delete_census_deadline_exceeded",
+            "post_delete_census",
+          );
+        }
+        throw error;
+      }
+      if (remaining || stillOnDisk)
         return failure(
           "indeterminate",
           "git_removal_not_confirmed",
@@ -607,14 +842,47 @@ export class WorktreeDeletionExecutor {
 
       let warning: string | undefined;
       if (this.deps.reconcileAfterDeletion) {
+        if (
+          this.deps.reconcileAfterDeletion[WORKTREE_RECONCILIATION_STAGE] !==
+            true ||
+          this.deps.reconcileAfterDeletion.kind !== "worktree-reconciliation"
+        ) {
+          return failure(
+            "indeterminate",
+            "uncooperative_reconciliation",
+            "reconcile",
+          );
+        }
+        const unregisterReconciliation = operation.registerChildLease({
+          terminate: this.deps.reconcileAfterDeletion.cancel,
+        });
+        operation.startStage("reconcile");
         try {
-          await this.deps.reconcileAfterDeletion({
-            plan,
-            census: after,
-            operation,
-          });
+          await runBounded("reconcile", () =>
+            this.deps.reconcileAfterDeletion!.start({
+              plan,
+              census: after,
+              operation,
+              signal: operation.signal,
+            }),
+          );
         } catch (error) {
-          warning = `reconciliation failed after confirmed removal: ${error instanceof Error ? error.message : String(error)}`;
+          if (operation.terminationError) {
+            return failure(
+              "indeterminate",
+              "operation_quiescence_failed",
+              "reconcile",
+            );
+          }
+          if (error instanceof WorktreeDeletionStageDeadline) {
+            warning =
+              "reconciliation deadline exceeded after confirmed Git removal";
+          } else {
+            warning = `reconciliation failed after confirmed removal: ${error instanceof Error ? error.message : String(error)}`;
+          }
+        } finally {
+          unregisterReconciliation();
+          operation.finishStage("reconcile");
         }
       }
       return {
@@ -631,6 +899,15 @@ export class WorktreeDeletionExecutor {
           : {}),
       };
     } catch (error) {
+      if (operation.terminationError) {
+        return failure(
+          "indeterminate",
+          "operation_quiescence_failed",
+          operation.currentStage,
+        );
+      }
+      if (error instanceof WorktreeDeletionStageDeadline)
+        return failure("deadline_exceeded", error.message, error.stage);
       if (
         operation.signal.aborted ||
         operation.remainingMs() <= operation.responseReserveMs
@@ -640,8 +917,6 @@ export class WorktreeDeletionExecutor {
           "deadline_exceeded",
           operation.currentStage,
         );
-      if (error instanceof WorktreeDeletionStageDeadline)
-        return failure("deadline_exceeded", error.message, error.stage);
       if (error instanceof LocalBranchIntegrationDeadline)
         return failure(
           "deadline_exceeded",
@@ -649,8 +924,9 @@ export class WorktreeDeletionExecutor {
           operation.currentStage,
         );
       if (
-        error instanceof Error &&
-        /unsupported.*platform/i.test(error.message)
+        error instanceof GitWorktreeFlockUnsupportedError ||
+        error instanceof GitWorktreeFlockQuiescenceError ||
+        (error instanceof Error && /unsupported.*platform/i.test(error.message))
       )
         return failure("unsupported", error.message, operation.currentStage);
       return failure(
@@ -659,9 +935,17 @@ export class WorktreeDeletionExecutor {
         operation.currentStage,
       );
     } finally {
-      await operation.abort("operation_complete");
-      operation.dispose();
-      if (lock?.owned) await release(repositoryLeaseDir, lock.ownerToken);
+      if (ownsOperation) {
+        await operation.abort("operation_complete");
+        operation.dispose();
+      }
+      if (lock?.owned) {
+        try {
+          await settleLease(lock, repositoryLeaseDir, release);
+        } catch {
+          // A barrier failure is already represented by terminationError.
+        }
+      }
     }
   }
 }

--- a/plugin/src/tools/worktree/deletion-planner.ts
+++ b/plugin/src/tools/worktree/deletion-planner.ts
@@ -79,6 +79,8 @@ export interface WorktreeDeletionPlannerInput {
   /** Test/operator override for the five-minute token clock. */
   now?: number;
   budgetMs?: number;
+  /** Shared operation supplied by a public delete owner. */
+  operation?: WorktreeOperationContext;
 }
 
 export interface WorktreeDeletionTarget {
@@ -275,15 +277,20 @@ export class WorktreeDeletionPlanner {
     input: WorktreeDeletionPlannerInput,
   ): Promise<WorktreeDeletionPlanResult> {
     const now = input.now ?? this.deps.operationNow?.() ?? Date.now();
-    const operation = createWorktreeOperationContext({
-      now,
-      budgetMs: input.budgetMs,
-    });
+    const ownsOperation = input.operation === undefined;
+    const operation =
+      input.operation ??
+      createWorktreeOperationContext({
+        now,
+        budgetMs: input.budgetMs,
+      });
     const runWithDeadline = async <T>(work: () => Promise<T>): Promise<T> => {
       const remaining = operation.remainingMs();
       if (remaining <= 0) throw new Error("planning deadline exceeded");
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {
+        // Planning is read-only. This race bounds an uncooperative internal
+        // reader while the shared operation still guards every later mutation.
         return await Promise.race([
           work(),
           new Promise<T>((_resolve, reject) => {
@@ -642,7 +649,10 @@ export class WorktreeDeletionPlanner {
         stageTimings: operation.stageTimings,
       };
     } finally {
-      operation.dispose();
+      if (ownsOperation) {
+        await operation.abort("planning_complete");
+        operation.dispose();
+      }
     }
   }
 

--- a/plugin/src/tools/worktree/deletion-public-contract.test.ts
+++ b/plugin/src/tools/worktree/deletion-public-contract.test.ts
@@ -132,6 +132,12 @@ describe("shared public worktree deletion contract", () => {
     );
     expect(applied).toMatchObject({ ok: true, status: "deleted" });
     expect(executor).toHaveBeenCalledTimes(1);
+    const [executorInput, executorDeps] = executor.mock.calls[0] as [
+      { operation?: unknown },
+      { operation?: unknown },
+    ];
+    expect(executorInput.operation).toBeDefined();
+    expect(executorInput.operation).toBe(executorDeps.operation);
   });
 
   it("rejects blank approval before decoding or executing a plan", async () => {

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -87,7 +87,11 @@ import {
   createWorktreeDeletionPlanner,
   type WorktreeDeletionPlanResult,
 } from "./deletion-planner";
-import { executeWorktreeDeletion } from "./deletion-executor";
+import {
+  createWorktreeBeforeRemoveStage,
+  createWorktreeReconciliationStage,
+  executeWorktreeDeletion,
+} from "./deletion-executor";
 import { runHooksWithSafety } from "./hooks";
 import { appendDebugLog } from "../../utils/debug-log";
 import { execGit, getDefaultBranch } from "../../utils/git";
@@ -116,6 +120,7 @@ import { withTimeout, TimeoutError } from "../../utils/with-timeout";
 import { execGh } from "../../integrations/gh-cli";
 import { proveLocalBranchIntegration } from "../../utils/branch-integration";
 import type { WorktreeOperationContext } from "../../utils/worktree-operation";
+import { createWorktreeOperationContext } from "../../utils/worktree-operation";
 
 export { advWorktreeDetachBatch } from "./detach";
 export {
@@ -362,6 +367,7 @@ export async function detectUncommittedState(
 export async function reapEmptyWorktreeParents(
   removedWorktreePath: string,
   worktreeBase: string,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   const base = path.resolve(worktreeBase);
   let current = path.dirname(path.resolve(removedWorktreePath));
@@ -370,6 +376,7 @@ export async function reapEmptyWorktreeParents(
   assertPathInsideDirectory(current, base);
 
   while (current !== base) {
+    if (signal?.aborted) break;
     assertPathInsideDirectory(current, base);
     try {
       await rmdir(current);
@@ -1321,6 +1328,8 @@ export interface AdvWorktreeDeleteDeps {
    * before the SDK timeout instead of continuing destructive work silently.
    */
   operationTimeoutMs?: number;
+  /** End-to-end cancellation context owned by the public delete handler. */
+  operation?: WorktreeOperationContext;
   /** Optional timeout for live GitHub PR evidence lookup. */
   prEvidenceTimeoutMs?: number;
   /**
@@ -1450,13 +1459,23 @@ async function cleanupOpenCodeWorkspaceForWorktree(
   worktreePath: string,
   branch: string,
   deps: AdvWorktreeDeleteDeps,
+  operation: WorktreeOperationContext,
 ): Promise<OpenCodeWorkspaceCleanupResult> {
   if (!deps.warpDeps) return { ok: true, warning: null };
+  if (operation.signal.aborted) {
+    return {
+      ok: false,
+      error: "WORKSPACE_CLEANUP_FAILED",
+      reason: "operation cancelled before workspace lookup",
+      hint: "Retry with a fresh deletion plan.",
+    };
+  }
 
   const lookup = await findWorkspaceByDirectoryChecked(
     deps.warpDeps,
     worktreePath,
     branch,
+    operation.signal,
   );
   if (!lookup.ok) {
     // Advisory only: the local isWorktreeInUse check upstream already proved
@@ -1474,7 +1493,19 @@ async function cleanupOpenCodeWorkspaceForWorktree(
   if (!lookup.workspace) return { ok: true, warning: null };
 
   try {
-    await deleteAdvWorkspace(deps.warpDeps, lookup.workspace.workspaceID);
+    if (operation.signal.aborted) {
+      return {
+        ok: false,
+        error: "WORKSPACE_CLEANUP_FAILED",
+        reason: "operation cancelled before workspace deletion",
+        hint: "Retry with a fresh deletion plan.",
+      };
+    }
+    await deleteAdvWorkspace(
+      deps.warpDeps,
+      lookup.workspace.workspaceID,
+      operation.signal,
+    );
     deps.log.debug(
       `[worktree] Cleaned up OpenCode workspace ${lookup.workspace.workspaceID}`,
     );
@@ -1754,6 +1785,17 @@ async function advWorktreeDeleteShared(
     };
 
   const changeId = inferChangeIdFromBranch(branch);
+  const operation = deps.operation;
+  if (!operation) {
+    return {
+      ok: false,
+      error: "DELETION_BLOCKED",
+      status: "missing_operation_context",
+      reason: "destructive deletion requires an operation context",
+      branch,
+      hint: "Call the public worktree delete handler or provide an operation context.",
+    };
+  }
   const terminalProof = async (
     id: string,
   ): Promise<
@@ -1867,6 +1909,7 @@ async function advWorktreeDeleteShared(
       registry: deps.registry,
       force: opts.force === true,
       budgetMs: deps.operationTimeoutMs,
+      operation,
     });
     return plannerResultToDeleteResult(branch, planned);
   }
@@ -1951,6 +1994,7 @@ async function advWorktreeDeleteShared(
       cwd: process.cwd(),
       hooks: hooks.preDelete,
       budgetMs: deps.operationTimeoutMs,
+      operation,
     },
     {
       repository: deps.projectRoot,
@@ -1958,40 +2002,43 @@ async function advWorktreeDeleteShared(
       cwd: process.cwd(),
       hooks: hooks.preDelete,
       budgetMs: deps.operationTimeoutMs,
+      operation,
       isWorktreeInUse: deps.isWorktreeInUse,
       census: deps.census,
       terminalProof,
       integrationProof,
-      beforeRemove: async () => {
-        const workspace = await cleanupOpenCodeWorkspaceForWorktree(
-          plan.facts.worktree,
-          branch,
-          deps,
-        );
-        if (!workspace.ok)
+      beforeRemove: createWorktreeBeforeRemoveStage(
+        async ({ operation: sharedOperation }) => {
+          const workspace = await cleanupOpenCodeWorkspaceForWorktree(
+            plan.facts.worktree,
+            branch,
+            deps,
+            sharedOperation,
+          );
+          if (!workspace.ok)
+            return {
+              ok: false as const,
+              status: "repair_required" as const,
+              reason: workspace.reason,
+            };
           return {
-            ok: false as const,
-            status: "repair_required" as const,
-            reason: workspace.reason,
+            ok: true as const,
+            ...(workspace.warning ? { warning: workspace.warning } : {}),
           };
-        return {
-          ok: true as const,
-          ...(workspace.warning ? { warning: workspace.warning } : {}),
-        };
-      },
-      reconcileAfterDeletion: async () => {
-        try {
+        },
+      ),
+      reconcileAfterDeletion: createWorktreeReconciliationStage(
+        async ({ operation: sharedOperation }) => {
+          sharedOperation.throwIfAborted("reconciliation_aborted");
           await reapEmptyWorktreeParents(
             plan.facts.worktree,
             getWorktreeBase(deps.database.projectId),
+            sharedOperation.signal,
           );
-        } catch (error) {
-          deps.log.warn(
-            `Skipped empty-parent cleanup for ${plan.facts.worktree}: ${String(error)}`,
-          );
-        }
-        await clearPendingDelete(deps.database, branch);
-      },
+          sharedOperation.throwIfAborted("reconciliation_aborted");
+          await clearPendingDelete(deps.database, branch);
+        },
+      ),
     },
   );
   if (result.ok)
@@ -2043,7 +2090,23 @@ export async function advWorktreeDelete(
   } = {},
   deps: AdvWorktreeDeleteDeps,
 ): Promise<AdvWorktreeDeleteResult> {
-  return advWorktreeDeleteShared(branch, opts, deps);
+  const ownsOperation = deps.operation === undefined;
+  const operation =
+    deps.operation ??
+    createWorktreeOperationContext({
+      budgetMs: deps.operationTimeoutMs,
+    });
+  try {
+    return await advWorktreeDeleteShared(branch, opts, {
+      ...deps,
+      operation,
+    });
+  } finally {
+    if (ownsOperation) {
+      await operation.abort("operation_complete");
+      operation.dispose();
+    }
+  }
 }
 
 // =============================================================================

--- a/plugin/src/utils/git-worktree-flock.test.ts
+++ b/plugin/src/utils/git-worktree-flock.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 
 import {
   acquireGitWorktreeFlock,
+  acquireGitWorktreeProcessLease,
   releaseGitWorktreeFlock,
 } from "./git-worktree-flock";
 
@@ -59,5 +60,28 @@ describe("git worktree repository lease", () => {
     expect(fs.existsSync(path.join(dir, "git-worktree.lock"))).toBe(true);
     await releaseGitWorktreeFlock(dir, first.ownerToken);
     expect(fs.existsSync(path.join(dir, "git-worktree.lock"))).toBe(false);
+  });
+
+  it("holds a kernel flock until the dedicated process group exits", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "adv-process-flock-"));
+    dirs.push(dir);
+
+    const first = await acquireGitWorktreeProcessLease(dir);
+    expect(first.owned).toBe(true);
+    if (!first.owned) return;
+
+    const second = await acquireGitWorktreeProcessLease(dir);
+    expect(second).toMatchObject({ owned: false });
+
+    const legacyWhileHeld = await acquireGitWorktreeFlock(dir);
+    expect(legacyWhileHeld).toMatchObject({ owned: false });
+
+    const holderPid = first.ownerPid;
+    await first.terminate("test");
+    await first.settled;
+    expect(() => process.kill(-holderPid, 0)).toThrow();
+    const third = await acquireGitWorktreeProcessLease(dir);
+    expect(third.owned).toBe(true);
+    if (third.owned) await third.terminate("test");
   });
 });

--- a/plugin/src/utils/git-worktree-flock.ts
+++ b/plugin/src/utils/git-worktree-flock.ts
@@ -13,8 +13,10 @@
  * Citations: rq-multiSessionCoordination01, rq-worktreeRegistry01.
  */
 
+import { mkdirSync } from "node:fs";
 import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
 import { join } from "node:path";
 import { isProcessAlive } from "./process-liveness";
 
@@ -41,6 +43,244 @@ export type GitWorktreeLockResult =
  */
 export const GIT_WORKTREE_LOCK_FILENAME = "git-worktree.lock";
 
+export interface AcquireGitWorktreeFlockOptions {
+  signal?: AbortSignal;
+}
+
+export interface GitWorktreeProcessLease {
+  owned: true;
+  ownerPid: number;
+  ownerToken: string;
+  lockPath: string;
+  process: ChildProcess;
+  settled: Promise<void>;
+  terminate: (reason: string) => Promise<void>;
+  unregister?: () => void;
+}
+
+export type GitWorktreeProcessLeaseResult =
+  | GitWorktreeProcessLease
+  | {
+      owned: false;
+      ownerPid: number;
+      lockPath: string;
+      reason: "lock_held_by_alive_pid";
+    };
+
+export class GitWorktreeFlockUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitWorktreeFlockUnsupportedError";
+  }
+}
+
+export class GitWorktreeFlockQuiescenceError extends Error {
+  constructor(pgid: number) {
+    super(
+      `flock process group ${pgid} did not quiesce before the response barrier`,
+    );
+    this.name = "GitWorktreeFlockQuiescenceError";
+  }
+}
+
+const FLOCK_READY = "ADV_WORKTREE_FLOCK_READY\n";
+const FLOCK_HOLDER_SCRIPT =
+  "const fs = require('node:fs'); const { spawn } = require('node:child_process'); fs.writeFileSync(process.env.ADV_FLOCK_PATH, JSON.stringify({ pid: process.pid, owner_token: process.env.ADV_FLOCK_TOKEN })); spawn(process.execPath, ['-e', 'setInterval(() => {}, 0x7fffffff);'], { stdio: 'ignore' }); process.stdout.write('ADV_WORKTREE_FLOCK_READY\\n'); setInterval(() => {}, 0x7fffffff);";
+
+async function waitForSettlement(
+  settled: Promise<void>,
+  ms: number,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      settled,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, ms);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function processGroupAlive(pgid: number): boolean {
+  try {
+    process.kill(-pgid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+async function waitForProcessGroupGone(
+  pgid: number,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (processGroupAlive(pgid)) {
+    if (Date.now() >= deadline) throw new GitWorktreeFlockQuiescenceError(pgid);
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 5);
+      timer.unref?.();
+    });
+  }
+}
+
+function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (child.pid === undefined) return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      try {
+        child.kill(signal);
+      } catch {
+        // The close event remains authoritative for process completion.
+      }
+    }
+  }
+}
+
+export interface AcquireGitWorktreeProcessLeaseOptions extends AcquireGitWorktreeFlockOptions {
+  operation?: {
+    registerChildLease: (lease: {
+      terminate: (reason: string) => Promise<void>;
+    }) => () => void;
+  };
+}
+
+/**
+ * Acquire the deletion lease through a kernel flock held by a dedicated
+ * process group. The lock artifact is intentionally never unlinked: kernel
+ * ownership ends only after the holder process group has exited.
+ */
+export async function acquireGitWorktreeProcessLease(
+  projectStateDir: string,
+  options: AcquireGitWorktreeProcessLeaseOptions = {},
+): Promise<GitWorktreeProcessLeaseResult> {
+  if (options.signal?.aborted) throwIfAborted(options.signal);
+  if (process.platform !== "linux") {
+    throw new GitWorktreeFlockUnsupportedError(
+      `kernel flock lease requires Linux (got ${process.platform})`,
+    );
+  }
+  mkdirSync(projectStateDir, { recursive: true });
+  if (options.signal?.aborted) throwIfAborted(options.signal);
+
+  const lockPath = join(projectStateDir, GIT_WORKTREE_LOCK_FILENAME);
+  const ownerToken = randomUUID();
+  const child = spawn(
+    "flock",
+    ["-n", lockPath, process.execPath, "-e", FLOCK_HOLDER_SCRIPT],
+    {
+      detached: true,
+      env: {
+        ...process.env,
+        ADV_FLOCK_PATH: lockPath,
+        ADV_FLOCK_TOKEN: ownerToken,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    },
+  );
+
+  let settledState = false;
+  let resolveParentSettled!: () => void;
+  const parentSettled = new Promise<void>((resolve) => {
+    resolveParentSettled = resolve;
+  });
+  let readyState = false;
+  let output = "";
+  let terminatePromise: Promise<void> | undefined;
+  const settled = parentSettled.then(async () => {
+    const pgid = child.pid;
+    if (pgid === undefined) return;
+    signalProcessGroup(child, "SIGKILL");
+    await waitForProcessGroupGone(pgid);
+  });
+  // The executor observes the rejection through terminate(); keep an
+  // unexpected early close from becoming an unhandled rejection meanwhile.
+  void settled.catch(() => undefined);
+  const ready = new Promise<boolean>((resolve, reject) => {
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      output += chunk.toString();
+      if (!readyState && output.includes(FLOCK_READY)) {
+        readyState = true;
+        resolve(true);
+      }
+    });
+    child.once("error", (error) => {
+      if (!readyState) reject(error);
+    });
+    child.once("close", (code) => {
+      settledState = true;
+      resolveParentSettled();
+      if (!readyState) resolve(code === 1 ? false : false);
+    });
+  });
+
+  const terminate = async (_reason: string): Promise<void> => {
+    if (terminatePromise) return terminatePromise;
+    terminatePromise = (async () => {
+      if (!settledState) {
+        signalProcessGroup(child, "SIGTERM");
+        await waitForSettlement(parentSettled, 250);
+        if (!settledState) signalProcessGroup(child, "SIGKILL");
+      }
+      // `settled` includes the process-group ESRCH barrier, not merely the
+      // flock parent's close event.
+      await settled;
+    })();
+    return terminatePromise;
+  };
+  const unregister = options.operation?.registerChildLease({ terminate });
+  try {
+    const acquired = await ready;
+    if (!acquired) {
+      await terminate("busy");
+      unregister?.();
+      return {
+        owned: false,
+        ownerPid: -1,
+        lockPath,
+        reason: "lock_held_by_alive_pid",
+      };
+    }
+    if (options.signal?.aborted) {
+      await terminate("aborted");
+      throwIfAborted(options.signal);
+    }
+    return {
+      owned: true,
+      ownerPid: child.pid ?? -1,
+      ownerToken,
+      lockPath,
+      process: child,
+      settled,
+      terminate,
+      unregister,
+    };
+  } catch (error) {
+    await terminate("acquisition_failed");
+    unregister?.();
+    if (error instanceof GitWorktreeFlockUnsupportedError) throw error;
+    if (options.signal?.aborted) throwIfAborted(options.signal);
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new GitWorktreeFlockUnsupportedError(
+        "flock executable is unavailable",
+      );
+    }
+    throw error;
+  }
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw new DOMException("git worktree lock acquisition aborted", "AbortError");
+}
+
 /**
  * Acquire the per-project git-worktree flock.
  *
@@ -55,8 +295,11 @@ export const GIT_WORKTREE_LOCK_FILENAME = "git-worktree.lock";
  */
 export async function acquireGitWorktreeFlock(
   projectStateDir: string,
+  options: AcquireGitWorktreeFlockOptions = {},
 ): Promise<GitWorktreeLockResult> {
+  throwIfAborted(options.signal);
   await mkdir(projectStateDir, { recursive: true });
+  throwIfAborted(options.signal);
   const lockPath = join(projectStateDir, GIT_WORKTREE_LOCK_FILENAME);
   const ownerPid = process.pid;
   const workerId = randomUUID();
@@ -67,15 +310,29 @@ export async function acquireGitWorktreeFlock(
     owner_token: ownerToken,
     acquired_at: new Date().toISOString(),
   };
+  let ownLockCreated = false;
   try {
     const handle = await open(lockPath, "wx");
+    ownLockCreated = true;
     try {
+      throwIfAborted(options.signal);
       await handle.writeFile(JSON.stringify(record));
     } finally {
       await handle.close();
     }
+    if (options.signal?.aborted) {
+      await rm(lockPath, { force: true });
+      throw new DOMException(
+        "git worktree lock acquisition aborted",
+        "AbortError",
+      );
+    }
     return { owned: true, ownerPid, workerId, ownerToken, lockPath };
   } catch {
+    if (options.signal?.aborted) {
+      if (ownLockCreated) await rm(lockPath, { force: true });
+      throwIfAborted(options.signal);
+    }
     let existing: {
       pid?: number;
       worker_id?: string;
@@ -97,6 +354,7 @@ export async function acquireGitWorktreeFlock(
       // If a peer wins the race, leave its lock untouched and report contention.
       const reclaimPath = `${lockPath}.reclaim-${ownerToken}`;
       try {
+        throwIfAborted(options.signal);
         await rename(lockPath, reclaimPath);
         const reclaimed = JSON.parse(await readFile(reclaimPath, "utf8")) as {
           pid?: number;
@@ -107,11 +365,19 @@ export async function acquireGitWorktreeFlock(
           reclaimed.owner_token === existing.owner_token
         ) {
           await rm(reclaimPath, { force: true });
+          throwIfAborted(options.signal);
           const handle = await open(lockPath, "wx");
+          ownLockCreated = true;
           try {
+            throwIfAborted(options.signal);
             await handle.writeFile(JSON.stringify(record));
           } finally {
             await handle.close();
+          }
+          if (options.signal?.aborted) {
+            await rm(lockPath, { force: true });
+            ownLockCreated = false;
+            throwIfAborted(options.signal);
           }
           return { owned: true, ownerPid, workerId, ownerToken, lockPath };
         }

--- a/plugin/src/utils/process-runner.ts
+++ b/plugin/src/utils/process-runner.ts
@@ -51,6 +51,17 @@ export async function runAbortableProcess(
   if (input.destructiveSubtree && platform === "win32") {
     throw new UnsupportedDestructiveProcessPlatformError(platform);
   }
+  if (input.signal?.aborted || input.operation?.signal.aborted) {
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      aborted: true,
+      closed: true,
+    };
+  }
 
   const child = (input.spawnProcess ?? spawn)(
     input.command,

--- a/plugin/src/utils/workspace-warp.ts
+++ b/plugin/src/utils/workspace-warp.ts
@@ -60,6 +60,28 @@ const responseText = async (response: Response): Promise<string> => {
   }
 };
 
+function requestSignal(input?: AbortSignal): {
+  signal: AbortSignal;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const onAbort = () => controller.abort(input?.reason);
+  if (input?.aborted) onAbort();
+  else input?.addEventListener("abort", onAbort, { once: true });
+  const timer = setTimeout(
+    () => controller.abort("workspace operation timeout"),
+    WORKSPACE_OP_TIMEOUT_MS,
+  );
+  timer.unref?.();
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timer);
+      input?.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
 const workspaceUrl = (deps: WarpDeps, suffix = ""): URL =>
   new URL(`/experimental/workspace${suffix}`, deps.serverUrl);
 
@@ -239,23 +261,29 @@ const stringifyErrorDetail = (value: unknown): string => {
 export async function deleteAdvWorkspace(
   deps: WarpDeps,
   workspaceID: string,
+  signal?: AbortSignal,
 ): Promise<void> {
-  const response = await fetchWith(deps)(
-    workspaceUrl(deps, `/${encodeURIComponent(workspaceID)}`),
-    {
-      method: "DELETE",
-      headers: directoryHeaders(deps),
-      signal: AbortSignal.timeout(WORKSPACE_OP_TIMEOUT_MS),
-    },
-  );
+  const request = requestSignal(signal);
+  try {
+    const response = await fetchWith(deps)(
+      workspaceUrl(deps, `/${encodeURIComponent(workspaceID)}`),
+      {
+        method: "DELETE",
+        headers: directoryHeaders(deps),
+        signal: request.signal,
+      },
+    );
 
-  if (response.ok || response.status === 404) return;
+    if (response.ok || response.status === 404) return;
 
-  throw new Error(
-    `deleteAdvWorkspace failed: ${response.status} ${await responseText(
-      response,
-    )}`,
-  );
+    throw new Error(
+      `deleteAdvWorkspace failed: ${response.status} ${await responseText(
+        response,
+      )}`,
+    );
+  } finally {
+    request.dispose();
+  }
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -295,14 +323,16 @@ export async function findWorkspaceByDirectoryChecked(
   deps: WarpDeps,
   directory: string,
   branch?: string,
+  signal?: AbortSignal,
 ): Promise<WorkspaceDirectoryLookupResult> {
   if (!warpFlagEnabled()) return { ok: true, workspace: null };
 
   let list: unknown;
+  const request = requestSignal(signal);
   try {
     const response = await fetchWith(deps)(workspaceUrl(deps), {
       headers: directoryHeaders(deps),
-      signal: AbortSignal.timeout(WORKSPACE_OP_TIMEOUT_MS),
+      signal: request.signal,
     });
     if (!response.ok) {
       return {
@@ -320,6 +350,8 @@ export async function findWorkspaceByDirectoryChecked(
         error instanceof Error ? error.message : String(error)
       }`,
     };
+  } finally {
+    request.dispose();
   }
 
   if (!Array.isArray(list)) {

--- a/plugin/src/utils/worktree-operation.ts
+++ b/plugin/src/utils/worktree-operation.ts
@@ -28,10 +28,13 @@ export interface WorktreeOperationContext {
   readonly signal: AbortSignal;
   readonly stageTimings: readonly WorktreeStageTiming[];
   readonly currentStage: string | undefined;
+  readonly terminationError: Error | undefined;
   remainingMs(now?: number): number;
   startStage(stage: string, now?: number): void;
   finishStage(stage?: string, now?: number): void;
   registerChildLease(lease: WorktreeChildLease): () => void;
+  /** Reject work that would begin after the shared cancellation barrier. */
+  throwIfAborted(reason?: string): void;
   abort(reason: string): Promise<void>;
   dispose(): void;
 }
@@ -56,15 +59,28 @@ export function createWorktreeOperationContext(
   let currentStage: string | undefined;
   let currentStageStartedAt: number | undefined;
   let abortPromise: Promise<void> | undefined;
+  let terminationError: Error | undefined;
   const abort = async (reason: string): Promise<void> => {
     if (abortPromise) return abortPromise;
     abortPromise = (async () => {
       clearTimeout(deadlineTimer);
       if (!controller.signal.aborted) controller.abort(reason);
       const activeChildren = [...children];
-      await Promise.allSettled(
+      const settled = await Promise.allSettled(
         activeChildren.map((child) => Promise.resolve(child.terminate(reason))),
       );
+      const failures = settled.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (failures.length > 0) {
+        terminationError = new Error(
+          `worktree operation child termination failed: ${failures
+            .map((failure) =>
+              failure instanceof Error ? failure.message : String(failure),
+            )
+            .join("; ")}`,
+        );
+      }
     })();
     return abortPromise;
   };
@@ -79,6 +95,9 @@ export function createWorktreeOperationContext(
     },
     get currentStage() {
       return currentStage;
+    },
+    get terminationError() {
+      return terminationError;
     },
     remainingMs(now = Date.now()) {
       return Math.max(0, deadlineAt - now);
@@ -105,6 +124,11 @@ export function createWorktreeOperationContext(
     registerChildLease(lease) {
       children.add(lease);
       return () => children.delete(lease);
+    },
+    throwIfAborted(reason = "operation_aborted") {
+      if (controller.signal.aborted || context.remainingMs() <= 0) {
+        throw new DOMException(reason, "AbortError");
+      }
     },
     abort,
     dispose() {


### PR DESCRIPTION
## Summary
- propagate one deletion operation context from public handler through executor
- replace async file lease with killable kernel-flock process lease
- confirm process-group ESRCH before cancellation completes
- require branded cooperative workspace/reconciliation stages
- remove detached and non-cancelling mutable timeout paths
- bound post-delete census and reconcile without late mutation
- surface quiescence failure as indeterminate

## Verification
- AC4/AC5 acceptance review attempt 8: READY
- exact post-rebase cancellation suite: 87 passed
- broader focused suite: 151 passed
- plugin check: passed

## Safety
Deadline responses now occur only after registered process and mutable-stage quiescence. No lock, workspace, Git, or reconciliation mutation may continue after response.