### PR TITLE
fix: finalize phase 9 after merge and preserve archive timestamps

### DIFF
--- a/plugin/src/archive/archive.test.ts
+++ b/plugin/src/archive/archive.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, test } from "vitest";
 import type { Change } from "../types";
+import { ChangeSchema } from "../types";
+import { atomicWriteFile } from "../utils/fs";
 import {
   archiveChange,
   bundleJsonStringify,
@@ -16,6 +18,8 @@ import {
 } from "./archive";
 import {
   TERMINAL_SUMMARY_FILE,
+  buildTerminalArchiveSummary,
+  serializeTerminalArchiveSummary,
   validateTerminalArchiveSummary,
   verifyTerminalArchiveSummaryHash,
 } from "./terminal-summary";
@@ -319,18 +323,103 @@ describe("contract archive traceability", () => {
     const externalBundle = join(archiveDir, `${today}-${change.id}`);
 
     await mkdir(externalBundle, { recursive: true });
-    await writeFile(
-      join(externalBundle, "change.json"),
-      JSON.stringify({ ...change, status: "archived" }, null, 2),
+    const changeJsonRaw = bundleJsonStringify({
+      ...change,
+      status: "archived",
+    });
+    await atomicWriteFile(join(externalBundle, "change.json"), changeJsonRaw);
+    const changeHash = createHash("sha256")
+      .update(changeJsonRaw, "utf-8")
+      .digest("hex");
+    await atomicWriteFile(
+      join(externalBundle, TERMINAL_SUMMARY_FILE),
+      serializeTerminalArchiveSummary(
+        buildTerminalArchiveSummary({
+          change: ChangeSchema.parse({ ...change, status: "archived" }),
+          archivedAt: createdAt,
+          changeHash,
+        }),
+      ),
     );
 
-    await reconcileInRepoArchive(change, inRepoArchiveDir);
+    await reconcileInRepoArchive(change, archiveDir, inRepoArchiveDir);
 
     const inRepoChange = await readFile(
       join(inRepoArchiveDir, `${today}-${change.id}`, "change.json"),
       "utf8",
     );
     expect(JSON.parse(inRepoChange).status).toBe("archived");
+  });
+
+  // rq-fixReconcileArchivedAt (Defect A): reconcileInRepoArchive must
+  // resolve the authoritative archived_at from the existing source bundle's
+  // terminal summary and never silently stamp "now".
+  describe("reconcileInRepoArchive preserves authoritative archived_at", () => {
+    test("uses the external bundle's terminal-summary archived_at, not now()", async () => {
+      const root = await tempProject();
+      const change = changeWithContract({ id: "preserve-archived-at" });
+      const archiveDir = join(root, "external-archive");
+      const inRepoArchiveDir = join(root, "repo", ".adv", "archive");
+      const today = new Date().toISOString().split("T")[0];
+      const externalBundle = join(archiveDir, `${today}-${change.id}`);
+      const originalArchivedAt = "2026-04-01T12:34:56.000Z";
+
+      await mkdir(externalBundle, { recursive: true });
+      const changeJsonRaw = bundleJsonStringify({
+        ...change,
+        status: "archived",
+      });
+      await atomicWriteFile(join(externalBundle, "change.json"), changeJsonRaw);
+      const changeHash = createHash("sha256")
+        .update(changeJsonRaw, "utf-8")
+        .digest("hex");
+      await atomicWriteFile(
+        join(externalBundle, TERMINAL_SUMMARY_FILE),
+        serializeTerminalArchiveSummary(
+          buildTerminalArchiveSummary({
+            change: ChangeSchema.parse({ ...change, status: "archived" }),
+            archivedAt: originalArchivedAt,
+            changeHash,
+          }),
+        ),
+      );
+
+      // Wait so any silent "now()" fallback would be observably later than
+      // the original archived_at.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const beforeReconcile = new Date().toISOString();
+
+      await reconcileInRepoArchive(change, archiveDir, inRepoArchiveDir);
+
+      const inRepoSummaryRaw = await readFile(
+        join(inRepoArchiveDir, `${today}-${change.id}`, TERMINAL_SUMMARY_FILE),
+        "utf-8",
+      );
+      const inRepoSummary = validateTerminalArchiveSummary(
+        JSON.parse(inRepoSummaryRaw),
+      );
+      expect(inRepoSummary.archived_at).toBe(originalArchivedAt);
+      expect(inRepoSummary.archived_at < beforeReconcile).toBe(true);
+    });
+
+    test("fails loudly when the external bundle has no readable terminal summary", async () => {
+      const root = await tempProject();
+      const change = changeWithContract({ id: "missing-summary" });
+      const archiveDir = join(root, "external-archive");
+      const inRepoArchiveDir = join(root, "repo", ".adv", "archive");
+      const today = new Date().toISOString().split("T")[0];
+      const externalBundle = join(archiveDir, `${today}-${change.id}`);
+
+      await mkdir(externalBundle, { recursive: true });
+      await writeFile(
+        join(externalBundle, "change.json"),
+        JSON.stringify({ ...change, status: "archived" }, null, 2),
+      );
+
+      await expect(
+        reconcileInRepoArchive(change, archiveDir, inRepoArchiveDir),
+      ).rejects.toThrow(/terminal summary/i);
+    });
   });
 
   test("single-repo archive bundle remains unchanged without scope_repos", async () => {
@@ -493,6 +582,8 @@ describe("contract archive traceability", () => {
         changeWithContract({ id: "state-backed-archive", status: "active" }),
         archiveDir,
         sourceChangeDir,
+        undefined,
+        createdAt,
       );
 
       expect(existsSync(join(archivePath, "executive-summary.md"))).toBe(true);
@@ -512,6 +603,9 @@ describe("contract archive traceability", () => {
       const archivePath = await createInRepoArchive(
         changeWithContract({ id: "no-source-dir", status: "active" }),
         archiveDir,
+        undefined,
+        undefined,
+        createdAt,
       );
 
       expect(existsSync(join(archivePath, "change.json"))).toBe(true);
@@ -531,7 +625,13 @@ describe("contract archive traceability", () => {
         documents: { agreement: "# Agreement\n\nFrom the projection." },
       });
 
-      const archivePath = await createInRepoArchive(change, archiveDir);
+      const archivePath = await createInRepoArchive(
+        change,
+        archiveDir,
+        undefined,
+        undefined,
+        createdAt,
+      );
 
       expect(existsSync(join(archivePath, "agreement.md"))).toBe(true);
       await expect(
@@ -559,6 +659,8 @@ describe("contract archive traceability", () => {
         change,
         archiveDir,
         sourceChangeDir,
+        undefined,
+        createdAt,
       );
 
       const bundled = await readFile(
@@ -957,7 +1059,13 @@ describe("contract archive traceability", () => {
           },
         ],
       });
-      const archivePath = await createInRepoArchive(change, archiveDir);
+      const archivePath = await createInRepoArchive(
+        change,
+        archiveDir,
+        undefined,
+        undefined,
+        createdAt,
+      );
       await expectSingleTrailingNewline(join(archivePath, "change.json"));
       await expectSingleTrailingNewline(join(archivePath, "wisdom.json"));
     });
@@ -1013,7 +1121,13 @@ describe("contract archive traceability", () => {
         contract: undefined,
       });
 
-      const archivePath = await createInRepoArchive(change, archiveDir);
+      const archivePath = await createInRepoArchive(
+        change,
+        archiveDir,
+        undefined,
+        undefined,
+        createdAt,
+      );
       const summaryPath = join(archivePath, TERMINAL_SUMMARY_FILE);
       expect(existsSync(summaryPath)).toBe(true);
       const raw = await readFile(summaryPath, "utf-8");
@@ -1075,6 +1189,9 @@ describe("contract archive traceability", () => {
       const archivePath = await createInRepoArchive(
         change,
         join(root, "archive"),
+        undefined,
+        undefined,
+        createdAt,
       );
       const changeJson = await readFile(
         join(archivePath, "change.json"),
@@ -1104,6 +1221,9 @@ describe("contract archive traceability", () => {
       const archivePath = await createInRepoArchive(
         change,
         join(root, "archive"),
+        undefined,
+        undefined,
+        createdAt,
       );
       const changeJson = await readFile(
         join(archivePath, "change.json"),
@@ -1176,6 +1296,8 @@ describe("contract archive traceability", () => {
         }),
         archiveDir,
         sourceChangeDir,
+        undefined,
+        createdAt,
       );
 
       const changeJson = JSON.parse(

--- a/plugin/src/archive/archive.ts
+++ b/plugin/src/archive/archive.ts
@@ -1332,13 +1332,19 @@ function generateArchiveSummary(change: Change, archivedAt: string): string {
  * Create an identical archive bundle inside the repository.
  * Writes the same files as createArchive() but to an in-repo path.
  * Failure is warning-only — the caller logs it but does not fail the archive.
+ *
+ * `archivedAt` is required: callers MUST resolve the authoritative timestamp
+ * (from a sibling/source bundle's terminal summary, or from a real archive
+ * dispatch). A silent `new Date()` fallback would silently re-stamp the
+ * bundle's archive date on every reconcile, breaking cross-bundle identity
+ * invariants (rq-fixReconcileArchivedAt).
  */
 export async function createInRepoArchive(
   change: Change,
   inRepoArchiveDir: string,
-  sourceChangeDir?: string,
-  multiRepo?: MultiRepoArchiveMetadata,
-  archivedAt: string = new Date().toISOString(),
+  sourceChangeDir: string | undefined,
+  multiRepo: MultiRepoArchiveMetadata | undefined,
+  archivedAt: string,
   projectionManifest?: SpecProjectionManifest,
 ): Promise<string> {
   const archivePath = await archiveBundlePathForWrite(
@@ -1389,11 +1395,19 @@ export async function createInRepoArchive(
 }
 
 /**
- * Reconcile in-repo archive after a previous attempt already wrote external
+ * Reconcile in-repo archive after a previous attempt already wrote an external
  * archive bundle but skipped/failed before in-repo bundle creation.
+ *
+ * The in-repo bundle's archived_at MUST match the source bundle's terminal
+ * summary — never the current wall-clock — so cross-bundle identity and
+ * downstream tooling can rely on the original archive timestamp. If the
+ * source bundle's terminal summary is missing or unreadable, this throws
+ * (rq-fixReconcileArchivedAt): silently inventing a new timestamp would
+ * make the in-repo bundle appear to be a freshly archived change.
  */
 export async function reconcileInRepoArchive(
   change: Change,
+  externalArchiveDir: string,
   inRepoArchiveDir: string,
   sourceChangeDir?: string,
   multiRepo?: MultiRepoArchiveMetadata,
@@ -1403,11 +1417,35 @@ export async function reconcileInRepoArchive(
     return existing;
   }
 
+  const sourceBundle = await findArchiveBundle(externalArchiveDir, change.id);
+  if (!sourceBundle) {
+    throw new Error(
+      `Cannot reconcile in-repo archive for ${change.id}: source archive bundle not found under ${externalArchiveDir}.`,
+    );
+  }
+  const summaryRead = await readBoundedProjectionDocument(
+    join(sourceBundle, TERMINAL_SUMMARY_FILE),
+  );
+  if (summaryRead.kind !== "ok") {
+    throw new Error(
+      `Cannot preserve archive timestamp for ${change.id}: terminal summary is ${summaryRead.kind}.`,
+    );
+  }
+  const summary = validateTerminalArchiveSummary(
+    JSON.parse(summaryRead.content),
+  );
+  if (summary.change_id !== change.id) {
+    throw new Error(
+      `Archive bundle identity mismatch: expected ${change.id}, got ${summary.change_id}.`,
+    );
+  }
+
   return createInRepoArchive(
     change,
     inRepoArchiveDir,
     sourceChangeDir,
     multiRepo,
+    summary.archived_at,
   );
 }
 

--- a/plugin/src/artifact-authority-chain.test.ts
+++ b/plugin/src/artifact-authority-chain.test.ts
@@ -186,6 +186,8 @@ describe("artifact authority chain", () => {
       currentChange as Change,
       store.paths.archive,
       changeDir,
+      undefined,
+      "2026-05-08T00:00:00.000Z",
     );
     await expect(readArchiveArtifacts(archivePath)).resolves.toEqual(current);
   });
@@ -220,6 +222,8 @@ describe("artifact authority chain", () => {
       change,
       store.paths.archive,
       changeDir,
+      undefined,
+      "2026-05-08T00:00:00.000Z",
     );
 
     await expect(readArchiveArtifacts(archivePath)).resolves.toEqual(
@@ -258,6 +262,8 @@ describe("artifact authority chain", () => {
       change,
       store.paths.archive,
       changeDir,
+      undefined,
+      "2026-05-08T00:00:00.000Z",
     );
     await expect(readArchiveArtifacts(archivePath)).resolves.toEqual(legacy);
   });

--- a/plugin/src/storage/store-disk.test.ts
+++ b/plugin/src/storage/store-disk.test.ts
@@ -119,6 +119,8 @@ describe("store-disk — bounded warnings + monotonic IDs", () => {
       legacyChange,
       join(dir, ".adv/archive"),
       activeDir,
+      undefined,
+      "2026-05-08T00:00:00.000Z",
     );
     await expect(
       readFile(join(archivePath, "proposal.md"), "utf-8"),

--- a/plugin/src/tools/archive-helpers/git-finalize.test.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.test.ts
@@ -3302,6 +3302,378 @@ describe("git-finalize helpers", () => {
     );
   });
 
+  // rq-fixPhase9PostMergeFinalization (Defect B): when the change's PR is
+  // already merged, reconciling the stale change branch against the default
+  // branch is pointless and blocks phase9 finalization forever. Detect the
+  // already-merged state BEFORE reconcile and skip reconcile in that case.
+  describe("finalizeRelease PR-mode merged-PR short-circuit", () => {
+    const MERGED_PR_HEAD_SHA = "merged-pr-head-sha";
+
+    function makeMergedPrSetup(opts: {
+      conflictsOnMerge: boolean;
+      actualPrHeadSha?: string;
+    }) {
+      const main = join(
+        tempRoot,
+        `merged-pr-${Math.random().toString(36).slice(2)}`,
+      );
+      const worktree = join(
+        tempRoot,
+        `merged-pr-wt-${Math.random().toString(36).slice(2)}`,
+      );
+      const gitCalls: { cwd: string; args: string[] }[] = [];
+      const ghCalls: { cwd: string; args: string[] }[] = [];
+
+      return {
+        main,
+        worktree,
+        gitCalls,
+        ghCalls,
+        runGit: (cwd: string, args: string[]) => {
+          gitCalls.push({ cwd, args });
+          if (args[0] === "fetch" && args[1] === "origin") {
+            return { status: 0, stdout: "", stderr: "" };
+          }
+          if (args[0] === "reset" && args[1] === "--hard") {
+            return { status: 0, stdout: "reset", stderr: "" };
+          }
+          if (args[0] === "merge") {
+            // If short-circuit works, this should never be called for the
+            // merged-PR case. The unmerged-conflict case still calls it.
+            if (opts.conflictsOnMerge) {
+              return {
+                status: 1,
+                stdout: "",
+                stderr: "CONFLICT (.adv/archive/file): conflict marker",
+              };
+            }
+            return { status: 0, stdout: "merge", stderr: "" };
+          }
+          if (args[0] === "merge-base") {
+            return { status: 0, stdout: "", stderr: "" };
+          }
+          // verifyDirectMergedPrProof's default-branch reachability probe.
+          // The base is whatever detectDefaultBranch resolved to (trunk for
+          // a fresh test repo). Match by prefix so the mock survives both
+          // trunk and main detection paths.
+          if (
+            args[0] === "rev-parse" &&
+            args[1] === "--verify" &&
+            args.length >= 3 &&
+            args[2]!.startsWith("origin/")
+          ) {
+            return { status: 0, stdout: "current-default-sha\n", stderr: "" };
+          }
+          // Other rev-parse calls (--show-toplevel, --path-format=absolute
+          // --git-common-dir, branch refs) must fall through to real git so
+          // validateChangeWorktree and changeTipSha capture work.
+          if (
+            args[0] === "rev-parse" &&
+            (args[1] === "--path-format=absolute" ||
+              args[1] === "--show-toplevel" ||
+              args[1] === "--git-common-dir")
+          ) {
+            return defaultRunGit(cwd, args);
+          }
+          if (args[0] === "diff" && args.includes("--diff-filter=U")) {
+            return {
+              status: 0,
+              stdout: ".adv/archive/file\n",
+              stderr: "",
+            };
+          }
+          // Fall through to real git so validateChangeWorktree and other
+          // checks (branch --show-current, rev-parse --show-toplevel) work
+          // against the actual worktree.
+          return defaultRunGit(cwd, args);
+        },
+        runGh: (_cwd: string, args: string[]) => {
+          ghCalls.push({ cwd: _cwd, args });
+          // Branch protection rules query (route classification)
+          if (args[0] === "api" && args[1].includes("/rules/branches/")) {
+            return {
+              status: 0,
+              stdout: JSON.stringify([{ type: "required_status_checks" }]),
+              stderr: "",
+            };
+          }
+          // Repo allow_auto_merge query (route classification)
+          if (args[0] === "api" && args[1] === "repos/Sharper-Flow/Advance") {
+            return { status: 0, stdout: "true\n", stderr: "" };
+          }
+          // verifyDirectMergedPrProof: gh pr list --state merged --head ...
+          if (
+            args[0] === "pr" &&
+            args[1] === "list" &&
+            args.includes("--state") &&
+            args.includes("merged")
+          ) {
+            return {
+              status: 0,
+              stdout: JSON.stringify([
+                {
+                  number: 1347,
+                  url: "https://github.com/Sharper-Flow/Advance/pull/1347",
+                  state: "MERGED",
+                  mergedAt: "2026-08-17T12:00:00Z",
+                  mergeCommit: { oid: "merge-commit-sha" },
+                  headRefName: "change/example",
+                  headRefOid: opts.actualPrHeadSha ?? MERGED_PR_HEAD_SHA,
+                  baseRefName: "trunk",
+                  headRepositoryOwner: { login: "Sharper-Flow" },
+                  headRepository: {
+                    name: "Advance",
+                    nameWithOwner: "Sharper-Flow/Advance",
+                  },
+                  isCrossRepository: false,
+                },
+              ]),
+              stderr: "",
+            };
+          }
+          return { status: 1, stdout: "", stderr: "unexpected gh" };
+        },
+      };
+    }
+
+    it("skips reconcile and finalizes when the change's PR is already merged", async () => {
+      const main = join(tempRoot, "merged-skip-main");
+      const worktree = join(tempRoot, "merged-skip-wt");
+      await mkdir(main);
+      await initRepo(main);
+      git(main, [
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/Sharper-Flow/Advance.git",
+      ]);
+      git(main, ["worktree", "add", "-b", "change/example", worktree]);
+      await writeFile(join(worktree, "feature.txt"), "feature\n");
+      git(worktree, ["add", "feature.txt"]);
+      git(worktree, ["commit", "-m", "feature"]);
+      // The exact SHA the change branch currently points at — used by
+      // verifyDirectMergedPrProof to match the PR headRefOid (the merged PR
+      // must be provably THE PR for this branch, not an unrelated history).
+      const actualPrHeadSha = git(worktree, ["rev-parse", "HEAD"]);
+
+      const setup = makeMergedPrSetup({
+        conflictsOnMerge: true,
+        actualPrHeadSha,
+      });
+      const result = await finalizeRelease(
+        {
+          changeId: "example",
+          workdir: worktree,
+          archiveMode: "pr",
+          autoPush: true,
+        },
+        setup,
+      );
+
+      expect(result).toMatchObject({
+        status: "shipped",
+        route: "pr_auto_merge",
+        prNumber: 1347,
+        prUrl: "https://github.com/Sharper-Flow/Advance/pull/1347",
+        mergeCommitSha: "merge-commit-sha",
+        prHeadSha: actualPrHeadSha,
+        defaultBranchSha: "current-default-sha",
+      });
+
+      // Reconcile must NOT have been called: no `git merge --no-edit origin/...`.
+      const reconcileCalls = setup.gitCalls.filter(
+        (c) =>
+          c.args[0] === "merge" &&
+          c.args.includes("--no-edit") &&
+          c.args.some((a) => a.startsWith("origin/")),
+      );
+      expect(reconcileCalls).toHaveLength(0);
+    });
+
+    it("still blocks with RECONCILE_CONFLICT when PR is unmerged and reconcile conflicts", async () => {
+      const main = join(tempRoot, "conflict-still-blocks-main");
+      const worktree = join(tempRoot, "conflict-still-blocks-wt");
+      await mkdir(main);
+      await initRepo(main);
+      git(main, [
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/Sharper-Flow/Advance.git",
+      ]);
+      git(main, ["worktree", "add", "-b", "change/example", worktree]);
+      await writeFile(join(worktree, "feature.txt"), "feature\n");
+      git(worktree, ["add", "feature.txt"]);
+      git(worktree, ["commit", "-m", "feature"]);
+
+      const setup = makeMergedPrSetup({ conflictsOnMerge: true });
+      // Override: gh pr list --state merged returns empty (no merged PR).
+      setup.runGh = (_cwd, args) => {
+        const ghCalls = (
+          setup as { ghCalls: { cwd: string; args: string[] }[] }
+        ).ghCalls;
+        ghCalls.push({ cwd: _cwd, args });
+        if (args[0] === "api" && args[1].includes("/rules/branches/")) {
+          return {
+            status: 0,
+            stdout: JSON.stringify([{ type: "required_status_checks" }]),
+            stderr: "",
+          };
+        }
+        if (args[0] === "api" && args[1] === "repos/Sharper-Flow/Advance") {
+          return { status: 0, stdout: "true\n", stderr: "" };
+        }
+        if (args[0] === "pr" && args[1] === "list" && args.includes("merged")) {
+          return { status: 0, stdout: "[]", stderr: "" };
+        }
+        return { status: 1, stdout: "", stderr: "unexpected gh" };
+      };
+
+      const result = await finalizeRelease(
+        {
+          changeId: "example",
+          workdir: worktree,
+          archiveMode: "pr",
+          autoPush: true,
+        },
+        setup,
+      );
+
+      expect(result).toMatchObject({
+        status: "blocked",
+        route: "pr_auto_merge",
+        blocked: { reason: "RECONCILE_CONFLICT" },
+      });
+    });
+
+    it("proceeds to PR handoff when PR is unmerged and reconcile succeeds (existing behavior)", async () => {
+      const main = join(tempRoot, "unmerged-clean-main");
+      const worktree = join(tempRoot, "unmerged-clean-wt");
+      await mkdir(main);
+      await initRepo(main);
+      git(main, [
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/Sharper-Flow/Advance.git",
+      ]);
+      git(main, ["worktree", "add", "-b", "change/example", worktree]);
+      await writeFile(join(worktree, "feature.txt"), "feature\n");
+      git(worktree, ["add", "feature.txt"]);
+      git(worktree, ["commit", "-m", "feature"]);
+
+      const setup = makeMergedPrSetup({ conflictsOnMerge: false });
+      // Override: gh pr list --state merged returns empty (no merged PR),
+      // and add the regular PR-creation / arm-auto-merge mocks.
+      let branchViewCount = 0;
+      setup.runGh = (_cwd, args) => {
+        const ghCalls = (
+          setup as { ghCalls: { cwd: string; args: string[] }[] }
+        ).ghCalls;
+        ghCalls.push({ cwd: _cwd, args });
+        if (args[0] === "api" && args[1].includes("/rules/branches/")) {
+          return {
+            status: 0,
+            stdout: JSON.stringify([{ type: "required_status_checks" }]),
+            stderr: "",
+          };
+        }
+        if (args[0] === "api" && args[1] === "repos/Sharper-Flow/Advance") {
+          return { status: 0, stdout: "true\n", stderr: "" };
+        }
+        if (args[0] === "pr" && args[1] === "list" && args.includes("merged")) {
+          return { status: 0, stdout: "[]", stderr: "" };
+        }
+        if (args[0] === "pr" && args[1] === "view") {
+          const selector = args[2];
+          if (selector === "change/example") {
+            branchViewCount += 1;
+            if (branchViewCount === 1) {
+              return {
+                status: 1,
+                stdout: "",
+                stderr: "no pull requests found",
+              };
+            }
+            return {
+              status: 0,
+              stdout: JSON.stringify({
+                number: 42,
+                url: "https://github.com/Sharper-Flow/Advance/pull/42",
+                state: "OPEN",
+                autoMergeRequest: null,
+              }),
+              stderr: "",
+            };
+          }
+          if (selector === "42") {
+            return {
+              status: 0,
+              stdout: JSON.stringify({
+                state: "OPEN",
+                mergedAt: null,
+                mergeCommit: null,
+                autoMergeRequest: { enabledAt: "2026-06-07T00:00:00Z" },
+              }),
+              stderr: "",
+            };
+          }
+        }
+        if (args[0] === "pr" && args[1] === "create") {
+          return {
+            status: 0,
+            stdout: "https://github.com/Sharper-Flow/Advance/pull/42\n",
+            stderr: "",
+          };
+        }
+        if (args[0] === "pr" && args[1] === "merge") {
+          return { status: 0, stdout: "Auto-merge enabled", stderr: "" };
+        }
+        return { status: 1, stdout: "", stderr: "unexpected gh" };
+      };
+      setup.runGit = (cwd, args) => {
+        const gitCalls = (
+          setup as { gitCalls: { cwd: string; args: string[] }[] }
+        ).gitCalls;
+        gitCalls.push({ cwd, args });
+        if (args[0] === "fetch" && args[1] === "origin") {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+        if (args[0] === "reset" && args[1] === "--hard") {
+          return { status: 0, stdout: "reset", stderr: "" };
+        }
+        if (args[0] === "merge") {
+          return { status: 0, stdout: "merge", stderr: "" };
+        }
+        if (args[0] === "push" && args.includes("change/example")) {
+          return { status: 0, stdout: "pushed branch", stderr: "" };
+        }
+        // Other rev-parse calls (--path-format=absolute, --show-toplevel,
+        // --git-common-dir, branch refs) must fall through to real git so
+        // validateChangeWorktree and resolveRepoRoot work.
+        return defaultRunGit(cwd, args);
+      };
+
+      const result = await finalizeRelease(
+        {
+          changeId: "example",
+          workdir: worktree,
+          archiveMode: "pr",
+          autoPush: true,
+        },
+        setup,
+      );
+
+      expect(result).toMatchObject({
+        status: "pending_merge",
+        route: "pr_auto_merge",
+        prNumber: 42,
+        autoMergeArmed: true,
+        pushStatus: "pushed",
+      });
+    });
+  });
+
   it("finalizeRelease turns protected default push rejection into pending auto-merge PR", async () => {
     const main = join(tempRoot, "protected-main");
     const worktree = join(tempRoot, "protected-wt");

--- a/plugin/src/tools/archive-helpers/git-finalize.ts
+++ b/plugin/src/tools/archive-helpers/git-finalize.ts
@@ -2331,6 +2331,51 @@ function completeProtectedBranchViaPullRequest(
     };
   }
 
+  // rq-fixPhase9PostMergeFinalization: when the change's PR is already merged,
+  // reconciling the stale change branch against the default branch is
+  // pointless — main already carries the merged artifacts (including the
+  // .adv/archive/** bundle files), so a stale-branch merge inevitably
+  // conflicts and RECONCILE_CONFLICT blocks forever. Detect the already-merged
+  // state BEFORE reconcile and synthesize a shipped outcome so the merged-PR
+  // completion path in archive-gate.ts can finalize phase9_status. The
+  // verification is strict: exact repo/head/base/state/OID match against the
+  // persisted changeTipSha or preArchiveTipSha. A "none" or "invalid" result
+  // (e.g. ambiguous proof, missing tip SHA) falls through to reconcile so
+  // genuine conflicts on unmerged branches still block as before.
+  const mergedPrProof = verifyDirectMergedPrProof(
+    {
+      repoRoot: input.repoRoot,
+      repo: input.route.repo,
+      defaultBranch: input.defaultBranch,
+      changeId: input.changeId,
+      branchName: branch,
+      changeTipSha: input.changeTipSha,
+      preArchiveTipSha: input.preArchiveTipSha,
+    },
+    deps,
+  );
+  if (mergedPrProof.kind === "valid") {
+    return {
+      status: "shipped",
+      repoRoot: input.repoRoot,
+      defaultBranch: input.defaultBranch,
+      route: input.route.route,
+      releasedCommitSha: mergedPrProof.defaultBranchSha,
+      mergeCommitSha: mergedPrProof.mergeCommitOid,
+      changeTipSha: input.changeTipSha,
+      preArchiveTipSha: input.preArchiveTipSha,
+      pushStatus: "skipped",
+      pushFailureReason: "merged_pr_detected_pre_reconcile",
+      prBranch: branch,
+      repo: input.route.repo,
+      prNumber: mergedPrProof.prNumber,
+      prUrl: mergedPrProof.prUrl,
+      prHeadSha: mergedPrProof.prHeadSha,
+      defaultBranchSha: mergedPrProof.defaultBranchSha,
+      autoMergeArmed: false,
+    };
+  }
+
   const reconcileResult = reconcileChangeBranchWithDefault(
     {
       workdir: input.workdir,

--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -691,6 +691,7 @@ export const advChangeArchiveHandler = async (
       ) {
         reconciledInRepoPath = await reconcileInRepoArchive(
           change,
+          archivePaths.archive,
           archivePaths.inRepoArchive,
           archivePaths.changes
             ? join(archivePaths.changes, changeId)


### PR DESCRIPTION
## What broke

Two defects, found while archiving a change in a consumer repo.

**Phase 9 finalization was unreachable once a PR merged.** `completeProtectedBranchViaPullRequest` reconciled the change branch against the default branch *before* any merged-PR detection, which only happens downstream in `executePullRequestHandoff`. Once a PR merges, the default branch already carries the change's own `.adv/archive/**` bundle files — so merging it into the stale change branch conflicts on exactly those files and returns `RECONCILE_CONFLICT`. That aborted before the recovery in `archive-gate.ts` could set `phase9_status` to `done` with `completedAt`.

Result: the record sits at `pending_merge` permanently. Eight changes were found in this state, every one of their PRs merged days earlier. The release gate had to be recorded by hand.

**`reconcileInRepoArchive` re-stamped bundles with the current time.** `createInRepoArchive` defaulted `archivedAt` to `new Date().toISOString()` and `reconcileInRepoArchive` omitted the argument. A reconciled in-repo bundle therefore claimed to have been archived at reconcile time. Observed as a change archived `2026-08-18T17:57:53` being rewritten to `2026-08-21T23:21:05`, hashes rewritten to match — silent history corruption in tracked files that surfaces only as innocuous-looking dirty state.

## The fixes

Detect the already-merged state before reconciling, reusing `verifyDirectMergedPrProof` — the authority the direct route already trusts. It demands exact repo, head, base and state match, tip-SHA equality against `changeTipSha` or `preArchiveTipSha`, and merge-commit reachability from the default branch. Only `valid` short-circuits; `none` and `invalid` fall through to reconcile, so genuine conflicts on unmerged branches block exactly as before. Fail-closed by construction.

For the timestamp, follow the pattern `refreshArchiveBundleProjectionUnderLock` already established: read the source bundle's terminal summary, verify identity, reuse `archived_at`, and throw rather than invent one. The `new Date()` default is removed so omitting the timestamp is a compile error rather than silent corruption.

## Tests

Red-verified — reverting the production changes fails the new merged-PR test, restoring them passes it.

- reconcile preserves the external bundle's `archived_at` rather than now
- reconcile fails loudly when the terminal summary is unreadable
- merged PR skips reconcile and finalizes, asserting no `git merge` ran
- unmerged + conflict still blocks with `RECONCILE_CONFLICT`
- unmerged + clean still proceeds to PR handoff

`tsc --noEmit` clean, `eslint` clean, prettier clean, full suite 5227 passed / 1 skipped / 12 todo.