### PR TITLE
fix(adv): repair dead INTERNAL_CALL_PATTERNS

### DIFF
--- a/plugin/src/utils/system-block.test.ts
+++ b/plugin/src/utils/system-block.test.ts
@@ -9,10 +9,14 @@
  * and JC-3 (strict regex internal-call detection).
  */
 
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
-  INTERNAL_CALL_PATTERNS,
   VOLATILE_SENTINEL,
   applyAdvSystemBlock,
   assembleSystemBlock,
@@ -44,37 +48,35 @@ const cleanInput = (
   ...overrides,
 });
 
-// ─── Constants ──────────────────────────────────────────────────────────────
+const INTERNAL_CALL_FIXTURES = {
+  title:
+    "You are a title generator. You output ONLY a thread title. Nothing else.",
+  compaction: "You are a context summarization agent.",
+  agent:
+    "You are an elite AI agent architect specializing in crafting high-performance agent configurations.",
+} as const;
+
+function resolveOpencodeBinary(): string | null {
+  const configured = process.env.OPENCODE_BIN;
+  if (configured) return existsSync(configured) ? configured : null;
+
+  try {
+    const resolved = execFileSync("sh", ["-c", "command -v opencode"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (resolved && existsSync(resolved)) return resolved;
+  } catch {
+    // Fall through to the known local installation path.
+  }
+
+  const fallback = join(homedir(), ".opencode", "bin", "opencode");
+  return existsSync(fallback) ? fallback : null;
+}
 
 describe("VOLATILE_SENTINEL", () => {
   it("is the documented divider string per AC8 and design F3", () => {
     expect(VOLATILE_SENTINEL).toBe("--- ADV:VOLATILE ---");
-  });
-});
-
-describe("INTERNAL_CALL_PATTERNS", () => {
-  it("includes title-generation pattern (per JC-3)", () => {
-    expect(
-      INTERNAL_CALL_PATTERNS.some((re) =>
-        re.test("Generate a short title for this conversation"),
-      ),
-    ).toBe(true);
-  });
-
-  it("includes summarizer pattern (per JC-3)", () => {
-    expect(
-      INTERNAL_CALL_PATTERNS.some((re) =>
-        re.test("You are a helpful assistant that summarizes content"),
-      ),
-    ).toBe(true);
-  });
-
-  it("does NOT match a normal user prompt", () => {
-    expect(
-      INTERNAL_CALL_PATTERNS.some((re) =>
-        re.test("You are an ADV agent. Use the tools..."),
-      ),
-    ).toBe(false);
   });
 });
 
@@ -89,22 +91,38 @@ describe("isInternalCall", () => {
     expect(isInternalCall("")).toBe(false);
   });
 
-  it("returns true when existing system contains a title-gen pattern", () => {
-    expect(
-      isInternalCall("You are a model. Generate a short title for the input."),
-    ).toBe(true);
-  });
-
-  it("returns true when existing system contains the summarizer pattern", () => {
-    expect(
-      isInternalCall("You are a helpful assistant that summarizes content."),
-    ).toBe(true);
-  });
+  it.each(Object.values(INTERNAL_CALL_FIXTURES))(
+    "returns true for a real OpenCode internal prompt fixture",
+    (fixture) => {
+      expect(isInternalCall(fixture)).toBe(true);
+    },
+  );
 
   it("returns false for an ordinary system prompt", () => {
     expect(
       isInternalCall("You are working on ADV change makeFooBar. Use tools."),
     ).toBe(false);
+  });
+
+  // This skips in GitHub CI by design because no OpenCode binary exists there.
+  // This is a local calibration check. A named follow-up, scheduled upstream-drift CI job, restores CI coverage.
+  it("matches each fixture in the installed OpenCode binary", (ctx) => {
+    const bin = resolveOpencodeBinary();
+    if (!bin) {
+      ctx.skip();
+      return;
+    }
+
+    for (const fixture of Object.values(INTERNAL_CALL_FIXTURES)) {
+      try {
+        execFileSync("grep", ["-aqF", fixture, bin]);
+      } catch (error) {
+        throw new Error(
+          `OpenCode binary is missing internal prompt fixture: ${fixture}`,
+          { cause: error },
+        );
+      }
+    }
   });
 });
 
