### PR TITLE
fix(voice): repoint command voice standard from caveman-full to the STE contract

### DIFF
--- a/.opencode/command/adv-harden.md
+++ b/.opencode/command/adv-harden.md
@@ -571,7 +571,7 @@ Populate release-owned rows from harden evidence:
 Rules:
 
 - Every row must include status plus brief source/evidence pointer.
-- Summary prose must keep outcome, value/why it matters, verification, risks/follow-ups, and supporting evidence visible; caveman-full wording may tighten wording but must not remove those decision essentials.
+- Summary prose must keep outcome, value/why it matters, verification, risks/follow-ups, and supporting evidence visible; the global ASD-STE100 voice contract may tighten wording but must not remove those decision essentials.
 - Impact wording is evidence-only. Do not invent user/business benefit — but DO trace and surface benefit prose already articulated in the proposal, agreement, or executive summary (canonical source: `_executiveSummary ## Value`). Evidenced benefit MUST appear in the Release Readiness Summary; leaving evidenced benefit untraced is a gap to flag, not a safe default. If no value articulation exists in any artifact, omit the benefit line.
 - Ops readiness and open follow-ups must cite runbook/reconciliation fields when present: `status_source`, `completion_proof`, completion signal, health verification, rollback/cleanup disposition, and any unreachable child warning/blocker.
 - Missing scanner/sub-agent output needed for a release-owned row is `warning` or `blocked` with evidence `harden evidence unavailable`; never render it as `n/a`.

--- a/ADV_INSTRUCTIONS.md
+++ b/ADV_INSTRUCTIONS.md
@@ -8,7 +8,7 @@ Specs are laws. Requirements are formally defined, validated, and enforced.
 
 ### Instruction Compression Guard
 
-Use `docs/command-voice-standard.md` prose-load templates + caveman-full wording. Exact contract tokens stay unchanged: tool names, gate IDs, statuses, slash commands, enum values, quoted errors, `MUST`, `NEVER`, approval checkpoints, cancellation approval, archive sign-off, JSON/code examples.
+Use `docs/command-voice-standard.md` prose-load templates + the global ASD-STE100 voice contract wording. Exact contract tokens stay unchanged: tool names, gate IDs, statuses, slash commands, enum values, quoted errors, `MUST`, `NEVER`, approval checkpoints, cancellation approval, archive sign-off, JSON/code examples.
 
 ## Core Decision Rules
 

--- a/docs/command-voice-standard.md
+++ b/docs/command-voice-standard.md
@@ -190,7 +190,7 @@ Command doc frontmatter `description` MUST be a **single-line YAML scalar** — 
 
 Manifest descriptions and command doc text cover **what** and **when**. This section covers **how to speak** when emitting runtime user-facing prose.
 
-### Style target — caveman-full (uniform wording-density compression)
+### Style target — global ASD-STE100 voice contract (uniform wording-density compression)
 
 - Short sentences. Fragments OK.
 - Bullets and tables over prose.
@@ -234,7 +234,7 @@ Manifest descriptions and command doc text cover **what** and **when**. This sec
 
 - Lightweight: voice block referenced in `.opencode/agents/adv.md` and shared-agent overlays
 - Governed by `rq-handoffVoice01` (handoff voice spine)
-- Global `~/.config/opencode/instructions/caveman.md` remains user-config; not synced by repo
+- Global voice authority: injected per LLM call by the opencode-voice-contract plugin; full rules at `~/.config/opencode/instructions/asd-ste100.md`; not synced by this repo
 
 ## Prose-Load Reduction Rules
 
