### PR TITLE
refactor(prompt): dedup adv agent overlay against body and global rules

### DIFF
--- a/.opencode/agents/adv.md
+++ b/.opencode/agents/adv.md
@@ -99,16 +99,11 @@ permission:
 ## ADV Overlay
 
 - NEVER invoke `/adv-*` from inside ADV; execute ADV workflows inline with tools instead of slash-command dispatch
-- Only the top-level orchestrator may spawn sub-agents
-- Spawned workers must complete inline and must not spawn additional sub-agents; nesting depth is hard-limited to `1`
-- Structural correctness (P33): prefer types/schemas/parsers/state machines/validators/tests over heuristic inference; heuristics may assist discovery/ranking/triage, never own correctness, security, persistence, gate completion, or spec compliance.
+- Only the top-level orchestrator may spawn sub-agents; nesting depth is hard-limited to `1` (see Sub-Agent Policy)
 
 ## Voice Contract
 
-User-facing prose: terse, concrete, low-fluff. Prefer bullets/tables/fragments. Keep technical terms and quoted errors exact. See `docs/command-voice-standard.md` § Voice Contract.
-Normal prose OK for JSON/structured outputs, code, commits/PRs, status markers, safety warnings, destructive/cancellation approvals, and sequence-sensitive multi-step instructions.
-
-Lead user-facing messages with what the user sees / what changes for them. Move file paths, function names, schema details into artifacts (design.md, wisdom, code comments). See `docs/command-voice-standard.md` § User-Focus.
+User-facing prose: terse, concrete, low-fluff; lead with what the user sees. Structured output, code, commits/PRs, and safety warnings stay exempt. See `docs/command-voice-standard.md` § Voice Contract and § User-Focus.
 
 ## Scope Validity
 

--- a/skills/adv-instructions-audit/SKILL.md
+++ b/skills/adv-instructions-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adv-instructions-audit
-description: "Audit Advance instruction prose (AGENTS.md, project.md, ADV_INSTRUCTIONS.md, command/agent files) against executable anchors. Use when editing instructions, suspecting drift after a docs edit broke CI, or checking whether a protocol rule has any executable backing."
+description: "Audit Advance instruction prose against executable anchors. Use when editing instructions, suspecting drift after a docs edit broke CI, or checking a protocol rule's executable backing."
 keywords: ["adv", "instructions", "drift", "anchors", "docs-as-code", "coverage", "audit"]
 metadata:
   priority: medium


### PR DESCRIPTION
Saves ~185 o200k per adv-agent load with no normative loss: nesting/P33/voice-contract text is restated by the adv.md body, global rules.yaml (P33), and the voice-contract plugin. Scope Validity and the NEVER-invoke rule kept (no body duplicate). Also trims adv-instructions-audit skill description. Tests: mcp-runtime-matrix + agent-prompt-policy-binding 27/27.