### PR TITLE
fix: use runtime-independent flock holder

### DIFF
--- a/plugin/src/tools/worktree/deletion-executor.test.ts
+++ b/plugin/src/tools/worktree/deletion-executor.test.ts
@@ -17,6 +17,7 @@ import {
   type WorktreeDeletionExecutorDeps,
   type WorktreeBeforeRemoveStage,
 } from "./deletion-executor";
+import { GitWorktreeFlockUnsupportedError } from "../../utils/git-worktree-flock";
 import { createWorktreeOperationContext } from "../../utils/worktree-operation";
 
 const sha = "0123456789abcdef0123456789abcdef01234567";
@@ -233,6 +234,32 @@ describe("WorktreeDeletionExecutor", () => {
       await expect(firstPromise).resolves.toMatchObject({
         ok: true,
         status: "deleted",
+      });
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("returns unsupported when the flock holder command is unavailable", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const result = await executeWorktreeDeletion(
+        { plan },
+        depsFor(fx, plan, {
+          acquireLease: async () => {
+            throw new GitWorktreeFlockUnsupportedError(
+              "flock holder command is unavailable",
+            );
+          },
+        }),
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: "unsupported",
+        reason: "kernel_flock_unavailable",
+        stage: "lease",
       });
     } finally {
       fx.cleanup();
@@ -585,8 +612,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const acquireLease = vi.fn(
         () =>
@@ -627,8 +654,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const beforeRemove = createWorktreeBeforeRemoveStage(
         ({ signal }) =>
@@ -695,8 +722,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const deps = depsFor(fx, plan, {
         census: vi.fn(
@@ -738,8 +765,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 35,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const base = depsFor(fx, plan);
       const normalCensus = base.census!;
@@ -785,8 +812,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 50,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const reconciliation = createWorktreeReconciliationStage(
         ({ signal }) =>
@@ -820,8 +847,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const terminate = vi.fn(async () => {
         throw new Error("process group remained alive");
@@ -871,8 +898,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const terminate = vi.fn(async () => {
         throw new Error("held lease process group remained alive");

--- a/plugin/src/utils/git-worktree-flock.test.ts
+++ b/plugin/src/utils/git-worktree-flock.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
 
 import {
   acquireGitWorktreeFlock,
   acquireGitWorktreeProcessLease,
+  GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE,
+  GitWorktreeFlockUnsupportedError,
   releaseGitWorktreeFlock,
 } from "./git-worktree-flock";
 
@@ -83,5 +87,105 @@ describe("git worktree repository lease", () => {
     const third = await acquireGitWorktreeProcessLease(dir);
     expect(third.owned).toBe(true);
     if (third.owned) await third.terminate("test");
+  });
+
+  it("does not use the host runtime executable for the holder", async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-process-flock-runtime-"),
+    );
+    dirs.push(dir);
+    const previousExecPath = process.execPath;
+    process.execPath = "/opt/opencode/fake-compiled-runtime";
+    let invocation: { command: string; args: readonly string[] } | undefined;
+    try {
+      const first = await acquireGitWorktreeProcessLease(dir, {
+        spawnProcess: (command, args, options) => {
+          invocation = { command, args };
+          return spawn(command, [...args], options);
+        },
+      });
+
+      expect(first.owned).toBe(true);
+      if (first.owned) await first.terminate("test");
+      expect(invocation?.command).toBe("flock");
+      expect(invocation?.args).toEqual([
+        "-n",
+        "-E",
+        String(GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE),
+        path.join(dir, "git-worktree.lock"),
+        "sh",
+        "-c",
+        "command -v tail >/dev/null 2>&1 || { printf '%s\\n' 'ADV_WORKTREE_FLOCK_HOLDER_UNAVAILABLE' >&2; exit 127; }; printf '%s\\n' 'ADV_WORKTREE_FLOCK_READY'; exec tail -f /dev/null",
+      ]);
+      expect(invocation?.args).not.toContain(process.execPath);
+    } finally {
+      process.execPath = previousExecPath;
+    }
+  });
+
+  it("returns a typed non-busy error for holder startup failure", async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-process-flock-failure-"),
+    );
+    dirs.push(dir);
+    const child = Object.assign(new EventEmitter(), {
+      pid: 987654321,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      kill: () => true,
+    });
+    const acquisition = acquireGitWorktreeProcessLease(dir, {
+      spawnProcess: () => {
+        queueMicrotask(() => {
+          child.stderr.emit("data", "tail: command unavailable\n");
+          child.emit("close", 1, null);
+        });
+        return child as unknown as ChildProcess;
+      },
+    });
+
+    await expect(acquisition).rejects.toMatchObject({
+      name: "GitWorktreeFlockHolderError",
+      exitCode: 1,
+      stderr: "tail: command unavailable\n",
+    });
+  });
+
+  it("classifies a missing holder command as unsupported, not contention", async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-process-flock-missing-holder-"),
+    );
+    dirs.push(dir);
+    const child = Object.assign(new EventEmitter(), {
+      pid: 987654322,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      kill: () => true,
+    });
+
+    const acquisition = acquireGitWorktreeProcessLease(dir, {
+      spawnProcess: () => {
+        queueMicrotask(() => {
+          child.stderr.emit("data", "ADV_WORKTREE_FLOCK_HOLDER_UNAVAILABLE\n");
+          child.emit("close", 127, null);
+        });
+        return child as unknown as ChildProcess;
+      },
+    });
+
+    await expect(acquisition).rejects.toBeInstanceOf(
+      GitWorktreeFlockUnsupportedError,
+    );
+  });
+
+  it("fails closed on unsupported platforms", async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-process-flock-platform-"),
+    );
+    dirs.push(dir);
+
+    await expect(
+      acquireGitWorktreeProcessLease(dir, { platform: "darwin" }),
+    ).rejects.toThrow(/requires Linux/);
   });
 });

--- a/plugin/src/utils/git-worktree-flock.ts
+++ b/plugin/src/utils/git-worktree-flock.ts
@@ -16,7 +16,11 @@
 import { mkdirSync } from "node:fs";
 import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import { spawn, type ChildProcess } from "node:child_process";
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from "node:child_process";
 import { join } from "node:path";
 import { isProcessAlive } from "./process-liveness";
 
@@ -84,8 +88,34 @@ export class GitWorktreeFlockQuiescenceError extends Error {
 }
 
 const FLOCK_READY = "ADV_WORKTREE_FLOCK_READY\n";
+/** GNU util-linux documents 1 as the default conflict code; keep it distinct. */
+export const GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE = 73;
+const FLOCK_DIAGNOSTIC_LIMIT = 4_096;
+// Keep this shell program constant: the lock path is a separate argv and no
+// path, token, or runtime value is interpolated into shell syntax.
 const FLOCK_HOLDER_SCRIPT =
-  "const fs = require('node:fs'); const { spawn } = require('node:child_process'); fs.writeFileSync(process.env.ADV_FLOCK_PATH, JSON.stringify({ pid: process.pid, owner_token: process.env.ADV_FLOCK_TOKEN })); spawn(process.execPath, ['-e', 'setInterval(() => {}, 0x7fffffff);'], { stdio: 'ignore' }); process.stdout.write('ADV_WORKTREE_FLOCK_READY\\n'); setInterval(() => {}, 0x7fffffff);";
+  "command -v tail >/dev/null 2>&1 || { printf '%s\\n' 'ADV_WORKTREE_FLOCK_HOLDER_UNAVAILABLE' >&2; exit 127; }; printf '%s\\n' 'ADV_WORKTREE_FLOCK_READY'; exec tail -f /dev/null";
+
+export class GitWorktreeFlockHolderError extends Error {
+  constructor(
+    readonly exitCode: number | null,
+    readonly stdout: string,
+    readonly stderr: string,
+  ) {
+    const detail = stderr || stdout;
+    super(
+      `flock holder failed to start (exit ${exitCode ?? "unknown"})${
+        detail ? `: ${detail}` : ""
+      }`,
+    );
+    this.name = "GitWorktreeFlockHolderError";
+  }
+}
+
+function appendBounded(current: string, chunk: Buffer | string): string {
+  if (current.length >= FLOCK_DIAGNOSTIC_LIMIT) return current;
+  return `${current}${chunk.toString()}`.slice(0, FLOCK_DIAGNOSTIC_LIMIT);
+}
 
 async function waitForSettlement(
   settled: Promise<void>,
@@ -144,6 +174,12 @@ function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
 }
 
 export interface AcquireGitWorktreeProcessLeaseOptions extends AcquireGitWorktreeFlockOptions {
+  platform?: NodeJS.Platform;
+  spawnProcess?: (
+    command: string,
+    args: readonly string[],
+    options: SpawnOptions,
+  ) => ChildProcess;
   operation?: {
     registerChildLease: (lease: {
       terminate: (reason: string) => Promise<void>;
@@ -161,9 +197,10 @@ export async function acquireGitWorktreeProcessLease(
   options: AcquireGitWorktreeProcessLeaseOptions = {},
 ): Promise<GitWorktreeProcessLeaseResult> {
   if (options.signal?.aborted) throwIfAborted(options.signal);
-  if (process.platform !== "linux") {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "linux") {
     throw new GitWorktreeFlockUnsupportedError(
-      `kernel flock lease requires Linux (got ${process.platform})`,
+      `kernel flock lease requires Linux (got ${platform})`,
     );
   }
   mkdirSync(projectStateDir, { recursive: true });
@@ -171,16 +208,19 @@ export async function acquireGitWorktreeProcessLease(
 
   const lockPath = join(projectStateDir, GIT_WORKTREE_LOCK_FILENAME);
   const ownerToken = randomUUID();
-  const child = spawn(
+  const child = (options.spawnProcess ?? spawn)(
     "flock",
-    ["-n", lockPath, process.execPath, "-e", FLOCK_HOLDER_SCRIPT],
+    [
+      "-n",
+      "-E",
+      String(GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE),
+      lockPath,
+      "sh",
+      "-c",
+      FLOCK_HOLDER_SCRIPT,
+    ],
     {
       detached: true,
-      env: {
-        ...process.env,
-        ADV_FLOCK_PATH: lockPath,
-        ADV_FLOCK_TOKEN: ownerToken,
-      },
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     },
@@ -193,6 +233,7 @@ export async function acquireGitWorktreeProcessLease(
   });
   let readyState = false;
   let output = "";
+  let stderrOutput = "";
   let terminatePromise: Promise<void> | undefined;
   const settled = parentSettled.then(async () => {
     const pgid = child.pid;
@@ -205,11 +246,14 @@ export async function acquireGitWorktreeProcessLease(
   void settled.catch(() => undefined);
   const ready = new Promise<boolean>((resolve, reject) => {
     child.stdout?.on("data", (chunk: Buffer | string) => {
-      output += chunk.toString();
+      output = appendBounded(output, chunk);
       if (!readyState && output.includes(FLOCK_READY)) {
         readyState = true;
         resolve(true);
       }
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderrOutput = appendBounded(stderrOutput, chunk);
     });
     child.once("error", (error) => {
       if (!readyState) reject(error);
@@ -217,7 +261,17 @@ export async function acquireGitWorktreeProcessLease(
     child.once("close", (code) => {
       settledState = true;
       resolveParentSettled();
-      if (!readyState) resolve(code === 1 ? false : false);
+      if (!readyState) {
+        if (code === GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE) resolve(false);
+        else if (code === 127)
+          reject(
+            new GitWorktreeFlockUnsupportedError(
+              `flock holder command is unavailable: ${stderrOutput || output}`,
+            ),
+          );
+        else
+          reject(new GitWorktreeFlockHolderError(code, output, stderrOutput));
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- remove process.execPath `-e` assumption from deployed flock holder
- use fixed POSIX holder command with no untrusted interpolation
- assign distinct flock conflict exit code
- classify holder startup/missing-command failures as typed unsupported, never busy
- preserve readiness, process-group quiescence, competitor refusal, and reacquire
- stabilize deadline-stage tests without changing production budget

## Verification
- focused runtime/delete suites: 92 passed
- repeated lease/executor suite: 35 passed
- plugin check: passed
- independent harden review: READY

## Live blocker
Deployed compiled OpenCode does not guarantee `process.execPath -e`; the holder exits code 1 and is misclassified as repository lease contention despite direct kernel flock availability.