### PR TITLE
fix: make flock holder runtime-independent

### DIFF
--- a/plugin/src/tools/change/handlers-archive.partial-repair.test.ts
+++ b/plugin/src/tools/change/handlers-archive.partial-repair.test.ts
@@ -629,4 +629,34 @@ describe("adv_change_archive partial archive-delta repair", () => {
     expect(mocks.reconcileArchivedBundleRetry).toHaveBeenCalled();
     expect(mocks.archiveChange).not.toHaveBeenCalled();
   });
+
+  it("requires explicit approval before repairing an archived absent projection", async () => {
+    const change = makeChange({
+      status: "archived",
+      lifecycleState: "archived",
+    });
+    seedForChange(change);
+    mocks.verifyProjectionAtGitCommit.mockResolvedValue({
+      ok: false,
+      code: "MANIFEST_ABSENT",
+      message: "projection manifest is absent from the released commit",
+    });
+    const store = makeStore(change);
+
+    const result = await archiveChangeTools.adv_change_archive.execute(
+      {
+        changeId: CHANGE_ID,
+        worktreePath: REPAIR_WORKTREE,
+        phase9: "run",
+      },
+      store,
+    );
+
+    const parsed = parseResult(result);
+    expect(parsed.success).toBe(false);
+    expect(String(parsed.error)).toContain(
+      "explicit archived-delta repair approval",
+    );
+    expectNoRepairWrites();
+  });
 });

--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -2,7 +2,7 @@
 import { z } from "zod";
 import { rm } from "fs/promises";
 import { basename, join, relative } from "path";
-import type { Change, ProjectConfig } from "../../types";
+import { GATE_ORDER, type Change, type ProjectConfig } from "../../types";
 import type { Store } from "../../storage/store";
 import { loadAllSpecs, removeChangeDir } from "../../storage/json";
 import { validateChange } from "../../validator";
@@ -56,7 +56,9 @@ import {
   deleteChangeBranch,
   finalizeRelease,
   validateChangeWorktree,
+  validateArchiveDeltaRepairWorktree,
   type GitFinalizeOutcome,
+  type ArchiveDeltaRepairValidation,
 } from "../archive-helpers/git-finalize";
 import { logger } from "./helpers";
 import { coordinateChangeMutation } from "../change-mutation-coordinator";
@@ -74,6 +76,92 @@ function outputSpecs(archiveResult: {
     version: `${spec.originalVersion} → ${spec.newVersion}`,
     deltas: spec.deltaResults.length,
   }));