@@ -164,7 +182,7 @@ describe("assembleSystemBlock", () => {
     it("returns null when existing system matches title-gen pattern", () => {
       const block = assembleSystemBlock(
         cleanInput({
-          existingSystem: "Generate a short title for this conversation",
+          existingSystem: INTERNAL_CALL_FIXTURES.title,
           state: cleanState({ activeChange: { id: "c1" } }),
         }),
       );
@@ -174,7 +192,17 @@ describe("assembleSystemBlock", () => {
     it("returns null when existing system matches summarizer pattern", () => {
       const block = assembleSystemBlock(
         cleanInput({
-          existingSystem: "You are a helpful assistant that summarizes ...",
+          existingSystem: INTERNAL_CALL_FIXTURES.compaction,
+          state: cleanState({ activeChange: { id: "c1" } }),
+        }),
+      );
+      expect(block).toBeNull();
+    });
+
+    it("returns null when existing system matches agent-generation pattern", () => {
+      const block = assembleSystemBlock(
+        cleanInput({
+          existingSystem: INTERNAL_CALL_FIXTURES.agent,
           state: cleanState({ activeChange: { id: "c1" } }),
         }),
       );
@@ -533,16 +561,14 @@ describe("applyAdvSystemBlock", () => {
   });
 
   it("returns emitted: false and leaves system untouched on internal call", () => {
-    const output = { system: ["Generate a short title for this conversation"] };
+    const output = { system: [INTERNAL_CALL_FIXTURES.title] };
     const result = applyAdvSystemBlock(output, {
       state: cleanState({ activeChange: { id: "c1" } }),
       initError: null,
       storeAvailable: true,
     });
     expect(result.emitted).toBe(false);
-    expect(output.system).toEqual([
-      "Generate a short title for this conversation",
-    ]);
+    expect(output.system).toEqual([INTERNAL_CALL_FIXTURES.title]);
   });
 
   it("returns emitted: false when no section produces content", () => {

--- a/plugin/src/utils/system-block.test.ts
+++ b/plugin/src/utils/system-block.test.ts
@@ -104,8 +104,7 @@ describe("isInternalCall", () => {
     ).toBe(false);
   });
 
-  // This skips in GitHub CI by design because no OpenCode binary exists there.
-  // This is a local calibration check. A named follow-up, scheduled upstream-drift CI job, restores CI coverage.
+  // CI environments without OpenCode skip this local binary calibration check.
   it("matches each fixture in the installed OpenCode binary", (ctx) => {
     const bin = resolveOpencodeBinary();
     if (!bin) {

--- a/plugin/src/utils/system-block.ts
+++ b/plugin/src/utils/system-block.ts
@@ -22,8 +22,8 @@
  *     dividers.
  *   - Internal-call detection (per JC-3): when the existing
  *     `output.system[0]` matches one of the OpenCode internal-call
- *     patterns (title generation, summarizer), the assembler returns null
- *     so ADV content does not pollute internal flows.
+ *     patterns (title generation, compaction, agent generation), the
+ *     assembler returns null so ADV content does not pollute internal flows.
  *
  * Contract:
  *   - This module is a pure formatter. No IO, no side effects, no state
@@ -101,11 +101,10 @@ export const VOLATILE_SENTINEL = "--- ADV:VOLATILE ---";
 
 /** Patterns match the opening sentence of OpenCode's three internal prompts:
  *  `agent/prompt/title.txt`, `agent/prompt/compaction.txt`, and
- *  `agent/generate.txt`. The drift test keeps these anchors true.
- *  `compaction.txt` is the least stable anchor (6 commits in 8 months, last
- *  rewritten 2026-08-12). Conservative bias: a positive match here causes
- *  the assembler to return null, skipping ADV content. False negatives
- *  default to including ADV content, which may pollute the internal prompt. */
+ *  `agent/generate.txt`. The drift test verifies these anchors against the
+ *  installed binary. Conservative bias: a positive match here causes the
+ *  assembler to return null, skipping ADV content. False negatives default
+ *  to including ADV content, which may pollute the internal prompt. */
 export const INTERNAL_CALL_PATTERNS: readonly RegExp[] = [
   /You are a title generator\. You output ONLY a thread title/i,
   /You are a context summarization agent\./i,
@@ -115,7 +114,7 @@ export const INTERNAL_CALL_PATTERNS: readonly RegExp[] = [
 // ─── Predicates ─────────────────────────────────────────────────────────────
 
 /** True when the existing system content matches a known OpenCode
- *  internal-call pattern (title generation, summarizer, …). */
+ *  internal-call pattern (title generation, compaction, agent generation). */
 export function isInternalCall(existingSystem: string | null): boolean {
   if (!existingSystem) return false;
   return INTERNAL_CALL_PATTERNS.some((re) => re.test(existingSystem));
@@ -335,7 +334,7 @@ export function applyAdvSystemBlock(
  *
  * Returns null when:
  *   - The call is detected as an OpenCode internal call
- *     (title generation, summarizer)
+ *     (title generation, compaction, agent generation)
  *   - No section produces content
  *
  * Order:

--- a/plugin/src/utils/system-block.ts
+++ b/plugin/src/utils/system-block.ts
@@ -99,18 +99,17 @@ export interface AssembleSystemBlockInput {
  *  system entry on this token to mark the cacheable prefix. */
 export const VOLATILE_SENTINEL = "--- ADV:VOLATILE ---";
 
-/** Patterns identifying OpenCode internal calls (title gen, summarizer).
- *
- *  Per JC-3, strict-regex match is used; unrecognized internal-call shapes
- *  are the caller's responsibility to log via `debugLog` so this list can
- *  be calibrated over time. Conservative bias: a positive match here
- *  causes the assembler to return null, skipping ADV content. False
- *  negatives default to including ADV content (which is safe but may
- *  pollute the internal call's prompt — strictly worse than the previous
- *  multi-block emission). */
+/** Patterns match the opening sentence of OpenCode's three internal prompts:
+ *  `agent/prompt/title.txt`, `agent/prompt/compaction.txt`, and
+ *  `agent/generate.txt`. The drift test keeps these anchors true.
+ *  `compaction.txt` is the least stable anchor (6 commits in 8 months, last
+ *  rewritten 2026-08-12). Conservative bias: a positive match here causes
+ *  the assembler to return null, skipping ADV content. False negatives
+ *  default to including ADV content, which may pollute the internal prompt. */
 export const INTERNAL_CALL_PATTERNS: readonly RegExp[] = [
-  /Generate a short title/i,
-  /You are a helpful assistant that summarizes/i,
+  /You are a title generator\. You output ONLY a thread title/i,
+  /You are a context summarization agent\./i,
+  /You are an elite AI agent architect/i,
 ];
 
 // ─── Predicates ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`INTERNAL_CALL_PATTERNS` in `plugin/src/utils/system-block.ts` matched no OpenCode internal-call prompt. Verified by `grep -aF` against the installed binary: both guarded strings (`Generate a short title`, `You are a helpful assistant that summarizes`) absent; the three real prompt openings present. `isInternalCall()` always returned false, so ADV content was injected into every title-generation, compaction, and agent-generation call.

## Root cause

The patterns were authored from invented prompt text. The test suite asserted them against the same invented strings — a closed loop that could not fail.

## Change

- Patterns replaced with the three real internal prompt openings (unanchored full first sentences; `^` anchoring rejected in design review).
- Closed-loop test assertions replaced with checked-in real-prompt fixtures; assembler suppression call sites repointed.
- Binary drift test: fails when a fixture vanishes from the installed opencode binary, skips when no binary (CI). Adversarially verified both paths.
- `isInternalCall()` / `assembleSystemBlock()` signatures and control flow unchanged.

Paired with JRedeker/toolbox#253 (downstream copies of this pattern list).

## Verification

- system-block suite 60/60; full `bin/oc-test full`: 5240 passed, 1 skipped, 12 todo.
- typecheck, lint, format, test-isolation clean.
- Known pre-existing on trunk (identical on this branch): local `pnpm run check` prompt-budget floor 236847 > 233453. Not introduced here; not run in CI.

Change: fixDeadInternalCallGuards