### PR TITLE
fix: prove merged PR worktree integration

### DIFF
--- a/plugin/src/integrations/gh-cli.ts
+++ b/plugin/src/integrations/gh-cli.ts
@@ -57,6 +57,7 @@ export function execGh(
   args: string[],
   cwd: string,
   timeout: number = DEFAULT_TIMEOUT_MS,
+  signal?: AbortSignal,
 ): Promise<GhExecResult> {
   return new Promise((resolve) => {
     execFile(
@@ -65,6 +66,7 @@ export function execGh(
       {
         cwd,
         timeout,
+        signal,
         maxBuffer: DEFAULT_MAX_BUFFER,
         env: { ...process.env, ...GH_ENV },
       },
@@ -72,7 +74,12 @@ export function execGh(
         if (error) {
           const isEnoent = (error as NodeJS.ErrnoException).code === "ENOENT";
           const isKilled =
-            "killed" in error ? (error as { killed: boolean }).killed : false;
+            ("killed" in error
+              ? (error as { killed: boolean }).killed
+              : false) ||
+            ("name" in error &&
+              (error as { name?: string }).name === "AbortError") ||
+            signal?.aborted === true;
           const rawStderr = stderr ?? "";
           const isRateLimit =
             rawStderr.includes("HTTP 429") ||

--- a/plugin/src/tools/worktree/cleanup-git-budget.test.ts
+++ b/plugin/src/tools/worktree/cleanup-git-budget.test.ts
@@ -97,10 +97,9 @@ describe("AC6: cleanup discovery git subprocesses are bounded below the tool bud
     });
   });
 
-  // The worktree/index.ts helper is the OTHER half of AC6, and it carries the
-  // looser 30000ms default. Without these guards, silently changing that
-  // default — or dropping the gitTimeoutMs argument at a discovery call site —
-  // passes every other suite in the repo.
+  // The worktree/index.ts helper is the OTHER half of AC6. Cleanup discovery
+  // must use the shared operation budget rather than a standalone 30000ms
+  // default, or a hung PR probe can outlive the tool response.
   describe("worktree/index.ts git helper", () => {
     /** Drive the discovery path far enough to reach the local git() helper. */
     async function runDiscovery(gitTimeoutMs?: number) {
@@ -169,14 +168,14 @@ describe("AC6: cleanup discovery git subprocesses are bounded below the tool bud
       }
     });
 
-    // C6 regression guard for the 30000ms default.
-    it("preserves the 30000ms default when no gitTimeoutMs is supplied", async () => {
+    it("uses the remaining operation budget when no gitTimeoutMs is supplied", async () => {
       await runDiscovery();
 
       const timeouts = localHelperTimeouts();
       expect(timeouts.length).toBeGreaterThan(0);
       for (const timeout of timeouts) {
-        expect(timeout).toBe(30_000);
+        expect(timeout).toBeGreaterThan(0);
+        expect(timeout as number).toBeLessThan(8_000);
       }
     });
   });

--- a/plugin/src/tools/worktree/deletion-contracts.ts
+++ b/plugin/src/tools/worktree/deletion-contracts.ts
@@ -40,6 +40,12 @@ export const WorktreeDeletionIntegrationProofSchema = z
     defaultBranch: NonEmptyTextSchema,
     head: z.string().regex(HEX_SHA_RE),
     evidence: NonEmptyTextSchema,
+    /** Exact PR evidence, present for live pr_merged proofs. */
+    prNumber: z.number().int().positive().optional(),
+    prHeadOid: NonEmptyTextSchema.optional(),
+    mergeCommitOid: NonEmptyTextSchema.optional(),
+    headRepository: NonEmptyTextSchema.optional(),
+    baseRepository: NonEmptyTextSchema.optional(),
   })
   .strict();
 

--- a/plugin/src/tools/worktree/deletion-executor.ts
+++ b/plugin/src/tools/worktree/deletion-executor.ts
@@ -42,6 +42,7 @@ import {
   LocalBranchIntegrationDeadline,
   proveLocalBranchIntegration,
 } from "../../utils/branch-integration";
+import type { WorktreeDeletionIntegrationFailure } from "./deletion-planner";
 
 /** Dependency seams keep the destructive boundary testable without bypassing Git. */
 export interface WorktreeDeletionExecutorDeps {
@@ -68,7 +69,11 @@ export interface WorktreeDeletionExecutorDeps {
     defaultBranch: string,
     repository: string,
     operation: WorktreeOperationContext,
-  ) => Promise<WorktreeDeletionIntegrationProof | undefined>;
+  ) => Promise<
+    | WorktreeDeletionIntegrationProof
+    | WorktreeDeletionIntegrationFailure
+    | undefined
+  >;
   terminalProof?: (
     changeId: string,
     repository: string,
@@ -555,7 +560,12 @@ export class WorktreeDeletionExecutor {
             operation,
           ),
         );
-        if (!sameProof(integration, currentProof))
+        if (
+          !currentProof ||
+          ("classification" in currentProof &&
+            currentProof.classification !== undefined) ||
+          !sameProof(integration, currentProof)
+        )
           return failure("drifted", "integration_proof_changed", stage);
       } else if (branchFact.merged) {
         if (integration.kind !== "merged_to_default")

--- a/plugin/src/tools/worktree/deletion-planner.ts
+++ b/plugin/src/tools/worktree/deletion-planner.ts
@@ -47,6 +47,12 @@ export type WorktreeDeletionRefusalReason =
   | "git_corrupt"
   | "bare_worktree"
   | "branch_not_merged"
+  | "pr_evidence_invalid"
+  | "pr_not_found"
+  | "pr_not_merged"
+  | "local_commits_after_pr_head"
+  | "pr_merge_commit_unreachable"
+  | "integration_proof_unavailable"
   | "invalid_ref"
   | "terminal_proof_required";
 
@@ -54,7 +60,30 @@ export type WorktreeDeletionRepairReason =
   | "target_resolution_failed"
   | "census_unavailable"
   | "malformed_census"
-  | "terminal_state_corrupt";
+  | "terminal_state_corrupt"
+  | "integration_proof_unavailable";
+
+export type WorktreeDeletionIntegrationFailure =
+  | {
+      ok: false;
+      classification: "refusal";
+      reason: Extract<
+        WorktreeDeletionRefusalReason,
+        | "pr_evidence_invalid"
+        | "pr_not_found"
+        | "pr_not_merged"
+        | "local_commits_after_pr_head"
+        | "pr_merge_commit_unreachable"
+        | "integration_proof_unavailable"
+      >;
+      message: string;
+    }
+  | {
+      ok: false;
+      classification: "repair";
+      reason: "integration_proof_unavailable";
+      message: string;
+    };
 
 export type WorktreeDeletionUnsupportedReason =
   | "process_use_detection_unsupported"
@@ -113,7 +142,11 @@ export interface WorktreeDeletionPlannerDeps {
     defaultBranch: string,
     repository: string,
     operation: WorktreeOperationContext,
-  ) => Promise<WorktreeDeletionIntegrationProof | undefined>;
+  ) => Promise<
+    | WorktreeDeletionIntegrationProof
+    | WorktreeDeletionIntegrationFailure
+    | undefined
+  >;
   statePathResolver?: (
     repository: string,
     changeId: string,
@@ -527,7 +560,7 @@ export class WorktreeDeletionPlanner {
       operation.startStage("integration_proof");
       let integration: WorktreeDeletionIntegrationProof | undefined;
       try {
-        integration = await (this.deps.integrationProof
+        const integrationResult = await (this.deps.integrationProof
           ? runWithDeadline(() =>
               this.deps.integrationProof!(
                 branch,
@@ -552,6 +585,26 @@ export class WorktreeDeletionPlanner {
                 target.repository,
                 operation,
               )) as LocalBranchIntegrationProof | undefined));
+        if (integrationResult && "classification" in integrationResult) {
+          if (integrationResult.classification === "repair") {
+            return {
+              kind: "repair",
+              reason: integrationResult.reason,
+              message: integrationResult.message,
+              target,
+              stageTimings: operation.stageTimings,
+            };
+          }
+          return refusal(
+            integrationResult.reason,
+            integrationResult.message,
+            operation,
+            { facts, target },
+          );
+        }
+        integration = integrationResult as
+          | WorktreeDeletionIntegrationProof
+          | undefined;
       } catch (error) {
         if (isTimeoutError(error) || operation.remainingMs() <= 0)
           return this.deadline(operation, "integration_proof", error, target);

--- a/plugin/src/tools/worktree/index-delete.test.ts
+++ b/plugin/src/tools/worktree/index-delete.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 
 // Mock debug-log to capture audit trail.
 vi.mock("../../utils/debug-log", async (importOriginal) => {
@@ -51,6 +51,7 @@ import {
   setPendingDelete,
 } from "./state";
 import { synthesizeTestProjectId } from "../../utils/project-id";
+import { decodeWorktreeDeletionToken } from "./deletion-contracts";
 
 const isLinux = process.platform === "linux";
 
@@ -69,6 +70,67 @@ function addWorktree(repoRoot: string, branch: string): string {
   const wtDir = join(repoRoot, "worktrees", branch);
   execSync(`git worktree add -b ${branch} ${wtDir}`, { cwd: repoRoot });
   return wtDir;
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function makeSquashPrFixture(
+  branch: string,
+  prNumber: number,
+): {
+  root: string;
+  remote: string;
+  worktree: string;
+  head: string;
+  firstHead: string;
+  mergeCommit: string;
+  cleanup: () => void;
+} {
+  const root = createGitRepo();
+  const remote = mkdtempSync(join(tmpdir(), "adv-pr-remote-"));
+  const worktree = addWorktree(root, branch);
+  git(remote, "init", "--bare", "-b", "main");
+  git(root, "remote", "add", "origin", "https://github.com/owner/repo.git");
+  git(
+    root,
+    "config",
+    "url.file://" + remote + ".insteadOf",
+    "https://github.com/owner/repo.git",
+  );
+  git(root, "push", "-u", "origin", "main");
+  git(root, "remote", "set-head", "origin", "main");
+
+  writeFileSync(join(worktree, "one.txt"), "one\n");
+  git(worktree, "add", "one.txt");
+  git(worktree, "commit", "-m", "first PR commit");
+  const firstHead = git(worktree, "rev-parse", "HEAD");
+  writeFileSync(join(worktree, "two.txt"), "two\n");
+  git(worktree, "add", "two.txt");
+  git(worktree, "commit", "-m", "second PR commit");
+  const head = git(worktree, "rev-parse", "HEAD");
+
+  git(root, "cherry-pick", "--no-commit", firstHead);
+  git(root, "cherry-pick", "--no-commit", head);
+  git(root, "commit", "-m", "squash PR #" + prNumber);
+  const mergeCommit = git(root, "rev-parse", "HEAD");
+  git(root, "push", "origin", "main");
+  git(root, "push", "origin", branch);
+  git(remote, "update-ref", `refs/pull/${prNumber}/head`, head);
+
+  return {
+    root,
+    remote,
+    worktree,
+    head,
+    firstHead,
+    mergeCommit,
+    cleanup: () => {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(remote, { recursive: true, force: true });
+    },
+  };
 }
 
 function createMockDeps(
@@ -738,8 +800,9 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: "INTEGRATION_REQUIRED",
-      reason: "branch_not_merged",
+      error: "DELETION_BLOCKED",
+      status: "repair_required",
+      reason: expect.stringMatching(/gh_failed|git_remote_unavailable/),
     });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
@@ -928,8 +991,9 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: "INTEGRATION_REQUIRED",
-      reason: "branch_not_merged",
+      error: "DELETION_BLOCKED",
+      status: "repair_required",
+      reason: expect.stringMatching(/gh_failed|git_remote_unavailable/),
     });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
@@ -1000,8 +1064,9 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: "INTEGRATION_REQUIRED",
-      reason: "branch_not_merged",
+      error: "DELETION_BLOCKED",
+      status: "repair_required",
+      reason: expect.stringMatching(/gh_failed|git_remote_unavailable/),
     });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
@@ -1165,6 +1230,211 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
       execSync("git worktree list", { cwd: repoRoot }).toString(),
     ).not.toContain(branch);
   });
+
+  it("uses PR merge evidence for a non-change branch family", async () => {
+    const branch = "fix/delete-target-routing";
+    const wtPath = addWorktree(repoRoot, branch);
+    writeFileSync(join(wtPath, "fix.txt"), "squash merged fix\n");
+    execSync("git add fix.txt", { cwd: wtPath });
+    execSync("git commit -m 'squash merged fix'", { cwd: wtPath });
+    const headRefOid = execSync(`git rev-parse ${branch}`, {
+      cwd: repoRoot,
+    })
+      .toString()
+      .trim();
+    const deps = createMockDeps(repoRoot, wtPath);
+    deps.registry = [];
+    deps.integrationCheck = undefined;
+    deps.mergedBranches = async () => [];
+    deps.prMergeEvidence = async () => ({
+      ok: true,
+      proof: "pr-head-exact" as const,
+      prNumber: 407,
+      headRefOid,
+    });
+
+    const result = await advWorktreeDelete(branch, {}, deps);
+
+    expect(result).toMatchObject({ ok: true, branch, path: wtPath });
+    expect(
+      execSync("git worktree list", { cwd: repoRoot }).toString(),
+    ).not.toContain(branch);
+  });
+
+  it("plans a generic squash PR only with exact merged repository proof", async () => {
+    const branch = "fix/delete-patch-equivalence";
+    const fixture = makeSquashPrFixture(branch, 407);
+    try {
+      // Keep local main stale; reachability must use a fresh origin/main fetch.
+      git(fixture.root, "reset", "--hard", "HEAD~1");
+      const payload = {
+        number: 407,
+        state: "MERGED",
+        mergedAt: "2026-08-08T00:00:00Z",
+        headRefName: branch,
+        headRefOid: fixture.head,
+        baseRefName: "main",
+        headRepository: { nameWithOwner: "owner/repo" },
+        baseRepository: { nameWithOwner: "owner/repo" },
+        isCrossRepository: false,
+        mergeCommit: { oid: fixture.mergeCommit },
+      };
+      const ghExec = vi.fn(async () => ({
+        stdout: JSON.stringify([payload]),
+        stderr: "",
+        exitCode: 0,
+      }));
+      const deps = createMockDeps(fixture.root, fixture.worktree);
+      deps.integrationCheck = undefined;
+      deps.mergedBranches = async () => [];
+      deps.ghExec = ghExec;
+
+      const planned = await rawAdvWorktreeDelete(
+        branch,
+        { dryRun: true },
+        deps,
+      );
+      expect(planned).toMatchObject({ ok: true, status: "planned" });
+      if (planned.ok) {
+        expect(planned.plan.integration).toMatchObject({
+          kind: "pr_merged",
+          prNumber: 407,
+          prHeadOid: fixture.head,
+          mergeCommitOid: fixture.mergeCommit,
+          headRepository: "owner/repo",
+          baseRepository: "owner/repo",
+          defaultBranch: "main",
+        });
+        expect(
+          decodeWorktreeDeletionToken(planned.planToken).integration,
+        ).toEqual(planned.plan.integration);
+      }
+      expect(ghExec).toHaveBeenCalledWith(
+        expect.arrayContaining(["--repo", "owner/repo", "--base", "main"]),
+        fixture.root,
+        expect.any(Number),
+        expect.any(AbortSignal),
+      );
+
+      const refusal = async (
+        patch: Partial<typeof payload>,
+        reason: string,
+      ) => {
+        Object.assign(payload, patch);
+        const result = await rawAdvWorktreeDelete(
+          branch,
+          { dryRun: true },
+          deps,
+        );
+        expect(result).toMatchObject({
+          ok: false,
+          error: "INTEGRATION_REQUIRED",
+          reason,
+        });
+      };
+
+      await refusal(
+        {
+          headRepository: { nameWithOwner: "other/repo" },
+          baseRepository: { nameWithOwner: "other/repo" },
+        },
+        "pr_evidence_invalid",
+      );
+      await refusal(
+        {
+          headRepository: { nameWithOwner: "owner/repo" },
+          baseRepository: { nameWithOwner: "owner/repo" },
+          baseRefName: "develop",
+        },
+        "pr_evidence_invalid",
+      );
+      await refusal(
+        {
+          baseRefName: "main",
+          state: "OPEN",
+          mergedAt: null,
+        },
+        "pr_not_merged",
+      );
+      await refusal(
+        {
+          state: "MERGED",
+          mergedAt: "2026-08-08T00:00:00Z",
+          mergeCommit: { oid: "deadbeef" },
+        },
+        "pr_merge_commit_unreachable",
+      );
+
+      Object.assign(payload, {
+        state: "MERGED",
+        mergedAt: "2026-08-08T00:00:00Z",
+        headRefOid: fixture.firstHead,
+        baseRefName: "main",
+        headRepository: { nameWithOwner: "owner/repo" },
+        baseRepository: { nameWithOwner: "owner/repo" },
+        mergeCommit: { oid: fixture.mergeCommit },
+      });
+      git(
+        fixture.remote,
+        "update-ref",
+        "refs/pull/407/head",
+        fixture.firstHead,
+      );
+      await refusal({}, "local_commits_after_pr_head");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each([
+    [408, "fix/delete-cancellation-barrier"],
+    [409, "fix/flock-runtime-holder"],
+    [415, "fix/worktree-pr-proof"],
+  ] as const)(
+    "plans multi-commit squash PR #%i for %s",
+    async (prNumber, branch) => {
+      const fixture = makeSquashPrFixture(branch, prNumber);
+      try {
+        const payload = {
+          number: prNumber,
+          state: "MERGED",
+          mergedAt: "2026-08-08T00:00:00Z",
+          headRefName: branch,
+          headRefOid: fixture.head,
+          baseRefName: "main",
+          headRepository: { nameWithOwner: "owner/repo" },
+          baseRepository: { nameWithOwner: "owner/repo" },
+          isCrossRepository: false,
+          mergeCommit: { oid: fixture.mergeCommit },
+        };
+        const deps = createMockDeps(fixture.root, fixture.worktree);
+        deps.integrationCheck = undefined;
+        deps.mergedBranches = async () => [];
+        deps.ghExec = vi.fn(async () => ({
+          stdout: JSON.stringify([payload]),
+          stderr: "",
+          exitCode: 0,
+        }));
+
+        const planned = await rawAdvWorktreeDelete(
+          branch,
+          { dryRun: true },
+          deps,
+        );
+        expect(planned).toMatchObject({ ok: true, status: "planned" });
+        if (planned.ok)
+          expect(planned.plan.integration).toMatchObject({
+            kind: "pr_merged",
+            prNumber,
+            prHeadOid: fixture.head,
+            mergeCommitOid: fixture.mergeCommit,
+            defaultBranch: "main",
+          });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
 
   it("#55 non-registered clean branch is governed by Git census, not registry", async () => {
     const branch = "chore/no-force";

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -63,6 +63,7 @@ import {
 } from "./deletion-contracts";
 import {
   createWorktreeDeletionPlanner,
+  type WorktreeDeletionIntegrationFailure,
   type WorktreeDeletionPlanResult,
 } from "./deletion-planner";
 import {
@@ -89,8 +90,9 @@ import {
 } from "../../utils/workspace-warp";
 import type { Store } from "../../storage/store";
 import { withTimeout, TimeoutError } from "../../utils/with-timeout";
-import { execGh } from "../../integrations/gh-cli";
+import { execGh, type GhExecResult } from "../../integrations/gh-cli";
 import { proveLocalBranchIntegration } from "../../utils/branch-integration";
+import { parseGitRemoteUrl } from "../../utils/git-remote";
 import type { WorktreeOperationContext } from "../../utils/worktree-operation";
 import { createWorktreeOperationContext } from "../../utils/worktree-operation";
 
@@ -390,6 +392,7 @@ async function git(
   args: string[],
   cwd: string,
   timeoutMs: number = DEFAULT_WORKTREE_GIT_TIMEOUT_MS,
+  signal?: AbortSignal,
 ): Promise<Result<string, string>> {
   return new Promise((resolve) => {
     execFileGitCb(
@@ -397,6 +400,7 @@ async function git(
       {
         cwd,
         timeout: timeoutMs,
+        signal,
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -1010,6 +1014,13 @@ export interface AdvWorktreeDeleteDeps {
   operation?: WorktreeOperationContext;
   /** Optional timeout for live GitHub PR evidence lookup. */
   prEvidenceTimeoutMs?: number;
+  /** Test seam for the bounded GitHub PR evidence command. */
+  ghExec?: (
+    args: string[],
+    cwd: string,
+    timeout: number,
+    signal?: AbortSignal,
+  ) => Promise<GhExecResult>;
   /**
    * Optional per-subprocess git bound for the cleanup discovery path. Cleanup
    * callers set this strictly below the worktree tool budget so no single hung
@@ -1035,6 +1046,7 @@ export interface AdvWorktreeDeleteDeps {
   prMergeEvidence?: (
     branch: string,
     repoRoot: string,
+    operation?: WorktreeOperationContext,
   ) => Promise<PrMergedBranchIntegrationResult>;
   /** Lightweight path resolver used by the shared planner's terminal proof. */
   statePathResolver?: (changeId: string) => Promise<string | undefined>;
@@ -1210,9 +1222,14 @@ type PrMergedBranchIntegrationResult =
       prNumber: number;
       prUrl?: string;
       headRefOid: string;
+      baseRefName?: string;
+      headRepository?: string;
+      baseRepository?: string;
+      mergeCommitOid?: string;
     }
   | {
       ok: false;
+      classification?: "refusal" | "repair";
       reason: string;
       hint: string;
       details?: string[];
@@ -1222,41 +1239,113 @@ interface GhPullRequestSummary {
   number?: number;
   state?: string;
   mergedAt?: string | null;
+  headRefName?: string | null;
   headRefOid?: string | null;
+  baseRefName?: string | null;
+  headRepository?: { nameWithOwner?: string | null } | null;
+  baseRepository?: { nameWithOwner?: string | null } | null;
+  isCrossRepository?: boolean | null;
+  mergeCommit?: { oid?: string | null } | null;
   url?: string;
 }
 
 async function getPrMergedBranchIntegration(
   branch: string,
+  defaultBranch: string,
   deps: AdvWorktreeDeleteDeps,
+  operation: WorktreeOperationContext,
 ): Promise<PrMergedBranchIntegrationResult> {
-  if (!branch.startsWith("change/")) {
+  if (!isValidGitBranchRef(branch) || !isValidGitBranchRef(defaultBranch)) {
     return {
       ok: false,
-      reason: "branch_not_change_branch",
-      hint: "PR-aware squash cleanup is limited to ADV change/* branches.",
+      classification: "refusal",
+      reason: "pr_evidence_invalid",
+      hint: "PR-aware cleanup requires valid local branch and default refs.",
     };
   }
 
   if (deps.prMergeEvidence) {
-    return deps.prMergeEvidence(branch, deps.projectRoot);
+    return deps.prMergeEvidence(branch, deps.projectRoot, operation);
   }
 
+  const remaining = (): number =>
+    Math.max(1, operation.remainingMs() - operation.responseReserveMs);
+  const checkBudget = (): void => operation.throwIfAborted("pr_proof_aborted");
+  const repairForGitFailure = (
+    error: string,
+  ): PrMergedBranchIntegrationResult => ({
+    ok: false,
+    classification: "repair",
+    reason: "git_failed",
+    hint: "Git PR integration evidence could not be completed within the operation budget; retaining worktree.",
+    details: [error],
+  });
+
+  checkBudget();
   const localHead = await git(
-    ["rev-parse", branch],
+    ["rev-parse", "--verify", `${branch}^{commit}`],
     deps.projectRoot,
-    deps.gitTimeoutMs,
+    Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+    operation.signal,
   );
   if (!localHead.ok) {
     return {
       ok: false,
+      classification: "repair",
       reason: "local_branch_missing",
       hint: `Local branch ${branch} does not exist or cannot be resolved.`,
       details: [localHead.error],
     };
   }
 
-  const prList = await execGh(
+  checkBudget();
+  const remote = await git(
+    ["config", "--get", "remote.origin.url"],
+    deps.projectRoot,
+    Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+    operation.signal,
+  );
+  if (!remote.ok) {
+    return {
+      ok: false,
+      classification: "repair",
+      reason: "git_remote_unavailable",
+      hint: `The GitHub repository for ${branch} could not be resolved; retaining worktree.`,
+      details: [remote.error],
+    };
+  }
+  const parsedRemote = parseGitRemoteUrl(remote.value);
+  if (!parsedRemote) {
+    return {
+      ok: false,
+      classification: "refusal",
+      reason: "pr_evidence_invalid",
+      hint: "The origin remote is not an unambiguous GitHub repository; retaining worktree.",
+    };
+  }
+  const repository = `${parsedRemote.owner}/${parsedRemote.name}`;
+
+  checkBudget();
+  const remoteHead = await git(
+    ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+    deps.projectRoot,
+    Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+    operation.signal,
+  );
+  const detectedDefault = remoteHead.ok
+    ? remoteHead.value.trim().replace(/^origin\//, "")
+    : undefined;
+  if (detectedDefault && detectedDefault !== defaultBranch) {
+    return {
+      ok: false,
+      classification: "refusal",
+      reason: "pr_evidence_invalid",
+      hint: `PR base ${defaultBranch} does not match detected default ${detectedDefault}; retaining worktree.`,
+    };
+  }
+
+  checkBudget();
+  const prList = await (deps.ghExec ?? execGh)(
     [
       "pr",
       "list",
@@ -1264,17 +1353,23 @@ async function getPrMergedBranchIntegration(
       "all",
       "--head",
       branch,
+      "--repo",
+      repository,
+      "--base",
+      defaultBranch,
       "--limit",
       "20",
       "--json",
-      "number,state,mergedAt,headRefOid,url",
+      "number,state,mergedAt,headRefName,headRefOid,baseRefName,headRepository,baseRepository,isCrossRepository,mergeCommit,url",
     ],
     deps.projectRoot,
-    deps.prEvidenceTimeoutMs ?? DEFAULT_CHANGE_STATUS_READ_TIMEOUT_MS,
+    Math.min(deps.prEvidenceTimeoutMs ?? remaining(), remaining()),
+    operation.signal,
   );
   if (prList.exitCode !== 0) {
     return {
       ok: false,
+      classification: "repair",
       reason: "gh_failed",
       hint: `GitHub PR evidence unavailable for ${branch}; retaining worktree.`,
       details: [prList.stderr || prList.stdout || "gh pr list failed"],
@@ -1288,6 +1383,7 @@ async function getPrMergedBranchIntegration(
   } catch (error) {
     return {
       ok: false,
+      classification: "refusal",
       reason: "gh_json_invalid",
       hint: `GitHub PR evidence for ${branch} was not valid JSON; retaining worktree.`,
       details: [error instanceof Error ? error.message : String(error)],
@@ -1297,17 +1393,23 @@ async function getPrMergedBranchIntegration(
   if (prs.length === 0) {
     return {
       ok: false,
+      classification: "refusal",
       reason: "no_pr_evidence",
       hint: `No GitHub PR found for ${branch}; retaining worktree.`,
     };
   }
 
   const mergedPrs = prs.filter(
-    (pr) => Boolean(pr.mergedAt) && typeof pr.headRefOid === "string",
+    (pr) =>
+      pr.state === "MERGED" &&
+      Boolean(pr.mergedAt) &&
+      typeof pr.headRefOid === "string" &&
+      pr.headRefOid.trim().length > 0,
   );
   if (mergedPrs.length === 0) {
     return {
       ok: false,
+      classification: "refusal",
       reason: "pr_not_merged",
       hint: `GitHub PR for ${branch} is not merged; retaining worktree.`,
       details: prs.map(
@@ -1317,44 +1419,171 @@ async function getPrMergedBranchIntegration(
   }
 
   const localHeadSha = localHead.value.trim();
-  for (const pr of mergedPrs) {
-    if (pr.number && pr.headRefOid === localHeadSha) {
-      return {
-        ok: true,
-        proof: "pr-head-exact",
-        prNumber: pr.number,
-        prUrl: pr.url,
-        headRefOid: pr.headRefOid,
-      };
-    }
+  const structuralCandidates = mergedPrs.filter(
+    (pr) =>
+      pr.number &&
+      pr.headRefName === branch &&
+      pr.baseRefName === defaultBranch &&
+      pr.isCrossRepository === false &&
+      typeof pr.headRepository?.nameWithOwner === "string" &&
+      pr.headRepository.nameWithOwner.length > 0 &&
+      pr.headRepository.nameWithOwner === pr.baseRepository?.nameWithOwner &&
+      pr.headRepository.nameWithOwner === repository,
+  );
+  if (structuralCandidates.length === 0) {
+    return {
+      ok: false,
+      classification: "refusal",
+      reason: "pr_evidence_invalid",
+      hint: `Merged PR evidence for ${branch} did not match the exact repository/head/base proof; retaining worktree.`,
+    };
+  }
+  if (structuralCandidates.length > 1) {
+    return {
+      ok: false,
+      classification: "refusal",
+      reason: "pr_evidence_invalid",
+      hint: `Multiple merged PRs matched ${branch}; retaining worktree.`,
+      details: structuralCandidates.map((pr) => `PR #${pr.number}`),
+    };
   }
 
-  for (const pr of mergedPrs) {
+  for (const pr of structuralCandidates) {
     if (!pr.number || !pr.headRefOid) continue;
+    if (
+      pr.headRefName !== branch ||
+      pr.baseRefName !== defaultBranch ||
+      pr.isCrossRepository !== false ||
+      typeof pr.headRepository?.nameWithOwner !== "string" ||
+      pr.headRepository.nameWithOwner !== pr.baseRepository?.nameWithOwner
+    )
+      continue;
+
+    checkBudget();
     const fetch = await git(
       ["fetch", "origin", `refs/pull/${pr.number}/head`],
       deps.projectRoot,
-      deps.gitTimeoutMs,
+      Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+      operation.signal,
     );
-    if (!fetch.ok) continue;
+    if (!fetch.ok) {
+      if (
+        operation.signal.aborted ||
+        operation.remainingMs() <= operation.responseReserveMs ||
+        /timeout|timed out|deadline|abort/i.test(fetch.error)
+      )
+        return repairForGitFailure(fetch.error);
+      continue;
+    }
+    const fetchedHead = await git(
+      ["rev-parse", "--verify", "FETCH_HEAD^{commit}"],
+      deps.projectRoot,
+      Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+      operation.signal,
+    );
+    if (!fetchedHead.ok) {
+      if (
+        operation.signal.aborted ||
+        operation.remainingMs() <= operation.responseReserveMs ||
+        /timeout|timed out|deadline|abort/i.test(fetchedHead.error)
+      )
+        return repairForGitFailure(fetchedHead.error);
+      continue;
+    }
+    if (fetchedHead.value.trim() !== pr.headRefOid.trim()) continue;
     const ancestor = await git(
       ["merge-base", "--is-ancestor", branch, "FETCH_HEAD"],
       deps.projectRoot,
-      deps.gitTimeoutMs,
+      Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+      operation.signal,
     );
-    if (ancestor.ok) {
-      return {
-        ok: true,
-        proof: "local-ancestor-of-pr-head",
-        prNumber: pr.number,
-        prUrl: pr.url,
-        headRefOid: pr.headRefOid,
-      };
+    if (!ancestor.ok) {
+      if (
+        operation.signal.aborted ||
+        operation.remainingMs() <= operation.responseReserveMs ||
+        /timeout|timed out|deadline|abort/i.test(ancestor.error)
+      )
+        return repairForGitFailure(ancestor.error);
+      continue;
     }
+
+    const mergeCommitOid = pr.mergeCommit?.oid?.trim() || undefined;
+    if (mergeCommitOid) {
+      checkBudget();
+      const defaultFetch = await git(
+        [
+          "fetch",
+          "--no-tags",
+          "origin",
+          `refs/heads/${defaultBranch}:refs/remotes/origin/${defaultBranch}`,
+        ],
+        deps.projectRoot,
+        Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+        operation.signal,
+      );
+      if (!defaultFetch.ok) return repairForGitFailure(defaultFetch.error);
+      const fetchedDefault = await git(
+        [
+          "rev-parse",
+          "--verify",
+          `refs/remotes/origin/${defaultBranch}^{commit}`,
+        ],
+        deps.projectRoot,
+        Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+        operation.signal,
+      );
+      if (!fetchedDefault.ok) return repairForGitFailure(fetchedDefault.error);
+      const remoteDefault = await git(
+        [
+          "merge-base",
+          "--is-ancestor",
+          mergeCommitOid,
+          `refs/remotes/origin/${defaultBranch}`,
+        ],
+        deps.projectRoot,
+        Math.min(deps.gitTimeoutMs ?? remaining(), remaining()),
+        operation.signal,
+      );
+      if (!remoteDefault.ok) {
+        const detail = remoteDefault.error;
+        if (
+          operation.signal.aborted ||
+          operation.remainingMs() <= operation.responseReserveMs ||
+          /timeout|timed out|deadline|abort/i.test(detail)
+        )
+          return repairForGitFailure(detail);
+        return {
+          ok: false,
+          classification: "refusal",
+          reason: "pr_merge_commit_unreachable",
+          hint: `Merged PR #${pr.number} is not reachable from ${defaultBranch}; retaining worktree.`,
+          details: [detail],
+        };
+      }
+    }
+
+    const headRepository = pr.headRepository.nameWithOwner;
+    const baseRepository = pr.baseRepository?.nameWithOwner;
+    if (!baseRepository) continue;
+    return {
+      ok: true,
+      proof:
+        pr.headRefOid.trim() === localHeadSha
+          ? "pr-head-exact"
+          : "local-ancestor-of-pr-head",
+      prNumber: pr.number,
+      prUrl: pr.url,
+      headRefOid: pr.headRefOid.trim(),
+      baseRefName: defaultBranch,
+      headRepository,
+      baseRepository,
+      ...(mergeCommitOid ? { mergeCommitOid } : {}),
+    };
   }
 
   return {
     ok: false,
+    classification: "refusal",
     reason: "local_has_commits_after_pr_head",
     hint: `Merged PR exists for ${branch}, but local branch has commits not proven merged by the PR head; retaining worktree.`,
     details: mergedPrs.map(
@@ -1367,15 +1596,32 @@ async function verifyPrMergedChangeBranchIntegration(
   branch: string,
   deps: AdvWorktreeDeleteDeps,
 ): Promise<{ ok: true } | { ok: false; reason: string; hint: string }> {
-  const pr = await getPrMergedBranchIntegration(branch, deps);
-  if (pr.ok) {
-    appendDebugLog(
-      "worktree-delete",
-      `verified squash PR merge for ${branch} via PR #${pr.prNumber} (${pr.proof})`,
+  const ownsOperation = deps.operation === undefined;
+  const operation =
+    deps.operation ??
+    createWorktreeOperationContext({ budgetMs: deps.operationTimeoutMs });
+  try {
+    const defaultBranch = await getDefaultBranch(deps.projectRoot);
+    const pr = await getPrMergedBranchIntegration(
+      branch,
+      defaultBranch,
+      deps,
+      operation,
     );
-    return { ok: true };
+    if (pr.ok) {
+      appendDebugLog(
+        "worktree-delete",
+        `verified squash PR merge for ${branch} via PR #${pr.prNumber} (${pr.proof})`,
+      );
+      return { ok: true };
+    }
+    return { ok: false, reason: pr.reason, hint: pr.hint };
+  } finally {
+    if (ownsOperation) {
+      await operation.abort("operation_complete");
+      operation.dispose();
+    }
   }
-  return { ok: false, reason: pr.reason, hint: pr.hint };
 }
 
 function plannerResultToDeleteResult(
@@ -1496,76 +1742,117 @@ async function advWorktreeDeleteShared(
       evidence: `durable terminal status: ${loaded.status}`,
     };
   };
-  const integrationProof =
-    deps.integrationCheck || deps.prMergeEvidence || deps.mergedBranches
-      ? async (
-          branchName: string,
-          head: string,
-          defaultBranch: string,
-          repository: string,
-          operation: WorktreeOperationContext,
-        ) => {
-          if (deps.integrationCheck) {
-            const checked = await deps.integrationCheck(
-              branchName,
-              repository,
-              {},
-              {
-                registry: deps.registry,
-                mergedBranches: deps.mergedBranches,
-              },
-            );
-            if (checked.ok) {
-              return {
-                kind: "merged_to_default" as const,
-                branch: branchName,
-                defaultBranch,
-                head,
-                evidence: "legacy integration check",
-              };
-            }
-            if (checked.reason !== "branch_not_merged") return undefined;
-          }
-          if (deps.mergedBranches) {
-            const merged = await deps.mergedBranches(defaultBranch, repository);
-            if (
-              merged
-                .map((item) => item.replace(/^[*+ ]+/, "").trim())
-                .includes(branchName)
-            )
-              return {
-                kind: "merged_to_default" as const,
-                branch: branchName,
-                defaultBranch,
-                head,
-                evidence: `git branch --merged ${defaultBranch}`,
-              };
-          }
-          if (deps.prMergeEvidence) {
-            const proof = await deps.prMergeEvidence(branchName, repository);
-            if (proof.ok) {
-              appendDebugLog(
-                "worktree-delete",
-                `verified squash PR merge for ${branchName} via PR #${proof.prNumber} (${proof.proof})`,
-              );
-              return {
-                kind: "pr_merged" as const,
-                branch: branchName,
-                defaultBranch,
-                head,
-                evidence: `merged PR #${proof.prNumber}${proof.prUrl ? ` (${proof.prUrl})` : ""}`,
-              };
-            }
-          }
-          return proveLocalBranchIntegration(
-            branchName,
-            head,
-            defaultBranch,
-            repository,
-            operation,
-          );
-        }
-      : undefined;
+  const integrationProof = async (
+    branchName: string,
+    head: string,
+    defaultBranch: string,
+    repository: string,
+    operation: WorktreeOperationContext,
+  ) => {
+    // An explicitly supplied legacy integration gate remains authoritative;
+    // the normal proof order below is local ancestry/patch, then GitHub.
+    if (deps.integrationCheck) {
+      const checked = await deps.integrationCheck(
+        branchName,
+        repository,
+        {},
+        {
+          registry: deps.registry,
+          mergedBranches: deps.mergedBranches,
+        },
+      );
+      if (checked.ok) {
+        return {
+          kind: "merged_to_default" as const,
+          branch: branchName,
+          defaultBranch,
+          head,
+          evidence: "legacy integration check",
+        };
+      }
+      if (checked.reason !== "branch_not_merged") return undefined;
+    }
+
+    // Proof order is intentional: local ancestry/patch equivalence is
+    // authoritative and cheap; GitHub is only consulted for squash cases.
+    const localProof = await proveLocalBranchIntegration(
+      branchName,
+      head,
+      defaultBranch,
+      repository,
+      operation,
+    );
+    if (localProof) return localProof;
+
+    if (deps.mergedBranches) {
+      const merged = await deps.mergedBranches(defaultBranch, repository);
+      if (
+        merged
+          .map((item) => item.replace(/^[*+ ]+/, "").trim())
+          .includes(branchName)
+      )
+        return {
+          kind: "merged_to_default" as const,
+          branch: branchName,
+          defaultBranch,
+          head,
+          evidence: `git branch --merged ${defaultBranch}`,
+        };
+    }
+
+    const proof = deps.prMergeEvidence
+      ? await deps.prMergeEvidence(branchName, repository, operation)
+      : await getPrMergedBranchIntegration(
+          branchName,
+          defaultBranch,
+          { ...deps, projectRoot: repository },
+          operation,
+        );
+    if (proof.ok) {
+      appendDebugLog(
+        "worktree-delete",
+        `verified squash PR merge for ${branchName} via PR #${proof.prNumber} (${proof.proof})`,
+      );
+      return {
+        kind: "pr_merged" as const,
+        branch: branchName,
+        defaultBranch,
+        head,
+        evidence: `merged PR #${proof.prNumber}${proof.prUrl ? ` (${proof.prUrl})` : ""}`,
+        prNumber: proof.prNumber,
+        prHeadOid: proof.headRefOid,
+        ...(proof.mergeCommitOid
+          ? { mergeCommitOid: proof.mergeCommitOid }
+          : {}),
+        headRepository: proof.headRepository,
+        baseRepository: proof.baseRepository,
+      };
+    }
+    if (!proof.classification) return undefined;
+    if (proof.classification === "repair")
+      return {
+        ok: false as const,
+        classification: "repair" as const,
+        reason: "integration_proof_unavailable" as const,
+        message: `${proof.reason}: ${proof.hint}`,
+      } satisfies WorktreeDeletionIntegrationFailure;
+    const reason =
+      proof.reason === "no_pr_evidence"
+        ? "pr_not_found"
+        : proof.reason === "pr_not_merged"
+          ? "pr_not_merged"
+          : proof.reason === "local_has_commits_after_pr_head"
+            ? "local_commits_after_pr_head"
+            : proof.reason === "pr_merge_commit_unreachable"
+              ? "pr_merge_commit_unreachable"
+              : "pr_evidence_invalid";
+    return {
+      ok: false as const,
+      classification: "refusal" as const,
+      reason,
+      message: `${proof.reason}: ${proof.hint}`,
+    } satisfies WorktreeDeletionIntegrationFailure;
+  };
   const planner =
     deps.deletionPlanner ??
     createWorktreeDeletionPlanner({


### PR DESCRIPTION
## Summary
- generalize exact merged-PR proof to all valid worktree branch families
- validate merged state, exact head/base/same repository, and fetched origin/default reachability
- preserve ancestry and patch-equivalence as cheaper first proofs
- bind PR number, head, base, and merge commit into plan/executor drift checks
- fail closed on forks, stale heads, open PRs, malformed/API/timeout, and unreachable merge commits

## Verification
- focused planner/executor/public/index suites: 113 passed after rebase
- independent harden review: READY
- plugin check: passed

## Live blocker
Four exact user-approved cleanup worktrees were squash-merged through PRs #407/#408/#409/#415, but combined local commits cannot be proven by ancestry or per-commit patch equivalence.