### PR TITLE
fix: raise worktree tool timeout budget

### DIFF
--- a/plugin/src/tool-registry.ts
+++ b/plugin/src/tool-registry.ts
@@ -632,6 +632,15 @@ export function createFullToolMap(
         ),
       ),
     ),
+    // Delete and cleanup verify archived/merged/clean state per candidate via
+    // plan → git census → branch integration proof → PR evidence subprocess
+    // chains. On large repositories (dozens of worktrees, hundreds of changes)
+    // that chain cannot fit the 10s default execute ceiling: the 8s-era inner
+    // budget timed out at every stage while bare git/gh calls stayed
+    // sub-second. Carry the same >10s override pattern as adv_task_checkpoint
+    // and adv_worktree_triage: 50s outer net over the 45s
+    // WORKTREE_TOOL_SAFE_TIMEOUT_MS inner budget, preserving a 5s typed
+    // timeout response reserve.
     adv_worktree_delete: registerTool(
       advWorktreeTools.adv_worktree_delete.description,
       advWorktreeTools.adv_worktree_delete.args,
@@ -647,6 +656,8 @@ export function createFullToolMap(
               { serverUrl, client },
             ),
           "adv_worktree_delete",
+          undefined,
+          { timeoutMs: 50_000 },
         ),
       ),
     ),
@@ -665,6 +676,8 @@ export function createFullToolMap(
               { serverUrl, client },
             ),
           "adv_worktree_cleanup",
+          undefined,
+          { timeoutMs: 50_000 },
         ),
       ),
     ),

--- a/plugin/src/tools/adv-worktree.archived-branches-emergency.test.ts
+++ b/plugin/src/tools/adv-worktree.archived-branches-emergency.test.ts
@@ -63,7 +63,7 @@ describe("adv_worktree_cleanup archived_branches emergency guard", () => {
         reason: "archived branch cleanup",
         mode: "archived_branches",
         dryRun: true,
-        timeoutMs: 30_000,
+        timeoutMs: 60_000,
       },
       mockStore(),
     );
@@ -73,7 +73,7 @@ describe("adv_worktree_cleanup archived_branches emergency guard", () => {
     expect(parsed.remediation).not.toContain("larger timeoutMs");
     expect(parsed.remediation).not.toContain("skipDiscovery");
     expect(parsed.remediation).toMatch(/changeId|adv_worktree_triage/);
-  }, 20_000);
+  }, 50_000);
 
   // AC2 (archived_branches variant): unclamped may still offer a larger value.
   test("unclamped remediation may still offer a larger timeoutMs", async () => {

--- a/plugin/src/tools/adv-worktree.archived-branches.test.ts
+++ b/plugin/src/tools/adv-worktree.archived-branches.test.ts
@@ -1088,14 +1088,14 @@ describe("adv_worktree_cleanup mode=archived_branches", () => {
         reason: "archived branch cleanup",
         mode: "archived_branches",
         dryRun: true,
-        timeoutMs: 30_000,
+        timeoutMs: 60_000,
       },
       store,
     );
 
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
-    expect(parsed.effectiveTimeoutMs).toBe(8_000);
+    expect(parsed.effectiveTimeoutMs).toBe(45_000);
     expect(parsed.timeoutNote).toContain("clamped to safe budget");
   });
 