@@ -275,9 +275,9 @@ ADV instruction surfaces (`ADV_INSTRUCTIONS.md`, `docs/command-voice-standard.md
 |---|---|
 ```
 
-### Caveman-full composition
+### STE-profile composition
 
-Caveman-full is a wording-density layer on top of these templates, not a competing compression method.
+The STE profile is a wording-density layer on top of these templates, not a competing compression method.
 
 | Constraint | Rule |
 |---|---|
@@ -517,7 +517,7 @@ Mid-command banner taxonomy (CONTRACT ACTIVE, CONTRACT STATUS, CONTRACT FULFILLE
 | CONTRACT ACTIVE | Trim to purpose line | `Working on: {change-id}` + reference to `_contextSnapshot` for state |
 | CONTRACT STATUS | Drop entirely | No per-task status block. State visible via `adv_task_list` and `_contextSnapshot`. TDD phase markers (`TDD_RED`/`TDD_GREEN`) were retired — TDD evidence lives in `adv_run_test` tool records |
 | CONTRACT FULFILLED | Replace with spine | Use the canonical three-section spine + footer (apply → review handoff) |
-| QUICK CONTRACT | Keep, apply caveman-full | Retain contract-confirmation shape (INTENT / SCOPE / USER OUTCOMES). Tighten labels, drop filler. Not a handoff — mid-command confirmation block |
+| QUICK CONTRACT | Keep, apply STE profile | Retain contract-confirmation shape (INTENT / SCOPE / USER OUTCOMES). Tighten labels, drop filler. Not a handoff — mid-command confirmation block |
 | READY FOR BUILD | Replace with fast-track spine | Use the fast-track variant above |
 | ARCHIVE COMPLETE | Replace with archive terminal spine | Use the archive terminal variant above |
 
@@ -638,7 +638,7 @@ Remaining gates: design ○, planning ○, execution ○, acceptance ○, releas
 Gate handoff messages dump internal mechanics instead of user-relevant content.
 
 ## Chosen direction
-Agreed objectives + constraints + user decisions. Spine = Problem / Chosen direction / Delivered + blockquote wayfinder block. Banner cleanup included. Caveman-full matches global config. Extend existing voice standard doc. Replace Orchestration Summary entirely.
+Agreed objectives + constraints + user decisions. Spine = Problem / Chosen direction / Delivered + blockquote wayfinder block. Banner cleanup included. STE profile matches global config. Extend existing voice standard doc. Replace Orchestration Summary entirely.
 
 ## Delivered
 - Agreement confirmed: three-section spine + blockquote wayfinder block for all gate handoffs

--- a/docs/provider-adv-smoke-checklist.md
+++ b/docs/provider-adv-smoke-checklist.md
@@ -47,7 +47,7 @@ Run after `scripts/deploy-local.sh --fix` and after any manual provider-agent co
 - [ ] Provider eval reports `adv_reference_protocol`
 - [ ] Provider eval reports `provider_hint`
 - [ ] Provider eval reports `adv_dynamic_system_block_estimate`
-- [ ] Provider eval reports `caveman_voice_contract_allowance`
+- [ ] Provider eval reports `voice_contract_allowance`
 - [ ] Provider eval reports `selected_agent_runtime_prompt`
 - [ ] Provider eval reports `avoided_provider_variant_duplication` when stale retired files are measurable
 - [ ] Provider eval does not require generated `adv-{provider}.md` files as canonical prompt sources

--- a/docs/provider-agent-assembly.md
+++ b/docs/provider-agent-assembly.md
@@ -71,7 +71,7 @@ Provider hint deployment is handled by `~/toolbox/scripts/deploy-provider-hints.
 | `adv_reference_protocol` | Full `ADV_INSTRUCTIONS.md` reference protocol size, not embedded into runtime `adv.md` |
 | `provider_hint` | Provider hint payload from standalone plugin when available |
 | `adv_dynamic_system_block_estimate` | Estimated ADV runtime banner/status additions appended to `output.system[0]` |
-| `caveman_voice_contract_allowance` | Reporting allowance for caveman voice contract when that plugin is active |
+| `voice_contract_allowance` | Reporting allowance for the global ASD-STE100 voice contract appended by the opencode-voice-contract plugin |
 | `selected_agent_runtime_prompt` | Single ADV runtime prompt plus one runtime hint |
 | `avoided_provider_variant_duplication` | Retired generated provider file size if a stale file is still present |
 

--- a/docs/specs/advance-meta.md
+++ b/docs/specs/advance-meta.md
@@ -783,7 +783,7 @@ ADV must expose one canonical lean ADV runtime prompt while preserving provider-
 
 **ID:** `rq-providerAdvMetrics01` | **Priority:** **[MUST]**
 
-Provider ADV evaluation must report prompt-size planes for the single-agent architecture: lean ADV runtime prompt size, ADV reference protocol size, provider hint size, dynamic ADV system-block estimate, caveman voice-contract allowance, selected runtime prompt size, and removed or avoided provider-variant duplication. Metrics must be coverage-first reporting and must not require generated adv-{provider}.md files as canonical inputs or impose a hard prompt-size cap as correctness proof.
+Provider ADV evaluation must report prompt-size planes for the single-agent architecture: lean ADV runtime prompt size, ADV reference protocol size, provider hint size, dynamic ADV system-block estimate, global voice-contract allowance, selected runtime prompt size, and removed or avoided provider-variant duplication. Metrics must be coverage-first reporting and must not require generated adv-{provider}.md files as canonical inputs or impose a hard prompt-size cap as correctness proof.
 
 **Tags:** `provider-adv`, `metrics`, `prompt-size`
 
@@ -801,7 +801,7 @@ Provider ADV evaluation must report prompt-size planes for the single-agent arch
 - Metrics include adv_reference_protocol bytes and lines
 - Metrics include provider hint bytes and lines
 - Metrics include adv_dynamic_system_block_estimate bytes and lines
-- Metrics include caveman_voice_contract_allowance bytes and lines
+- Metrics include voice_contract_allowance bytes and lines
 - Metrics include selected_agent_runtime_prompt bytes and lines for the composed single ADV prompt plus one runtime provider hint
 - Metrics include removed or avoided provider-variant duplication when measurable
 - The harness does not require generated provider variant files as canonical prompt sources

--- a/docs/specs/advance-workflow.md
+++ b/docs/specs/advance-workflow.md
@@ -1131,7 +1131,7 @@ Release-repair recovery for completed or unavailable change projections MUST be 
 
 **ID:** `rq-executiveSummaryAudience01` | **Priority:** **[MUST]**
 
-ADV executive summaries MUST be written for non-technical release-approval readers while preserving audit evidence and technical traceability. Each summary MUST include the decision essentials: outcome, delivered value or why it matters, verification, risks/follow-ups, and supporting evidence. Summary guidance MUST use evidence-only impact wording: do not fabricate user or business benefit beyond proposal, agreement, task, review, harden, archive, or follow-up evidence. Unavoidable technical terms MAY appear only as parenthetical supporting detail after the plain-English meaning. Caveman-full voice MUST NOT compress away executive-summary or release-readiness artifact substance.
+ADV executive summaries MUST be written for non-technical release-approval readers while preserving audit evidence and technical traceability. Each summary MUST include the decision essentials: outcome, delivered value or why it matters, verification, risks/follow-ups, and supporting evidence. Summary guidance MUST use evidence-only impact wording: do not fabricate user or business benefit beyond proposal, agreement, task, review, harden, archive, or follow-up evidence. Unavoidable technical terms MAY appear only as parenthetical supporting detail after the plain-English meaning. The global voice contract MUST NOT compress away executive-summary or release-readiness artifact substance.
 
 **Tags:** `workflow`, `executive-summary`, `release`, `approval`, `voice`
 
@@ -1173,17 +1173,17 @@ ADV executive summaries MUST be written for non-technical release-approval reade
 - Technical terms appear as parenthetical supporting detail
 - Dense implementation jargon does not lead the summary
 
-**Caveman-full preserves summary substance** (`rq-executiveSummaryAudience01.4`)
+**Voice-contract compression preserves summary substance** (`rq-executiveSummaryAudience01.4`)
 
 **Given:**
-- Caveman-full voice compression applies to runtime prose
+- Global voice-contract compression applies to runtime prose
 - The content is executive-summary or release-readiness artifact substance
 
 **When:** The artifact is written or displayed
 
 **Then:**
-- Caveman-full may make wording scannable
-- Caveman-full must not compress away outcome, value, verification, risks/follow-ups, or supporting evidence
+- The voice contract may make wording scannable
+- The voice contract must not compress away outcome, value, verification, risks/follow-ups, or supporting evidence
 - Required approval consequence context remains visible
 
 ---

--- a/plugin/src/deploy-local.test.ts
+++ b/plugin/src/deploy-local.test.ts
@@ -456,7 +456,7 @@ describe("deploy-local.sh", () => {
       expect(providerEval).toContain("adv_reference_protocol");
       expect(providerEval).toContain("provider_hint");
       expect(providerEval).toContain("adv_dynamic_system_block_estimate");
-      expect(providerEval).toContain("caveman_voice_contract_allowance");
+      expect(providerEval).toContain("voice_contract_allowance");
       expect(providerEval).toContain("selected_agent_runtime_prompt");
       expect(providerEval).toContain("avoided_provider_variant_duplication");
       expect(providerEval).toContain("Lean ADV runtime prompt");
@@ -532,7 +532,7 @@ describe("deploy-local.sh", () => {
         "adv_reference_protocol",
         "provider_hint",
         "adv_dynamic_system_block_estimate",
-        "caveman_voice_contract_allowance",
+        "voice_contract_allowance",
         "selected_agent_runtime_prompt",
       ]) {
         expect(`${assemblyDoc}\n${smokeDoc}`).toContain(required);
@@ -586,7 +586,7 @@ describe("deploy-local.sh", () => {
       expect(specText).toContain("lean ADV runtime prompt");
       expect(specText).toContain("runtime protocol coverage inventory");
       expect(specText).toContain("adv_reference_protocol");
-      expect(specText).toContain("caveman_voice_contract_allowance");
+      expect(specText).toContain("voice_contract_allowance");
       expect(specText).not.toContain(
         "Global adv.md contains the canonical ADV body and ADV_INSTRUCTIONS.md protocol content",
       );

--- a/scripts/provider-eval.ts
+++ b/scripts/provider-eval.ts
@@ -114,7 +114,7 @@ interface PromptSizeMetrics {
   adv_reference_protocol: PromptSizeMetric;
   provider_hint: PromptSizeMetric | null;
   adv_dynamic_system_block_estimate: PromptSizeMetric;
-  caveman_voice_contract_allowance: PromptSizeMetric;
+  voice_contract_allowance: PromptSizeMetric;
   selected_agent_runtime_prompt: PromptSizeMetric;
   avoided_provider_variant_duplication: PromptSizeMetric | null;
 }
@@ -183,8 +183,8 @@ const ADV_DYNAMIC_SYSTEM_BLOCK_ESTIMATE = [
   "[ADV:WORKTREE_SESSION] Active worktree and change context",
 ].join("\n");
 
-const CAVEMAN_VOICE_CONTRACT_ALLOWANCE =
-  "Caveman voice contract allowance: terse concrete prose appended to output.system[0] when caveman is active.";
+const VOICE_CONTRACT_ALLOWANCE =
+  "Voice contract allowance: the global ASD-STE100 voice contract appended to output.system[0] by the opencode-voice-contract plugin.";
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -358,8 +358,8 @@ export function collectPromptSizeMetrics(input: {
     adv_dynamic_system_block_estimate: sizeOfContent(
       ADV_DYNAMIC_SYSTEM_BLOCK_ESTIMATE,
     ),
-    caveman_voice_contract_allowance: sizeOfContent(
-      CAVEMAN_VOICE_CONTRACT_ALLOWANCE,
+    voice_contract_allowance: sizeOfContent(
+      VOICE_CONTRACT_ALLOWANCE,
     ),
     selected_agent_runtime_prompt: sizeOfContent(input.runtimePrompt),
     avoided_provider_variant_duplication,
@@ -719,7 +719,7 @@ async function runEvaluation(
     `ADV dynamic system block estimate: ${formatSize(promptMetrics.adv_dynamic_system_block_estimate)}`,
   );
   console.log(
-    `Caveman voice contract allowance: ${formatSize(promptMetrics.caveman_voice_contract_allowance)}`,
+    `Voice contract allowance: ${formatSize(promptMetrics.voice_contract_allowance)}`,
   );
   if (promptMetrics.avoided_provider_variant_duplication) {
     console.log(


### PR DESCRIPTION
The caveman plugin was removed from the host on 2026-08-23. The global voice authority is now the ASD-STE100 contract injected by `opencode-voice-contract`, backed by the always-loaded `~/.config/opencode/instructions/asd-ste100.md`. This repo still named the dead plugin as its style target in nine active surfaces.

## Voice concept repoint

| Surface | Change |
|---|---|
| `ADV_INSTRUCTIONS.md` | compression guard cites the global ASD-STE100 voice contract |
| `docs/command-voice-standard.md` | style target retitled; dead pointer to `instructions/caveman.md` replaced with the live authority pair; composition section and two template rows renamed |
| `.opencode/command/adv-harden.md` | release-readiness rule cites the global voice contract |
| `docs/specs/advance-workflow.md` | `rq-executiveSummaryAudience01.4` + parent MUST reworded; semantics unchanged |

## Metric rename: `caveman_voice_contract_allowance` → `voice_contract_allowance`

Renamed together across implementation, tests, and spec law so `rq-providerAdvMetrics01` and `provider-eval.ts` stay in lockstep:

- `scripts/provider-eval.ts` (field, constant, description, output)
- `plugin/src/deploy-local.test.ts` (3 assertions)
- `docs/provider-agent-assembly.md`, `docs/provider-adv-smoke-checklist.md`, `docs/specs/advance-meta.md`

The description now describes the live contract rather than the deleted plugin.

## Untouched

CHANGELOG entries and `.adv` archive bundles are history.

## Verification

- Full plugin suite: **5227 passed, 1 skipped, 12 todo**
- Zero active caveman references outside CHANGELOG and `.adv`