### PR TITLE
fix: revalidate PR proof locally on apply

### DIFF
--- a/plugin/src/tools/worktree/deletion-executor.ts
+++ b/plugin/src/tools/worktree/deletion-executor.ts
@@ -21,6 +21,8 @@ import type {
   AbortableProcessResult,
 } from "../../utils/process-runner";
 import { resolveGitBinary } from "../../utils/git-binary";
+import { parseGitRemoteUrl } from "../../utils/git-remote";
+import { isValidGitBranchRef } from "../../utils/git-ref";
 import {
   acquireGitWorktreeProcessLease,
   GitWorktreeLegacyLockError,
@@ -515,6 +517,190 @@ export class WorktreeDeletionExecutor {
       }
     };
 
+    const revalidatePrMerged = async (
+      integration: WorktreeDeletionIntegrationProof,
+      actual: WorktreeDeletionFacts,
+      stage: string,
+    ): Promise<WorktreeDeletionExecutorResult | null> => {
+      const {
+        prNumber,
+        prHeadOid,
+        mergeCommitOid,
+        headRepository,
+        baseRepository,
+        defaultBranch,
+        branch,
+        head,
+      } = integration;
+      if (
+        typeof prNumber !== "number" ||
+        !Number.isInteger(prNumber) ||
+        prNumber <= 0 ||
+        typeof prHeadOid !== "string" ||
+        prHeadOid.trim().length === 0 ||
+        typeof mergeCommitOid !== "string" ||
+        mergeCommitOid.trim().length === 0 ||
+        typeof headRepository !== "string" ||
+        headRepository.trim().length === 0 ||
+        typeof baseRepository !== "string" ||
+        baseRepository.trim().length === 0 ||
+        typeof defaultBranch !== "string" ||
+        !isValidGitBranchRef(defaultBranch) ||
+        typeof branch !== "string" ||
+        !isValidGitBranchRef(branch) ||
+        typeof head !== "string" ||
+        head.trim().length === 0
+      )
+        return failure(
+          "repair_required",
+          "pr_revalidation_missing_bound_fact",
+          stage,
+        );
+
+      const runGit = async (
+        args: string[],
+      ): Promise<
+        | { ok: true; stdout: string }
+        | { ok: false; timedOut: boolean; detail: string }
+      > => {
+        const remaining = operation.remainingMs() - operation.responseReserveMs;
+        if (remaining <= 0 || operation.signal.aborted) {
+          await operation.abort("deadline");
+          throw new WorktreeDeletionStageDeadline(stage);
+        }
+        const result = await runBounded(stage, () =>
+          runProcess({
+            command: resolveGitBinary(),
+            args,
+            cwd: plan.repository,
+            signal: operation.signal,
+            timeoutMs: Math.max(1, remaining),
+            operation,
+          }),
+        );
+        if (
+          isTimeout(result) ||
+          operation.remainingMs() <= operation.responseReserveMs
+        ) {
+          await operation.abort("deadline");
+          throw new WorktreeDeletionStageDeadline(stage);
+        }
+        if (!result.closed || result.exitCode !== 0)
+          return {
+            ok: false,
+            timedOut: false,
+            detail:
+              result.stderr.trim() ||
+              result.stdout.trim() ||
+              `git ${args[0]} failed`,
+          };
+        return { ok: true, stdout: result.stdout.trim() };
+      };
+
+      const gitFailure = (_result: {
+        ok: false;
+        timedOut: boolean;
+        detail: string;
+      }): WorktreeDeletionExecutorResult =>
+        failure("repair_required", "pr_revalidation_git_failed", stage);
+
+      const localHead = await runGit([
+        "rev-parse",
+        "--verify",
+        `refs/heads/${branch}^{commit}`,
+      ]);
+      if (!localHead.ok) return gitFailure(localHead);
+      if (localHead.stdout !== actual.head || localHead.stdout !== head)
+        return failure("drifted", "pr_revalidation_local_head_drifted", stage);
+
+      const localBelongsToPrHead = await runGit([
+        "merge-base",
+        "--is-ancestor",
+        localHead.stdout,
+        prHeadOid,
+      ]);
+      if (!localBelongsToPrHead.ok)
+        return failure(
+          "drifted",
+          "pr_revalidation_local_head_not_in_pr",
+          stage,
+        );
+
+      const origin = await runGit(["config", "--get", "remote.origin.url"]);
+      if (!origin.ok) return gitFailure(origin);
+      const currentRepository = parseGitRemoteUrl(origin.stdout);
+      const currentRepositoryName = currentRepository
+        ? `${currentRepository.owner}/${currentRepository.name}`
+        : undefined;
+      if (
+        !currentRepositoryName ||
+        currentRepositoryName !== headRepository ||
+        currentRepositoryName !== baseRepository
+      )
+        return failure("drifted", "pr_revalidation_repository_drifted", stage);
+
+      const currentDefault = await runGit([
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        "refs/remotes/origin/HEAD",
+      ]);
+      if (!currentDefault.ok) return gitFailure(currentDefault);
+      if (currentDefault.stdout.replace(/^origin\//, "") !== defaultBranch)
+        return failure(
+          "drifted",
+          "pr_revalidation_default_branch_drifted",
+          stage,
+        );
+
+      const fetchedPrHead = await runGit([
+        "fetch",
+        "--no-tags",
+        "origin",
+        `refs/pull/${prNumber}/head`,
+      ]);
+      if (!fetchedPrHead.ok) return gitFailure(fetchedPrHead);
+      const fetchedPrHeadOid = await runGit([
+        "rev-parse",
+        "--verify",
+        "FETCH_HEAD^{commit}",
+      ]);
+      if (!fetchedPrHeadOid.ok) return gitFailure(fetchedPrHeadOid);
+      if (fetchedPrHeadOid.stdout !== prHeadOid)
+        return failure("drifted", "pr_revalidation_pr_head_drifted", stage);
+
+      const fetchedDefault = await runGit([
+        "fetch",
+        "--no-tags",
+        "origin",
+        `refs/heads/${defaultBranch}:refs/remotes/origin/${defaultBranch}`,
+      ]);
+      if (!fetchedDefault.ok) return gitFailure(fetchedDefault);
+      const fetchedDefaultOid = await runGit([
+        "rev-parse",
+        "--verify",
+        `refs/remotes/origin/${defaultBranch}^{commit}`,
+      ]);
+      if (!fetchedDefaultOid.ok) return gitFailure(fetchedDefaultOid);
+      const mergeIsReachable = await runGit([
+        "merge-base",
+        "--is-ancestor",
+        mergeCommitOid,
+        `refs/remotes/origin/${defaultBranch}`,
+      ]);
+      if (!mergeIsReachable.ok)
+        return failure(
+          "drifted",
+          "pr_revalidation_merge_commit_unreachable",
+          stage,
+        );
+
+      const expired = expiryDecision(stage);
+      if (expired) return expired;
+
+      return null;
+    };
+
     const evaluate = async (
       current: GitWorkspaceFacts,
       stage: string,
@@ -550,7 +736,10 @@ export class WorktreeDeletionExecutor {
         branchFact.headSha !== integration.head
       )
         return failure("drifted", "integration_fact_changed", stage);
-      if (this.deps.integrationProof) {
+      if (integration.kind === "pr_merged") {
+        const prDecision = await revalidatePrMerged(integration, actual, stage);
+        if (prDecision) return prDecision;
+      } else if (this.deps.integrationProof) {
         const currentProof = await runBounded(stage, () =>
           this.deps.integrationProof!(
             plan.facts.branch ?? "",
@@ -600,6 +789,8 @@ export class WorktreeDeletionExecutor {
         if (stableStringify(plan.terminal) !== stableStringify(terminal))
           return failure("drifted", "terminal_proof_changed", stage);
       }
+      const expired = expiryDecision(stage);
+      if (expired) return expired;
       return null;
     };
 

--- a/plugin/src/tools/worktree/index-delete.test.ts
+++ b/plugin/src/tools/worktree/index-delete.test.ts
@@ -1133,17 +1133,14 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const result = await advWorktreeDelete(branch, {}, deps);
 
     expect(result).toMatchObject({
-      ok: true,
-      branch,
-      path: wtPath,
+      ok: false,
+      error: "DELETION_BLOCKED",
+      status: "repair_required",
+      reason: "pr_revalidation_missing_bound_fact",
     });
-    expect(appendDebugLog).toHaveBeenCalledWith(
-      "worktree-delete",
-      expect.stringContaining("verified squash PR merge"),
-    );
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
-    ).not.toContain(branch);
+    ).toContain(branch);
   });
 
   it("deletes missing-registry change branch when local head is ancestor of merged PR head", async () => {
@@ -1167,13 +1164,14 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
     const result = await advWorktreeDelete(branch, {}, deps);
 
     expect(result).toMatchObject({
-      ok: true,
-      branch,
-      path: wtPath,
+      ok: false,
+      error: "DELETION_BLOCKED",
+      status: "repair_required",
+      reason: "pr_revalidation_missing_bound_fact",
     });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
-    ).not.toContain(branch);
+    ).toContain(branch);
   });
 
   it("retains missing-registry change branch when local commits are not proven in merged PR head", async () => {
@@ -1289,10 +1287,15 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
 
     const result = await advWorktreeDelete(branch, {}, deps);
 
-    expect(result).toMatchObject({ ok: true, branch, path: wtPath });
+    expect(result).toMatchObject({
+      ok: false,
+      error: "DELETION_BLOCKED",
+      status: "repair_required",
+      reason: "pr_revalidation_missing_bound_fact",
+    });
     expect(
       execSync("git worktree list", { cwd: repoRoot }).toString(),
-    ).not.toContain(branch);
+    ).toContain(branch);
   });
 
   it("plans a generic squash PR only with exact merged repository proof", async () => {
@@ -1451,6 +1454,56 @@ describe.skipIf(!isLinux)("ADV-safe worktree delete (T9)", () => {
         fixture.firstHead,
       );
       await refusal({}, "local_commits_after_pr_head");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("applies a bound squash PR plan with local Git only", async () => {
+    const branch = "fix/delete-target-routing";
+    const fixture = makeSquashPrFixture(branch, 407);
+    try {
+      const payload = {
+        ...LIVE_PR_407_SHAPE,
+        headRefName: branch,
+        headRefOid: fixture.head,
+        baseRefName: "main",
+        headRepository: { nameWithOwner: "owner/repo" },
+        headRepositoryOwner: { login: "owner" },
+        mergeCommit: { oid: fixture.mergeCommit },
+      };
+      const ghExec = createPrGhExec(payload);
+      const deps = createMockDeps(fixture.root, fixture.worktree);
+      deps.integrationCheck = undefined;
+      deps.mergedBranches = async () => [];
+      deps.ghExec = ghExec;
+
+      const planned = await rawAdvWorktreeDelete(
+        branch,
+        { dryRun: true },
+        deps,
+      );
+      expect(planned).toMatchObject({ ok: true, status: "planned" });
+      if (!planned.ok || !planned.planToken) throw new Error("plan missing");
+
+      const ghCallsDuringPlan = ghExec.mock.calls.length;
+      deps.ghExec = vi.fn(async () => {
+        throw new Error("gh must not be called during apply");
+      });
+      const applied = await rawAdvWorktreeDelete(
+        branch,
+        {
+          planToken: planned.planToken,
+          approvalEvidence: "approved exact PR deletion plan",
+        },
+        deps,
+      );
+
+      expect(applied).toMatchObject({ ok: true, status: "deleted", branch });
+      expect(ghExec).toHaveBeenCalledTimes(ghCallsDuringPlan);
+      expect(
+        execSync("git worktree list", { cwd: fixture.root }).toString(),
+      ).not.toContain(branch);
     } finally {
       fixture.cleanup();
     }

--- a/plugin/src/tools/worktree/index.ts
+++ b/plugin/src/tools/worktree/index.ts
@@ -1486,7 +1486,9 @@ async function getPrMergedBranchIntegration(
       pr.headRepository.nameWithOwner.length > 0 &&
       pr.headRepository.nameWithOwner === currentRepository &&
       typeof pr.headRepositoryOwner?.login === "string" &&
-      pr.headRepositoryOwner.login === currentRepositoryOwner,
+      pr.headRepositoryOwner.login === currentRepositoryOwner &&
+      typeof pr.mergeCommit?.oid === "string" &&
+      pr.mergeCommit.oid.trim().length > 0,
   );
   if (structuralCandidates.length === 0) {
     return {
@@ -1567,7 +1569,7 @@ async function getPrMergedBranchIntegration(
       continue;
     }
 
-    const mergeCommitOid = pr.mergeCommit?.oid?.trim() || undefined;
+    const mergeCommitOid = pr.mergeCommit?.oid?.trim();
     if (mergeCommitOid) {
       checkBudget();
       const defaultFetch = await git(


### PR DESCRIPTION
## Summary
- keep exact GitHub proof in dry-run plan only
- revalidate token-bound PR head through fetched pull ref during apply
- revalidate merge commit against freshly fetched origin/default
- verify repository/default/branch identities without a second GitHub query
- preserve shared deadline budget for actual deletion and quiescence

## Verification
- focused planner/executor/public/index suites: 107 passed after rebase
- plugin check: passed
- independent harden review: READY

## Live blocker
Dry-run PR proof succeeds, but apply repeats GitHub queries and exceeds the 8-second end-to-end deadline before deletion.