--- a/plugin/src/tools/adv-worktree.test.ts
+++ b/plugin/src/tools/adv-worktree.test.ts
@@ -1047,7 +1047,7 @@ describe("advWorktreeTools", () => {
     );
 
     const out = await advWorktreeTools.adv_worktree_cleanup.execute(
-      { reason: "clamped cleanup", timeoutMs: 30_000 },
+      { reason: "clamped cleanup", timeoutMs: 60_000 },
       store,
     );
 
@@ -1055,7 +1055,7 @@ describe("advWorktreeTools", () => {
     expect(parsed.timedOut).toBe(true);
     expect(parsed.remediation).not.toContain("larger timeoutMs");
     expect(parsed.remediation).toMatch(/skipDiscovery|adv_worktree_triage/);
-  }, 20_000);
+  }, 50_000);
 
   // AC2 — with no clamp, offering a larger timeoutMs is still reachable.
   it("may still advise a larger timeoutMs when no clamp was applied (worktrees)", async () => {
@@ -1090,7 +1090,7 @@ describe("advWorktreeTools", () => {
       () => new Promise(() => {}),
     );
 
-    for (const timeoutMs of [25, 30_000]) {
+    for (const timeoutMs of [25, 60_000]) {
       const out = await advWorktreeTools.adv_worktree_cleanup.execute(
         { reason: "no poison guess", timeoutMs },
         store,
@@ -1101,7 +1101,7 @@ describe("advWorktreeTools", () => {
       expect(parsed.remediation).not.toMatch(/poison/i);
       expect(parsed.remediation).not.toContain("adv_doctor");
     }
-  }, 20_000);
+  }, 50_000);
 
   it("reports discovery stage and pending-delete count when cleanup hangs in discovery", async () => {
     const database = {
@@ -1176,10 +1176,10 @@ describe("advWorktreeTools", () => {
     expect(discoveryGitBudgetForToolBudget(1)).toBeGreaterThan(0);
   });
 
-  it("exports WORKTREE_TOOL_SAFE_TIMEOUT_MS = 8000", async () => {
+  it("exports WORKTREE_TOOL_SAFE_TIMEOUT_MS = 45000", async () => {
     // Will fail until the constant is exported from adv-worktree
     const mod = await import("./adv-worktree");
-    expect(mod.WORKTREE_TOOL_SAFE_TIMEOUT_MS).toBe(8000);
+    expect(mod.WORKTREE_TOOL_SAFE_TIMEOUT_MS).toBe(45_000);
   });
 
   // rq-worktreeBoundedCleanup02 AC2: oversize timeoutMs is clamped to safe budget
@@ -1195,17 +1195,17 @@ describe("advWorktreeTools", () => {
     });
 
     const out = await advWorktreeTools.adv_worktree_cleanup.execute(
-      { reason: "test clamp", timeoutMs: 30_000 },
+      { reason: "test clamp", timeoutMs: 60_000 },
       store,
     );
 
     expect(out).toContain("effectiveTimeoutMs");
-    expect(out).toContain("8000");
+    expect(out).toContain("45000");
     // Should succeed (not time out) since the mock resolves instantly
     expect(out).toContain('"success":true');
   });
 
-  // rq-worktreeBoundedCleanup02 AC4: default timeout is the safe budget (8000ms)
+  // rq-worktreeBoundedCleanup02 AC4: default timeout is the safe budget (45000ms)
   it("adv_worktree_cleanup uses safe budget default when no timeoutMs provided", async () => {
     const database = {
       projectDir: "/repo",
@@ -1281,8 +1281,8 @@ describe("advWorktreeTools", () => {
         }),
     );
 
-    // The delete tool currently hardcodes the safe budget (8s) internally
-    // with no caller override, so we must allow a longer test timeout.
+    // The delete tool hardcodes the safe budget (45s) internally with no
+    // caller override, so the timeout path genuinely waits it out.
     const out = await advWorktreeTools.adv_worktree_delete.execute(
       { branch: "change/test-timeout" },
       store,
@@ -1291,7 +1291,7 @@ describe("advWorktreeTools", () => {
     expect(out).toContain("timedOut");
     expect(out).toContain("timed out after");
     expect(out).toContain("effectiveTimeoutMs");
-  }, 12_000);
+  }, 50_000);
 
   it("adv_worktree_triage delegates to triageWorktrees", async () => {
     triageMock.triageWorktrees.mockResolvedValue({
@@ -1382,5 +1382,5 @@ describe("advWorktreeTools", () => {
     expect(parsed.error).not.toContain("adv_doctor");
     expect(parsed.remediation).not.toMatch(/poison/i);
     expect(parsed.remediation).not.toContain("adv_doctor");
-  }, 20_000);
+  }, 50_000);
 });

--- a/plugin/src/tools/adv-worktree.ts
+++ b/plugin/src/tools/adv-worktree.ts
@@ -50,13 +50,18 @@ import {
 /**
  * Safe timeout budget for worktree tool wrappers (cleanup and delete).
  *
- * Must be strictly below the SDK's `DEFAULT_TOOL_TIMEOUT_MS` (10 000 ms)
- * so the shared operation deadline can cancel and settle every destructive
- * stage before the SDK's `safeExecute` wrapper rejects.
+ * Must be strictly below the 50s execute override these tools carry in
+ * `tool-registry.ts` (the same mechanism as `adv_worktree_triage`) so the
+ * shared operation deadline can cancel and settle every destructive stage
+ * before the `safeExecute` wrapper rejects. The 8s predecessor sat under the
+ * 10s default execute ceiling, which could not fit the plan → git census →
+ * branch integration proof → PR evidence chain on large repositories
+ * (measured on a 40-worktree project: every stage timed out while bare
+ * `git worktree list` took 11ms and `gh pr view` 1.4s).
  *
  * rq-worktreeBoundedCleanup02 AC1.
  */
-export const WORKTREE_TOOL_SAFE_TIMEOUT_MS = 8_000;
+export const WORKTREE_TOOL_SAFE_TIMEOUT_MS = 45_000;
 
 /** Reserve time for formatting and SDK handoff before the 10s tool ceiling. */
 const WORKTREE_TOOL_RETURN_RESERVE_MS = 500;
@@ -74,8 +79,8 @@ const DISCOVERY_GIT_BUDGET_CEILING_MS = 2_000;
  * rq-worktreeBoundedCleanup02 requires internal operations to be bounded
  * *below* the tool budget. The local git helpers default to 30s
  * (`worktree/index.ts`) and 10s (`worktree/census.ts`) for non-cleanup
- * callers, so a single slow invocation could otherwise consume an 8s budget
- * several times over. Bounding each call keeps the failure granular: one hung
+ * callers, so a single slow invocation could otherwise consume the tool
+ * budget several times over. Bounding each call keeps the failure granular: one hung
  * subprocess is killed instead of starving the whole pass.
  *
  * Aggregate discovery cost across many worktrees remains policed by the outer
@@ -1048,7 +1053,7 @@ const advWorktreeToolDefinitions = {
         .number()
         .optional()
         .describe(
-          `Optional wall-clock timeout for the cleanup pass. Defaults to ${WORKTREE_TOOL_SAFE_TIMEOUT_MS}ms (the safe tool budget below the SDK's 10s ceiling). Values exceeding the safe budget are clamped automatically. The effective timeout is reported in the response as effectiveTimeoutMs. Applies to both mode=worktrees and mode=archived_branches; in archived_branches mode the helper self-bounds and returns typed partial results (partial:true + omissions) rather than a hard timeout when the budget is exhausted.`,
+          `Optional wall-clock timeout for the cleanup pass. Defaults to ${WORKTREE_TOOL_SAFE_TIMEOUT_MS}ms (the safe tool budget below these tools' 50s execute override). Values exceeding the safe budget are clamped automatically. The effective timeout is reported in the response as effectiveTimeoutMs. Applies to both mode=worktrees and mode=archived_branches; in archived_branches mode the helper self-bounds and returns typed partial results (partial:true + omissions) rather than a hard timeout when the budget is exhausted.`,
         ),
       mode: z
         .enum(["worktrees", "archived_branches"])

--- a/plugin/src/utils/workspace-warp.ts
+++ b/plugin/src/utils/workspace-warp.ts
@@ -40,7 +40,7 @@ const fetchWith = (deps: WarpDeps): typeof fetch => deps.fetchImpl ?? fetch;
 
 /**
  * Default timeout for workspace HTTP operations (find, delete).
- * Must be well below the tool safe budget (8s) so these operations
+ * Must be well below WORKTREE_TOOL_SAFE_TIMEOUT_MS so these operations
  * complete or abort before the tool-level timeout fires.
  *
  * rq-worktreeBoundedCleanup02 AC6.


### PR DESCRIPTION
## Why

`adv_worktree_delete` and `adv_worktree_cleanup` fail closed on large repositories. Their verification chain (plan → git census → branch integration proof → PR evidence) cannot complete inside the 8s `WORKTREE_TOOL_SAFE_TIMEOUT_MS`.

That 8s value existed only to stay under the 10s default `safeExecute` ceiling. Measured on the pokeedge project (40 worktrees, 320+ changes) on 2026-08-21: three stages timed out (`plan`, `git_census`, `integration_proof`) across both quiet and busy conditions, while bare `git worktree list` took 11ms and `gh pr view` 1.4s. The budget was the blocker, not the repository. Nine verified-merged worktrees were stuck in the retained queue as a result.

## What changed

- `tool-registry.ts` — `adv_worktree_delete` and `adv_worktree_cleanup` get a `{ timeoutMs: 50_000 }` execute override, the same mechanism already used by `adv_task_checkpoint` (35s), `adv_wip_state` (60s), and `adv_worktree_triage` (60s).
- `adv-worktree.ts` — `WORKTREE_TOOL_SAFE_TIMEOUT_MS` 8_000 → 45_000. The 5s spread beneath the 50s outer override preserves the typed-timeout response reserve.
- Comment and schema-description truthfulness: the constant rationale now anchors to the 50s registry override and records the measured failure evidence; the `timeoutMs` arg description no longer claims a 10s SDK ceiling; `workspace-warp.ts` references the constant instead of a hardcoded 8s.

The clamp mechanism itself is unchanged (`rq-worktreeBoundedCleanup02`) — only its ceiling moves. `DISCOVERY_GIT_BUDGET_CEILING_MS` (2s per git op) is untouched, since per-op bounding is independent of the total budget.

## Test changes are contract-value updates, not loosening

Two budget-pinning assertions move to 45_000. Five timeout-path tests that encoded 30_000-as-oversize now use 60_000 — still oversize, still clamped. Their vitest timeouts rose to 50_000 because a clamped timeout now genuinely waits 45s under real timers, which is the established style for these tests in this repo. The two delete timeout tests keep their no-override shape, since `delete` exposes no `timeoutMs` arg and its budget is internal. One cleanup clamp test asserts the reported value 45000.

No assertion was deleted or weakened.

## Verification

- `pnpm exec vitest run` on the three affected files — **74/74 passed** (181s wall, dominated by real 45s clamp-path waits)
- `pnpm run check` — clean (schemas, typecheck, manifests, frontmatter, prompt budget, lockfile policy, skill references, eslint, prettier)
- `pnpm run architecture:check` — 0 errors
- `pnpm run dead-code:check` — fails on `worktreeDetachHandler`, **confirmed pre-existing**: the same finding reproduces on untouched `trunk`, and the diff never references that symbol
- Live behavior confirmed after deploy: `adv_worktree_cleanup` reports `effectiveTimeoutMs: 45000`