### PR TITLE
docs(rules): rewrite recommended P29 as yagni-scope-discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 
+- **Recommended rule P29 rewritten as `yagni-scope-discipline`** in `SETUP.md` and `skills/adv-rule-rationale`. YAGNI now leads the rule affirmatively (build only what the accepted request requires now; record plausible future needs as named follow-ups), a new `scope` field binds the rule to solution design during delivery — never to accepting, questioning, or renegotiating the request — and an explicit non-license clause bars under-building, narrowing approved scope, skipping research/tests/verification, and refusing user-requested work (challenges route through clarification P08). The clarity-over-smallest-diff substance is retained, subordinated to the YAGNI lead, and the `(see P41)` cross-reference is restored at the closer. Replaces the `clean-not-minimal` framing whose headline pulled opposite its buried YAGNI clause. Origin: toolbox corpus rewrite `promoteYagniP29` (PR #255, 2026-08-29, independent-validator approved). `rules.yaml` stays user-managed.
 - **Disk-only runtime persistence** — Removed the historical Temporal runtime architecture. Advance now keeps authoritative change, task, gate, and Epic state in per-project disk projections with per-change locking, atomic crash-safe writes, optimistic version checks for Epics, and fail-closed transaction verification. No external runtime service is required.
 
 ### Added

--- a/SETUP.md
+++ b/SETUP.md
@@ -391,12 +391,14 @@ cp -r /path/to/Advance/.opencode/command/* .opencode/command/
 
 ---
 
-## Clean-Not-Minimal Rule (P29)
+## YAGNI Scope-Discipline Rule (P29)
 
-ADV recommends a clarity-first design rule that explicitly counters the
-agent failure mode of "minimize touch / minimize blast radius at the cost
-of structural quality." Like P28, `rules.yaml` is **user-managed** so this
-rule must be added manually:
+ADV recommends a solutioning-scope rule that states YAGNI affirmatively:
+build only what the accepted request requires now, and never use YAGNI to
+contend with the request itself. Rewritten 2026-08-29 from the earlier
+`clean-not-minimal` framing, which carried YAGNI only as a mid-paragraph
+clause under a headline that pulled the opposite direction. Like P28,
+`rules.yaml` is **user-managed** so this rule must be added manually:
 
 1. Open `~/.config/opencode/instructions/rules.yaml`
 2. Add the following entry in the `rules:` map (P29 recommended):
@@ -406,16 +408,31 @@ rules:
   # ... existing rules ...
 
   P29:
-    name: clean-not-minimal
-    rule: Optimize for clarity and maintainability, not for the smallest
-      possible diff. When a wider architectural change produces a cleaner
-      result, surface it — do not suppress better ideas to minimize blast
-      radius or touch. Avoid speculative features and abstractions for
-      hypothetical future needs (YAGNI), but do not confuse YAGNI with
-      refusing necessary structural work or withholding stronger design
-      proposals.
-    tags: [clarity, design, simplicity, architecture, yagni]
-    hint: clean_not_minimal
+    name: yagni-scope-discipline
+    scope: >-
+      Solution design and implementation scope while delivering an accepted
+      request. Governs what you build, not whether to accept, question, or
+      renegotiate the request itself.
+    rule: >-
+      Build only what the accepted request requires now. Do not add unrequested
+      capability, configuration knobs, abstraction layers, extension points,
+      generality, or defensive breadth for anticipated future needs (YAGNI);
+      record a plausible future need as a named follow-up instead of building
+      it. YAGNI governs the solution, never the delivery: it does not license
+      under-building the request, narrowing approved scope, skipping research,
+      tests, or verification, or refusing user-requested work — challenge a
+      request through clarification (P08), not through silent omission. It
+      also does not license refusing necessary structural work or withholding
+      a stronger design proposal.
+
+      Within that boundary, optimize for clarity and maintainability, not for
+      the smallest possible diff: when a wider architectural change produces
+      a cleaner result, surface it — do not suppress better ideas to minimize
+      blast radius or touch. This rule governs scope ambition, not leftover
+      code: it never licenses retaining a construct the change supersedes
+      (see P41).
+    tags: [yagni, scope, clarity, design, simplicity]
+    hint: yagni_scope_discipline
     priority: 7
 ```
 
@@ -428,9 +445,12 @@ not at the priority-9/10 tier reserved for security and safety constraints.
 caused agents to pattern-match on "smallest" and "reversible," reading the
 rule as "minimize touch / avoid wider architectural changes." That suppressed
 legitimate proposals to refactor or restructure when the cleaner answer was
-larger. The rewrite keeps the YAGNI/anti-speculation intent but explicitly
-instructs agents to **surface** wider architectural changes when they
-produce a cleaner result.
+larger. The `clean-not-minimal` rewrite fixed that but buried YAGNI
+mid-paragraph; operators reaching for YAGNI as a core rule found no
+affirmative statement. The 2026-08-29 rewrite leads with YAGNI, adds a
+`scope` field binding the rule to solution design during delivery, and adds
+an explicit non-license clause so YAGNI can never justify under-building,
+narrowing approved scope, or refusing user-requested work.
 
 Restart OpenCode after editing.
 

--- a/skills/adv-rule-rationale/SKILL.md
+++ b/skills/adv-rule-rationale/SKILL.md
@@ -55,11 +55,11 @@ Full scope and rationale for the eager ADV priority rules. Load this skill when 
 
 **Full rule:** Keep options concise, domain-specific, and capped so the user can choose or provide a different answer without fighting the UI.
 
-## P29 — clean-not-minimal
+## P29 — yagni-scope-discipline
 
-**Scope:** Not separately specified.
+**Scope:** Solution design and implementation scope while delivering an accepted request. Governs what you build, not whether to accept, question, or renegotiate the request itself.
 
-**Full rule:** When a wider architectural change produces a cleaner result, surface it — do not suppress better ideas to minimize blast radius or touch. Avoid speculative features and abstractions for hypothetical future needs (YAGNI), but do not confuse YAGNI with refusing necessary structural work or withholding stronger design proposals. This rule governs scope ambition, not leftover code: it never licenses retaining a construct the change supersedes (see P41).
+**Full rule:** Build only what the accepted request requires now. Do not add unrequested capability, configuration knobs, abstraction layers, extension points, generality, or defensive breadth for anticipated future needs (YAGNI); record a plausible future need as a named follow-up instead of building it. YAGNI governs the solution, never the delivery: it does not license under-building the request, narrowing approved scope, skipping research, tests, or verification, or refusing user-requested work — challenge a request through clarification (P08), not through silent omission. It also does not license refusing necessary structural work or withholding a stronger design proposal. Within that boundary, optimize for clarity and maintainability, not for the smallest possible diff: when a wider architectural change produces a cleaner result, surface it — do not suppress better ideas to minimize blast radius or touch. This rule governs scope ambition, not leftover code: it never licenses retaining a construct the change supersedes (see P41).
 
 ## P31 — thoroughness
 


### PR DESCRIPTION
Syncs upstream recommended-rule docs with the toolbox corpus rewrite `promoteYagniP29` (JRedeker/toolbox#255, 2026-08-29).

- `SETUP.md` P29 section: renamed `yagni-scope-discipline`, new `scope` field, folded rule text leading with the affirmative YAGNI statement, non-license clause (no under-building / scope narrowing / skipped verification / refused user-requested work; challenges route through P08), clean-not-minimal substance retained subordinated, `(see P41)` cross-ref restored. Tags/hint updated; priority 7 rationale kept; Why-this-rule-exists extended with the rewrite rationale.
- `skills/adv-rule-rationale/SKILL.md`: P29 entry header, scope, and full rule text synced.
- `CHANGELOG.md`: Unreleased → Changed entry.

Verification: fenced YAML block parsed and field-asserted (name/scope/rule/hint, 1035-char rule); no stray `clean-not-minimal` outside intentional rename-rationale mentions and released history. `rules.yaml` remains user-managed — docs-only change.

Related: JRedeker/toolbox follow-up `fixWorktreeDeletionMultiPr` (worktree-deletion multi-PR guard defect, filed in toolbox project store).