### PR TITLE
fix: keep worktree locks in Git admin state

### DIFF
--- a/ADV_INSTRUCTIONS.md
+++ b/ADV_INSTRUCTIONS.md
@@ -303,7 +303,7 @@ Multi-session is the supported design center. Per-change filesystem advisory loc
 **Operational model:**
 
 - Each mutating execution session owns its own worktree; read-only/status sessions may run from the main checkout.
-- ADV change mutations are serialized by per-change filesystem advisory locks acquired inside `commitChangeProjection` (15s budget, jittered exponential backoff, stale-PID reclaim). A lock timeout fails closed as `operator_required`. Mutations to DIFFERENT changes are unconstrained — they touch disjoint files. Cross-session `git worktree add/remove` is serialized separately by a per-project `git-worktree.lock` (1.5s retry budget).
+- ADV change mutations are serialized by per-change filesystem advisory locks acquired inside `commitChangeProjection` (15s budget, jittered exponential backoff, stale-PID reclaim). A lock timeout fails closed as `operator_required`. Mutations to DIFFERENT changes are unconstrained — they touch disjoint files. Cross-session `git worktree add/remove` is serialized separately by a kernel `git-worktree.lock` under the repository's canonical `git-common-dir/advance` administrative state (1.5s retry budget); it never lives in a checkout or `.adv`.
 - Git filesystem ops (`git worktree add/remove`) coordinate via narrow per-repo flock (~50ms hold)
 - ADV-managed worktree paths are tool-owned. Agents must not invent repo-specific
   directories such as `~/dev/<repo>-wt` for ADV changes. Use

--- a/plugin/src/tools/worktree/deletion-executor.test.ts
+++ b/plugin/src/tools/worktree/deletion-executor.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -17,7 +18,11 @@ import {
   type WorktreeDeletionExecutorDeps,
   type WorktreeBeforeRemoveStage,
 } from "./deletion-executor";
-import { GitWorktreeFlockUnsupportedError } from "../../utils/git-worktree-flock";
+import {
+  acquireGitWorktreeProcessLease,
+  GitWorktreeFlockUnsupportedError,
+  resolveGitWorktreeLeaseDir,
+} from "../../utils/git-worktree-flock";
 import { createWorktreeOperationContext } from "../../utils/worktree-operation";
 
 const sha = "0123456789abcdef0123456789abcdef01234567";
