### PR TITLE
fix: honor merged PR proof during archive

### DIFF
--- a/plugin/schemas/change.schema.json
+++ b/plugin/schemas/change.schema.json
@@ -3484,7 +3484,19 @@
         "completedAt": {
           "type": "string"
         },
+        "defaultBranchSha": {
+          "minLength": 1,
+          "type": "string"
+        },
         "error": {
+          "type": "string"
+        },
+        "mergeCommitSha": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "prHeadSha": {
+          "minLength": 1,
           "type": "string"
         },
         "prNumber": {

--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -50,6 +50,7 @@ import {
   ensureOriginDefaultFetched,
   discoverMergedPr,
   readPrMergeState,
+  verifyDirectMergedPrProof,
 } from "./git-finalize";
 import type { PrTitlePolicy } from "../../types/project";
 
@@ -577,6 +578,110 @@ describe("git-finalize helpers", () => {
       route: "direct",
       remoteUrl: bareRepo,
       protected: false,
+    });
+  });
+
+  describe("direct-route merged PR proof", () => {
+    const validPayload = {
+      number: 405,
+      url: "https://github.com/owner/repo/pull/405",
+      state: "MERGED",
+      mergedAt: "2026-08-08T00:00:00Z",
+      mergeCommit: { oid: "merge-commit" },
+      headRefName: "change/example",
+      headRefOid: "local-tip",
+      baseRefName: "trunk",
+      headRepositoryOwner: { login: "owner" },
+      headRepository: { name: "repo", nameWithOwner: "owner/repo" },
+      isCrossRepository: false,
+    };
+
+    function proof(overrides: Record<string, unknown> = {}) {
+      return verifyDirectMergedPrProof(
+        {
+          repoRoot: "/repo",
+          repo: "owner/repo",
+          defaultBranch: "trunk",
+          changeId: "example",
+          changeTipSha: "local-tip",
+        },
+        {
+          runGh: () => ({
+            status: 0,
+            stdout: JSON.stringify([{ ...validPayload, ...overrides }]),
+            stderr: "",
+          }),
+          runGit: (_cwd, args) => {
+            if (args[0] === "merge-base")
+              return { status: 0, stdout: "", stderr: "" };
+            if (args[0] === "rev-parse")
+              return { status: 0, stdout: "current-default\n", stderr: "" };
+            return { status: 1, stdout: "", stderr: "unexpected" };
+          },
+        },
+      );
+    }
+
+    it("accepts exact merged PR proof and records current default reachability", () => {
+      expect(proof()).toEqual({
+        kind: "valid",
+        prNumber: 405,
+        prUrl: "https://github.com/owner/repo/pull/405",
+        prHeadSha: "local-tip",
+        mergeCommitOid: "merge-commit",
+        defaultBranchSha: "current-default",
+      });
+    });
+
+    for (const [label, overrides] of [
+      ["wrong head OID", { headRefOid: "other-tip" }],
+      ["wrong base", { baseRefName: "main" }],
+      ["wrong state", { state: "OPEN", mergedAt: null }],
+    ] as const) {
+      it(`rejects ${label}`, () => {
+        expect(proof(overrides)).toMatchObject({ kind: "invalid" });
+      });
+    }
+
+    it("rejects an unreachable merge commit", () => {
+      const result = verifyDirectMergedPrProof(
+        {
+          repoRoot: "/repo",
+          repo: "owner/repo",
+          defaultBranch: "trunk",
+          changeId: "example",
+          changeTipSha: "local-tip",
+        },
+        {
+          runGh: () => ({
+            status: 0,
+            stdout: JSON.stringify([validPayload]),
+            stderr: "",
+          }),
+          runGit: () => ({ status: 1, stdout: "", stderr: "not reachable" }),
+        },
+      );
+      expect(result).toMatchObject({
+        kind: "invalid",
+        reason: "MERGED_PR_COMMIT_UNREACHABLE",
+      });
+    });
+
+    it("continues direct behavior only when the merged PR list is explicitly empty", () => {
+      expect(
+        verifyDirectMergedPrProof(
+          {
+            repoRoot: "/repo",
+            repo: "owner/repo",
+            defaultBranch: "trunk",
+            changeId: "example",
+            changeTipSha: "local-tip",
+          },
+          {
+            runGh: () => ({ status: 0, stdout: "[]", stderr: "" }),
+          },
+        ),
+      ).toEqual({ kind: "none" });
     });
   });
 
