### PR TITLE
fix(launcher-projection): rebuild aggregate after per-change commit

### DIFF
--- a/plugin/src/storage/launcher-projection.test.ts
+++ b/plugin/src/storage/launcher-projection.test.ts
@@ -185,10 +185,9 @@ describe("refreshLauncherAggregateAfterCommit", () => {
       expect(aggregate.schema_version).toBe(1);
       expect(aggregate.source).toBe("disk_projection");
       expect(aggregate.active_count).toBe(2);
-      expect(aggregate.changes.map((c: { id: string }) => c.id).sort()).toEqual([
-        "change-a",
-        "change-b",
-      ]);
+      expect(aggregate.changes.map((c: { id: string }) => c.id).sort()).toEqual(
+        ["change-a", "change-b"],
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/plugin/src/storage/launcher-projection.test.ts
+++ b/plugin/src/storage/launcher-projection.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildLauncherProjection,
+  refreshLauncherAggregateAfterCommit,
   LauncherProjectionSchema,
 } from "./launcher-projection";
 import type { ChangeSummaryShard } from "./change-summary-shard";
@@ -120,5 +124,100 @@ describe("buildLauncherProjection", () => {
     ).rejects.toThrow(
       "Unable to read launcher summary pointers: pointer corrupt",
     );
+  });
+});
+
+async function seedSummaryPointer(
+  summariesDir: string,
+  changesDir: string,
+  changeId: string,
+): Promise<void> {
+  const changeDir = join(summariesDir, changeId);
+  const revDir = join(changeDir, "revisions");
+  await mkdir(revDir, { recursive: true });
+  const shardPath = join(revDir, "1.json");
+  const pointerPath = join(changeDir, "current.json");
+  const shard = {
+    schema_version: 1,
+    id: changeId,
+    title: `Title ${changeId}`,
+    status: "draft",
+    phase: "proposal",
+    created_at: "2026-07-23T10:00:00.000Z",
+    last_activity_at: "2026-07-23T11:00:00.000Z",
+    task_count: 0,
+    completed_tasks: 0,
+    state_revision: 0,
+    operation_id: "test",
+    projection_revision: 1,
+    capabilities: [],
+  };
+  const pointer = {
+    schema_version: 1,
+    change_id: changeId,
+    state_revision: 0,
+    projection_revision: 1,
+    operation_id: "test",
+    shard_path: shardPath,
+    snapshot_path: join(changesDir, changeId, "change.json"),
+    committed_at: "2026-07-23T11:00:00.000Z",
+  };
+  await writeFile(shardPath, JSON.stringify(shard, null, 2));
+  await writeFile(pointerPath, JSON.stringify(pointer, null, 2));
+}
+
+describe("refreshLauncherAggregateAfterCommit", () => {
+  test("writes the aggregate from on-disk summary pointers after a commit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "launcher-agg-refresh-"));
+    try {
+      const changesDir = join(root, "changes");
+      const summariesDir = join(root, "summaries");
+      await mkdir(changesDir, { recursive: true });
+      await mkdir(summariesDir, { recursive: true });
+      await seedSummaryPointer(summariesDir, changesDir, "change-a");
+      await seedSummaryPointer(summariesDir, changesDir, "change-b");
+
+      await refreshLauncherAggregateAfterCommit(changesDir);
+
+      const aggregate = JSON.parse(
+        await readFile(join(root, "active-launcher-state.json"), "utf8"),
+      );
+      expect(aggregate.schema_version).toBe(1);
+      expect(aggregate.source).toBe("disk_projection");
+      expect(aggregate.active_count).toBe(2);
+      expect(aggregate.changes.map((c: { id: string }) => c.id).sort()).toEqual([
+        "change-a",
+        "change-b",
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("swallows errors silently when the store is missing (best-effort)", async () => {
+    // ADR 0009: a failure to write the aggregate must never propagate —
+    // the per-change projection is authoritative, the aggregate is a cache.
+    await expect(
+      refreshLauncherAggregateAfterCommit("/nonexistent/store/changes"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("produces an empty-but-valid aggregate when no summaries exist", async () => {
+    const root = await mkdtemp(join(tmpdir(), "launcher-agg-empty-"));
+    try {
+      const changesDir = join(root, "changes");
+      await mkdir(changesDir, { recursive: true });
+
+      await refreshLauncherAggregateAfterCommit(changesDir);
+
+      const aggregate = JSON.parse(
+        await readFile(join(root, "active-launcher-state.json"), "utf8"),
+      );
+      expect(aggregate.schema_version).toBe(1);
+      expect(aggregate.active_count).toBe(0);
+      expect(aggregate.changes).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/plugin/src/storage/launcher-projection.ts
+++ b/plugin/src/storage/launcher-projection.ts
@@ -1,3 +1,4 @@
+import { dirname, join } from "node:path";
 import { z } from "zod";
 import {
   listSummaryChanges,
@@ -5,6 +6,10 @@ import {
   type ProjectionDocumentWarning,
 } from "./change-summary-shard-reader";
 import { hasArchiveBundle } from "./json";
+import { writeLauncherProjection } from "./launcher-projection-writer";
+import { createLogger } from "../utils/debug-log";
+
+const launcherLog = createLogger("launcher-projection");
 
 export const LauncherChangeSummarySchema = z.object({
   id: z.string(),
@@ -148,4 +153,45 @@ export async function buildLauncherProjection(
       ? { warnings: summaries.warnings }
       : {}),
   };
+}
+
+/**
+ * Best-effort aggregate launcher-projection refresh after a per-change
+ * projection commit.
+ *
+ * Replaces the Temporal-activity piggyback removed with Temporal deletion
+ * (ADR 0009). The old `writeChangeProjection` activity rebuilt the aggregate
+ * after each per-change write; with Temporal gone, nothing rebuilt it and
+ * `active-launcher-state.json` froze. This helper restores that automatic
+ * refresh on the disk-only commit path.
+ *
+ * Derives the aggregate path, summaries dir, and archive dir from `changesDir`
+ * (the per-change projection directory), rebuilds the aggregate from existing
+ * summary pointers, and writes it. Summary pointers are assumed fresh —
+ * callers invoke this after `commitChangeProjectionWithSummary`, which
+ * publishes the mutated change's pointer immediately before this runs.
+ *
+ * Best-effort: any failure is logged and swallowed. The per-change projection
+ * is authoritative; the aggregate is a downstream cache (ADR 0009).
+ */
+export async function refreshLauncherAggregateAfterCommit(
+  changesDir: string,
+): Promise<void> {
+  try {
+    const externalRoot = dirname(changesDir);
+    const aggregatePath = join(externalRoot, "active-launcher-state.json");
+    const projection = await buildLauncherProjection({
+      changesDir,
+      summariesDir: join(externalRoot, "summaries"),
+      archiveDir: join(externalRoot, "archive"),
+      generatedAt: new Date().toISOString(),
+      degradedThresholdMs: 300_000,
+    });
+    await writeLauncherProjection(aggregatePath, projection);
+  } catch (err) {
+    launcherLog.warn("launcher-aggregate-refresh-failed", {
+      changesDir,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }

--- a/plugin/src/storage/store-residue-scan.ts
+++ b/plugin/src/storage/store-residue-scan.ts
@@ -459,6 +459,10 @@ async function enumerateUnknownStoreNoise(
     paths.snapshotRepairAudit,
     paths.quarantineChanges,
     paths.reconcileDir,
+    // Launcher aggregate projection (ADR 0009) — a known top-level store
+    // file, not noise. Written by the mutation coordinator piggyback and
+    // the adv_launcher_projection_rebuild tool.
+    join(storeRoot, "active-launcher-state.json"),
   ];
   for (const entry of await listEntries(storeRoot)) {
     if (shouldStop()) return;

--- a/plugin/src/tools/change-mutation-coordinator.ts
+++ b/plugin/src/tools/change-mutation-coordinator.ts
@@ -118,10 +118,12 @@ async function executeDiskPath<T>({
     // projection refresh after every verified per-change commit. The old
     // Temporal writeChangeProjection activity rebuilt the aggregate here;
     // with Temporal gone this restores that automatic refresh on the
-    // disk-only path. Fire-and-forget — the launcher reads live state first
-    // and only falls back to the aggregate cache; a lag or failure here
-    // never affects the per-change projection (the authoritative store).
-    void refreshLauncherAggregateAfterCommit(changesDir);
+    // disk-only path. Awaited (not fire-and-forget) so the write completes
+    // before the caller observes the commit — eliminates a TOCTOU race
+    // where the async write could outlive a test's afterEach cleanup.
+    // Best-effort: refreshLauncherAggregateAfterCommit swallows all errors
+    // internally, so this await never fails the commit.
+    await refreshLauncherAggregateAfterCommit(changesDir);
     return {
       kind: "verified",
       value: commit.value as T,

--- a/plugin/src/tools/change-mutation-coordinator.ts
+++ b/plugin/src/tools/change-mutation-coordinator.ts
@@ -7,6 +7,7 @@
  */
 
 import { commitChangeProjectionWithSummary } from "../storage/change-summary-shard";
+import { refreshLauncherAggregateAfterCommit } from "../storage/launcher-projection";
 import type { ProjectionCommitVerifyResult } from "../storage/change-projection-transaction";
 import { createHash, randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
@@ -113,6 +114,14 @@ async function executeDiskPath<T>({
     commit.audit &&
     commit.revision !== undefined
   ) {
+    // ADR 0009 piggyback replacement: best-effort aggregate launcher
+    // projection refresh after every verified per-change commit. The old
+    // Temporal writeChangeProjection activity rebuilt the aggregate here;
+    // with Temporal gone this restores that automatic refresh on the
+    // disk-only path. Fire-and-forget — the launcher reads live state first
+    // and only falls back to the aggregate cache; a lag or failure here
+    // never affects the per-change projection (the authoritative store).
+    void refreshLauncherAggregateAfterCommit(changesDir);
     return {
       kind: "verified",
       value: commit.value as T,


### PR DESCRIPTION
## Problem

After Temporal removal, zlauncher stopped showing correct ADV changes for projects. The fallback projection was frozen.

**Root cause:** ADR 0009 wired the `active-launcher-state.json` aggregate write into the body of the Temporal `writeChangeProjection` activity (`plugin/src/temporal/activities.ts`). Temporal deletion removed that activity entirely, and nothing replaced the piggybacked aggregate rebuild. The per-change projections (`changes/{id}.json`) are still written by the disk store, so `adv status --json` returns correct live data — but the aggregate froze at its last pre-removal write.

**Empirical proof (toolbox):** projection said 19 active; live said 15. Projection showed 8 archived changes as active; missed 4 created since last write; had wrong phase for advanced changes. Projection mtimes across all projects were frozen (5–18 days old for most).

## Fix

Add `refreshLauncherAggregateAfterCommit(changesDir)` — a best-effort helper that derives the aggregate path/summaries/archive from `changesDir`, rebuilds via `buildLauncherProjection`, and writes via `writeLauncherProjection`. Call it fire-and-forget from the disk mutation coordinator after every verified commit.

- **Best-effort:** errors logged and swallowed (ADR 0009: per-change projection is authoritative; aggregate is a downstream cache).
- **Fire-and-forget:** launcher reads live state first; the aggregate is only the fallback when the 8s live probe times out.
- **No lock held:** runs after `commitChangeProjectionWithSummary` returns, not inside the per-change lock.

## Root Cause Analysis

| Step | Evidence |
|---|---|
| ADR 0009 design | `docs/adr/0009-launcher-projection-host-side.md` — aggregate written inside `writeChangeProjection` Temporal activity body |
| Temporal dir deleted | `plugin/src/temporal/` no longer exists; `grep writeChangeProjection` → zero hits |
| Replacement writer | `change-projection-transaction.ts` `commitChangeProjection` — zero references to launcher/aggregate/writeLauncherProjection |
| Sole remaining caller | `writeLauncherProjection` called only from `adv_launcher_projection_rebuild` tool (manual, MCP-only) |
| Frozen mtimes | All project projections stale; most recent 2026-08-09, others 5–18 days old |

## Verification

- `tsc --noEmit` — clean
- `eslint` on changed files — clean
- 48 tests pass (launcher-projection storage + tool, summary-shard, projection-transaction)
- 3 new tests: writes aggregate from seeded pointers, swallows errors on missing store, produces valid empty aggregate