### PR TITLE
fix: reconcile archived delta projections

### DIFF
--- a/docs/specs/advance-workflow.md
+++ b/docs/specs/advance-workflow.md
@@ -781,6 +781,8 @@ When the spawned “adv-ci-waiter” returns a non-terminal outcome (timeout, bl
 
 When `/adv-archive` Phase 9 finalization succeeds, archive success MUST be gated by durable release-gate projection proof. Before `adv_change_archive phase9:"run"` reports success or performs archive retirement side effects, the store-backed gate read used by `adv_gate_status` MUST report `gates.release.status === "done"` with Phase 9 evidence in the release completion record. If this proof cannot be established, archive MUST return a blocked/recoverable result and MUST NOT claim shipped success, close linked issues, or run terminal cleanup as a successful retirement. Existing-bundle or completed-workflow retries MAY reconcile release metadata only after structural Phase 9 evidence is re-verified from the main checkout or PR branch state.
 
+An already-archived change with accepted deltas and a missing or invalid projection proof MAY use the bounded `archive_delta_repair` recovery path only with an explicit clean worktree on `repair/archive-{changeId}`. That worktree MUST belong to the exact target repository, start at the fetched `origin/{defaultBranch}`-equal local default HEAD/tree, and carry durable gate approval evidence before any spec, documentation, or in-repository archive write. Recovery MUST reuse the normal archive and Phase 9 paths, verify the manifest against the immutable released commit and exact accepted delta set, and record typed repair evidence. Active archives and normal `change/{changeId}` worktrees MUST NOT use this path.
+
 **Tags:** `workflow`, `archive`, `release`, `projection`, `durability`
 
 #### Scenarios

--- a/plugin/schemas/change.schema.json
+++ b/plugin/schemas/change.schema.json
@@ -83,6 +83,67 @@
     "archive_projection_proof": {
       "additionalProperties": false,
       "properties": {
+        "archive_delta_repair": {
+          "additionalProperties": false,
+          "properties": {
+            "default_branch": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "default_branch_sha": {
+              "pattern": "^[a-f0-9]{40,64}$",
+              "type": "string"
+            },
+            "delta_ids_by_capability": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "delta_set_sha256": {
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            },
+            "kind": {
+              "const": "archive_delta_repair",
+              "type": "string"
+            },
+            "release_proof": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "released_commit_sha": {
+              "pattern": "^[a-f0-9]{40,64}$",
+              "type": "string"
+            },
+            "repair_branch": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "repair_head_sha": {
+              "pattern": "^[a-f0-9]{40,64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "repair_branch",
+            "repair_head_sha",
+            "default_branch",
+            "default_branch_sha",
+            "released_commit_sha",
+            "delta_set_sha256",
+            "delta_ids_by_capability",
+            "release_proof"
+          ],
+          "type": "object"
+        },
         "change_id": {
           "minLength": 1,
           "type": "string"

--- a/plugin/src/archive/projection-proof.ts
+++ b/plugin/src/archive/projection-proof.ts
@@ -48,11 +48,14 @@ export async function readProjectionManifest(
     join(bundlePath, "spec-projection.json"),
   );
   if (result.kind !== "ok") return null;
-  const parsed = SpecProjectionManifestSchema.safeParse(
-    JSON.parse(result.content),
-  );
-  if (!parsed.success) return null;
-  return parsed.data;
+  try {
+    const parsed = SpecProjectionManifestSchema.safeParse(
+      JSON.parse(result.content),
+    );
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
 }
 
 async function verifyProjection(

--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -34,6 +34,7 @@ import {
   redactGitOutput,
   resolveReleaseReachability,
   validateChangeWorktree,
+  validateArchiveDeltaRepairWorktree,
   commitArchiveArtifacts,
   verifyChangeBranchReachableFromOrigin,
   detectArchivedUnmergedBranches,
@@ -3634,6 +3635,68 @@ describe("git-finalize helpers", () => {
     });
     expect(detached.valid).toBe(false);
     expect(detached.error).toContain("detached");
+  });
+
+  it("validateArchiveDeltaRepairWorktree requires a clean exact current-trunk repair basis", async () => {
+    const repo = join(tempRoot, "repair-repo");
+    const origin = join(tempRoot, "repair-origin.git");
+    const repair = join(tempRoot, "repair-wt");
+    const wrong = join(tempRoot, "wrong-wt");
+    await mkdir(repo);
+    await initRepo(repo);
+    git(repo, ["init", "--bare", origin]);
+    git(repo, ["remote", "add", "origin", origin]);
+    git(repo, ["push", "-u", "origin", "trunk"]);
+    git(origin, ["symbolic-ref", "HEAD", "refs/heads/trunk"]);
+    git(repo, ["fetch", "origin", "trunk"]);
+    git(repo, [
+      "worktree",
+      "add",
+      "-b",
+      "repair/archive-example",
+      repair,
+      "trunk",
+    ]);
+    git(repo, ["worktree", "add", "-b", "change/example", wrong, "trunk"]);
+
+    const valid = validateArchiveDeltaRepairWorktree(repair, "example", repo);
+    expect(valid.valid).toBe(true);
+    expect(valid.repairBranch).toBe("repair/archive-example");
+    expect(valid.repairHeadSha).toBe(valid.defaultBranchSha);
+
+    await writeFile(join(repair, "dirty.txt"), "must refuse\n");
+    const dirty = validateArchiveDeltaRepairWorktree(repair, "example", repo);
+    expect(dirty.valid).toBe(false);
+    expect(dirty.error).toContain("uncommitted");
+
+    const wrongBranch = validateArchiveDeltaRepairWorktree(
+      wrong,
+      "example",
+      repo,
+    );
+    expect(wrongBranch.valid).toBe(false);
+    expect(wrongBranch.error).toContain("repair/archive-example");
+
+    const behind = join(tempRoot, "behind-wt");
+    git(repo, [
+      "worktree",
+      "add",
+      "-b",
+      "repair/archive-behind",
+      behind,
+      "trunk",
+    ]);
+    await writeFile(join(repo, "advance.txt"), "trunk advanced\n");
+    git(repo, ["add", "advance.txt"]);
+    git(repo, ["commit", "-m", "advance trunk"]);
+    git(repo, ["push", "origin", "trunk"]);
+    const behindResult = validateArchiveDeltaRepairWorktree(
+      behind,
+      "behind",
+      repo,
+    );
+    expect(behindResult.valid).toBe(false);
+    expect(behindResult.error).toContain("start exactly");
   });
 
   it("commitArchiveArtifacts stages and commits .adv/ changes", async () => {

--- a/plugin/src/tools/archive-helpers/git-finalize.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.ts
@@ -70,6 +70,8 @@ export interface GitFinalizeDeps {
   };
   /** Project state directory required when `ephemeralWorktreeLock` is provided. */
   projectStateDir?: string;
+  /** Alternate source branch used only by structurally validated archive repair. */
+  sourceBranch?: string;
 }
 
 export type ReleaseFinalizationRouteName =
@@ -271,6 +273,7 @@ export interface ReleaseReachabilityInput {
   repoRoot: string;
   defaultBranch: string;
   changeId: string;
+  sourceBranch?: string;
   route?: FinalizationRoute;
   prNumber?: number;
   /** Optional repo override; falls back to route.repo. */
@@ -888,11 +891,12 @@ export function verifyChangeBranchReachable(
   refUnresolved?: true;
 } {
   const runGit = deps.runGit ?? defaultRunGit;
+  const sourceBranch = deps.sourceBranch ?? `change/${changeId}`;
   const resolved = runGit(repoRoot, [
     "rev-parse",
     "--verify",
     "--quiet",
-    `refs/heads/change/${changeId}`,
+    `refs/heads/${sourceBranch}`,
   ]);
   if (resolved.status !== 0 || !resolved.stdout.trim()) {
     return { reachable: false, unmergedCommits: [], refUnresolved: true };
@@ -901,7 +905,7 @@ export function verifyChangeBranchReachable(
   const result = runGit(repoRoot, [
     "log",
     "--oneline",
-    `${defaultBranch}..change/${changeId}`,
+    `${defaultBranch}..${sourceBranch}`,
   ]);
   if (result.status !== 0) {
     // Ref resolved, so this is an operational git failure, not commit evidence.
@@ -951,6 +955,7 @@ export function verifyChangeBranchReachableFromOrigin(
 
   let tipRef: string;
   let refSource: "persisted" | "refreshed_ref";
+  const sourceBranch = deps.sourceBranch ?? `change/${changeId}`;
   if (deps.changeTipSha?.trim()) {
     tipRef = deps.changeTipSha.trim();
     refSource = "persisted";
@@ -959,7 +964,7 @@ export function verifyChangeBranchReachableFromOrigin(
       "fetch",
       "origin",
       `refs/heads/${defaultBranch}:refs/remotes/origin/${defaultBranch}`,
-      `+refs/heads/change/${changeId}:refs/remotes/origin/change/${changeId}`,
+      `+refs/heads/${sourceBranch}:refs/remotes/origin/${sourceBranch}`,
     ]);
     if (fetch.status !== 0) {
       return {
@@ -972,7 +977,7 @@ export function verifyChangeBranchReachableFromOrigin(
     const resolvedTip = runGit(repoRoot, [
       "rev-parse",
       "--verify",
-      `refs/remotes/origin/change/${changeId}`,
+      `refs/remotes/origin/${sourceBranch}`,
     ]);
     if (resolvedTip.status !== 0 || !resolvedTip.stdout.trim()) {
       return {
@@ -1035,6 +1040,7 @@ export function mergeChangeBranch(
   deps: GitFinalizeDeps = {},
 ): MergeChangeBranchResult {
   const runGit = deps.runGit ?? defaultRunGit;
+  const sourceBranch = deps.sourceBranch ?? `change/${changeId}`;
   // rq-harden-archive-flow AC3: already-reachable branch is a no-op merge.
   // Detect before invoking `git merge` so a previously-merged (FF or no-FF
   // squash) change branch doesn't surface as MERGE_FAILED.
@@ -1051,7 +1057,7 @@ export function mergeChangeBranch(
       mergeMethod: "already-reachable",
     };
   }
-  const merge = runGit(repoRoot, ["merge", "--ff-only", `change/${changeId}`]);
+  const merge = runGit(repoRoot, ["merge", "--ff-only", sourceBranch]);
   if (merge.status === 0) {
     return {
       status: "merged",
@@ -1091,7 +1097,7 @@ export function mergeChangeBranch(
     "--no-edit",
     "-m",
     `merge: archive bundle for ${changeId}`,
-    `change/${changeId}`,
+    sourceBranch,
   ]);
   if (noff.status === 0) {
     return {
@@ -1160,6 +1166,7 @@ export function pushChangeBranch(
     autoPush: boolean;
     skipPush?: boolean;
     runGit?: GitFinalizeDeps["runGit"];
+    branchName?: string;
   },
 ):
   | { status: "pushed"; output: string }
@@ -1170,7 +1177,7 @@ export function pushChangeBranch(
   if (!options.autoPush)
     return { status: "skipped", reason: "auto_push disabled" };
 
-  const branch = `change/${changeId}`;
+  const branch = options.branchName ?? `change/${changeId}`;
   const push = (options.runGit ?? defaultRunGit)(
     workdir,
     ["push", "origin", branch],
@@ -1188,20 +1195,18 @@ export function pushChangeBranch(
 export function verifyChangeBranchPushed(
   repoRoot: string,
   changeId: string,
-  deps: Pick<GitFinalizeDeps, "runGit"> = {},
+  deps: Pick<GitFinalizeDeps, "runGit" | "sourceBranch"> = {},
 ): { pushed: boolean; reason?: string } {
   const runGit = deps.runGit ?? defaultRunGit;
-  const local = runGit(repoRoot, [
-    "rev-parse",
-    `refs/heads/change/${changeId}`,
-  ]);
+  const branch = deps.sourceBranch ?? `change/${changeId}`;
+  const local = runGit(repoRoot, ["rev-parse", `refs/heads/${branch}`]);
   if (local.status !== 0 || !local.stdout.trim()) {
     return {
       pushed: false,
       reason: (
         local.stderr ||
         local.stdout ||
-        `change/${changeId} not found locally`
+        `${branch} not found locally`
       ).trim(),
     };
   }
@@ -1209,7 +1214,7 @@ export function verifyChangeBranchPushed(
   const lsRemote = runGit(repoRoot, [
     "ls-remote",
     "origin",
-    `refs/heads/change/${changeId}`,
+    `refs/heads/${branch}`,
   ]);
   if (
     lsRemote.status === 0 &&
@@ -1222,7 +1227,7 @@ export function verifyChangeBranchPushed(
     reason: (
       lsRemote.stderr ||
       lsRemote.stdout ||
-      `change/${changeId} not found on origin`
+      `${branch} not found on origin`
     ).trim(),
   };
 }
@@ -1360,14 +1365,16 @@ export function verifyDirectMergedPrProof(
     repo?: string;
     defaultBranch: string;
     changeId: string;
+    branchName?: string;
     changeTipSha?: string;
+    sourceBranch?: string;
   },
   deps: Pick<GitFinalizeDeps, "runGit" | "runGh"> = {},
 ): DirectMergedPrProof {
   if (!input.repo) return { kind: "none" };
 
   const runGh = deps.runGh ?? defaultRunGh;
-  const branch = `change/${input.changeId}`;
+  const branch = input.branchName ?? `change/${input.changeId}`;
   const result = runGh(input.repoRoot, [
     "pr",
     "list",
@@ -1566,6 +1573,7 @@ export function discoverMergedPr(
   repo: string | undefined,
   changeId: string,
   deps: Pick<GitFinalizeDeps, "runGh"> = {},
+  branchName?: string,
 ):
   | { prNumber: number; mergeCommitOid?: string }
   | { error: string; details?: string[] } {
@@ -1576,7 +1584,7 @@ export function discoverMergedPr(
     "--state",
     "merged",
     "--head",
-    `change/${changeId}`,
+    branchName ?? `change/${changeId}`,
     "--json",
     "number,mergeCommit",
     "--limit",
@@ -1628,13 +1636,14 @@ export function detectSquashMergeByTree(
     // content-addressed tip instead of the live change/{id} ref so
     // detection survives branch deletion.
     changeTipSha?: string;
+    sourceBranch?: string;
   } = {},
 ): { reachable: boolean; mergeCommitOid?: string } {
   const runGit = deps.runGit ?? defaultRunGit;
 
   // Get tree SHA of change branch HEAD. Prefer the persisted tip SHA when
   // available (survives branch deletion); fall back to the live branch ref.
-  const tipRef = deps.changeTipSha ?? `change/${changeId}`;
+  const tipRef = deps.changeTipSha ?? deps.sourceBranch ?? `change/${changeId}`;
   const changeTree = runGit(repoRoot, ["rev-parse", `${tipRef}^{tree}`]);
   if (changeTree.status !== 0) {
     return { reachable: false };
@@ -2000,12 +2009,14 @@ export function executePullRequestHandoff(
     prTitleType?: string;
     prTitlePolicy?: PrTitlePolicy;
     changeTipSha?: string;
+    sourceBranch?: string;
   },
   deps: GitFinalizeDeps = {},
 ): GitFinalizeOutcome {
   const branchPush = pushChangeBranch(input.workdir, input.changeId, {
     autoPush: true,
     runGit: deps.runGit,
+    branchName: input.branch,
   });
   if (branchPush.status !== "pushed") {
     return {
@@ -2093,6 +2104,7 @@ export function executePullRequestHandoff(
       changeId: input.changeId,
       route: input.route,
       prNumber: pr.number,
+      sourceBranch: input.sourceBranch,
     },
     deps,
   );
@@ -2159,10 +2171,11 @@ export function completeMergeQueueHandoff(
     prTitleType?: string;
     prTitlePolicy?: PrTitlePolicy;
     changeTipSha?: string;
+    sourceBranch?: string;
   },
   deps: GitFinalizeDeps = {},
 ): GitFinalizeOutcome {
-  const branch = `change/${input.changeId}`;
+  const branch = input.sourceBranch ?? `change/${input.changeId}`;
   if (!input.route.repo) {
     return {
       status: "blocked",
@@ -2194,6 +2207,7 @@ export function completeMergeQueueHandoff(
       prTitleType: input.prTitleType,
       prTitlePolicy: input.prTitlePolicy,
       changeTipSha: input.changeTipSha,
+      sourceBranch: input.sourceBranch,
     },
     deps,
   );
@@ -2211,10 +2225,11 @@ function completeProtectedBranchViaPullRequest(
     prTitleType?: string;
     prTitlePolicy?: PrTitlePolicy;
     changeTipSha?: string;
+    sourceBranch?: string;
   },
   deps: GitFinalizeDeps = {},
 ): GitFinalizeOutcome {
-  const branch = `change/${input.changeId}`;
+  const branch = input.sourceBranch ?? `change/${input.changeId}`;
   if (!input.route.repo) {
     return {
       status: "blocked",
@@ -2270,6 +2285,7 @@ function completeProtectedBranchViaPullRequest(
       prTitleType: input.prTitleType,
       prTitlePolicy: input.prTitlePolicy,
       changeTipSha: input.changeTipSha,
+      sourceBranch: input.sourceBranch,
     },
     deps,
   );
@@ -2793,7 +2809,11 @@ export function resolveReleaseReachability(
       input.repoRoot,
       input.defaultBranch,
       input.changeId,
-      { ...deps, changeTipSha: input.changeTipSha },
+      {
+        ...deps,
+        changeTipSha: input.changeTipSha,
+        sourceBranch: input.sourceBranch,
+      },
     );
     if (originReachability.reachable) {
       return {
@@ -2812,6 +2832,7 @@ export function resolveReleaseReachability(
         directRepo,
         input.changeId,
         deps,
+        input.sourceBranch,
       );
       if (!("error" in discovered)) {
         effectivePrNumber = discovered.prNumber;
@@ -2829,6 +2850,7 @@ export function resolveReleaseReachability(
           defaultBranch: input.defaultBranch,
           changeId: input.changeId,
           changeTipSha: input.changeTipSha,
+          branchName: input.sourceBranch,
         },
         deps,
       );
@@ -2894,7 +2916,11 @@ export function resolveReleaseReachability(
       input.repoRoot,
       `origin/${input.defaultBranch}`,
       input.changeId,
-      { ...deps, changeTipSha: input.changeTipSha },
+      {
+        ...deps,
+        changeTipSha: input.changeTipSha,
+        sourceBranch: input.sourceBranch,
+      },
     );
     if (treeMatch.reachable && treeMatch.mergeCommitOid) {
       return {
@@ -2925,6 +2951,7 @@ export function resolveReleaseReachability(
       repo,
       input.changeId,
       deps,
+      input.sourceBranch,
     );
     if ("error" in discovered) {
       discoveryError = discovered.error;
@@ -2977,7 +3004,11 @@ export function resolveReleaseReachability(
       input.repoRoot,
       `origin/${input.defaultBranch}`,
       input.changeId,
-      { ...deps, changeTipSha: input.changeTipSha },
+      {
+        ...deps,
+        changeTipSha: input.changeTipSha,
+        sourceBranch: input.sourceBranch,
+      },
     );
     if (treeMatch.reachable && treeMatch.mergeCommitOid) {
       return {
@@ -3041,7 +3072,7 @@ export function validateChangeWorktree(
   // 2. Must be on change/{changeId} branch
   const branchResult = runGit(workdir, ["branch", "--show-current"]);
   const currentBranch = branchResult.stdout.trim();
-  const expectedBranch = `change/${changeId}`;
+  const expectedBranch = deps.sourceBranch ?? `change/${changeId}`;
   if (currentBranch !== expectedBranch) {
     return {
       valid: false,
@@ -3092,6 +3123,188 @@ export function validateChangeWorktree(
   }
 
   return { valid: true, repoRoot, currentBranch };
+}
+
+export interface ArchiveDeltaRepairValidation {
+  valid: boolean;
+  repoRoot: string;
+  repairBranch?: string;
+  repairHeadSha?: string;
+  defaultBranch?: string;
+  defaultBranchSha?: string;
+  defaultTreeSha?: string;
+  error?: string;
+}
+
+/**
+ * Validate the only worktree allowed to repair an archived delta projection.
+ * The fetch and equality checks happen before archiveChange can write any
+ * tracked projection, making an old or diverged repair basis fail closed.
+ */
+export function validateArchiveDeltaRepairWorktree(
+  workdir: string,
+  changeId: string,
+  expectedRepoRoot: string,
+  deps: GitFinalizeDeps = {},
+): ArchiveDeltaRepairValidation {
+  const runGit = deps.runGit ?? defaultRunGit;
+  const repairBranch = `repair/archive-${changeId}`;
+  let repoRoot: string;
+  try {
+    repoRoot = resolveRepoRoot(workdir, deps);
+    if (realpathSync(repoRoot) !== realpathSync(expectedRepoRoot)) {
+      return {
+        valid: false,
+        repoRoot,
+        error: `Repair worktree belongs to ${repoRoot}, expected ${expectedRepoRoot}`,
+      };
+    }
+  } catch (error) {
+    return {
+      valid: false,
+      repoRoot: "",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const branch = runGit(workdir, ["branch", "--show-current"]).stdout.trim();
+  if (branch !== repairBranch) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      error: `Repair worktree is on ${branch || "(detached)"}, expected ${repairBranch}`,
+    };
+  }
+  const topLevel = runGit(workdir, ["rev-parse", "--show-toplevel"]);
+  if (topLevel.status !== 0 || !topLevel.stdout.trim()) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      error: `Unable to resolve repair worktree root for ${workdir}`,
+    };
+  }
+  try {
+    if (realpathSync(workdir) !== realpathSync(topLevel.stdout.trim())) {
+      return {
+        valid: false,
+        repoRoot,
+        repairBranch: branch,
+        error: `Repair worktree path ${workdir} is not its repository root`,
+      };
+    }
+  } catch (error) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const dirty = splitLines(runGit(workdir, ["status", "--porcelain"]).stdout);
+  if (dirty.length > 0) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      error: `Repair worktree has uncommitted changes: ${dirty.join(", ")}`,
+    };
+  }
+
+  let defaultBranch: string;
+  try {
+    defaultBranch = detectDefaultBranch(repoRoot, deps).branch;
+  } catch (error) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  const fetch = runGit(repoRoot, ["fetch", "origin", defaultBranch]);
+  if (fetch.status !== 0) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      defaultBranch,
+      error: `Unable to refresh origin/${defaultBranch}: ${fetch.stderr || fetch.stdout}`,
+    };
+  }
+
+  const localDefault = runGit(repoRoot, [
+    "rev-parse",
+    `refs/heads/${defaultBranch}`,
+  ]);
+  const originDefault = runGit(repoRoot, [
+    "rev-parse",
+    `refs/remotes/origin/${defaultBranch}`,
+  ]);
+  const repairHead = runGit(workdir, ["rev-parse", "HEAD"]);
+  const repairTree = runGit(workdir, ["rev-parse", "HEAD^{tree}"]);
+  const defaultTree = runGit(repoRoot, [
+    "rev-parse",
+    `refs/heads/${defaultBranch}^{tree}`,
+  ]);
+  const values = [
+    localDefault.stdout.trim(),
+    originDefault.stdout.trim(),
+    repairHead.stdout.trim(),
+    repairTree.stdout.trim(),
+    defaultTree.stdout.trim(),
+  ];
+  if (
+    [localDefault, originDefault, repairHead, repairTree, defaultTree].some(
+      (result) => result.status !== 0,
+    ) ||
+    values.some((value) => value.length === 0)
+  ) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      defaultBranch,
+      error: `Unable to resolve repair/default branch identity before archive writes`,
+    };
+  }
+  const [localSha, originSha, repairSha, repairTreeSha, defaultTreeSha] =
+    values;
+  if (localSha !== originSha) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      repairHeadSha: repairSha,
+      defaultBranch,
+      defaultBranchSha: localSha,
+      defaultTreeSha,
+      error: `Local ${defaultBranch} ${localSha} differs from fetched origin/${defaultBranch} ${originSha}`,
+    };
+  }
+  if (repairSha !== localSha || repairTreeSha !== defaultTreeSha) {
+    return {
+      valid: false,
+      repoRoot,
+      repairBranch: branch,
+      repairHeadSha: repairSha,
+      defaultBranch,
+      defaultBranchSha: localSha,
+      defaultTreeSha,
+      error: `Repair branch must start exactly at current ${defaultBranch} HEAD/tree`,
+    };
+  }
+  return {
+    valid: true,
+    repoRoot,
+    repairBranch: branch,
+    repairHeadSha: repairSha,
+    defaultBranch,
+    defaultBranchSha: localSha,
+    defaultTreeSha,
+  };
 }
 
 export function commitArchiveArtifacts(
@@ -3158,6 +3371,8 @@ export function commitArchiveArtifacts(
 export interface GitFinalizeContext {
   changeId: string;
   workdir: string;
+  /** Source branch; normal archives use change/{changeId}. */
+  sourceBranch?: string;
   expectedRepoRoot?: string;
   archiveMode: ArchiveMode;
   autoPush: boolean;
@@ -3318,11 +3533,15 @@ export async function finalizeRelease(
   ctx: GitFinalizeContext,
   deps: GitFinalizeDeps = {},
 ): Promise<GitFinalizeOutcome> {
+  const sourceBranch = ctx.sourceBranch ?? `change/${ctx.changeId}`;
+  const finalizationDeps = ctx.sourceBranch
+    ? { ...deps, sourceBranch: ctx.sourceBranch }
+    : deps;
   // Validate worktree before any mutation
   const worktreeValidation = validateChangeWorktree(
     ctx.workdir,
     ctx.changeId,
-    deps,
+    finalizationDeps,
   );
   if (!worktreeValidation.valid) {
     return {
@@ -3332,7 +3551,7 @@ export async function finalizeRelease(
       pushStatus: "not_attempted",
       blocked: {
         reason: "INVALID_WORKTREE",
-        remediation: `${worktreeValidation.error}. rq-releaseFinalization01 requires a validated change worktree on branch change/${ctx.changeId}.`,
+        remediation: `${worktreeValidation.error}. rq-releaseFinalization01 requires a validated archive worktree on branch ${sourceBranch}.`,
       },
     };
   }
@@ -3351,17 +3570,20 @@ export async function finalizeRelease(
     };
   }
 
-  const { branch: defaultBranch } = detectDefaultBranch(repoRoot, deps);
+  const { branch: defaultBranch } = detectDefaultBranch(
+    repoRoot,
+    finalizationDeps,
+  );
 
   // Per-invocation accumulator: caches idempotent git queries and tracks
   // fetch dedup. Mutations call invalidate(state, kind) to drop stale entries.
-  const state = createState(repoRoot, defaultBranch, deps);
+  const state = createState(repoRoot, defaultBranch, finalizationDeps);
 
   // Commit in-repo archive artifacts before merge
   const commitResult = commitArchiveArtifacts(
     ctx.workdir,
     ctx.changeId,
-    deps,
+    finalizationDeps,
     ctx.artifactPaths,
   );
   invalidate(state, "commit-archive-artifacts");
@@ -3385,8 +3607,8 @@ export async function finalizeRelease(
   try {
     changeTipSha = runGitOrThrow(
       repoRoot,
-      ["rev-parse", `change/${ctx.changeId}`],
-      deps,
+      ["rev-parse", sourceBranch],
+      finalizationDeps,
     );
   } catch {
     changeTipSha = undefined;
@@ -3400,7 +3622,7 @@ export async function finalizeRelease(
         repoRoot,
         defaultBranch,
         route: route.route,
-        prBranch: `change/${ctx.changeId}`,
+        prBranch: sourceBranch,
         pushStatus: "not_attempted",
         blocked: {
           reason:
@@ -3425,8 +3647,9 @@ export async function finalizeRelease(
           prTitleType: ctx.prTitleType,
           prTitlePolicy: ctx.prTitlePolicy,
           changeTipSha,
+          sourceBranch,
         },
-        deps,
+        finalizationDeps,
       );
     }
 
@@ -3442,8 +3665,9 @@ export async function finalizeRelease(
         prTitleType: ctx.prTitleType,
         prTitlePolicy: ctx.prTitlePolicy,
         changeTipSha,
+        sourceBranch,
       },
-      deps,
+      finalizationDeps,
     );
   }
   // Direct / no_remote path: perform merge+push inside an ephemeral detached
@@ -3509,9 +3733,10 @@ export async function finalizeRelease(
         repo: route.repo,
         defaultBranch,
         changeId: ctx.changeId,
+        branchName: sourceBranch,
         changeTipSha,
       },
-      deps,
+      finalizationDeps,
     );
     if (mergedPrProof.kind === "invalid") {
       return {
@@ -3520,7 +3745,7 @@ export async function finalizeRelease(
         defaultBranch,
         route: route.route,
         pushStatus: "not_attempted",
-        prBranch: `change/${ctx.changeId}`,
+        prBranch: sourceBranch,
         blocked: {
           reason: mergedPrProof.reason,
           remediation:
@@ -3539,7 +3764,7 @@ export async function finalizeRelease(
         mergeCommitSha: mergedPrProof.mergeCommitOid,
         changeTipSha,
         pushStatus: "pushed",
-        prBranch: `change/${ctx.changeId}`,
+        prBranch: sourceBranch,
         repo: route.repo,
         prNumber: mergedPrProof.prNumber,
         prUrl: mergedPrProof.prUrl,
@@ -3562,14 +3787,14 @@ export async function finalizeRelease(
     return await withEphemeralDefaultBranchWorktree(
       repoRoot,
       baseRef,
-      deps,
+      finalizationDeps,
       async (ephemeral) => {
         // Merge the change branch into the detached default-branch HEAD.
         const merge = mergeToTrunk(
           ephemeral,
           defaultBranch,
           ctx.changeId,
-          deps,
+          finalizationDeps,
         );
         invalidate(state, "merge-change-branch");
         if (merge.status === "blocked") {
@@ -3591,7 +3816,7 @@ export async function finalizeRelease(
         const push = pushToOrigin(ephemeral, defaultBranch, {
           autoPush: ctx.autoPush,
           skipPush: ctx.skipPush,
-          runGit: deps.runGit,
+          runGit: finalizationDeps.runGit,
         });
         invalidate(state, "push-to-origin");
 
@@ -3599,7 +3824,7 @@ export async function finalizeRelease(
           const remoteDefault = verifyDefaultBranchPushed(
             ephemeral,
             defaultBranch,
-            deps,
+            finalizationDeps,
           );
           if (!remoteDefault.pushed) {
             return {
@@ -3644,8 +3869,9 @@ export async function finalizeRelease(
                 prTitleType: ctx.prTitleType,
                 prTitlePolicy: ctx.prTitlePolicy,
                 changeTipSha,
+                sourceBranch,
               },
-              deps,
+              finalizationDeps,
             );
           }
           if (route.route === "pr_auto_merge") {
@@ -3661,8 +3887,9 @@ export async function finalizeRelease(
                 prTitleType: ctx.prTitleType,
                 prTitlePolicy: ctx.prTitlePolicy,
                 changeTipSha,
+                sourceBranch,
               },
-              deps,
+              finalizationDeps,
             );
           }
           if (route.route === "pr_manual") {
@@ -3674,10 +3901,10 @@ export async function finalizeRelease(
               mergeCommitSha: merge.mergeCommitSha,
               pushStatus: push.status,
               pushFailureReason: push.reason,
-              prBranch: `change/${ctx.changeId}`,
+              prBranch: sourceBranch,
               blocked: {
                 reason: route.reason ?? "PR_MANUAL_REQUIRED",
-                remediation: `Default branch push failed and ADV could not arm auto-merge. Manually open or merge PR for change/${ctx.changeId}, then rerun archive finalization (rq-releaseFinalization01).`,
+                remediation: `Default branch push failed and ADV could not arm auto-merge. Manually open or merge PR for ${sourceBranch}, then rerun archive finalization (rq-releaseFinalization01).`,
                 details: [push.reason, ...(route.details ?? [])],
               },
             };

--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -2,7 +2,7 @@
 import { z } from "zod";
 import { rm } from "fs/promises";
 import { basename, join, relative } from "path";
-import type { Change, ProjectConfig } from "../../types";
+import { GATE_ORDER, type Change, type ProjectConfig } from "../../types";
 import type { Store } from "../../storage/store";
 import { loadAllSpecs, removeChangeDir } from "../../storage/json";
 import { validateChange } from "../../validator";
@@ -55,7 +55,9 @@ import {
   deleteChangeBranch,
   finalizeRelease,
   validateChangeWorktree,
+  validateArchiveDeltaRepairWorktree,
   type GitFinalizeOutcome,
+  type ArchiveDeltaRepairValidation,
 } from "../archive-helpers/git-finalize";
 import { logger } from "./helpers";
 import { coordinateChangeMutation } from "../change-mutation-coordinator";
@@ -73,6 +75,18 @@ function outputSpecs(archiveResult: {
     version: `${spec.originalVersion} → ${spec.newVersion}`,
     deltas: spec.deltaResults.length,
   }));
+}
+
+function getArchiveDeltaRepairApprovalBlockers(
+  gates: Change["gates"],
+): string[] {
+  if (!gates) return [...GATE_ORDER];
+  return GATE_ORDER.filter((gateId) => {
+    const gate = gates[gateId];
+    const approval = gate.approval_evidence?.trim();
+    const recovery = gate.recovery_audit?.evidence?.trim();
+    return gate.status !== "done" || (!approval && !recovery);
+  });
 }
 
 export const advChangeArchiveHandler = async (
@@ -278,10 +292,15 @@ export const advChangeArchiveHandler = async (
     const existingBundlePath = !dryRun
       ? await findArchiveBundle(archivePaths.archive, changeId)
       : null;
+    const hasAcceptedDeltas = Object.values(change.deltas).some(
+      (deltas) => deltas.length > 0,
+    );
+    let archiveDeltaRepair: ArchiveDeltaRepairValidation | undefined;
     if (
       !dryRun &&
       !worktreePath &&
-      Object.values(change.deltas).some((deltas) => deltas.length > 0)
+      hasAcceptedDeltas &&
+      !(change.status === "archived" && existingBundlePath)
     )
       return formatToolOutput({
         success: false,
@@ -303,7 +322,113 @@ export const advChangeArchiveHandler = async (
         requirement: "rq-releaseFinalization01",
         changeId,
       });
-    if (!dryRun && worktreePath) {
+    if (
+      !dryRun &&
+      change.status === "archived" &&
+      existingBundlePath &&
+      hasAcceptedDeltas
+    ) {
+      const manifest = await readProjectionManifest(existingBundlePath);
+      const release = verifyReleaseEvidenceFromMain({
+        store: activeStore,
+        changeId,
+        archiveMode,
+        change,
+      });
+      let projectionFailure: unknown;
+      if (
+        !manifest ||
+        release.status !== "shipped" ||
+        !release.releasedCommitSha
+      ) {
+        projectionFailure = {
+          code: !manifest ? "MANIFEST_UNREADABLE" : "RELEASE_PROOF_MISSING",
+          message: !manifest
+            ? "Archive bundle has no valid projection manifest"
+            : "Archive has no immutable released commit proof",
+        };
+      } else {
+        const proof = await verifyProjectionAtGitCommit({
+          manifest,
+          repo: release.repoRoot,
+          releasedCommitSha: release.releasedCommitSha,
+          manifestGitPath: `.adv/archive/${basename(existingBundlePath)}/spec-projection.json`,
+          expectedChangeId: change.id,
+          expectedDeltaSetSha256: canonicalSha256(change.deltas),
+          expectedDeltaIdsByCapability: Object.fromEntries(
+            Object.entries(change.deltas).map(([capability, deltas]) => [
+              capability,
+              deltas.map((delta) => delta.id),
+            ]),
+          ),
+        });
+        if (proof.ok) {
+          return reconcileArchivedBundleRetry({
+            store: activeStore,
+            change,
+            changeId,
+            archiveMode,
+            phase9,
+            existingBundlePath,
+            openOpsObligationsPayload,
+            validationWarnings: validationResult.warnings,
+          });
+        }
+        projectionFailure = proof;
+      }
+
+      if (phase9 !== "run")
+        return formatToolOutput({
+          success: false,
+          error:
+            "Archived delta repair requires phase9=run so the repaired projection is released and re-proven.",
+          requirement: "rq-archiveDeltaReconciliation01",
+          changeId,
+          archivePath: existingBundlePath,
+          projectionFailure,
+        });
+      const approvalBlockers = getArchiveDeltaRepairApprovalBlockers(
+        gateState.effectiveGates,
+      );
+      if (approvalBlockers.length > 0)
+        return formatToolOutput({
+          success: false,
+          error:
+            "Archived delta repair requires durable sign-off and release approval evidence.",
+          requirement: "rq-archiveDeltaReconciliation01",
+          changeId,
+          archivePath: existingBundlePath,
+          approvalBlockers,
+          projectionFailure,
+        });
+      if (!worktreePath)
+        return formatToolOutput({
+          success: false,
+          error:
+            "Archived delta repair requires an explicit trusted repair worktree.",
+          requirement: "rq-archiveDeltaReconciliation01",
+          changeId,
+          archivePath: existingBundlePath,
+          projectionFailure,
+        });
+      const repairValidation = validateArchiveDeltaRepairWorktree(
+        worktreePath,
+        changeId,
+        activeStore.paths.root,
+      );
+      if (!repairValidation.valid)
+        return formatToolOutput({
+          success: false,
+          error: "Archived delta repair refused before writes.",
+          requirement: "rq-archiveDeltaReconciliation01",
+          changeId,
+          archivePath: existingBundlePath,
+          repairValidation,
+          projectionFailure,
+        });
+      archiveDeltaRepair = repairValidation;
+    }
+    if (!dryRun && worktreePath && !archiveDeltaRepair) {
       const worktreeValidation = validateChangeWorktree(
         worktreePath,
         changeId,
@@ -323,54 +448,12 @@ export const advChangeArchiveHandler = async (
             `Worktree belongs to ${worktreeValidation.repoRoot}, expected ${activeStore.paths.root}.`,
         });
     }
-    if (!dryRun && change.status === "archived" && existingBundlePath) {
-      if (Object.values(change.deltas).some((deltas) => deltas.length > 0)) {
-        const manifest = await readProjectionManifest(existingBundlePath);
-        const release = verifyReleaseEvidenceFromMain({
-          store: activeStore,
-          changeId,
-          archiveMode,
-          change,
-        });
-        if (
-          !manifest ||
-          release.status !== "shipped" ||
-          !release.releasedCommitSha
-        ) {
-          return formatToolOutput({
-            success: false,
-            error:
-              "Archived retry cannot prove accepted delta projection; run approved archive delta reconciliation in a trusted repair worktree.",
-            requirement: "rq-archiveDeltaReconciliation01",
-            changeId,
-            archivePath: existingBundlePath,
-          });
-        }
-        const proof = await verifyProjectionAtGitCommit({
-          manifest,
-          repo: release.repoRoot,
-          releasedCommitSha: release.releasedCommitSha,
-          manifestGitPath: `.adv/archive/${basename(existingBundlePath)}/spec-projection.json`,
-          expectedChangeId: change.id,
-          expectedDeltaSetSha256: canonicalSha256(change.deltas),
-          expectedDeltaIdsByCapability: Object.fromEntries(
-            Object.entries(change.deltas).map(([capability, deltas]) => [
-              capability,
-              deltas.map((delta) => delta.id),
-            ]),
-          ),
-        });
-        if (!proof.ok) {
-          return formatToolOutput({
-            success: false,
-            error: `Archived retry projection proof failed: ${proof.code}: ${proof.message}`,
-            requirement: "rq-archiveDeltaReconciliation01",
-            changeId,
-            archivePath: existingBundlePath,
-            projectionFailure: proof,
-          });
-        }
-      }
+    if (
+      !dryRun &&
+      change.status === "archived" &&
+      existingBundlePath &&
+      !archiveDeltaRepair
+    ) {
       return reconcileArchivedBundleRetry({
         store: activeStore,
         change,
@@ -460,6 +543,9 @@ export const advChangeArchiveHandler = async (
           ? await finalizeRelease({
               changeId,
               workdir: worktreePath,
+              ...(archiveDeltaRepair?.repairBranch
+                ? { sourceBranch: archiveDeltaRepair.repairBranch }
+                : {}),
               expectedRepoRoot: activeStore.paths.root,
               archiveMode,
               autoPush,
@@ -620,7 +706,36 @@ export const advChangeArchiveHandler = async (
           archivePath: archiveResult.archivePath,
           projectionFailure: projectionProof,
         });
-      change.archive_projection_proof = projectionProof.receipt;
+      change.archive_projection_proof = {
+        ...projectionProof.receipt,
+        ...(archiveDeltaRepair
+          ? {
+              archive_delta_repair: {
+                kind: "archive_delta_repair" as const,
+                repair_branch:
+                  archiveDeltaRepair.repairBranch ??
+                  `repair/archive-${change.id}`,
+                repair_head_sha:
+                  finalization.changeTipSha ??
+                  archiveDeltaRepair.repairHeadSha ??
+                  "",
+                default_branch: finalization.defaultBranch,
+                default_branch_sha:
+                  finalization.defaultBranchSha ??
+                  finalization.releasedCommitSha,
+                released_commit_sha: finalization.releasedCommitSha,
+                delta_set_sha256: canonicalSha256(change.deltas),
+                delta_ids_by_capability: Object.fromEntries(
+                  Object.entries(change.deltas).map(([capability, deltas]) => [
+                    capability,
+                    deltas.map((delta) => delta.id),
+                  ]),
+                ),
+                release_proof: buildReleaseCompletionEvidence(finalization),
+              },
+            }
+          : {}),
+      };
     }
 
     if (!dryRun) {
@@ -708,14 +823,14 @@ export const advChangeArchiveHandler = async (
             worktreePath,
           };
           const deletionPlan = await advWorktreeDelete(
-            `change/${change.id}`,
+            archiveDeltaRepair?.repairBranch ?? `change/${change.id}`,
             { force: false, dryRun: true },
             deletionDeps,
           );
           targetedWorktreeDeleteResult =
             deletionPlan.ok && deletionPlan.planToken
               ? await advWorktreeDelete(
-                  `change/${change.id}`,
+                  archiveDeltaRepair?.repairBranch ?? `change/${change.id}`,
                   {
                     force: false,
                     planToken: deletionPlan.planToken,
@@ -746,7 +861,8 @@ export const advChangeArchiveHandler = async (
           targetedWorktreeDeleteResult?.error === "WORKTREE_NOT_FOUND")
       ) {
         try {
-          deleteChangeBranch(finalization.repoRoot, change.id);
+          if (!archiveDeltaRepair)
+            deleteChangeBranch(finalization.repoRoot, change.id);
         } catch (error) {
           archiveResult.errors.push(
             `Branch cleanup warning: ${error instanceof Error ? error.message : String(error)}`,
@@ -779,6 +895,23 @@ export const advChangeArchiveHandler = async (
             continueFrom: {
               path: finalization.repoRoot,
               branch: finalization.defaultBranch,
+            },
+          }
+        : {}),
+      ...(archiveDeltaRepair
+        ? {
+            archiveDeltaRepair: {
+              kind: "archive_delta_repair" as const,
+              repairBranch: archiveDeltaRepair.repairBranch,
+              repairHeadSha: finalization?.changeTipSha,
+              defaultBranch: finalization?.defaultBranch,
+              defaultBranchSha:
+                finalization?.defaultBranchSha ??
+                finalization?.releasedCommitSha,
+              releasedCommitSha: finalization?.releasedCommitSha,
+              releaseProof: finalization
+                ? buildReleaseCompletionEvidence(finalization)
+                : undefined,
             },
           }
         : {}),

--- a/plugin/src/types/archive-projection.ts
+++ b/plugin/src/types/archive-projection.ts
@@ -15,6 +15,22 @@ export const ArchiveProjectionProofReceiptSchema = z
       ),
     status: z.literal("verified"),
     verified_at: z.string().datetime({ offset: true }),
+    archive_delta_repair: z
+      .object({
+        kind: z.literal("archive_delta_repair"),
+        repair_branch: z.string().min(1),
+        repair_head_sha: z.string().regex(/^[a-f0-9]{40,64}$/),
+        default_branch: z.string().min(1),
+        default_branch_sha: z.string().regex(/^[a-f0-9]{40,64}$/),
+        released_commit_sha: z.string().regex(/^[a-f0-9]{40,64}$/),
+        delta_set_sha256: z
+          .string()
+          .regex(/^[a-f0-9]{64}$/, "Expected a lowercase SHA-256 hex digest"),
+        delta_ids_by_capability: z.record(z.string(), z.array(z.string())),
+        release_proof: z.string().min(1),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- add fail-closed trusted repair-worktree path for partial archived delta state
- require deterministic repair branch at clean current default branch
- reuse canonical archiveChange/reconcile logic; no manual state edits
- finalize repair through normal Phase 9 and immutable projection proof
- preserve exact change/delta hashes and idempotent retry evidence

## Verification
- focused archive/projection/finalization suites: 161 passed
- broader engineer/reviewer suite: 192 passed
- plugin check: passed
- independent harden review: READY

## Live blocker
`fixWorktreeDeletionReliability` is archived from an earlier failed Phase 9 attempt but lacks accepted delta projection proof; current retry has no executable trusted repair path.