@@ -32,6 +37,21 @@ function fixture(): {
   const worktree = join(repository, "linked");
   mkdirSync(worktree);
   writeFileSync(join(repository, "root"), "root\n");
+  execFileSync("git", ["init", "-q", "-b", "trunk"], { cwd: repository });
+  execFileSync("git", ["add", "root"], { cwd: repository });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=ADV test",
+      "-c",
+      "user.email=adv@example.test",
+      "commit",
+      "-qm",
+      "fixture",
+    ],
+    { cwd: repository },
+  );
   return {
     repository,
     worktree,
@@ -186,15 +206,90 @@ describe("WorktreeDeletionExecutor", () => {
       const result = await executeWorktreeDeletion(
         { plan },
         depsFor(fx, plan, {
+          repositoryLeaseDir: undefined,
           acquireLease: undefined,
           releaseLease: undefined,
         }),
       );
 
       expect(result).toMatchObject({ ok: true, status: "deleted" });
-      expect(existsSync(join(fx.repository, "git-worktree.lock"))).toBe(true);
+      const leaseDir = await resolveGitWorktreeLeaseDir(fx.repository);
+      expect(existsSync(join(leaseDir, "git-worktree.lock"))).toBe(true);
+      expect(
+        execFileSync("git", ["status", "--short"], {
+          cwd: fx.repository,
+          encoding: "utf8",
+        }),
+      ).toBe("");
     } finally {
       fx.cleanup();
+    }
+  });
+
+  it("migrates an unlocked legacy lock only through deletion", async () => {
+    const fx = fixture();
+    try {
+      const legacyPath = join(fx.repository, ".adv", "git-worktree.lock");
+      mkdirSync(join(fx.repository, ".adv"), { recursive: true });
+      writeFileSync(legacyPath, "");
+      const plan = makePlan(fx);
+      const result = await executeWorktreeDeletion(
+        { plan },
+        depsFor(fx, plan, {
+          repositoryLeaseDir: undefined,
+          acquireLease: undefined,
+          releaseLease: undefined,
+        }),
+      );
+      expect(result).toMatchObject({ ok: true, status: "deleted" });
+      expect(existsSync(legacyPath)).toBe(false);
+      expect(
+        execFileSync("git", ["status", "--short"], {
+          cwd: fx.repository,
+          encoding: "utf8",
+        }),
+      ).toBe("");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("refuses held and malformed legacy locks with typed repair reasons", async () => {
+    for (const mode of ["held", "malformed"] as const) {
+      const fx = fixture();
+      let holder:
+        | Awaited<ReturnType<typeof acquireGitWorktreeProcessLease>>
+        | undefined;
+      try {
+        const legacyDir = join(fx.repository, ".adv");
+        const legacyPath = join(legacyDir, "git-worktree.lock");
+        mkdirSync(legacyDir, { recursive: true });
+        writeFileSync(legacyPath, mode === "held" ? "" : '{"unexpected":true}');
+        if (mode === "held") {
+          holder = await acquireGitWorktreeProcessLease(legacyDir);
+          if (!holder.owned) throw new Error("legacy holder was not acquired");
+        }
+        const plan = makePlan(fx);
+        const result = await executeWorktreeDeletion(
+          { plan },
+          depsFor(fx, plan, {
+            repositoryLeaseDir: undefined,
+            acquireLease: undefined,
+            releaseLease: undefined,
+          }),
+        );
+        expect(result).toMatchObject({
+          ok: false,
+          status: "repair_required",
+          reason: `legacy_lock_${mode}`,
+          stage: "lease",
+        });
+        expect(existsSync(legacyPath)).toBe(true);
+        expect(exists(fx.worktree)).toBe(true);
+      } finally {
+        if (holder?.owned) await holder.terminate("test");
+        fx.cleanup();
+      }
     }
   });
 

--- a/plugin/src/tools/worktree/deletion-executor.ts
+++ b/plugin/src/tools/worktree/deletion-executor.ts
@@ -23,6 +23,10 @@ import type {
 import { resolveGitBinary } from "../../utils/git-binary";
 import {
   acquireGitWorktreeProcessLease,
+  GitWorktreeLegacyLockError,
+  GitWorktreeLeaseResolutionError,
+  migrateLegacyGitWorktreeLock,
+  resolveGitWorktreeLeaseDir,
   type GitWorktreeProcessLeaseResult,
   GitWorktreeFlockUnsupportedError,
   GitWorktreeFlockQuiescenceError,
@@ -32,6 +36,7 @@ import {
   type WorktreeOperationContext,
 } from "../../utils/worktree-operation";
 import { stableStringify } from "../../utils/digest";
+import { appendDebugLog } from "../../utils/debug-log";
 import { isWorktreeInUse } from "./in-use";
 import {
   LocalBranchIntegrationDeadline,
@@ -42,7 +47,7 @@ import {
 export interface WorktreeDeletionExecutorDeps {
   /** Repository path selected by the caller; it must match the token exactly. */
   repository?: string;
-  /** Directory containing the repository owner-token lock. */
+  /** Test seam; production derives the lease directory from Git common-dir. */
   repositoryLeaseDir?: string;
   /** Current process CWD, supplied by the adapter rather than inferred in tests. */
   cwd?: string;
@@ -432,8 +437,7 @@ export class WorktreeDeletionExecutor {
         responseReserveMs: DEFAULT_RESPONSE_RESERVE_MS,
         now,
       });
-    const repositoryLeaseDir =
-      this.deps.repositoryLeaseDir ?? resolve(plan.repository, ".adv");
+    let repositoryLeaseDir = this.deps.repositoryLeaseDir;
     const acquire = this.deps.acquireLease ?? acquireGitWorktreeProcessLease;
     const release = this.deps.releaseLease;
     let lock: WorktreeLeaseResult | undefined;
@@ -590,13 +594,25 @@ export class WorktreeDeletionExecutor {
     };
 
     try {
+      if (!repositoryLeaseDir) {
+        repositoryLeaseDir = await runBounded("lease", () =>
+          resolveGitWorktreeLeaseDir(plan.repository),
+        );
+      }
+      if (!repositoryLeaseDir)
+        return failure(
+          "repair_required",
+          "git_common_dir_unavailable",
+          "lease",
+        );
+      const activeRepositoryLeaseDir = repositoryLeaseDir;
       if (expiryDecision("lease")) return expiryDecision("lease")!;
       if (operation.remainingMs() <= operation.responseReserveMs)
         return failure("deadline_exceeded", "deadline_exceeded", "lease");
       operation.startStage("lease");
       try {
         lock = await runBounded("lease", () =>
-          acquire(repositoryLeaseDir, {
+          acquire(activeRepositoryLeaseDir, {
             signal: operation.signal,
             operation,
           }),
@@ -628,7 +644,7 @@ export class WorktreeDeletionExecutor {
       ) {
         if (lock.owned) {
           try {
-            await settleLease(lock, repositoryLeaseDir, release);
+            await settleLease(lock, activeRepositoryLeaseDir, release);
           } catch {
             // The operation's terminationError is surfaced by the barrier;
             // cleanup must not replace that typed result with a rejection.
@@ -637,8 +653,22 @@ export class WorktreeDeletionExecutor {
         await operation.abort("deadline");
         return failure("deadline_exceeded", "deadline_exceeded", "lease");
       }
+      if (!lock.owned) {
+        operation.finishStage("lease");
+        return failure("busy", "repository_lease_held", "lease");
+      }
+      const migration = await runBounded("lease", () =>
+        migrateLegacyGitWorktreeLock(plan.repository),
+      );
+      if (migration.removed) {
+        // The migration is deliberately audited at the deletion boundary;
+        // no startup/background path is allowed to mutate repository files.
+        appendDebugLog(
+          "worktree-delete",
+          `migrated legacy repository lock ${migration.lockPath} to Git administrative lease state`,
+        );
+      }
       operation.finishStage("lease");
-      if (!lock.owned) return failure("busy", "repository_lease_held", "lease");
 
       const initialExpiry = expiryDecision("census");
       if (initialExpiry) return initialExpiry;
@@ -929,6 +959,22 @@ export class WorktreeDeletionExecutor {
         (error instanceof Error && /unsupported.*platform/i.test(error.message))
       )
         return failure("unsupported", error.message, operation.currentStage);
+      if (error instanceof GitWorktreeLegacyLockError) {
+        return {
+          ...failure(
+            "repair_required",
+            `legacy_lock_${error.failure}`,
+            "lease",
+          ),
+          warning: error.message,
+        };
+      }
+      if (error instanceof GitWorktreeLeaseResolutionError) {
+        return {
+          ...failure("repair_required", "git_common_dir_unavailable", "lease"),
+          warning: error.message,
+        };
+      }
       return failure(
         "indeterminate",
         error instanceof Error ? error.message : String(error),
@@ -939,7 +985,7 @@ export class WorktreeDeletionExecutor {
         await operation.abort("operation_complete");
         operation.dispose();
       }
-      if (lock?.owned) {
+      if (lock?.owned && repositoryLeaseDir) {
         try {
           await settleLease(lock, repositoryLeaseDir, release);
         } catch {

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -1678,7 +1678,6 @@ async function advWorktreeDeleteShared(
     },
     {
       repository: deps.projectRoot,
-      repositoryLeaseDir: path.join(deps.projectRoot, ".adv"),
       cwd: process.cwd(),
       hooks: hooks.preDelete,
       budgetMs: deps.operationTimeoutMs,

--- a/plugin/src/utils/git-worktree-flock.test.ts
+++ b/plugin/src/utils/git-worktree-flock.test.ts
@@ -3,17 +3,47 @@ import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 
 import {
   acquireGitWorktreeFlock,
   acquireGitWorktreeProcessLease,
   GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE,
+  GitWorktreeLegacyLockError,
   GitWorktreeFlockUnsupportedError,
+  LEGACY_GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE,
+  migrateLegacyGitWorktreeLock,
   releaseGitWorktreeFlock,
+  resolveGitWorktreeLeaseDir,
 } from "./git-worktree-flock";
 
 const dirs: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function makeGitRepo(prefix: string): string {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  dirs.push(repo);
+  git(repo, "init", "-q", "-b", "trunk");
+  fs.writeFileSync(path.join(repo, "README"), "fixture\n");
+  git(repo, "add", "README");
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=ADV test",
+      "-c",
+      "user.email=adv@example.test",
+      "commit",
+      "-qm",
+      "fixture",
+    ],
+    { cwd: repo },
+  );
+  return repo;
+}
 
 afterEach(() => {
   for (const dir of dirs.splice(0))
@@ -187,5 +217,146 @@ describe("git worktree repository lease", () => {
     await expect(
       acquireGitWorktreeProcessLease(dir, { platform: "darwin" }),
     ).rejects.toThrow(/requires Linux/);
+  });
+
+  it("shares the canonical administrative lease across main and linked worktrees", async () => {
+    const repo = makeGitRepo("adv-common-dir-");
+    const linked = path.join(repo, "linked");
+    git(repo, "worktree", "add", "-q", "-b", "linked", linked);
+
+    const mainLeaseDir = await resolveGitWorktreeLeaseDir(repo);
+    const linkedLeaseDir = await resolveGitWorktreeLeaseDir(linked);
+    expect(linkedLeaseDir).toBe(mainLeaseDir);
+    expect(mainLeaseDir).toBe(path.join(repo, ".git", "advance"));
+
+    const first = await acquireGitWorktreeProcessLease(mainLeaseDir);
+    expect(first.owned).toBe(true);
+    if (!first.owned) return;
+    try {
+      await expect(
+        acquireGitWorktreeProcessLease(linkedLeaseDir),
+      ).resolves.toMatchObject({ owned: false });
+      expect(first.lockPath).toBe(
+        path.join(repo, ".git", "advance", "git-worktree.lock"),
+      );
+    } finally {
+      await first.terminate("test");
+    }
+  });
+
+  it("keeps administrative lease paths independent across separate clones", async () => {
+    const first = makeGitRepo("adv-clone-a-");
+    const second = makeGitRepo("adv-clone-b-");
+    await expect(resolveGitWorktreeLeaseDir(first)).resolves.not.toBe(
+      await resolveGitWorktreeLeaseDir(second),
+    );
+  });
+
+  it("removes an unlocked known legacy artifact and leaves .adv otherwise untouched", async () => {
+    const repo = makeGitRepo("adv-legacy-empty-");
+    const advDir = path.join(repo, ".adv");
+    const lockPath = path.join(advDir, "git-worktree.lock");
+    fs.mkdirSync(advDir);
+    fs.writeFileSync(lockPath, "");
+    fs.writeFileSync(path.join(advDir, "keep.txt"), "keep\n");
+
+    await expect(migrateLegacyGitWorktreeLock(repo)).resolves.toMatchObject({
+      removed: true,
+      lockPath,
+    });
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(path.join(advDir, "keep.txt"))).toBe(true);
+  });
+
+  it("removes a bounded JSON legacy artifact", async () => {
+    const repo = makeGitRepo("adv-legacy-json-");
+    const lockPath = path.join(repo, ".adv", "git-worktree.lock");
+    fs.mkdirSync(path.dirname(lockPath));
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: process.pid,
+        worker_id: "worker",
+        owner_token: "token",
+        acquired_at: new Date().toISOString(),
+      }),
+    );
+    await expect(migrateLegacyGitWorktreeLock(repo)).resolves.toMatchObject({
+      removed: true,
+    });
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("preserves and refuses a held legacy artifact with the distinct conflict code", async () => {
+    const repo = makeGitRepo("adv-legacy-held-");
+    const advDir = path.join(repo, ".adv");
+    const lockPath = path.join(advDir, "git-worktree.lock");
+    fs.mkdirSync(advDir);
+    fs.writeFileSync(lockPath, "");
+    const holder = await acquireGitWorktreeProcessLease(advDir);
+    expect(holder.owned).toBe(true);
+    if (!holder.owned) return;
+    try {
+      await expect(migrateLegacyGitWorktreeLock(repo)).rejects.toMatchObject({
+        name: "GitWorktreeLegacyLockError",
+        failure: "held",
+        lockPath,
+      } satisfies Partial<GitWorktreeLegacyLockError>);
+      expect(fs.existsSync(lockPath)).toBe(true);
+      expect(LEGACY_GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE).not.toBe(
+        GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE,
+      );
+    } finally {
+      await holder.terminate("test");
+    }
+  });
+
+  it("preserves and refuses malformed legacy artifacts", async () => {
+    const repo = makeGitRepo("adv-legacy-malformed-");
+    const lockPath = path.join(repo, ".adv", "git-worktree.lock");
+    fs.mkdirSync(path.dirname(lockPath));
+    fs.writeFileSync(lockPath, JSON.stringify({ unexpected: true }));
+    await expect(migrateLegacyGitWorktreeLock(repo)).rejects.toMatchObject({
+      name: "GitWorktreeLegacyLockError",
+      failure: "malformed",
+      lockPath,
+    });
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  it("refuses legacy symlink paths without traversing outside the repository", async () => {
+    const repo = makeGitRepo("adv-legacy-symlink-");
+    const external = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-legacy-external-"),
+    );
+    dirs.push(external);
+    const externalLock = path.join(external, "git-worktree.lock");
+    fs.writeFileSync(externalLock, "");
+    fs.symlinkSync(external, path.join(repo, ".adv"));
+
+    await expect(migrateLegacyGitWorktreeLock(repo)).rejects.toMatchObject({
+      name: "GitWorktreeLegacyLockError",
+      failure: "malformed",
+    });
+    expect(fs.existsSync(externalLock)).toBe(true);
+  });
+
+  it("preserves a symlinked legacy artifact without following it", async () => {
+    const repo = makeGitRepo("adv-legacy-lock-symlink-");
+    const external = fs.mkdtempSync(
+      path.join(os.tmpdir(), "adv-legacy-external-"),
+    );
+    dirs.push(external);
+    const externalLock = path.join(external, "git-worktree.lock");
+    fs.writeFileSync(externalLock, "");
+    const legacyDir = path.join(repo, ".adv");
+    fs.mkdirSync(legacyDir);
+    fs.symlinkSync(externalLock, path.join(legacyDir, "git-worktree.lock"));
+
+    await expect(migrateLegacyGitWorktreeLock(repo)).rejects.toMatchObject({
+      name: "GitWorktreeLegacyLockError",
+      failure: "malformed",
+    });
+    expect(fs.existsSync(externalLock)).toBe(true);
   });
 });

--- a/plugin/src/utils/git-worktree-flock.ts
+++ b/plugin/src/utils/git-worktree-flock.ts
@@ -1,7 +1,7 @@
 /**
  * Git Worktree File-Lock (T15 — KD-2, KD-7, R16).
  *
- * A narrow per-project filesystem lock used **only** to serialize git filesystem
+ * A narrow per-repository filesystem lock used **only** to serialize git filesystem
  * operations (`git worktree add` / `git worktree remove`) that race against
  * each other when multiple peer sessions create or delete worktrees
  * concurrently. Hold time is targeted at ~50ms — long enough to cover the
@@ -14,15 +14,16 @@
  */
 
 import { mkdirSync } from "node:fs";
-import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import {
   spawn,
   type ChildProcess,
   type SpawnOptions,
 } from "node:child_process";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { isProcessAlive } from "./process-liveness";
+import { execFileGitAsync } from "./git-binary";
 
 export type GitWorktreeLockResult =
   | {
@@ -41,11 +42,265 @@ export type GitWorktreeLockResult =
     };
 
 /**
- * Lock filename used inside the per-project state directory. Distinct from
- * `worker.lock` so the singleton-worker election is not coupled to git
- * operations.
+ * Lock filename used inside the per-repository administrative lease
+ * directory. Distinct from
+ * `worker.lock` so singleton-worker election is not coupled to git operations.
+ * The file lives under `<git-common-dir>/advance`, never in a checkout.
  */
 export const GIT_WORKTREE_LOCK_FILENAME = "git-worktree.lock";
+/** Git administrative subdirectory shared by linked worktrees. */
+export const GIT_WORKTREE_LEASE_DIRECTORY = "advance";
+/** Distinct from the process-lease contention code for legacy migration. */
+export const LEGACY_GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE = 74;
+const LEGACY_LOCK_MAX_BYTES = 4_096;
+const LEGACY_REMOVE_SCRIPT =
+  'test ! -L "$1" && test -f "$1" && mv -- "$1" "$2" && rm -f -- "$2"';
+
+export type LegacyGitWorktreeLockFailure =
+  | "held"
+  | "malformed"
+  | "probe_failed"
+  | "remove_failed";
+
+/** Typed, fail-closed legacy migration error. The artifact is never force-removed. */
+export class GitWorktreeLegacyLockError extends Error {
+  constructor(
+    readonly failure: LegacyGitWorktreeLockFailure,
+    readonly lockPath: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GitWorktreeLegacyLockError";
+  }
+}
+
+export class GitWorktreeLeaseResolutionError extends Error {
+  constructor(
+    readonly repository: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GitWorktreeLeaseResolutionError";
+  }
+}
+
+/**
+ * Resolve the one lease directory shared by a repository's main and linked
+ * worktrees. Git's common directory is repository administrative state, not a
+ * checkout, so this path is invisible to `git status` and independent across
+ * separate clones.
+ */
+export async function resolveGitWorktreeLeaseDir(
+  repository: string,
+): Promise<string> {
+  try {
+    const { stdout } = await execFileGitAsync(
+      ["rev-parse", "--git-common-dir"],
+      { cwd: repository },
+    );
+    const commonDir = stdout.trim();
+    if (!commonDir) throw new Error("git returned an empty common directory");
+    return join(resolve(repository, commonDir), GIT_WORKTREE_LEASE_DIRECTORY);
+  } catch (error) {
+    throw new GitWorktreeLeaseResolutionError(
+      repository,
+      `unable to resolve git common directory for ${repository}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+function isKnownLegacyLockRecord(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    return false;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort().join(",");
+  if (keys !== "acquired_at,owner_token,pid,worker_id") return false;
+  return (
+    typeof record.pid === "number" &&
+    Number.isInteger(record.pid) &&
+    record.pid >= 0 &&
+    typeof record.worker_id === "string" &&
+    record.worker_id.length > 0 &&
+    record.worker_id.length <= 256 &&
+    typeof record.owner_token === "string" &&
+    record.owner_token.length > 0 &&
+    record.owner_token.length <= 256 &&
+    typeof record.acquired_at === "string" &&
+    record.acquired_at.length > 0 &&
+    record.acquired_at.length <= 128
+  );
+}
+
+async function probeLegacyKernelLock(lockPath: string): Promise<void> {
+  await new Promise<void>((resolveProbe, rejectProbe) => {
+    const child = spawn(
+      "flock",
+      [
+        "-n",
+        "-E",
+        String(LEGACY_GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE),
+        lockPath,
+        "true",
+      ],
+      { stdio: "ignore", windowsHide: true },
+    );
+    child.once("error", rejectProbe);
+    child.once("close", (code) => {
+      if (code === 0) return resolveProbe();
+      if (code === LEGACY_GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE) {
+        rejectProbe(
+          new GitWorktreeLegacyLockError(
+            "held",
+            lockPath,
+            `legacy worktree lock is held: ${lockPath}; retry deletion after its owner exits`,
+          ),
+        );
+        return;
+      }
+      rejectProbe(
+        new GitWorktreeLegacyLockError(
+          "probe_failed",
+          lockPath,
+          `unable to probe legacy worktree lock ${lockPath} (flock exit ${code ?? "unknown"})`,
+        ),
+      );
+    });
+  });
+}
+
+/**
+ * Reacquire nonblocking before removal so a holder arriving after the probe
+ * wins. Rename the locked inode before unlinking it: a peer that opens the
+ * canonical path after flock is taken gets a new inode that is left in place.
+ */
+async function removeLegacyKernelLock(lockPath: string): Promise<void> {
+  const retiredPath = join(
+    dirname(lockPath),
+    `.git-worktree.lock.migrating-${randomUUID()}`,
+  );
+  await new Promise<void>((resolveRemoval, rejectRemoval) => {
+    const child = spawn(
+      "flock",
+      [
+        "-n",
+        "-E",
+        String(LEGACY_GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE),
+        lockPath,
+        "sh",
+        "-c",
+        LEGACY_REMOVE_SCRIPT,
+        "sh",
+        lockPath,
+        retiredPath,
+      ],
+      { stdio: "ignore", windowsHide: true },
+    );
+    child.once("error", rejectRemoval);
+    child.once("close", (code) => {
+      if (code === 0) return resolveRemoval();
+      if (code === LEGACY_GIT_WORKTREE_FLOCK_CONFLICT_EXIT_CODE) {
+        rejectRemoval(
+          new GitWorktreeLegacyLockError(
+            "held",
+            lockPath,
+            `legacy worktree lock became held during migration: ${lockPath}; retry deletion after its owner exits`,
+          ),
+        );
+        return;
+      }
+      rejectRemoval(
+        new GitWorktreeLegacyLockError(
+          "remove_failed",
+          lockPath,
+          `unable to remove migrated legacy worktree lock ${lockPath} (flock exit ${code ?? "unknown"})`,
+        ),
+      );
+    });
+  });
+}
+
+/**
+ * Migrate only the known historical repository-local lock artifact. This is
+ * intentionally called by deletion, never startup: malformed or held files
+ * remain in place and produce typed repair guidance instead of broad cleanup.
+ */
+export async function migrateLegacyGitWorktreeLock(
+  repository: string,
+): Promise<{ removed: boolean; lockPath: string }> {
+  const lockPath = join(
+    resolve(repository),
+    ".adv",
+    GIT_WORKTREE_LOCK_FILENAME,
+  );
+  try {
+    const legacyDir = dirname(lockPath);
+    const legacyDirDetails = await lstat(legacyDir);
+    if (!legacyDirDetails.isDirectory() || legacyDirDetails.isSymbolicLink()) {
+      throw new GitWorktreeLegacyLockError(
+        "malformed",
+        lockPath,
+        `legacy worktree lock parent is not a real directory: ${legacyDir}; preserve it for operator repair`,
+      );
+    }
+    const details = await lstat(lockPath);
+    if (!details.isFile() || details.size > LEGACY_LOCK_MAX_BYTES) {
+      throw new GitWorktreeLegacyLockError(
+        "malformed",
+        lockPath,
+        `legacy worktree lock is not a bounded regular artifact: ${lockPath}; preserve it for operator repair`,
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT")
+      return { removed: false, lockPath };
+    if (error instanceof GitWorktreeLegacyLockError) throw error;
+    throw new GitWorktreeLegacyLockError(
+      "probe_failed",
+      lockPath,
+      `unable to inspect legacy worktree lock ${lockPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  // Probe before reading or unlinking. A held legacy inode is never removed.
+  await probeLegacyKernelLock(lockPath);
+  let content: string;
+  try {
+    content = await readFile(lockPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT")
+      return { removed: false, lockPath };
+    throw new GitWorktreeLegacyLockError(
+      "probe_failed",
+      lockPath,
+      `unable to read legacy worktree lock ${lockPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (
+    content.length > LEGACY_LOCK_MAX_BYTES ||
+    (content.length > 0 &&
+      (() => {
+        try {
+          return !isKnownLegacyLockRecord(JSON.parse(content));
+        } catch {
+          return true;
+        }
+      })())
+  ) {
+    throw new GitWorktreeLegacyLockError(
+      "malformed",
+      lockPath,
+      `legacy worktree lock has an unexpected format: ${lockPath}; preserve it for operator repair`,
+    );
+  }
+  await removeLegacyKernelLock(lockPath);
+  return { removed: true, lockPath };
+}
 
 export interface AcquireGitWorktreeFlockOptions {
   signal?: AbortSignal;
@@ -336,7 +591,9 @@ function throwIfAborted(signal?: AbortSignal): void {
 }
 
 /**
- * Acquire the per-project git-worktree flock.
+ * Acquire the per-repository git-worktree flock. Callers pass the directory
+ * returned by `resolveGitWorktreeLeaseDir`; linked worktrees therefore share
+ * one Git-administrative artifact.
  *
  * Returns a lock result whose `owned` field indicates whether
  * the lock was taken (`true`) or contended (`false`). Callers MUST honour
@@ -458,7 +715,7 @@ export async function acquireGitWorktreeFlock(
 }
 
 /**
- * Release the per-project git-worktree flock previously taken via
+ * Release the per-repository git-worktree flock previously taken via
  * `acquireGitWorktreeFlock`. Idempotent — no-op when the lock file is
  * absent or owned by another PID (defensive: avoids stealing peer locks).
  */


### PR DESCRIPTION
## Summary
- move deletion lease from tracked `.adv` into canonical Git common administrative state
- share one lock across sibling worktrees while keeping clones independent
- safely migrate only unlocked known legacy lock artifacts
- preserve held/malformed/symlink/replacement-race artifacts and fail closed
- prevent lease lifecycle from dirtying repositories or blocking freshness

## Verification
- focused flock/executor/public/delete suites: 154 passed after rebase
- pre-review focused suite: 155 passed
- plugin check: passed
- independent harden review: READY

## Live blocker
Post-archive repair cleanup left `.adv/git-worktree.lock` untracked, making clean trunk appear dirty and preventing `oc-fresh sync`.