### PR TITLE
fix: preserve archive timestamps and record terminal phase-9 status in in-repo bundles

### DIFF
--- a/plugin/src/archive/archive.test.ts
+++ b/plugin/src/archive/archive.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "crypto";
 import { execSync } from "child_process";
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
-import { join } from "path";
+import { basename, join } from "path";
 import { afterEach, describe, expect, test } from "vitest";
 import type { Change } from "../types";
 import { ChangeSchema } from "../types";
@@ -420,6 +420,69 @@ describe("contract archive traceability", () => {
         reconcileInRepoArchive(change, archiveDir, inRepoArchiveDir),
       ).rejects.toThrow(/terminal summary/i);
     });
+  });
+
+  test("reuses the existing bundle archived_at for external and in-repo retries", async () => {
+    const root = await tempProject();
+    const change = changeWithContract({ id: "retry-preserves-archived-at" });
+    const archiveDir = join(root, "external-archive");
+    const inRepoArchiveDir = join(root, "repo", ".adv", "archive");
+    const paths = {
+      specs: join(root, "specs"),
+      docs: join(root, "docs"),
+      archive: archiveDir,
+      inRepoArchive: inRepoArchiveDir,
+    };
+
+    const firstResult = await archiveChange({
+      change,
+      specs: new Map(),
+      paths,
+    });
+    const inRepoBundlePath = join(
+      inRepoArchiveDir,
+      basename(firstResult.archivePath),
+    );
+    const originalArchivedAt = validateTerminalArchiveSummary(
+      JSON.parse(
+        await readFile(
+          join(firstResult.archivePath, TERMINAL_SUMMARY_FILE),
+          "utf8",
+        ),
+      ),
+    ).archived_at;
+    const originalInRepoArchivedAt = validateTerminalArchiveSummary(
+      JSON.parse(
+        await readFile(join(inRepoBundlePath, TERMINAL_SUMMARY_FILE), "utf8"),
+      ),
+    ).archived_at;
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await archiveChange({
+      change,
+      specs: new Map(),
+      paths,
+      reuseExistingBundlePath: firstResult.archivePath,
+    });
+
+    const retriedArchivedAt = validateTerminalArchiveSummary(
+      JSON.parse(
+        await readFile(
+          join(firstResult.archivePath, TERMINAL_SUMMARY_FILE),
+          "utf8",
+        ),
+      ),
+    ).archived_at;
+    const retriedInRepoArchivedAt = validateTerminalArchiveSummary(
+      JSON.parse(
+        await readFile(join(inRepoBundlePath, TERMINAL_SUMMARY_FILE), "utf8"),
+      ),
+    ).archived_at;
+
+    expect(retriedArchivedAt).toBe(originalArchivedAt);
+    expect(retriedInRepoArchivedAt).toBe(originalInRepoArchivedAt);
+    expect(retriedInRepoArchivedAt).toBe(originalArchivedAt);
   });
 
   test("single-repo archive bundle remains unchanged without scope_repos", async () => {
@@ -955,6 +1018,49 @@ describe("contract archive traceability", () => {
         name.endsWith("-digest-cross-day"),
       );
       expect(matchingBundles).toEqual(["2026-01-01-digest-cross-day"]);
+    });
+
+    test("reports a structured failure when a reused bundle lacks its terminal summary", async () => {
+      const root = await tempProject();
+      const change = changeWithContract({
+        id: "digest-missing-terminal-summary",
+        status: "active",
+        contract: undefined,
+      });
+      const paths = {
+        specs: join(root, "specs"),
+        docs: join(root, "docs"),
+        archive: join(root, "archive"),
+      };
+      const existingArchivePath = join(
+        paths.archive,
+        "2026-01-01-digest-missing-terminal-summary",
+      );
+      await mkdir(existingArchivePath, { recursive: true });
+      await writeFile(
+        join(existingArchivePath, "change.json"),
+        JSON.stringify({ ...change, status: "archived" }, null, 2),
+      );
+
+      const result = await archiveChange({
+        change,
+        specs: new Map(),
+        paths,
+        reuseExistingBundlePath: existingArchivePath,
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: false,
+          changeId: change.id,
+          archivePath: existingArchivePath,
+          archivedAt: "",
+          requirement: "rq-archiveTerminalDurability01.1",
+        }),
+      );
+      expect(result.errors).toContain(
+        "Cannot preserve archive timestamp for digest-missing-terminal-summary: terminal summary is not_found.",
+      );
     });
   });
 

