### PR TITLE
fix(agents): teach adv-ci-waiter merge-queue semantics

### DIFF
--- a/.opencode/agents/adv-ci-waiter.md
+++ b/.opencode/agents/adv-ci-waiter.md
@@ -56,7 +56,20 @@ Rules:
 
 ## CI success is not PR MERGED
 
-`oc-ci-wait` reports CI terminal states. Its `conclusion` is CI success or failure, not PR merge state. Do not report `MERGED` based on `oc-ci-wait` output alone. PR `MERGED` requires separate PR-state evidence (`gh pr view <number> --json state,mergedAt,mergeCommit`). When CI success is reported but PR state is not `MERGED`, hand back honestly with a `Pending auto-merge.`-shaped terminal so the parent flow can keep the change active.
+`oc-ci-wait` reports CI terminal states. Its `conclusion` is CI success or failure, not PR merge state. Do not report `MERGED` based on `oc-ci-wait` output alone. PR `MERGED` requires separate PR-state evidence (`gh pr view <number> --json state,mergedAt,mergeCommit`). When CI success is reported but PR state is not `MERGED`, hand back honestly with a `Pending auto-merge.`-shaped terminal — or `Queued.` when the next section applies — so the parent flow can keep the change active. CI success is necessary but not sufficient for release completion.
+
+## Merge queue
+
+A queued PR reports `state: OPEN`, `autoMergeRequest: null`, usually `mergeStateStatus: CLEAN`. That shape is normal and is NOT evidence auto-merge is unarmed — queue membership is independent of `autoMergeRequest`. `gh pr view --json` has no queue field; query GraphQL before reporting any green non-`MERGED` PR:
+
+```bash
+gh api graphql -f query='query{repository(owner:"OWNER",name:"REPO"){pullRequest(number:NUMBER){state isInMergeQueue mergeStateStatus}}}'
+```
+
+- `isInMergeQueue` true: report `PR state: OPEN (queued)`, `next action: wait for queue`. Pending, not terminal-unmerged.
+- Report observed fields only. Arming history is not observable; never claim auto-merge was unarmed or disarmed.
+- Never recommend manual merge, force-push, re-arm, or dequeue. A queued PR rejects force-push and manual merge fights the queue.
+- Queue checks run on a temporary `gh-readonly-queue/<base>/...` branch. Failure ejects the PR back to `OPEN`; report that as a failing-check outcome with names.
 
 ## On red CI: return, do not remediate
 
@@ -94,7 +107,5 @@ done
 - Failing checks: `<names + URLs if available>` or `None`
 - URL: `<workflow/PR URL if available>`
 - Watch ID: `<id>`
-- PR state (if you queried it separately): `MERGED | OPEN | CLOSED | unknown`
-- Next action: `<merge|fix failing checks|rerun|investigate|none>`
-
-If a parent flow asked for terminal CI/PR status and CI is green but PR `MERGED` could not be confirmed in this turn, hand back a `Pending auto-merge.`-shaped terminal rather than guessing. CI success is necessary but not sufficient for release completion.
+- PR state (if you queried it separately): `MERGED | OPEN | OPEN (queued) | CLOSED | unknown`
+- Next action: `<merge|wait for queue|fix failing checks|rerun|investigate|none>`

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -90,5 +90,22 @@
     "mcp",
     "model-context-protocol"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "overrides": {
+    "minimatch": "^10.2.3",
+    "rollup": "^4.59.0",
+    "flatted": ">=3.4.2",
+    "vite": ">=8.0.5",
+    "picomatch": ">=4.0.4",
+    "brace-expansion": ">=5.0.9",
+    "protobufjs": "^7.6.5",
+    "uuid": ">=14.0.0",
+    "fast-uri": ">=4.1.2",
+    "ip-address": ">=10.3.1",
+    "hono": ">=4.12.34",
+    "esbuild": ">=0.28.1",
+    "zod": "4.4.3",
+    "postcss": ">=8.5.23",
+    "@hono/node-server": ">=2.0.5"
+  }
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -90,22 +90,5 @@
     "mcp",
     "model-context-protocol"
   ],
-  "license": "MIT",
-  "overrides": {
-    "minimatch": "^10.2.3",
-    "rollup": "^4.59.0",
-    "flatted": ">=3.4.2",
-    "vite": ">=8.0.5",
-    "picomatch": ">=4.0.4",
-    "brace-expansion": ">=5.0.9",
-    "protobufjs": "^7.6.5",
-    "uuid": ">=14.0.0",
-    "fast-uri": ">=4.1.2",
-    "ip-address": ">=10.3.1",
-    "hono": ">=4.12.34",
-    "esbuild": ">=0.28.1",
-    "zod": "4.4.3",
-    "postcss": ">=8.5.23",
-    "@hono/node-server": ">=2.0.5"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
A PR sitting in a GitHub merge queue reports `state: OPEN` with `autoMergeRequest: null` and `mergeStateStatus: CLEAN`.

`adv-ci-waiter` had no queue semantics, so it read that shape as auto-merge being unarmed, asserted the PR `was not armed, or was disarmed`, and recommended merging manually. Acting on that means force-pushing or manually merging a queued PR — the push is rejected, and a manual merge fights the queue. Observed live against Sharper-Flow/concord#390, which was queued and landed normally while the agent reported it as stalled.

## Fix

- Adds the authoritative check. `gh pr view --json` exposes no queue field; queue membership requires the GraphQL `isInMergeQueue` field, verified working against a real PR. It is now queried before reporting any green non-`MERGED` PR.
- Constrains the agent to observed fields. Arming history is not observable from PR state, so it may no longer claim auto-merge was unarmed or disarmed, nor recommend manual merge, force-push, re-arm, or dequeue.
- Records that queue checks run on a temporary `gh-readonly-queue/<base>/...` branch and that failure ejects the PR back to `OPEN`, which is a failing-check outcome rather than a merge that did not happen.

## Prompt budget

The first draft added 1808 bytes over trunk and tripped the prompt floor check. Rather than raise the ceiling, the section was compressed and the trailing paragraph that restated the "CI success is not PR MERGED" section verbatim was deleted. Net cost is now +903 bytes over trunk, passing at 233379/233453.

Two pre-existing observations, neither introduced here: the recorded baseline reports `44` instruction entries while trunk measures `43`, so the baseline is stale; and headroom is now 74 bytes, so the next instruction edit will trip the check.