@@ -3329,6 +3434,112 @@ describe("git-finalize helpers", () => {
     expect(git(remote, ["show", `${remoteHead}:feature.txt`])).toBe("feature");
   });
 
+  it("finalizeRelease accepts an exact squash-merged PR on a direct route without invoking merge", async () => {
+    const seed = join(tempRoot, "seed-pr-proof");
+    const remote = join(tempRoot, "remote-pr-proof.git");
+    const main = join(tempRoot, "main-pr-proof");
+    const mergeClone = join(tempRoot, "merge-pr-proof");
+    const worktree = join(tempRoot, "wt-pr-proof");
+    await mkdir(seed);
+    await mkdir(remote);
+    await mkdir(main);
+    await mkdir(mergeClone);
+
+    await initRepo(seed, "trunk");
+    git(tempRoot, ["init", "--bare", "-q", "-b", "trunk", remote]);
+    git(seed, ["remote", "add", "origin", remote]);
+    git(seed, ["push", "origin", "trunk"]);
+    git(tempRoot, ["clone", "-q", remote, main]);
+    git(main, ["config", "user.email", "adv-test@example.invalid"]);
+    git(main, ["config", "user.name", "ADV Test"]);
+    git(tempRoot, ["clone", "-q", remote, mergeClone]);
+    git(mergeClone, ["config", "user.email", "adv-test@example.invalid"]);
+    git(mergeClone, ["config", "user.name", "ADV Test"]);
+    git(main, ["worktree", "add", "-b", "change/example", worktree]);
+    await writeFile(join(worktree, "feature.txt"), "feature\n");
+    git(worktree, ["add", "feature.txt"]);
+    git(worktree, ["commit", "-m", "feature"]);
+    const prHeadSha = git(worktree, ["rev-parse", "HEAD"]);
+    git(worktree, ["push", "-u", "origin", "change/example"]);
+
+    // Simulate a squash merge through GitHub, followed by unrelated trunk
+    // commits that make a second direct merge attempt conflict-prone.
+    git(mergeClone, ["fetch", "origin", "change/example"]);
+    git(mergeClone, ["merge", "--squash", "origin/change/example"]);
+    git(mergeClone, ["commit", "-m", "squash merge"]);
+    const mergeCommitOid = git(mergeClone, ["rev-parse", "HEAD"]);
+    await writeFile(join(mergeClone, "later.txt"), "later\n");
+    git(mergeClone, ["add", "later.txt"]);
+    git(mergeClone, ["commit", "-m", "later trunk change"]);
+    git(mergeClone, ["push", "origin", "trunk"]);
+    const defaultBranchSha = git(mergeClone, ["rev-parse", "HEAD"]);
+
+    const gitCalls: string[][] = [];
+    const result = await finalizeRelease(
+      {
+        changeId: "example",
+        workdir: worktree,
+        archiveMode: "direct",
+        autoPush: true,
+      },
+      {
+        runGit: (cwd, args) => {
+          gitCalls.push(args);
+          if (args[0] === "remote" && args[1] === "get-url") {
+            return {
+              status: 0,
+              stdout: "https://github.com/owner/repo.git\n",
+              stderr: "",
+            };
+          }
+          return defaultRunGit(cwd, args);
+        },
+        runGh: (_cwd, args) => {
+          if (args[0] === "api" && args[1].includes("/rules/branches/")) {
+            return { status: 0, stdout: "[]", stderr: "" };
+          }
+          if (args[0] === "pr" && args[1] === "list") {
+            return {
+              status: 0,
+              stdout: JSON.stringify([
+                {
+                  number: 405,
+                  url: "https://github.com/owner/repo/pull/405",
+                  state: "MERGED",
+                  mergedAt: "2026-08-08T00:00:00Z",
+                  mergeCommit: { oid: mergeCommitOid },
+                  headRefName: "change/example",
+                  headRefOid: prHeadSha,
+                  baseRefName: "trunk",
+                  headRepositoryOwner: { login: "owner" },
+                  headRepository: {
+                    name: "repo",
+                    nameWithOwner: "owner/repo",
+                  },
+                  isCrossRepository: false,
+                },
+              ]),
+              stderr: "",
+            };
+          }
+          return { status: 1, stdout: "", stderr: "unexpected gh" };
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "shipped",
+      route: "direct",
+      prNumber: 405,
+      prHeadSha,
+      mergeCommitSha: mergeCommitOid,
+      releasedCommitSha: defaultBranchSha,
+      defaultBranchSha,
+    });
+    expect(gitCalls.filter((args) => args[0] === "merge")).toEqual([]);
+    expect(git(worktree, ["rev-parse", "change/example"])).toBe(prHeadSha);
+  });
+
   it("finalizeRelease in PR mode blocks when origin is missing", async () => {
     const main = join(tempRoot, "main");
     const worktree = join(tempRoot, "wt");
@@ -3361,6 +3572,18 @@ describe("git-finalize helpers", () => {
         },
       }),
     ).toEqual({ pushed: true, sha: "abc" });
+  });
+
+  it("verifyDefaultBranchPushed fails closed when origin/default cannot be refreshed", () => {
+    expect(
+      verifyDefaultBranchPushed("/repo", "trunk", {
+        runGit: (_cwd, args) => {
+          if (args[0] === "fetch")
+            return { status: 1, stdout: "", stderr: "network unavailable" };
+          return { status: 1, stdout: "", stderr: "must not use stale ref" };
+        },
+      }),
+    ).toEqual({ pushed: false, reason: "network unavailable" });
   });
 
   it("verifyChangeBranchPushed rejects stale remote branch refs", () => {

--- a/plugin/src/tools/archive-helpers/git-finalize.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.ts
@@ -28,9 +28,14 @@ export interface GitFinalizeOutcome {
   /** SHA of the change branch tip captured before merge/cleanup so tree-SHA
    *  re-proof can survive branch deletion (rq-fixArchivedBranchFinalization SC1). */
   changeTipSha?: string;
+  /** Exact PR head SHA accepted for a direct-route merged-PR proof. */
+  prHeadSha?: string;
+  /** Current origin/default SHA containing the accepted PR merge commit. */
+  defaultBranchSha?: string;
   pushStatus: "pushed" | "skipped" | "failed" | "not_attempted";
   pushFailureReason?: string;
   prBranch?: string;
+  repo?: string;
   prNumber?: number;
   prUrl?: string;
   autoMergeArmed?: boolean;
@@ -242,6 +247,18 @@ export interface PullRequestMergeState {
   raw?: unknown;
 }
 
+export type DirectMergedPrProof =
+  | { kind: "none" }
+  | {
+      kind: "valid";
+      prNumber: number;
+      prUrl?: string;
+      prHeadSha: string;
+      mergeCommitOid: string;
+      defaultBranchSha: string;
+    }
+  | { kind: "invalid"; reason: string; details?: string[] };
+
 interface PullRequestSummary {
   number: number;
   url: string;
@@ -258,6 +275,8 @@ export interface ReleaseReachabilityInput {
   prNumber?: number;
   /** Optional repo override; falls back to route.repo. */
   repo?: string;
+  /** Persisted exact PR head SHA for a prior direct-route finalization. */
+  prHeadSha?: string;
   // rq-fixPhase9SquashMergeRedetect SC1: persisted change-tip SHA captured at
   // archive dispatch time. When provided, detection uses this content-addressed
   // tip instead of the live change/{id} git ref so reachability survives
@@ -272,7 +291,9 @@ export type ReleaseReachabilityProof =
       /** Route-neutral SHA from the authority that proved release (required). */
       releasedCommitSha: string;
       prNumber?: number;
+      prHeadSha?: string;
       mergeCommitOid?: string;
+      defaultBranchSha?: string;
       details?: string[];
     }
   | {
@@ -1212,7 +1233,17 @@ export function verifyDefaultBranchPushed(
   deps: Pick<GitFinalizeDeps, "runGit"> = {},
 ): { pushed: true; sha: string } | { pushed: false; reason: string } {
   const runGit = deps.runGit ?? defaultRunGit;
-  runGit(repoRoot, ["fetch", "origin", defaultBranch]);
+  const fetch = runGit(repoRoot, ["fetch", "origin", defaultBranch]);
+  if (fetch.status !== 0) {
+    return {
+      pushed: false,
+      reason: (
+        fetch.stderr ||
+        fetch.stdout ||
+        `unable to fetch origin/${defaultBranch}`
+      ).trim(),
+    };
+  }
   const localHead = runGit(repoRoot, ["rev-parse", "HEAD"]);
   if (localHead.status !== 0 || !localHead.stdout.trim()) {
     return {
@@ -1308,6 +1339,226 @@ export function readPrMergeState(
     default:
       return assertNever(parsed);
   }
+}
+
+/**
+ * Query and verify an already-merged PR before a direct-route merge attempt.
+ *
+ * A direct route can still have been merged through GitHub before Phase 9 is
+ * resumed (notably after a squash merge plus later trunk commits). The proof
+ * is accepted only when the API response identifies the exact repository,
+ * head/base branches, local change-tip SHA, and a non-empty merge commit that
+ * is reachable from the freshly fetched origin/default ref.
+ *
+ * An explicit empty list means no merged-PR proof exists and preserves the
+ * existing direct merge path. Every other malformed, conflicting, or failed
+ * response is ambiguous and therefore fails closed.
+ */
+export function verifyDirectMergedPrProof(
+  input: {
+    repoRoot: string;
+    repo?: string;
+    defaultBranch: string;
+    changeId: string;
+    changeTipSha?: string;
+  },
+  deps: Pick<GitFinalizeDeps, "runGit" | "runGh"> = {},
+): DirectMergedPrProof {
+  if (!input.repo) return { kind: "none" };
+
+  const runGh = deps.runGh ?? defaultRunGh;
+  const branch = `change/${input.changeId}`;
+  const result = runGh(input.repoRoot, [
+    "pr",
+    "list",
+    "--repo",
+    input.repo,
+    "--state",
+    "merged",
+    "--head",
+    branch,
+    "--base",
+    input.defaultBranch,
+    "--json",
+    "number,url,state,mergedAt,mergeCommit,headRefName,headRefOid,baseRefName,headRepositoryOwner,headRepository,isCrossRepository",
+    "--limit",
+    "20",
+  ]);
+  if (result.status !== 0) {
+    return {
+      kind: "invalid",
+      reason: "MERGED_PR_PROOF_QUERY_FAILED",
+      details: splitLines(result.stderr || result.stdout),
+    };
+  }
+
+  const parsed = parseGhJson(result.stdout);
+  if (parsed.kind === "empty") {
+    return {
+      kind: "invalid",
+      reason: "MERGED_PR_PROOF_UNPARSEABLE",
+      details: [],
+    };
+  }
+  if (parsed.kind === "malformed") {
+    return {
+      kind: "invalid",
+      reason: "MERGED_PR_PROOF_UNPARSEABLE",
+      details: [parsed.message],
+    };
+  }
+  if (!Array.isArray(parsed.value)) {
+    return {
+      kind: "invalid",
+      reason: "MERGED_PR_PROOF_UNPARSEABLE",
+      details: ["GitHub returned a non-array pull-request payload"],
+    };
+  }
+  if (parsed.value.length === 0) return { kind: "none" };
+
+  const repoParts = input.repo.split("/").slice(-2);
+  if (repoParts.length !== 2 || repoParts.some((part) => !part)) {
+    return {
+      kind: "invalid",
+      reason: "MERGED_PR_PROOF_REPOSITORY_UNPARSEABLE",
+    };
+  }
+  const [expectedOwner, expectedName] = repoParts;
+  const localTip = input.changeTipSha?.trim();
+  const candidates: DirectMergedPrProof[] = [];
+
+  for (const value of parsed.value) {
+    if (!value || typeof value !== "object") {
+      candidates.push({
+        kind: "invalid",
+        reason: "MERGED_PR_PROOF_RECORD_UNPARSEABLE",
+      });
+      continue;
+    }
+    const payload = value as {
+      number?: unknown;
+      url?: unknown;
+      state?: unknown;
+      mergedAt?: unknown;
+      mergeCommit?: { oid?: unknown } | null;
+      headRefName?: unknown;
+      headRefOid?: unknown;
+      baseRefName?: unknown;
+      headRepositoryOwner?: { login?: unknown } | string | null;
+      headRepository?: {
+        name?: unknown;
+        nameWithOwner?: unknown;
+      } | null;
+      isCrossRepository?: unknown;
+    };
+    const owner =
+      typeof payload.headRepositoryOwner === "string"
+        ? payload.headRepositoryOwner
+        : payload.headRepositoryOwner?.login;
+    const headRepository = payload.headRepository;
+    const exactHeadRepository =
+      typeof headRepository?.nameWithOwner === "string"
+        ? headRepository.nameWithOwner === input.repo
+        : owner === expectedOwner && headRepository?.name === expectedName;
+    const prNumber = payload.number;
+    const prHeadSha =
+      typeof payload.headRefOid === "string" ? payload.headRefOid.trim() : "";
+    const mergeCommitOid =
+      typeof payload.mergeCommit?.oid === "string"
+        ? payload.mergeCommit.oid.trim()
+        : "";
+    const validPrNumber =
+      typeof prNumber === "number" && Number.isInteger(prNumber) && prNumber > 0
+        ? prNumber
+        : undefined;
+    const exactRecord =
+      validPrNumber !== undefined &&
+      payload.state === "MERGED" &&
+      typeof payload.mergedAt === "string" &&
+      payload.mergedAt.trim() !== "" &&
+      payload.headRefName === branch &&
+      payload.baseRefName === input.defaultBranch &&
+      payload.isCrossRepository !== true &&
+      exactHeadRepository &&
+      prHeadSha !== "" &&
+      mergeCommitOid !== "" &&
+      localTip !== undefined &&
+      prHeadSha === localTip;
+
+    if (!exactRecord) {
+      candidates.push({
+        kind: "invalid",
+        reason: "MERGED_PR_PROOF_MISMATCH",
+        details: [
+          `PR ${String(prNumber)} did not match exact repo/head/base/state/OID proof`,
+        ],
+      });
+      continue;
+    }
+
+    candidates.push({
+      kind: "valid",
+      prNumber: validPrNumber as number,
+      prUrl: typeof payload.url === "string" ? payload.url : undefined,
+      prHeadSha,
+      mergeCommitOid,
+      defaultBranchSha: "",
+    });
+  }
+
+  const valid = candidates.filter(
+    (candidate): candidate is Extract<DirectMergedPrProof, { kind: "valid" }> =>
+      candidate.kind === "valid",
+  );
+  if (valid.length !== 1 || candidates.length !== 1) {
+    return {
+      kind: "invalid",
+      reason:
+        valid.length > 1
+          ? "MERGED_PR_PROOF_AMBIGUOUS"
+          : (candidates.find((candidate) => candidate.kind === "invalid")
+              ?.reason ?? "MERGED_PR_PROOF_MISMATCH"),
+      details: candidates.flatMap((candidate) =>
+        candidate.kind === "invalid" ? (candidate.details ?? []) : [],
+      ),
+    };
+  }
+
+  const runGit = deps.runGit ?? defaultRunGit;
+  const reachable = runGit(input.repoRoot, [
+    "merge-base",
+    "--is-ancestor",
+    valid[0].mergeCommitOid,
+    `origin/${input.defaultBranch}`,
+  ]);
+  if (reachable.status !== 0) {
+    return {
+      kind: "invalid",
+      reason:
+        reachable.status === 1
+          ? "MERGED_PR_COMMIT_UNREACHABLE"
+          : "MERGED_PR_REACHABILITY_CHECK_FAILED",
+      details: splitLines(reachable.stderr || reachable.stdout),
+    };
+  }
+
+  const defaultBranch = runGit(input.repoRoot, [
+    "rev-parse",
+    "--verify",
+    `origin/${input.defaultBranch}`,
+  ]);
+  if (defaultBranch.status !== 0 || !defaultBranch.stdout.trim()) {
+    return {
+      kind: "invalid",
+      reason: "DEFAULT_BRANCH_REACHABILITY_UNRESOLVED",
+      details: splitLines(defaultBranch.stderr || defaultBranch.stdout),
+    };
+  }
+
+  return {
+    ...valid[0],
+    defaultBranchSha: defaultBranch.stdout.trim(),
+  };
 }
 
 export function discoverMergedPr(
@@ -2567,6 +2818,52 @@ export function resolveReleaseReachability(
       }
     }
 
+    // A persisted exact head SHA upgrades release-gate rechecks to the same
+    // strict proof used before a direct merge. This keeps a later gate check
+    // from accepting an unrelated merged PR or unreachable merge commit.
+    if (directRepo && input.prHeadSha) {
+      const exactProof = verifyDirectMergedPrProof(
+        {
+          repoRoot: input.repoRoot,
+          repo: directRepo,
+          defaultBranch: input.defaultBranch,
+          changeId: input.changeId,
+          changeTipSha: input.changeTipSha,
+        },
+        deps,
+      );
+      if (exactProof.kind === "valid") {
+        if (
+          input.prNumber === undefined ||
+          input.prNumber === exactProof.prNumber
+        ) {
+          return {
+            reachable: true,
+            proof: "pr_merged",
+            releasedCommitSha: exactProof.mergeCommitOid,
+            prNumber: exactProof.prNumber,
+            prHeadSha: exactProof.prHeadSha,
+            mergeCommitOid: exactProof.mergeCommitOid,
+            defaultBranchSha: exactProof.defaultBranchSha,
+          };
+        }
+        return {
+          reachable: false,
+          proof: "blocked",
+          prNumber: input.prNumber,
+          details: ["Merged PR number does not match persisted Phase 9 proof"],
+        };
+      }
+      if (exactProof.kind === "invalid") {
+        return {
+          reachable: false,
+          proof: "blocked",
+          prNumber: input.prNumber,
+          details: [exactProof.reason, ...(exactProof.details ?? [])],
+        };
+      }
+    }
+
     // Existing PR merge state check (now with auto-discovered PR)
     if (effectivePrNumber && directRepo) {
       const prState = readPrMergeState(
@@ -3199,6 +3496,58 @@ export async function finalizeRelease(
         details: splitLines(fetchOrigin.stderr || fetchOrigin.stdout),
       },
     };
+  }
+
+  // A direct route may be resumed after the change branch was already
+  // squash-merged through GitHub. Prove that exact merge before creating the
+  // ephemeral merge worktree; otherwise the old branch can conflict with
+  // later trunk commits and the finalizer would attempt a duplicate merge.
+  if (route.route === "direct") {
+    const mergedPrProof = verifyDirectMergedPrProof(
+      {
+        repoRoot,
+        repo: route.repo,
+        defaultBranch,
+        changeId: ctx.changeId,
+        changeTipSha,
+      },
+      deps,
+    );
+    if (mergedPrProof.kind === "invalid") {
+      return {
+        status: "blocked",
+        repoRoot,
+        defaultBranch,
+        route: route.route,
+        pushStatus: "not_attempted",
+        prBranch: `change/${ctx.changeId}`,
+        blocked: {
+          reason: mergedPrProof.reason,
+          remediation:
+            "The merged PR proof is ambiguous or unreachable. Verify the exact PR head/base, local change-tip SHA, and origin/default reachability before rerunning archive finalization.",
+          details: mergedPrProof.details,
+        },
+      };
+    }
+    if (mergedPrProof.kind === "valid") {
+      return {
+        status: "shipped",
+        repoRoot,
+        defaultBranch,
+        route: route.route,
+        releasedCommitSha: mergedPrProof.defaultBranchSha,
+        mergeCommitSha: mergedPrProof.mergeCommitOid,
+        changeTipSha,
+        pushStatus: "pushed",
+        prBranch: `change/${ctx.changeId}`,
+        repo: route.repo,
+        prNumber: mergedPrProof.prNumber,
+        prUrl: mergedPrProof.prUrl,
+        prHeadSha: mergedPrProof.prHeadSha,
+        defaultBranchSha: mergedPrProof.defaultBranchSha,
+        autoMergeArmed: false,
+      };
+    }
   }
 
   const originDefaultRef = runGit(repoRoot, [

--- a/plugin/src/tools/change/archive-gate.test.ts
+++ b/plugin/src/tools/change/archive-gate.test.ts
@@ -63,6 +63,28 @@ async function writeDiskChange(
 }
 
 describe("archive-gate disk projection", () => {
+  it("records exact PR and current default reachability in durable evidence", () => {
+    const evidence = buildReleaseCompletionEvidence({
+      status: "shipped",
+      repoRoot: "/repo",
+      defaultBranch: "trunk",
+      pushStatus: "pushed",
+      route: "direct",
+      repo: "owner/repo",
+      prNumber: 405,
+      prHeadSha: "pr-head-sha",
+      mergeCommitSha: "merge-commit-sha",
+      defaultBranchSha: "current-default-sha",
+      releasedCommitSha: "current-default-sha",
+    });
+    expect(evidence).toContain("prNumber=405");
+    expect(evidence).toContain("prHeadSha=pr-head-sha");
+    expect(evidence).toContain("mergeCommitSha=merge-commit-sha");
+    expect(evidence).toContain(
+      "defaultBranchReachability=origin/trunk@current-default-sha",
+    );
+  });
+
   it("accepts audited disk release proof with matching finalization evidence", async () => {
     const root = await mkdtemp(join(tmpdir(), "adv-archive-gate-"));
     try {

--- a/plugin/src/tools/change/archive-gate.ts
+++ b/plugin/src/tools/change/archive-gate.ts
@@ -115,7 +115,12 @@ export function buildReleaseCompletionEvidence(
       ? `mergeCommitSha=${finalization.mergeCommitSha}`
       : null,
     finalization.prBranch ? `prBranch=${finalization.prBranch}` : null,
+    finalization.repo ? `repo=${finalization.repo}` : null,
     finalization.prNumber ? `prNumber=${finalization.prNumber}` : null,
+    finalization.prHeadSha ? `prHeadSha=${finalization.prHeadSha}` : null,
+    finalization.defaultBranchSha
+      ? `defaultBranchReachability=origin/${finalization.defaultBranch}@${finalization.defaultBranchSha}`
+      : null,
     finalization.prUrl ? `prUrl=${finalization.prUrl}` : null,
     finalization.route ? `route=${finalization.route}` : null,
   ].filter(Boolean);
@@ -143,6 +148,13 @@ export function preservePhase9Evidence(
       : {}),
     ...(previous.changeTipSha !== undefined && next.changeTipSha === undefined
       ? { changeTipSha: previous.changeTipSha }
+      : {}),
+    ...(previous.prHeadSha !== undefined && next.prHeadSha === undefined
+      ? { prHeadSha: previous.prHeadSha }
+      : {}),
+    ...(previous.defaultBranchSha !== undefined &&
+    next.defaultBranchSha === undefined
+      ? { defaultBranchSha: previous.defaultBranchSha }
       : {}),
     ...(previous.autoMergeArmed !== undefined &&
     next.autoMergeArmed === undefined
@@ -286,6 +298,7 @@ export function verifyReleaseEvidenceFromMain(input: {
       changeId: input.changeId,
       route,
       prNumber: input.change?.phase9_status?.prNumber,
+      prHeadSha: input.change?.phase9_status?.prHeadSha,
       changeTipSha: input.change?.phase9_status?.changeTipSha,
       repo: input.change?.phase9_status?.repo,
     },
@@ -303,6 +316,9 @@ export function verifyReleaseEvidenceFromMain(input: {
           ? reachability.mergeCommitOid
           : undefined,
       prNumber: reachability.prNumber,
+      prHeadSha: reachability.prHeadSha,
+      defaultBranchSha: reachability.defaultBranchSha,
+      repo: input.change?.phase9_status?.repo,
       prUrl: input.change?.phase9_status?.prUrl,
       autoMergeArmed: false,
       pushStatus: route.route === "no_remote" ? "skipped" : "pushed",

--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -654,6 +654,15 @@ export const advChangeArchiveHandler = async (
                     startedAt: latest.phase9_status?.startedAt ?? archivedAt,
                     completedAt: archivedAt,
                     changeTipSha: finalization?.changeTipSha,
+                    repo: finalization?.repo,
+                    prNumber: finalization?.prNumber,
+                    prUrl: finalization?.prUrl,
+                    route: finalization?.route,
+                    prHeadSha: finalization?.prHeadSha,
+                    defaultBranchSha: finalization?.defaultBranchSha,
+                    ...(finalization?.mergeCommitSha
+                      ? { mergeCommitSha: finalization.mergeCommitSha }
+                      : {}),
                   }),
                 }
               : {}),

--- a/plugin/src/tools/change/helpers.ts
+++ b/plugin/src/tools/change/helpers.ts
@@ -315,6 +315,12 @@ export async function saveRecoveredArchiveConvergence(input: {
           ...(input.finalization.mergeCommitSha
             ? { mergeCommitSha: input.finalization.mergeCommitSha }
             : {}),
+          ...(input.finalization.prHeadSha
+            ? { prHeadSha: input.finalization.prHeadSha }
+            : {}),
+          ...(input.finalization.defaultBranchSha
+            ? { defaultBranchSha: input.finalization.defaultBranchSha }
+            : {}),
           ...(input.finalization.changeTipSha
             ? { changeTipSha: input.finalization.changeTipSha }
             : {}),

--- a/plugin/src/tools/gate.ts
+++ b/plugin/src/tools/gate.ts
@@ -497,8 +497,16 @@ function durableReleaseProofEvidence(input: {
       ...(input.reachability.prNumber
         ? [`prNumber=${input.reachability.prNumber}`]
         : []),
+      ...(input.reachability.prHeadSha
+        ? [`prHeadSha=${input.reachability.prHeadSha}`]
+        : []),
       ...(input.reachability.mergeCommitOid
         ? [`mergeCommitOid=${input.reachability.mergeCommitOid}`]
+        : []),
+      ...(input.reachability.defaultBranchSha
+        ? [
+            `defaultBranchReachability=origin/${input.defaultBranch}@${input.reachability.defaultBranchSha}`,
+          ]
         : []),
     ].join("; "),
   };
@@ -522,6 +530,7 @@ function getReleaseFinalizationBlocker(input: {
       changeId: input.changeId,
       route,
       prNumber: input.change.phase9_status?.prNumber,
+      prHeadSha: input.change.phase9_status?.prHeadSha,
       repo: input.change.phase9_status?.repo,
       changeTipSha: input.change.phase9_status?.changeTipSha,
     });
@@ -561,6 +570,7 @@ function getReleaseFinalizationBlocker(input: {
     changeId: input.changeId,
     route,
     prNumber: input.change.phase9_status?.prNumber,
+    prHeadSha: input.change.phase9_status?.prHeadSha,
     repo: input.change.phase9_status?.repo,
     changeTipSha: input.change.phase9_status?.changeTipSha,
   });

--- a/plugin/src/types/changes.archive-passthrough.test.ts
+++ b/plugin/src/types/changes.archive-passthrough.test.ts
@@ -70,4 +70,13 @@ describe("Phase9FinalizationStatusSchema changeTipSha", () => {
       }).success,
     ).toBe(false);
   });
+
+  test("preserves the exact merged PR commit OID", () => {
+    expect(
+      Phase9FinalizationStatusSchema.parse({
+        ...baseStatus,
+        mergeCommitSha: "b".repeat(40),
+      }).mergeCommitSha,
+    ).toBe("b".repeat(40));
+  });
 });

--- a/plugin/src/types/changes.ts
+++ b/plugin/src/types/changes.ts
@@ -1118,6 +1118,12 @@ export const Phase9FinalizationStatusSchema = z.object({
     .string()
     .regex(/^[0-9a-f]{40}$/, "changeTipSha must be a 40-hex Git SHA")
     .optional(),
+  /** Exact PR head SHA used by direct-route merged-PR proof. */
+  prHeadSha: z.string().min(1).optional(),
+  /** Exact merged PR commit OID used by direct-route merged-PR proof. */
+  mergeCommitSha: z.string().min(1).optional(),
+  /** Current origin/default SHA proven to contain the merged PR commit. */
+  defaultBranchSha: z.string().min(1).optional(),
 });
 
 export type Phase9FinalizationStatus = z.infer<


### PR DESCRIPTION
## Summary
- verify exact merged PR proof before direct Phase 9 merge
- require exact repository/head/base/state/head OID and reachable merge commit
- skip duplicate local merge for squash-merged change branches
- fail closed on refresh/API/malformed/unreachable/ambiguous proof
- persist PR head, merge commit, and default-branch reachability evidence

## Verification
- focused archive/release suites: 151 passed
- plugin check: passed
- independent harden review: READY

## Live blocker
`fixWorktreeDeletionReliability` PR #405 is merged, but current Phase 9 selected direct route and conflicted against later merged remediation PRs #407-#409.