--- a/plugin/src/archive/archive.ts
+++ b/plugin/src/archive/archive.ts
@@ -96,6 +96,29 @@ export interface ArchiveBundleWriteResult {
   };
 }
 
+async function readArchiveBundleArchivedAt(
+  changeId: string,
+  archivePath: string,
+): Promise<string> {
+  const summaryRead = await readBoundedProjectionDocument(
+    join(archivePath, TERMINAL_SUMMARY_FILE),
+  );
+  if (summaryRead.kind !== "ok") {
+    throw new Error(
+      `Cannot preserve archive timestamp for ${changeId}: terminal summary is ${summaryRead.kind}.`,
+    );
+  }
+  const summary = validateTerminalArchiveSummary(
+    JSON.parse(summaryRead.content),
+  );
+  if (summary.change_id !== changeId) {
+    throw new Error(
+      `Archive bundle identity mismatch: expected ${changeId}, got ${summary.change_id}.`,
+    );
+  }
+  return summary.archived_at;
+}
+
 /**
  * Write the generated archive bundle artifacts for a change.
  *
@@ -218,26 +241,9 @@ export async function refreshArchiveBundleProjectionUnderLock(input: {
   archivePath: string;
   archivedAt?: string;
 }): Promise<ArchiveBundleWriteResult> {
-  let archivedAt = input.archivedAt;
-  if (!archivedAt) {
-    const summaryRead = await readBoundedProjectionDocument(
-      join(input.archivePath, TERMINAL_SUMMARY_FILE),
-    );
-    if (summaryRead.kind !== "ok") {
-      throw new Error(
-        `Cannot preserve archive timestamp for ${input.change.id}: terminal summary is ${summaryRead.kind}.`,
-      );
-    }
-    const summary = validateTerminalArchiveSummary(
-      JSON.parse(summaryRead.content),
-    );
-    if (summary.change_id !== input.change.id) {
-      throw new Error(
-        `Archive bundle identity mismatch: expected ${input.change.id}, got ${summary.change_id}.`,
-      );
-    }
-    archivedAt = summary.archived_at;
-  }
+  const archivedAt =
+    input.archivedAt ??
+    (await readArchiveBundleArchivedAt(input.change.id, input.archivePath));
 
   const result = await writeArchiveBundleFiles(
     input.change,
@@ -881,7 +887,29 @@ async function archiveChangeUnderLock(
   const targetArchivePath =
     context.reuseExistingBundlePath ??
     archiveBundlePath(paths.archive, change.id);
-  const archivedAt = new Date().toISOString();
+  let archivedAt: string;
+  if (context.reuseExistingBundlePath) {
+    try {
+      archivedAt = await readArchiveBundleArchivedAt(
+        change.id,
+        context.reuseExistingBundlePath,
+      );
+    } catch (error) {
+      return {
+        success: false,
+        changeId: change.id,
+        specsUpdated,
+        docsGenerated,
+        commitPaths,
+        archivePath: targetArchivePath,
+        errors: [error instanceof Error ? error.message : String(error)],
+        requirement: "rq-archiveTerminalDurability01.1",
+        archivedAt: "",
+      };
+    }
+  } else {
+    archivedAt = new Date().toISOString();
+  }
 
   const contractProofErrors = getArchiveContractProofErrors(change);
   if (contractProofErrors.length > 0) {
@@ -1204,10 +1232,10 @@ async function createArchive(
   change: Change,
   archiveDir: string,
   dryRun: boolean,
-  sourceChangeDir?: string,
-  errors?: string[],
-  multiRepo?: MultiRepoArchiveMetadata,
-  archivedAt: string = new Date().toISOString(),
+  sourceChangeDir: string | undefined,
+  errors: string[],
+  multiRepo: MultiRepoArchiveMetadata | undefined,
+  archivedAt: string,
   projectionManifest?: SpecProjectionManifest,
 ): Promise<{
   path: string;
@@ -1423,29 +1451,12 @@ export async function reconcileInRepoArchive(
       `Cannot reconcile in-repo archive for ${change.id}: source archive bundle not found under ${externalArchiveDir}.`,
     );
   }
-  const summaryRead = await readBoundedProjectionDocument(
-    join(sourceBundle, TERMINAL_SUMMARY_FILE),
-  );
-  if (summaryRead.kind !== "ok") {
-    throw new Error(
-      `Cannot preserve archive timestamp for ${change.id}: terminal summary is ${summaryRead.kind}.`,
-    );
-  }
-  const summary = validateTerminalArchiveSummary(
-    JSON.parse(summaryRead.content),
-  );
-  if (summary.change_id !== change.id) {
-    throw new Error(
-      `Archive bundle identity mismatch: expected ${change.id}, got ${summary.change_id}.`,
-    );
-  }
-
   return createInRepoArchive(
     change,
     inRepoArchiveDir,
     sourceChangeDir,
     multiRepo,
-    summary.archived_at,
+    await readArchiveBundleArchivedAt(change.id, sourceBundle),
   );
 }
 

--- a/plugin/src/archive/types.ts
+++ b/plugin/src/archive/types.ts
@@ -60,6 +60,8 @@ export interface ArchiveOperationResult {
   archivePath: string;
   /** Errors encountered */
   errors: string[];