+}
+
+function getArchiveDeltaRepairApprovalBlockers(
+  gates: Change["gates"],
+): string[] {
+  if (!gates) return [...GATE_ORDER];
+  return GATE_ORDER.filter((gateId) => {
+    const gate = gates[gateId];
+    const approval = gate.approval_evidence?.trim();
+    const recovery = gate.recovery_audit?.evidence?.trim();
+    return gate.status !== "done" || (!approval && !recovery);
+  });
+}
+
+function isClosedLifecycle(change: Change): boolean {
+  return change.status === "closed" || change.lifecycleState === "closed";
+}
+
+function hasPriorPhase9ArchiveEvidence(change: Change): boolean {
+  const status = change.phase9_status?.status;
+  return status === "failed" || status === "pending_merge";
+}
+
+async function verifyExistingBundleIdentity(
+  existingBundlePath: string,
+  change: Change,
+): Promise<
+  | { ok: true; manifest: Awaited<ReturnType<typeof readProjectionManifest>> }
+  | { ok: false; reason: string }
+> {
+  const manifest = await readProjectionManifest(existingBundlePath);
+  if (!manifest) {
+    return {
+      ok: false,
+      reason: "Archive bundle has no valid projection manifest",
+    };
+  }
+  if (manifest.change_id !== change.id) {
+    return {
+      ok: false,
+      reason: `Bundle change_id ${manifest.change_id} does not match ${change.id}`,
+    };
+  }
+  const expectedDeltaSha = canonicalSha256(change.deltas);
+  if (manifest.delta_set_sha256 !== expectedDeltaSha) {
+    return {
+      ok: false,
+      reason: "Bundle delta_set_sha256 does not match accepted deltas",
+    };
+  }
+  const expectedCapabilities = Object.entries(change.deltas)
+    .filter(([, deltas]) => deltas.length > 0)
+    .map(([capability, deltas]) => ({
+      capability,
+      deltaIds: deltas
+        .map((delta) => delta.id)
+        .sort((left, right) => left.localeCompare(right)),
+    }))
+    .sort((left, right) => left.capability.localeCompare(right.capability));
+  const manifestCapabilities = [...manifest.capabilities]
+    .map((capability) => ({
+      capability: capability.capability,
+      deltaIds: capability.dispositions
+        .map((disposition) => disposition.deltaId)
+        .sort((left, right) => left.localeCompare(right)),
+    }))
+    .sort((left, right) => left.capability.localeCompare(right.capability));
+  if (
+    manifestCapabilities.length !== expectedCapabilities.length ||
+    manifestCapabilities.some(
+      (capability, index) =>
+        capability.capability !== expectedCapabilities[index]?.capability ||
+        capability.deltaIds.length !==
+          expectedCapabilities[index]?.deltaIds.length ||
+        capability.deltaIds.some(
+          (deltaId, deltaIndex) =>
+            deltaId !== expectedCapabilities[index]?.deltaIds[deltaIndex],
+        ),
+    )
+  ) {
+    return {
+      ok: false,
+      reason: "Bundle does not account for the exact accepted delta IDs",
+    };
+  }
+  return { ok: true, manifest };
 }
 
 export const advChangeArchiveHandler = async (
@@ -279,10 +367,15 @@ export const advChangeArchiveHandler = async (
     const existingBundlePath = !dryRun
       ? await findArchiveBundle(archivePaths.archive, changeId)
       : null;
+    const hasAcceptedDeltas = Object.values(change.deltas).some(
+      (deltas) => deltas.length > 0,
+    );
+    let archiveDeltaRepair: ArchiveDeltaRepairValidation | undefined;
     if (
       !dryRun &&
       !worktreePath &&
-      Object.values(change.deltas).some((deltas) => deltas.length > 0)
+      hasAcceptedDeltas &&
+      !(change.status === "archived" && existingBundlePath)
     )
       return formatToolOutput({
         success: false,
@@ -304,7 +397,228 @@ export const advChangeArchiveHandler = async (
         requirement: "rq-releaseFinalization01",
         changeId,
       });
-    if (!dryRun && worktreePath) {
+    const isArchiveDeltaRepairCandidate =
+      !dryRun && existingBundlePath && hasAcceptedDeltas;
+
+    if (isArchiveDeltaRepairCandidate) {
+      if (change.status === "archived") {
+        const manifest = await readProjectionManifest(existingBundlePath);
+        const release = verifyReleaseEvidenceFromMain({
+          store: activeStore,
+          changeId,
+          archiveMode,
+          change,
+        });
+        let projectionFailure: unknown;
+        if (
+          !manifest ||
+          release.status !== "shipped" ||
+          !release.releasedCommitSha
+        ) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archived retry cannot prove accepted delta projection; run approved archive delta reconciliation in a trusted repair worktree.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+          });
+        } else {
+          const proof = await verifyProjectionAtGitCommit({
+            manifest,
+            repo: release.repoRoot,
+            releasedCommitSha: release.releasedCommitSha,
+            manifestGitPath: `.adv/archive/${basename(existingBundlePath)}/spec-projection.json`,
+            expectedChangeId: change.id,
+            expectedDeltaSetSha256: canonicalSha256(change.deltas),
+            expectedDeltaIdsByCapability: Object.fromEntries(
+              Object.entries(change.deltas).map(([capability, deltas]) => [
+                capability,
+                deltas.map((delta) => delta.id),
+              ]),
+            ),
+          });
+          if (proof.ok) {
+            return reconcileArchivedBundleRetry({
+              store: activeStore,
+              change,
+              changeId,
+              archiveMode,
+              phase9,
+              existingBundlePath,
+              openOpsObligationsPayload,
+              validationWarnings: validationResult.warnings,
+            });
+          }
+          projectionFailure = proof;
+          if (!projectionFailureRoutesToReconcile(proof.code))
+            return formatToolOutput({
+              success: false,
+              error: `Archived retry projection proof failed: ${proof.code}: ${proof.message}`,
+              requirement: "rq-archiveDeltaReconciliation01",
+              changeId,
+              archivePath: existingBundlePath,
+              projectionFailure,
+            });
+        }
+
+        if (phase9 !== "run")
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archived delta repair requires phase9=run so the repaired projection is released and re-proven.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+            projectionFailure,
+          });
+        const approvalBlockers = getArchiveDeltaRepairApprovalBlockers(
+          gateState.effectiveGates,
+        );
+        if (approvalBlockers.length > 0)
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archived delta repair requires durable sign-off and release approval evidence.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+            approvalBlockers,
+            projectionFailure,
+          });
+        if (!confirmationEvidence?.trim())
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archive delta repair refused: explicit archived-delta repair approval evidence is required.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+            projectionFailure,
+          });
+        if (!worktreePath)
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archived delta repair requires an explicit trusted repair worktree.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+            projectionFailure,
+          });
+        const repairValidation = validateArchiveDeltaRepairWorktree(
+          worktreePath,
+          changeId,
+          activeStore.paths.root,
+        );
+        if (!repairValidation.valid)
+          return formatToolOutput({
+            success: false,
+            error: "Archived delta repair refused before writes.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+            repairValidation,
+            projectionFailure,
+          });
+        archiveDeltaRepair = repairValidation;
+      } else {
+        if (isClosedLifecycle(change)) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archive delta repair refused: lifecycle is closed, cancelled, or superseded.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+          });
+        }
+        const identity = await verifyExistingBundleIdentity(
+          existingBundlePath,
+          change,
+        );
+        if (!identity.ok) {
+          return formatToolOutput({
+            success: false,
+            error: `Archive delta repair refused: ${identity.reason}`,
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+          });
+        }
+        if (!hasPriorPhase9ArchiveEvidence(change)) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archive delta repair refused: no prior Phase 9 or archive attempt evidence.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+          });
+        }
+        const approvalBlockers = getArchiveDeltaRepairApprovalBlockers(
+          gateState.effectiveGates,
+        );
+        if (approvalBlockers.length > 0) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archived delta repair requires durable sign-off and release approval evidence.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+            approvalBlockers,
+          });
+        }
+        if (!confirmationEvidence?.trim()) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archive delta repair refused: explicit archived-delta repair approval evidence is required.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+          });
+        }
+        if (phase9 !== "run") {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archived delta repair requires phase9=run so the repaired projection is released and re-proven.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+          });
+        }
+        if (!worktreePath) {
+          return formatToolOutput({
+            success: false,
+            error:
+              "Archived delta repair requires an explicit trusted repair worktree.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+          });
+        }
+        const repairValidation = validateArchiveDeltaRepairWorktree(
+          worktreePath,
+          changeId,
+          activeStore.paths.root,
+        );
+        if (!repairValidation.valid) {
+          return formatToolOutput({
+            success: false,
+            error: "Archived delta repair refused before writes.",
+            requirement: "rq-archiveDeltaReconciliation01",
+            changeId,
+            archivePath: existingBundlePath,
+            repairValidation,
+          });
+        }
+        archiveDeltaRepair = repairValidation;
+      }
+    }
+    if (!dryRun && worktreePath && !archiveDeltaRepair) {
       const worktreeValidation = validateChangeWorktree(
         worktreePath,
         changeId,
@@ -324,80 +638,22 @@ export const advChangeArchiveHandler = async (
             `Worktree belongs to ${worktreeValidation.repoRoot}, expected ${activeStore.paths.root}.`,
         });
     }
