### PR TITLE
chore: ignore plugin/.adv/ runtime projections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ scripts/provider-eval-results/
 
 # ADV working state (local project data - in .adv directory)
 .adv/changes/
+# Same ADV runtime projections when the store root is plugin/ (untracked by design)
+plugin/.adv/
 # Leaked-in-repo runtime files: ADV state lives outside the repo per AGENTS.md.
 # Add explicit ignores so accidental fallback writes don't get committed.
 .adv/agenda.jsonl


### PR DESCRIPTION
ADV disk projections under `plugin/.adv/` (active-epics, changes, migration markers) are local runtime state — untracked by design, same as the root `.adv/` rules at .gitignore:59-69.

Their untracked presence kept the trunk checkout permanently dirty, which makes strict freshness checks (`oc-fresh`) refuse to sync.

## Verification
- `git check-ignore -v plugin/.adv/changes` matches the new rule
- No tracked files touched; ignore-only change