+  /** Requirement governing a structured durability failure, when applicable. */
+  requirement?: string;
   /** Timestamp of archive operation */
   archivedAt: string;
   /** Number of wisdom entries auto-promoted to project level */

--- a/plugin/src/tools/change/archive-gate.ts
+++ b/plugin/src/tools/change/archive-gate.ts
@@ -38,6 +38,27 @@ function formatArchiveBundleRefreshError(error: unknown): string {
   return `Archive bundle refresh failed: ${error instanceof Error ? error.message : String(error)}`;
 }
 
+async function refreshArchiveBundleProjectionsUnderLock(input: {
+  change: Change;
+  archivePath: string;
+  inRepoArchivePath?: string;
+}): Promise<{ terminalSummaryDegradation?: { reason: string } }> {
+  const archivePaths = [
+    input.archivePath,
+    ...(input.inRepoArchivePath && input.inRepoArchivePath !== input.archivePath
+      ? [input.inRepoArchivePath]
+      : []),
+  ];
+  for (const archivePath of archivePaths) {
+    const writeResult = await refreshArchiveBundleProjectionUnderLock({
+      change: input.change,
+      archivePath,
+    });
+    if (writeResult.terminalSummaryDegradation) return writeResult;
+  }
+  return {};
+}
+
 function getProjectionCommitError(
   outcome: Exclude<ProjectionCommitOutcome, { kind: "committed" }>,
 ): string {
@@ -492,6 +513,7 @@ async function completeArchivedBundleRelease(input: {
   changeId: string;
   finalization: GitFinalizeOutcome;
   existingBundlePath: string;
+  inRepoBundlePath?: string;
 }): Promise<ArchiveReleaseGateResult> {
   if (input.finalization.status !== "shipped") {
     return {
@@ -530,9 +552,10 @@ async function completeArchivedBundleRelease(input: {
       loaded.data.lifecycleState === "archived"
     ) {
       try {
-        const writeResult = await refreshArchiveBundleProjectionUnderLock({
+        const writeResult = await refreshArchiveBundleProjectionsUnderLock({
           change: loaded.data,
           archivePath: input.existingBundlePath,
+          inRepoArchivePath: input.inRepoBundlePath,
         });
         if (writeResult.terminalSummaryDegradation) {
           return {
@@ -623,9 +646,10 @@ async function completeArchivedBundleRelease(input: {
         readback.phase9_status?.status === "done",
       afterCommit: async ({ readback }) => {
         try {
-          const writeResult = await refreshArchiveBundleProjectionUnderLock({
+          const writeResult = await refreshArchiveBundleProjectionsUnderLock({
             change: readback,
             archivePath: input.existingBundlePath,
+            inRepoArchivePath: input.inRepoBundlePath,
           });
           return writeResult.terminalSummaryDegradation
             ? {
@@ -734,6 +758,7 @@ export async function completeReleaseGateAfterFinalization(input: {
   changeId: string;
   finalization: GitFinalizeOutcome;
   existingBundlePath?: string;
+  inRepoBundlePath?: string;
 }): Promise<ArchiveReleaseGateResult> {
   if (input.finalization.status !== "shipped")
     return {
@@ -754,6 +779,7 @@ export async function completeReleaseGateAfterFinalization(input: {
       changeId: input.changeId,
       finalization: input.finalization,
       existingBundlePath: input.existingBundlePath,
+      inRepoBundlePath: input.inRepoBundlePath,
     });
   }
   if (!currentProjection.success) {
@@ -821,6 +847,7 @@ export async function reconcileArchivedBundleRetry(input: {
   archiveMode: "direct" | "pr";
   phase9?: "run" | "skip";
   existingBundlePath: string;
+  inRepoBundlePath?: string;
   openOpsObligationsPayload: Record<string, unknown>;
   validationWarnings: Array<{ code: string; message: string; path?: string }>;
 }): Promise<string> {
@@ -863,6 +890,7 @@ export async function reconcileArchivedBundleRetry(input: {
     changeId: input.changeId,
     finalization,
     existingBundlePath: input.existingBundlePath,
+    inRepoBundlePath: input.inRepoBundlePath,
   });
   if (!releaseResult.ok)
     return formatToolOutput({

--- a/plugin/src/tools/change/handlers-archive.partial-repair.test.ts
+++ b/plugin/src/tools/change/handlers-archive.partial-repair.test.ts
@@ -488,6 +488,20 @@ describe("adv_change_archive partial archive-delta repair", () => {
         }),
       }),
     );
+    expect(mocks.refreshArchiveBundleProjectionUnderLock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        archivePath: join(
+          REPAIR_WORKTREE,
+          ".adv",
+          "archive",
+          `2026-08-08-${CHANGE_ID}`,
+        ),
+        change: expect.objectContaining({
+          status: "archived",
+          phase9_status: expect.objectContaining({ status: "done" }),
+        }),
+      }),
+    );
     expect(
       mocks.refreshArchiveBundleProjectionUnderLock.mock.invocationCallOrder[0],
     ).toBeLessThan(mocks.removeChangeDir.mock.invocationCallOrder[0]);

--- a/plugin/src/tools/change/handlers-archive.ts
+++ b/plugin/src/tools/change/handlers-archive.ts
@@ -372,6 +372,9 @@ export const advChangeArchiveHandler = async (
     const existingBundlePath = !dryRun
       ? await findArchiveBundle(archivePaths.archive, changeId)
       : null;
+    const existingInRepoBundlePath = !dryRun
+      ? await findArchiveBundle(inRepoArchive, changeId)
+      : null;
     const hasAcceptedDeltas = Object.values(change.deltas).some(
       (deltas) => deltas.length > 0,
     );
@@ -451,6 +454,7 @@ export const advChangeArchiveHandler = async (
               archiveMode,
               phase9,
               existingBundlePath,
+              inRepoBundlePath: existingInRepoBundlePath ?? undefined,
               openOpsObligationsPayload,
               validationWarnings: validationResult.warnings,
             });
@@ -675,6 +679,7 @@ export const advChangeArchiveHandler = async (
           archiveMode,
           phase9,
           existingBundlePath,
+          inRepoBundlePath: existingInRepoBundlePath ?? undefined,
           openOpsObligationsPayload,
           validationWarnings: validationResult.warnings,
         });
@@ -729,7 +734,16 @@ export const advChangeArchiveHandler = async (
         changeId,
         archivePath: archiveResult.archivePath,
         errors: archiveResult.errors,
+        ...(archiveResult.requirement
+          ? { requirement: archiveResult.requirement }
+          : {}),
       });
+
+    const inRepoBundlePath = archiveResult.commitPaths.find((path) =>
+      relative(inRepoBase, path)
+        .replaceAll("\\", "/")
+        .startsWith(".adv/archive/"),
+    );
 
     let finalization: GitFinalizeOutcome | undefined;
     let releaseGateCompletion:
@@ -829,6 +843,7 @@ export const advChangeArchiveHandler = async (
         changeId,
         finalization,
         existingBundlePath: archiveResult.archivePath,
+        inRepoBundlePath,
       });
       if (!releaseResult.ok)
         return formatToolOutput({
@@ -873,6 +888,7 @@ export const advChangeArchiveHandler = async (
           archiveMode,
           phase9,
           existingBundlePath: archiveResult.archivePath,
+          inRepoBundlePath,
           openOpsObligationsPayload,
           validationWarnings: validationResult.warnings,
         });
@@ -1019,19 +1035,35 @@ export const advChangeArchiveHandler = async (
           archivePath: archiveResult.archivePath,
         });
       try {
-        const refreshResult = await withArchiveProjectionLock(
+        const bundlePaths = [
+          archiveResult.archivePath,
+          ...(inRepoBundlePath && inRepoBundlePath !== archiveResult.archivePath
+            ? [inRepoBundlePath]
+            : []),
+        ];
+        const refreshResults = await withArchiveProjectionLock(
           activeStore.paths.root,
-          () =>
-            refreshArchiveBundleProjectionUnderLock({
-              change: outcome.value,
-              archivePath: archiveResult.archivePath,
-              archivedAt: archiveResult.archivedAt,
-            }),
+          async () => {
+            const results = [];
+            for (const archivePath of bundlePaths) {
+              results.push(
+                await refreshArchiveBundleProjectionUnderLock({
+                  change: outcome.value,
+                  archivePath,
+                  archivedAt: archiveResult.archivedAt,
+                }),
+              );
+            }
+            return results;
+          },
         );
-        if (refreshResult.terminalSummaryDegradation)
+        const degradedRefresh = refreshResults.find(
+          (result) => result.terminalSummaryDegradation,
+        );
+        if (degradedRefresh?.terminalSummaryDegradation)
           return formatToolOutput({
             success: false,
-            error: `Archive bundle projection refresh blocked: ${refreshResult.terminalSummaryDegradation.reason}`,
+            error: `Archive bundle projection refresh blocked: ${degradedRefresh.terminalSummaryDegradation.reason}`,
             requirement: "rq-archiveTerminalDurability01.1",
             changeId,
             archivePath: archiveResult.archivePath,


### PR DESCRIPTION
Two defects made an archive bundle non-deterministic across re-runs. Both were observed producing corrupted output, not inferred from reading.

## Defect 1 — `archivedAt` re-derived on every run

`archiveChangeUnderLock` computed the timestamp unconditionally at entry:

```ts
const targetArchivePath =
  context.reuseExistingBundlePath ?? archiveBundlePath(paths.archive, change.id);
const archivedAt = new Date().toISOString();   // :884
```

The first statement already knows the run may be re-archiving — it reuses the *path*. The second re-dated the *content* anyway, and every derived hash was recomputed against it.

**Why PR #428 did not stop this.** That PR made `reconcileInRepoArchive` preserve `archived_at`, which was correct. But on the reuse path `handlers-archive.ts:692` calls `reconcileInRepoArchive`, and then `:703` calls `archiveChange`, which re-writes the same in-repo bundle at `archive.ts:1148` with the freshly stamped value — clobbering what reconcile had just written correctly.

Observed: during the 2026-08-22 phase-9 repair sweep, `pokeedge::fixSetReconciliationPptNullKey` re-stamped `01:48:03 → 04:27:08`. The same mechanism had previously re-dated seven bundles from `2026-08-18T17:57:53` to `2026-08-21T23:21:05`.

## Defect 2 — in-repo bundle written before phase-9 finalization

`archive.ts:1145-1163` wrote the in-repo bundle and returned; phase-9 finalization only began afterwards at `handlers-archive.ts:738`. The bundle could not observe terminal status and was permanently stuck at `pending_merge`. Ordering, not a race — there is no interleaving under which it sees `done`.

`archive-gate.ts:624` already refreshed the **external** bundle after phase-9 commit. The in-repo bundle was not refreshed there.

`addMergeTriggeredArchive` documents a sibling of this on a different field: a change archived with `gates.release.status=pending` despite canonical shipped proof.

## Changes

- Extracted the terminal-summary read that already existed inside `refreshArchiveBundleProjectionUnderLock` into a single `readArchiveBundleArchivedAt` helper. It is now the one owner of that policy, called from three sites — bundle refresh, the main archive path, and `reconcileInRepoArchive`. No logic was cloned; `reconcileInRepoArchive` lost its duplicate copy.
- `archiveChangeUnderLock` resolves `archivedAt` from the existing bundle when reusing one, and only falls back to the clock on a genuine first archive.
- Added `refreshArchiveBundleProjectionsUnderLock`, which refreshes external and in-repo bundles together after phase-9 completion. `inRepoBundlePath` is threaded through `completeReleaseGateAfterFinalization` and `reconcileArchivedBundleRetry`.
- A missing, unreadable, or identity-mismatched terminal summary on the reuse path returns a structured unsuccessful result carrying `rq-archiveTerminalDurability01.1`, rather than rejecting uncaught out of the tool handler. The refusal itself is unchanged — the helper still never invents a timestamp.
- `createArchive` lost its `archivedAt: string = new Date().toISOString()` default and three optional params became required, removing a second silent-default footgun on the same path.

## Verification

- `pnpm exec vitest run src/archive/ src/tools/change/` — **21 files, 174/174 passed**
- `pnpm run check` — clean
- Red-first for all three behaviors: timestamp preservation across external and in-repo bundles, in-repo refresh after phase-9, and the structured-failure path for a bundle with `change.json` but no terminal summary. Each failed before its fix.
- `dead-code:check` not run: it fails pre-existing on trunk (`worktreeDetachHandler` and ~30 others), reproduced on untouched trunk.

## Constraint honored

`.adv/archive/**` is a tracked historical record. This changes only how future writes derive their timestamp; no existing `archived_at` value is rewritten in either direction.