-    // When a change carries status "archived" with an external-store bundle,
-    // the retry path verifies the in-repo committed projection. If the
-    // projection was never committed in-repo (MANIFEST_ABSENT), the work is
-    // unstarted — route to the reconcile path below instead of refusing.
-    // rq-archiveDeltaReconciliation01.5: external-store bundle presence is
-    // advisory metadata, never authority for an in-repo committed projection.
-    let projectionNeedsReconcile = false;
-    if (!dryRun && change.status === "archived" && existingBundlePath) {
-      if (Object.values(change.deltas).some((deltas) => deltas.length > 0)) {
-        const manifest = await readProjectionManifest(existingBundlePath);
-        const release = verifyReleaseEvidenceFromMain({
-          store: activeStore,
-          changeId,
-          archiveMode,
-          change,
-        });
-        if (
-          !manifest ||
-          release.status !== "shipped" ||
-          !release.releasedCommitSha
-        ) {
-          return formatToolOutput({
-            success: false,
-            error:
-              "Archived retry cannot prove accepted delta projection; run approved archive delta reconciliation in a trusted repair worktree.",
-            requirement: "rq-archiveDeltaReconciliation01",
-            changeId,
-            archivePath: existingBundlePath,
-          });
-        }
-        const proof = await verifyProjectionAtGitCommit({
-          manifest,
-          repo: release.repoRoot,
-          releasedCommitSha: release.releasedCommitSha,
-          manifestGitPath: `.adv/archive/${basename(existingBundlePath)}/spec-projection.json`,
-          expectedChangeId: change.id,
-          expectedDeltaSetSha256: canonicalSha256(change.deltas),
-          expectedDeltaIdsByCapability: Object.fromEntries(
-            Object.entries(change.deltas).map(([capability, deltas]) => [
-              capability,
-              deltas.map((delta) => delta.id),
-            ]),
-          ),
-        });
-        if (!proof.ok) {
-          if (projectionFailureRoutesToReconcile(proof.code)) {
-            // MANIFEST_ABSENT: the in-repo projection was never committed.
-            // Fall through to the reconcile path at archiveResult below
-            // (existingBundlePath !== null → stage bundle, apply deltas).
-            projectionNeedsReconcile = true;
-          } else {
-            return formatToolOutput({
-              success: false,
-              error: `Archived retry projection proof failed: ${proof.code}: ${proof.message}`,
-              requirement: "rq-archiveDeltaReconciliation01",
-              changeId,
-              archivePath: existingBundlePath,
-              projectionFailure: proof,
-            });
-          }
-        }
-      }
-      if (!projectionNeedsReconcile) {
-        return reconcileArchivedBundleRetry({
-          store: activeStore,
-          change,
-          changeId,
-          archiveMode,
-          phase9,
-          existingBundlePath,
-          openOpsObligationsPayload,
-          validationWarnings: validationResult.warnings,
-        });
-      }
+    if (
+      !dryRun &&
+      change.status === "archived" &&
+      existingBundlePath &&
+      !archiveDeltaRepair
+    ) {
+      return reconcileArchivedBundleRetry({
+        store: activeStore,
+        change,
+        changeId,
+        archiveMode,
+        phase9,
+        existingBundlePath,
+        openOpsObligationsPayload,
+        validationWarnings: validationResult.warnings,
+      });
     }
 
     let archiveResult: import("../../archive/types").ArchiveOperationResult;
@@ -477,6 +733,9 @@ export const advChangeArchiveHandler = async (
           ? await finalizeRelease({
               changeId,
               workdir: worktreePath,
+              ...(archiveDeltaRepair?.repairBranch
+                ? { sourceBranch: archiveDeltaRepair.repairBranch }
+                : {}),
               expectedRepoRoot: activeStore.paths.root,
               archiveMode,
               autoPush,
@@ -637,7 +896,36 @@ export const advChangeArchiveHandler = async (
           archivePath: archiveResult.archivePath,
           projectionFailure: projectionProof,
         });
-      change.archive_projection_proof = projectionProof.receipt;
+      change.archive_projection_proof = {
+        ...projectionProof.receipt,
+        ...(archiveDeltaRepair
+          ? {
+              archive_delta_repair: {
+                kind: "archive_delta_repair" as const,
+                repair_branch:
+                  archiveDeltaRepair.repairBranch ??
+                  `repair/archive-${change.id}`,
+                repair_head_sha:
+                  finalization.changeTipSha ??
+                  archiveDeltaRepair.repairHeadSha ??
+                  "",
+                default_branch: finalization.defaultBranch,
+                default_branch_sha:
+                  finalization.defaultBranchSha ??
+                  finalization.releasedCommitSha,
+                released_commit_sha: finalization.releasedCommitSha,
+                delta_set_sha256: canonicalSha256(change.deltas),
+                delta_ids_by_capability: Object.fromEntries(
+                  Object.entries(change.deltas).map(([capability, deltas]) => [
+                    capability,
+                    deltas.map((delta) => delta.id),
+                  ]),
+                ),
+                release_proof: buildReleaseCompletionEvidence(finalization),
+              },
+            }
+          : {}),
+      };
     }
 
     if (!dryRun) {
@@ -725,14 +1013,14 @@ export const advChangeArchiveHandler = async (
             worktreePath,
           };
           const deletionPlan = await advWorktreeDelete(
-            `change/${change.id}`,
+            archiveDeltaRepair?.repairBranch ?? `change/${change.id}`,
             { force: false, dryRun: true },
             deletionDeps,
           );
           targetedWorktreeDeleteResult =
             deletionPlan.ok && deletionPlan.planToken
               ? await advWorktreeDelete(
-                  `change/${change.id}`,
+                  archiveDeltaRepair?.repairBranch ?? `change/${change.id}`,
                   {
                     force: false,
                     planToken: deletionPlan.planToken,
@@ -763,7 +1051,8 @@ export const advChangeArchiveHandler = async (
           targetedWorktreeDeleteResult?.error === "WORKTREE_NOT_FOUND")
       ) {
         try {
-          deleteChangeBranch(finalization.repoRoot, change.id);
+          if (!archiveDeltaRepair)
+            deleteChangeBranch(finalization.repoRoot, change.id);
         } catch (error) {
           archiveResult.errors.push(
             `Branch cleanup warning: ${error instanceof Error ? error.message : String(error)}`,
@@ -796,6 +1085,23 @@ export const advChangeArchiveHandler = async (
             continueFrom: {
               path: finalization.repoRoot,
               branch: finalization.defaultBranch,
+            },
+          }
+        : {}),
+      ...(archiveDeltaRepair
+        ? {
+            archiveDeltaRepair: {
+              kind: "archive_delta_repair" as const,
+              repairBranch: archiveDeltaRepair.repairBranch,
+              repairHeadSha: finalization?.changeTipSha,
+              defaultBranch: finalization?.defaultBranch,
+              defaultBranchSha:
+                finalization?.defaultBranchSha ??
+                finalization?.releasedCommitSha,
+              releasedCommitSha: finalization?.releasedCommitSha,
+              releaseProof: finalization
+                ? buildReleaseCompletionEvidence(finalization)
+                : undefined,
             },
           }
         : {}),

--- a/plugin/src/tools/worktree/deletion-executor.test.ts
+++ b/plugin/src/tools/worktree/deletion-executor.test.ts
@@ -17,6 +17,7 @@ import {
   type WorktreeDeletionExecutorDeps,
   type WorktreeBeforeRemoveStage,
 } from "./deletion-executor";
+import { GitWorktreeFlockUnsupportedError } from "../../utils/git-worktree-flock";
 import { createWorktreeOperationContext } from "../../utils/worktree-operation";
 
 const sha = "0123456789abcdef0123456789abcdef01234567";
@@ -233,6 +234,32 @@ describe("WorktreeDeletionExecutor", () => {
       await expect(firstPromise).resolves.toMatchObject({
         ok: true,
         status: "deleted",
+      });
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("returns unsupported when the flock holder command is unavailable", async () => {
+    const fx = fixture();
+    try {
+      const plan = makePlan(fx);
+      const result = await executeWorktreeDeletion(
+        { plan },
+        depsFor(fx, plan, {
+          acquireLease: async () => {
+            throw new GitWorktreeFlockUnsupportedError(
+              "flock holder command is unavailable",
+            );
+          },
+        }),
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: "unsupported",
+        reason: "kernel_flock_unavailable",
+        stage: "lease",
       });
     } finally {
       fx.cleanup();
@@ -585,8 +612,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const acquireLease = vi.fn(
         () =>
@@ -627,8 +654,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const beforeRemove = createWorktreeBeforeRemoveStage(
         ({ signal }) =>
@@ -695,8 +722,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const deps = depsFor(fx, plan, {
         census: vi.fn(
@@ -738,8 +765,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 35,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const base = depsFor(fx, plan);
       const normalCensus = base.census!;
@@ -785,8 +812,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 50,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const reconciliation = createWorktreeReconciliationStage(
         ({ signal }) =>
@@ -820,8 +847,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const terminate = vi.fn(async () => {
         throw new Error("process group remained alive");
@@ -871,8 +898,8 @@ describe("WorktreeDeletionExecutor", () => {
     try {
       const plan = makePlan(fx);
       const operation = createWorktreeOperationContext({
-        budgetMs: 25,
-        responseReserveMs: 5,
+        budgetMs: 500,
+        responseReserveMs: 50,
       });
       const terminate = vi.fn(async () => {
         throw new Error("held lease process group remained alive");

--- a/plugin/src/utils/git-worktree-flock.test.ts
+++ b/plugin/src/utils/git-worktree-flock.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
 
 import {
   acquireGitWorktreeFlock,
   acquireGitWorktreeProcessLease,
+  GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE,
+  GitWorktreeFlockUnsupportedError,
   releaseGitWorktreeFlock,
 } from "./git-worktree-flock";
 
@@ -83,5 +87,105 @@ describe("git worktree repository lease", () => {
     const third = await acquireGitWorktreeProcessLease(dir);
     expect(third.owned).toBe(true);
     if (third.owned) await third.terminate("test");
+  });
+
+  it("does not use the host runtime executable for the holder", async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-process-flock-runtime-"),
+    );
+    dirs.push(dir);
+    const previousExecPath = process.execPath;
+    process.execPath = "/opt/opencode/fake-compiled-runtime";
+    let invocation: { command: string; args: readonly string[] } | undefined;
+    try {
+      const first = await acquireGitWorktreeProcessLease(dir, {
+        spawnProcess: (command, args, options) => {
+          invocation = { command, args };
+          return spawn(command, [...args], options);
+        },
+      });
+
+      expect(first.owned).toBe(true);
+      if (first.owned) await first.terminate("test");
+      expect(invocation?.command).toBe("flock");
+      expect(invocation?.args).toEqual([
+        "-n",
+        "-E",
+        String(GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE),
+        path.join(dir, "git-worktree.lock"),
+        "sh",
+        "-c",
+        "command -v tail >/dev/null 2>&1 || { printf '%s\\n' 'ADV_WORKTREE_FLOCK_HOLDER_UNAVAILABLE' >&2; exit 127; }; printf '%s\\n' 'ADV_WORKTREE_FLOCK_READY'; exec tail -f /dev/null",
+      ]);
+      expect(invocation?.args).not.toContain(process.execPath);
+    } finally {
+      process.execPath = previousExecPath;
+    }
+  });
+
+  it("returns a typed non-busy error for holder startup failure", async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-process-flock-failure-"),
+    );
+    dirs.push(dir);
+    const child = Object.assign(new EventEmitter(), {
+      pid: 987654321,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      kill: () => true,
+    });
+    const acquisition = acquireGitWorktreeProcessLease(dir, {
+      spawnProcess: () => {
+        queueMicrotask(() => {
+          child.stderr.emit("data", "tail: command unavailable\n");
+          child.emit("close", 1, null);
+        });
+        return child as unknown as ChildProcess;
+      },
+    });
+
+    await expect(acquisition).rejects.toMatchObject({
+      name: "GitWorktreeFlockHolderError",
+      exitCode: 1,
+      stderr: "tail: command unavailable\n",
+    });
+  });
+
+  it("classifies a missing holder command as unsupported, not contention", async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-process-flock-missing-holder-"),
+    );
+    dirs.push(dir);
+    const child = Object.assign(new EventEmitter(), {
+      pid: 987654322,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      kill: () => true,
+    });
+
+    const acquisition = acquireGitWorktreeProcessLease(dir, {
+      spawnProcess: () => {
+        queueMicrotask(() => {
+          child.stderr.emit("data", "ADV_WORKTREE_FLOCK_HOLDER_UNAVAILABLE\n");
+          child.emit("close", 127, null);
+        });
+        return child as unknown as ChildProcess;
+      },
+    });
+
+    await expect(acquisition).rejects.toBeInstanceOf(
+      GitWorktreeFlockUnsupportedError,
+    );
+  });
+
+  it("fails closed on unsupported platforms", async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-process-flock-platform-"),
+    );
+    dirs.push(dir);
+
+    await expect(
+      acquireGitWorktreeProcessLease(dir, { platform: "darwin" }),
+    ).rejects.toThrow(/requires Linux/);
   });
 });

--- a/plugin/src/utils/git-worktree-flock.ts
+++ b/plugin/src/utils/git-worktree-flock.ts
@@ -16,7 +16,11 @@
 import { mkdirSync } from "node:fs";
 import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import { spawn, type ChildProcess } from "node:child_process";
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from "node:child_process";
 import { join } from "node:path";
 import { isProcessAlive } from "./process-liveness";
 
@@ -84,8 +88,34 @@ export class GitWorktreeFlockQuiescenceError extends Error {
 }
 
 const FLOCK_READY = "ADV_WORKTREE_FLOCK_READY\n";
+/** GNU util-linux documents 1 as the default conflict code; keep it distinct. */
+export const GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE = 73;
+const FLOCK_DIAGNOSTIC_LIMIT = 4_096;
+// Keep this shell program constant: the lock path is a separate argv and no
+// path, token, or runtime value is interpolated into shell syntax.
 const FLOCK_HOLDER_SCRIPT =
-  "const fs = require('node:fs'); const { spawn } = require('node:child_process'); fs.writeFileSync(process.env.ADV_FLOCK_PATH, JSON.stringify({ pid: process.pid, owner_token: process.env.ADV_FLOCK_TOKEN })); spawn(process.execPath, ['-e', 'setInterval(() => {}, 0x7fffffff);'], { stdio: 'ignore' }); process.stdout.write('ADV_WORKTREE_FLOCK_READY\\n'); setInterval(() => {}, 0x7fffffff);";
+  "command -v tail >/dev/null 2>&1 || { printf '%s\\n' 'ADV_WORKTREE_FLOCK_HOLDER_UNAVAILABLE' >&2; exit 127; }; printf '%s\\n' 'ADV_WORKTREE_FLOCK_READY'; exec tail -f /dev/null";
+
+export class GitWorktreeFlockHolderError extends Error {
+  constructor(
+    readonly exitCode: number | null,
+    readonly stdout: string,
+    readonly stderr: string,
+  ) {
+    const detail = stderr || stdout;
+    super(
+      `flock holder failed to start (exit ${exitCode ?? "unknown"})${
+        detail ? `: ${detail}` : ""
+      }`,
+    );
+    this.name = "GitWorktreeFlockHolderError";
+  }
+}
+
+function appendBounded(current: string, chunk: Buffer | string): string {
+  if (current.length >= FLOCK_DIAGNOSTIC_LIMIT) return current;
+  return `${current}${chunk.toString()}`.slice(0, FLOCK_DIAGNOSTIC_LIMIT);
+}
 
 async function waitForSettlement(
   settled: Promise<void>,
@@ -144,6 +174,12 @@ function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
 }
 
 export interface AcquireGitWorktreeProcessLeaseOptions extends AcquireGitWorktreeFlockOptions {
+  platform?: NodeJS.Platform;
+  spawnProcess?: (
+    command: string,
+    args: readonly string[],
+    options: SpawnOptions,
+  ) => ChildProcess;
   operation?: {
     registerChildLease: (lease: {
       terminate: (reason: string) => Promise<void>;
@@ -161,9 +197,10 @@ export async function acquireGitWorktreeProcessLease(
   options: AcquireGitWorktreeProcessLeaseOptions = {},
 ): Promise<GitWorktreeProcessLeaseResult> {
   if (options.signal?.aborted) throwIfAborted(options.signal);
-  if (process.platform !== "linux") {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "linux") {
     throw new GitWorktreeFlockUnsupportedError(
-      `kernel flock lease requires Linux (got ${process.platform})`,
+      `kernel flock lease requires Linux (got ${platform})`,
     );
   }
   mkdirSync(projectStateDir, { recursive: true });
@@ -171,16 +208,19 @@ export async function acquireGitWorktreeProcessLease(
 
   const lockPath = join(projectStateDir, GIT_WORKTREE_LOCK_FILENAME);
   const ownerToken = randomUUID();
-  const child = spawn(
+  const child = (options.spawnProcess ?? spawn)(
     "flock",
-    ["-n", lockPath, process.execPath, "-e", FLOCK_HOLDER_SCRIPT],
+    [
+      "-n",
+      "-E",
+      String(GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE),
+      lockPath,
+      "sh",
+      "-c",
+      FLOCK_HOLDER_SCRIPT,
+    ],
     {
       detached: true,
-      env: {
-        ...process.env,
-        ADV_FLOCK_PATH: lockPath,
-        ADV_FLOCK_TOKEN: ownerToken,
-      },
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     },
@@ -193,6 +233,7 @@ export async function acquireGitWorktreeProcessLease(
   });
   let readyState = false;
   let output = "";
+  let stderrOutput = "";
   let terminatePromise: Promise<void> | undefined;
   const settled = parentSettled.then(async () => {
     const pgid = child.pid;
@@ -205,11 +246,14 @@ export async function acquireGitWorktreeProcessLease(
   void settled.catch(() => undefined);
   const ready = new Promise<boolean>((resolve, reject) => {
     child.stdout?.on("data", (chunk: Buffer | string) => {
-      output += chunk.toString();
+      output = appendBounded(output, chunk);
       if (!readyState && output.includes(FLOCK_READY)) {
         readyState = true;
         resolve(true);
       }
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderrOutput = appendBounded(stderrOutput, chunk);
     });
     child.once("error", (error) => {
       if (!readyState) reject(error);
@@ -217,7 +261,17 @@ export async function acquireGitWorktreeProcessLease(
     child.once("close", (code) => {
       settledState = true;
       resolveParentSettled();
-      if (!readyState) resolve(code === 1 ? false : false);
+      if (!readyState) {
+        if (code === GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE) resolve(false);
+        else if (code === 127)
+          reject(
+            new GitWorktreeFlockUnsupportedError(
+              `flock holder command is unavailable: ${stderrOutput || output}`,
+            ),
+          );
+        else
+          reject(new GitWorktreeFlockHolderError(code, output, stderrOutput));
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- replace process.execPath-dependent flock holder with fixed POSIX holder
- distinguish true lock contention from holder startup/runtime failure
- preserve process-group quiescence and typed unsupported outcomes
- restore both partial archive repair and absent-projection reconciliation after concurrent trunk regression
- stabilize stage-specific deadline tests without changing production budgets

## Verification
- combined flock/delete/archive/projection suites: 262 passed
- repeated lease/executor suites: green
- plugin check: passed
- independent harden review: READY

## Live blockers
- deployed compiled OpenCode holder exits before readiness and is misclassified busy
- current trunk concurrently regressed PR #413 partial archive recovery while adding absent-projection handling; this branch preserves both.